### PR TITLE
RAIL-1790: Add Rush preInstall hook to avoid errors with catalog-export CLI linkage

### DIFF
--- a/common/scripts/bootstrap-catalog-export.sh
+++ b/common/scripts/bootstrap-catalog-export.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Rush install runs into trouble when depending on packages that specify 'bin' script and this script does not
+# exist at install/link time; rush tries to link the script to node_modules/.bin dir of the dependant package.
+#
+# However as is often the case, the script in package JSON's 'bin' dir is not immediately present after the
+# repo is cloned. It is a result of build - and thus chicken-egg problem happens.
+#
+# We run into this problem with our catalog-export CLI tool; which is depended on by reference-workspace. In order
+# to get out of the deadlock, this script is registered as preInstall hook. Its goal is to verify whether
+# the catalog export's CLI entry point exists. If not, it will create an empty file and the rush install / link
+# will work.
+#
+# The subsequent build / rebuild will then overwrite the dummy file and everything will be on track.
+#
+
+if [ ! -f "tools/catalog-export/dist/index.js" ]; then
+  mkdir -p "tools/catalog-export/dist"
+  cat >"tools/catalog-export/dist/index.js" << EOF
+console.error("You are calling dummy-garage bootstrapped version of catalog export; this was created by bootstrap-catalog-export preInstall hook - in order for rush link to work. Please run rush rebuild.");
+EOF
+fi

--- a/rush.json
+++ b/rush.json
@@ -222,9 +222,7 @@
         /**
          * The list of shell commands to run before the Rush installation starts
          */
-        "preRushInstall": [
-            // "common/scripts/pre-rush-install.js"
-        ],
+        "preRushInstall": ["common/scripts/bootstrap-catalog-export.sh"],
 
         /**
          * The list of shell commands to run after the Rush installation finishes


### PR DESCRIPTION
- Rush fails when doing install on freshly cloned repo
- This is because it tries to link non-existent catalog-export CLI
  tool entry point mentioned in package.json/bin
- Chicken-egg problem
- This commit delivers preInstall hook that will verify whether the
  catalog-export CLI file in dist/index.js exists; if not it will
  create a placeholder
- With the placeholder, the install / link works
- Subsequent build/rebuild will wipe the placeholder and add
  the real built artifact

