### PR TITLE
RAIL-1790: fix isNotAuthenticatedError implementation

### DIFF
--- a/libs/sdk-backend-bear/src/backend.ts
+++ b/libs/sdk-backend-bear/src/backend.ts
@@ -244,7 +244,7 @@ class AuthProviderCallGuard implements IAuthenticationProvider {
 }
 
 function isNotAuthenticatedError(err: any): boolean {
-    return isApiResponseError(err) && err.response === 401;
+    return isApiResponseError(err) && err.response.status === 401;
 }
 
 function currentProfileToPrincipalInformation(obj: any): AuthenticatedPrincipal {


### PR DESCRIPTION
err.response is a [Response](https://developer.mozilla.org/en-US/docs/Web/API/Response) object there,
we need to check its status property.
This was preventing authorization in  the bear-react-app.

JIRA: RAIL-1790