### PR TITLE
RAIL-1752 - Fix circular dependency xhr.ts -> util.ts -> xhr.ts in gd-bear-client

### DIFF
--- a/libs/gd-bear-client/src/util.ts
+++ b/libs/gd-bear-client/src/util.ts
@@ -3,8 +3,6 @@ import get from "lodash/get";
 import { delay } from "./utils/promise";
 import { ApiResponse, ApiResponseError } from "./xhr";
 
-import { name as pkgName, version as pkgVersion } from "../package.json";
-
 /**
  * Utility methods. Mostly private
  *
@@ -12,12 +10,6 @@ import { name as pkgName, version as pkgVersion } from "../package.json";
  * @class util
  *
  */
-
-/**
- * Gooddata-js package signature
- * @private
- */
-export const thisPackage = { name: pkgName, version: pkgVersion };
 
 /**
  * Create getter function for accessing nested objects

--- a/libs/gd-bear-client/src/xhr.ts
+++ b/libs/gd-bear-client/src/xhr.ts
@@ -5,8 +5,7 @@ import set from "lodash/set";
 import defaults from "lodash/defaults";
 import merge from "lodash/merge";
 import result from "lodash/result";
-
-import { thisPackage } from "./util";
+import { name as pkgName, version as pkgVersion } from "../package.json";
 
 /**
  * Ajax wrapper around GDC authentication mechanisms, SST and TT token handling and polling.
@@ -27,6 +26,12 @@ const REST_API_DEPRECATED_VERSION_HEADER = "X-GDC-DEPRECATED";
 
 // The version used in X-GDC-VERSION header (see https://confluence.intgdc.com/display/Development/REST+API+versioning)
 const LATEST_REST_API_VERSION = 3;
+
+/**
+ * Gooddata-js package signature
+ * @private
+ */
+const thisPackage = { name: pkgName, version: pkgVersion };
 
 function simulateBeforeSend(url: string, settings: any) {
     const xhrMockInBeforeSend = {


### PR DESCRIPTION
"./util.ts" imports `ApiResponse` & `ApiResponseError` from "./xhr.ts";
and
"./xhr.ts" imports `thisPackage` from "./util.ts"

`thisPackage` is only used in xhr.ts, so I moved it there to get rid of circular dependencies