### PR TITLE
RAIL1752: Fix tests broken after last lockfile update

### DIFF
--- a/libs/sdk-ui/src/base/helpers/model/tests/objectToModelNotation.spec.ts
+++ b/libs/sdk-ui/src/base/helpers/model/tests/objectToModelNotation.spec.ts
@@ -34,7 +34,7 @@ describe("getModelNotationFor", () => {
             [42, 42],
             [[], "[]"],
             [{ foo: "bar" }, '{foo: "bar"}'],
-        ])(`should not touch irrelevant input %p`, (value, expectedValue) => {
+        ])(`should not touch irrelevant input %p`, (value: any, expectedValue: any) => {
             expect(getModelNotationFor(value)).toEqual(expectedValue);
         });
     });

--- a/libs/sdk-ui/src/charts/comboChart/tests/ComboChart.spec.tsx
+++ b/libs/sdk-ui/src/charts/comboChart/tests/ComboChart.spec.tsx
@@ -79,7 +79,7 @@ describe("ComboChart", () => {
 
         it.each([["primary", [M5, M5WithRatio], []], ["secondary", [], [M5, M5WithRatio]]])(
             "should ignore computeRatio when %s measure bucket has multiple items",
-            (_name: string, primaryMeasures: IMeasure[], secondaryMeasures: IMeasure[]) => {
+            (_name: any, primaryMeasures: any, secondaryMeasures: any) => {
                 const wrapper = renderChart(primaryMeasures, secondaryMeasures, config);
                 const execution = wrapper.find(CoreComboChart).prop("execution");
                 const expectedMeasures = [

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/test/autohideColumnLabels.spec.ts
@@ -209,7 +209,7 @@ describe("areNeighborsOverlapping", () => {
     ] as any;
     it.each([[true, overlaplabels], [false, withoutOverlapLabel]])(
         "should return overlap is %s",
-        (isOverlap: number, labels: IDataLabelsConfig[][]) => {
+        (isOverlap: boolean, labels: IDataLabelsConfig[][]) => {
             const areNeighborsOverlapping = autohideColumnLabels.areNeighborsOverlapping(labels);
             expect(areNeighborsOverlapping).toEqual(isOverlap);
         },

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/test/adjustTickAmount.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/test/adjustTickAmount.spec.ts
@@ -72,7 +72,7 @@ describe("adjustTickAmount - general", () => {
             ["right", getRightAxis(), [-12000, -9000, -6000, -3000, 0, 3000, 6000, 9000]], // reduced to 8 ticks
         ])(
             "should return %s tick positions aligned zero with opposite",
-            (_side: string, axis: IHighchartsAxisExtend, expectation: number) => {
+            (_side: any, axis: any, expectation: any) => {
                 customAdjustTickAmount.call(axis);
                 expect(axis.tickPositions).toEqual(expectation);
             },
@@ -80,7 +80,7 @@ describe("adjustTickAmount - general", () => {
 
         it.each([["left", getLeftAxis(), -900, 1200], ["right", getRightAxis(), -12000, 9000]])(
             "should min/max be updated on %s axis",
-            (_side: string, axis: IHighchartsAxisExtend, min: number, max: number) => {
+            (_side: any, axis: any, min: number, max: number) => {
                 customAdjustTickAmount.call(axis);
                 expect(axis.min).toBe(min);
                 expect(axis.max).toBe(max);
@@ -132,14 +132,14 @@ describe("adjustTickAmount - general", () => {
             ["right", rightAxis, [-5600, -4800, -4000, -3200, -2400, -1600, -800, 0]], // adjusted to 8 ticks
         ])(
             "should return %s tick positions aligned zero with opposite",
-            (_side: string, axis: IHighchartsAxisExtend, expectation: number) => {
+            (_side: any, axis: any, expectation: any) => {
                 expect(axis.tickPositions).toEqual(expectation);
             },
         );
 
         it.each([["left", leftAxis, -105, 0], ["right", rightAxis, -5600, 0]])(
             "should min/max be updated on %s axis",
-            (_side: string, axis: IHighchartsAxisExtend, min: number, max: number) => {
+            (_side: any, axis: any, min: number, max: number) => {
                 expect(axis.min).toBe(min);
                 expect(axis.max).toBe(max);
             },

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/test/comboConfiguration.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/test/comboConfiguration.spec.ts
@@ -53,7 +53,7 @@ describe("Combo Configuration", () => {
 
         it.each([[COLUMN, LINE], [COLUMN, AREA], [LINE, COLUMN], [AREA, COLUMN]])(
             "should return 'column' if primaryChartType=%s and secondaryChartType=%s",
-            (primaryChartType, secondaryChartType) => {
+            (primaryChartType: any, secondaryChartType: any) => {
                 const config: IChartConfig = {
                     primaryChartType,
                     secondaryChartType,

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/test/getOptionalStackingConfiguration.spec.ts
@@ -107,7 +107,7 @@ describe("getOptionalStackingConfiguration", () => {
 
         it.each([[NORMAL_STACK, { stackMeasures: true }], [PERCENT_STACK, { stackMeasuresToPercent: true }]])(
             "should return series config with %s stacking",
-            (type: string, chartConfig: IChartConfig) => {
+            (type: any, chartConfig: IChartConfig) => {
                 const chartOptions = { yAxes: [{}] };
                 const config = { series: Array(2).fill({ yAxis: 0 }) };
 

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/test/getZeroAlignConfiguration.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/test/getZeroAlignConfiguration.spec.ts
@@ -517,7 +517,7 @@ describe("getZeroAlignConfiguration", () => {
 
         it.each([[VisualizationTypes.COLUMN], [VisualizationTypes.LINE]])(
             "should hide left Y axis when min > max in %s chart",
-            (chartType: string) => {
+            (chartType: any) => {
                 const chartOptions = {
                     type: chartType,
                 };

--- a/libs/sdk-ui/src/highcharts/chart/test/chartOptionsBuilder.spec.ts
+++ b/libs/sdk-ui/src/highcharts/chart/test/chartOptionsBuilder.spec.ts
@@ -36,13 +36,7 @@ import {
     MeasureColorStrategy,
     TreemapColorStrategy,
 } from "../colorFactory";
-import {
-    IChartOptions,
-    IColorPaletteItem,
-    IMeasuresStackConfig,
-    IChartConfig,
-    IPointData,
-} from "../../Config";
+import { IChartOptions, IColorPaletteItem, IChartConfig, IPointData } from "../../Config";
 import { VisualizationTypes } from "../../../base/constants/visualizationTypes";
 import { NORMAL_STACK, PERCENT_STACK } from "../highcharts/getOptionalStackingConfiguration";
 import { DataViewFacade, emptyDef } from "@gooddata/sdk-backend-spi";
@@ -3159,7 +3153,7 @@ describe("chartOptionsBuilder", () => {
                 [NORMAL_STACK, { stackMeasures: true }],
             ])(
                 "should return %s when column+line chart is dual axis",
-                (stacking: string, stackingConfig: IMeasuresStackConfig) => {
+                (stacking: any, stackingConfig: any) => {
                     const chartOptions = generateChartOptions(
                         fixtures.comboWithTwoMeasuresAndViewByAttribute,
                         {

--- a/libs/sdk-ui/src/highcharts/utils/tests/dualAxis.spec.ts
+++ b/libs/sdk-ui/src/highcharts/utils/tests/dualAxis.spec.ts
@@ -16,7 +16,7 @@ describe("setMeasuresToSecondaryAxis", () => {
 
     it.each(TEST_CASES)(
         "should %s add measures to secondary axis when dualAxis=%s",
-        (_desc, value, expected) => {
+        (_desc: string, value: boolean, expected: any) => {
             const config: IChartConfig = {
                 type: "combo2",
                 dualAxis: value,

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.spec.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.spec.tsx
@@ -254,7 +254,7 @@ describe("PluggableComboChart", () => {
             [VisualizationTypes.AREA, true],
         ])(
             "should return stack measures by %s chart type is %s",
-            (chartType: VisualizationObject.VisualizationType, expectedResult: boolean) => {
+            (chartType: any, expectedResult: boolean) => {
                 const mockProps = {
                     ...defaultProps,
                     visualizationProperties: {
@@ -312,7 +312,7 @@ describe("PluggableComboChart", () => {
             ],
         ])(
             "should return combo chart uiconfig by chart type is %s with optional stacking",
-            (chartType: VisualizationObject.VisualizationType, expectedUiConfig: IUiConfig) => {
+            (chartType: any, expectedUiConfig: IUiConfig) => {
                 const mockProps = {
                     ...defaultProps,
                     visualizationProperties: {

--- a/libs/sdk-ui/src/internal/utils/tests/drillablePredicates.spec.ts
+++ b/libs/sdk-ui/src/internal/utils/tests/drillablePredicates.spec.ts
@@ -2,14 +2,13 @@
 import sdk from "@gooddata/gd-bear-client";
 import { IPostMessageData, convertPostMessageToDrillablePredicates } from "../drillablePredicates";
 import SpyInstance = jest.SpyInstance;
-import Mock = jest.Mock;
 import { IHeaderPredicate } from "../../../base/interfaces/HeaderPredicate";
 import * as HeaderPredicateFactory from "../../../base/factory/HeaderPredicateFactory";
 
 describe("convertPostMessageToDrillablePredicates", () => {
     let uriMatchSpy: SpyInstance;
     let composedFromUriSpy: SpyInstance;
-    let getUrisFromIdentifiersMock: Mock;
+    let getUrisFromIdentifiersMock: SpyInstance;
 
     function checkResult(result: IHeaderPredicate[], responsesCount: number) {
         expect(result).toHaveLength(responsesCount);


### PR DESCRIPTION
My guerilla update of lockfile to latest semver broke several parameterized tests. The jest typings have been 'upgraded' and about 20 of the tests failed to compile.

This removes the compilation errors - by switching types to 'any' as needed. Given the hosed nature of the jest typings in this area (param tests), I guess we should consider using a safer convention where types as on the test function are always 'any'.