### PR TITLE
RELATED: RAIL-1906 extend backend-spi with resources needed by AD

### DIFF
--- a/libs/gd-bear-client/src/catalogue.ts
+++ b/libs/gd-bear-client/src/catalogue.ts
@@ -8,7 +8,7 @@ import cloneDeep from "lodash/cloneDeep";
 import { XhrModule } from "./xhr";
 import { ExecutionModule } from "./execution";
 import { IAdHocItemDescription, IStoredItemDescription, ItemDescription } from "./interfaces";
-import { GdcCatalog } from "@gooddata/gd-bear-model";
+import { GdcCatalog, GdcDataSets } from "@gooddata/gd-bear-model";
 
 const REQUEST_DEFAULTS = {
     types: ["attribute", "metric", "fact"],
@@ -204,7 +204,10 @@ export class CatalogueModule {
         return this.loadCatalog(projectId, request);
     }
 
-    public async loadDateDataSets(projectId: string, options: any) {
+    public async loadDateDataSets(
+        projectId: string,
+        options: any,
+    ): Promise<GdcDataSets.IDateDataSetResponse> {
         const mdObj = cloneDeep(options).bucketItems;
         const bucketItems = mdObj
             ? await this.loadItemDescriptions(projectId, mdObj, get(options, "attributesMap"), true)
@@ -292,7 +295,20 @@ export class CatalogueModule {
         return itemDescriptions.map(unwrapItemDescriptionObject);
     }
 
-    private requestDateDataSets(projectId: string, dateDataSetsRequest: any) {
+    /**
+     * Loads all available data sets.
+     * @param projectId
+     */
+    public async loadDataSets(projectId: string): Promise<GdcDataSets.IDataSet[]> {
+        const uri = `/gdc/dataload/internal/projects/${projectId}/csv/datasets`;
+        const response: GdcDataSets.IDataSetResponse = await this.xhr.get(uri).then(res => res.getData());
+        return response.datasets.items;
+    }
+
+    private requestDateDataSets(
+        projectId: string,
+        dateDataSetsRequest: any,
+    ): Promise<GdcDataSets.IDateDataSetResponse> {
         const uri = `/gdc/internal/projects/${projectId}/loadDateDataSets`;
 
         return this.xhr

--- a/libs/gd-bear-client/src/interfaces.ts
+++ b/libs/gd-bear-client/src/interfaces.ts
@@ -48,6 +48,17 @@ export interface IGetObjectsByQueryOptions {
     author?: string;
     limit?: number;
     deprecated?: boolean;
+    orderBy?: "id" | "title" | "updated";
+    getTotalCount?: boolean;
+}
+
+export interface IGetObjectsByQueryWithPagingResponse<T> {
+    items: T[];
+    paging: {
+        count: number;
+        offset: number;
+        totalCount?: number;
+    };
 }
 
 export interface IGetObjectUsingOptions {

--- a/libs/gd-bear-client/src/project.ts
+++ b/libs/gd-bear-client/src/project.ts
@@ -1,8 +1,10 @@
-// (C) 2007-2017 GoodData Corporation
+// (C) 2007-2019 GoodData Corporation
+import qs from "qs";
 import { getIn, handlePolling, getAllPagesByOffsetLimit } from "./util";
 import { ITimezone, IColor, IColorPalette, IFeatureFlags } from "./interfaces";
 import { IStyleSettingsResponse, IFeatureFlagsResponse } from "./apiResponsesInterfaces";
 import { XhrModule, ApiResponse } from "./xhr";
+import { GdcProject } from "@gooddata/gd-bear-model";
 
 const DEFAULT_PALETTE = [
     { r: 0x2b, g: 0x6b, b: 0xae },
@@ -106,6 +108,29 @@ export class ProjectModule {
             `/gdc/account/profile/${profileId}/projects`,
             "projects",
         ).then((result: any) => result.map((p: any) => p.project));
+    }
+
+    /**
+     * Fetches projects available for the user represented by the given profileId page by page.
+     * @param userId
+     * @param offset
+     * @param limit
+     */
+    public getProjectsWithPaging(
+        userId: string,
+        offset: number,
+        limit: number,
+    ): Promise<GdcProject.IUserProjectsResponse> {
+        // inspired by ProjectDataSource in goodstrap. Maybe the /gdc/account/profile/${profileId}/projects would be suitable as well.
+        const mergedOptions = {
+            limit,
+            offset,
+            userId,
+            projectStates: "ENABLED",
+            userState: "ENABLED",
+        };
+        const uri = `/gdc/internal/projects/?${qs.stringify(mergedOptions)}`;
+        return this.xhr.get(uri).then(res => res.getData());
     }
 
     /**

--- a/libs/gd-bear-model/api/gd-bear-model.api.md
+++ b/libs/gd-bear-model/api/gd-bear-model.api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // Warning: (ae-internal-missing-underscore) The name "GdcCatalog" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export namespace GdcCatalog {
     // (undocumented)
@@ -135,7 +135,7 @@ export namespace GdcCatalog {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "GdcDashboardExport" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export namespace GdcDashboardExport {
     // (undocumented)
@@ -174,7 +174,7 @@ export namespace GdcDashboardExport {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "GdcDashboardLayout" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export namespace GdcDashboardLayout {
     // (undocumented)
@@ -251,6 +251,95 @@ export namespace GdcDashboardLayout {
     export type SectionHeader = ISectionHeader | ISectionDescription;
     // (undocumented)
     export type Widget = IPersistedWidget;
+}
+
+// @public (undocumented)
+export namespace GdcDataSets {
+    export type DataColumnType = "ATTRIBUTE" | "FACT" | "DATE";
+    export type DataSetLoadStatus = "RUNNING" | "OK" | "ERROR" | "CANCELLED" | "ERROR_METADATA" | "REFRESHING";
+    export interface IDataColumn {
+        // (undocumented)
+        column: {
+            name: string;
+            type: DataColumnType;
+            skip?: boolean;
+            format?: string;
+        };
+    }
+    export interface IDataHeader {
+        // (undocumented)
+        columns: IDataColumn[];
+        // (undocumented)
+        headerRowIndex?: number;
+    }
+    export interface IDataSet {
+        // (undocumented)
+        dataset: {
+            name: string;
+            dataHeader: IDataHeader;
+            dataSetId: string;
+            loadedRowCount: number;
+            dataSetLoadStatus: DataSetLoadStatus;
+            firstSuccessfulUpdate?: IDataSetLoadInfo;
+            lastSuccessfulUpdate?: IDataSetLoadInfo;
+            lastUpdate?: IDataSetLoadInfo;
+        };
+    }
+    export interface IDataSetLoadInfo {
+        // (undocumented)
+        created: string;
+        // (undocumented)
+        owner: IDataSetUser;
+        // (undocumented)
+        status: DataSetLoadStatus;
+    }
+    // (undocumented)
+    export interface IDataSetResponse {
+        // (undocumented)
+        datasets: {
+            items: IDataSet[];
+        };
+    }
+    export interface IDataSetUser {
+        // (undocumented)
+        fullName: string;
+        // (undocumented)
+        login: string;
+        // (undocumented)
+        profileUri: string;
+    }
+    export interface IDateDataSet {
+        // (undocumented)
+        availableDateAttributes?: IDateDataSetAttribute[];
+        // Warning: (ae-incompatible-release-tags) The symbol "meta" is marked as @public, but its signature references "GdcMetadata" which is marked as @internal
+        //
+        // (undocumented)
+        meta: GdcMetadata.IObjectMeta;
+        // (undocumented)
+        relevance: number;
+    }
+    export interface IDateDataSetAttribute {
+        // Warning: (ae-incompatible-release-tags) The symbol "attributeMeta" is marked as @public, but its signature references "GdcMetadata" which is marked as @internal
+        //
+        // (undocumented)
+        attributeMeta: GdcMetadata.IObjectMeta;
+        // Warning: (ae-incompatible-release-tags) The symbol "defaultDisplayFormMeta" is marked as @public, but its signature references "GdcMetadata" which is marked as @internal
+        //
+        // (undocumented)
+        defaultDisplayFormMeta: GdcMetadata.IObjectMeta;
+        // (undocumented)
+        type: string;
+    }
+    export interface IDateDataSetResponse {
+        // (undocumented)
+        dateDataSetsResponse: IDateDataSetResponseContent;
+    }
+    export interface IDateDataSetResponseContent {
+        // (undocumented)
+        dateDataSets: IDateDataSet[];
+        // (undocumented)
+        unavailableDateDataSetsCount?: number;
+    }
 }
 
 // @public
@@ -751,7 +840,7 @@ export namespace GdcExecution {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "GdcExtendedDateFilters" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export namespace GdcExtendedDateFilters {
     // (undocumented)
@@ -973,7 +1062,7 @@ export namespace GdcExtendedDateFilters {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "GdcMetadata" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export namespace GdcMetadata {
     // (undocumented)
@@ -1033,7 +1122,7 @@ export namespace GdcMetadata {
         // (undocumented)
         contributor: string;
         // Warning: (ae-forgotten-export) The symbol "Timestamp" needs to be exported by the entry point index.d.ts
-        // 
+        //
         // (undocumented)
         created: Timestamp;
         // (undocumented)
@@ -1124,13 +1213,42 @@ export namespace GdcMetadata {
 }
 
 // @public (undocumented)
+export namespace GdcProject {
+    // (undocumented)
+    export interface IUserProject {
+        // (undocumented)
+        links: {
+            self: string;
+        };
+        // (undocumented)
+        projectDescription: string;
+        // (undocumented)
+        projectState: UserProjectState;
+        // (undocumented)
+        projectTitle: string;
+        // (undocumented)
+        userState: UserProjectState;
+    }
+    // (undocumented)
+    export interface IUserProjectsResponse {
+        // (undocumented)
+        userProjects: {
+            items: IUserProject[];
+            paging: GdcPaging.IBearPagingWithTotalCount;
+        };
+    }
+    // (undocumented)
+    export type UserProjectState = "ENABLED" | "DISABLED";
+}
+
+// @public (undocumented)
 export namespace GdcVisualizationClass {
     // (undocumented)
     export interface IVisualizationClass {
         // (undocumented)
         content: IVisualizationClassContent;
         // Warning: (ae-incompatible-release-tags) The symbol "meta" is marked as @public, but its signature references "GdcMetadata" which is marked as @internal
-        // 
+        //
         // (undocumented)
         meta: GdcMetadata.IObjectMeta;
     }
@@ -1383,9 +1501,9 @@ export namespace GdcVisualizationObject {
         // (undocumented)
         content: IVisualizationObjectContent;
         // Warning: (ae-incompatible-release-tags) The symbol "meta" is marked as @public, but its signature references "GdcMetadata" which is marked as @internal
-        // 
+        //
         // (undocumented)
-        meta: GdcMetadata.IObjectMeta;
+        meta: Partial<GdcMetadata.IObjectMeta>;
     }
     // (undocumented)
     export interface IVisualizationObjectContent {
@@ -1422,21 +1540,22 @@ export namespace GdcVisualizationObject {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "getAttributesDisplayForms" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export function getAttributesDisplayForms(mdObject: IVisualizationObjectContent): string[];
 
 // Warning: (ae-internal-missing-underscore) The name "sanitizeDateFilters" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal (undocumented)
 export function sanitizeDateFilters(filters: GdcDashboardExport.FilterContextItem[]): GdcDashboardExport.FilterContextItem[];
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // dist/meta/GdcMetadata.d.ts:44:13 - (ae-forgotten-export) The symbol "MaqlExpression" needs to be exported by the entry point index.d.ts
 // dist/meta/GdcMetadata.d.ts:45:13 - (ae-forgotten-export) The symbol "Uri" needs to be exported by the entry point index.d.ts
 // dist/meta/GdcMetadata.d.ts:78:17 - (ae-forgotten-export) The symbol "NumberAsString" needs to be exported by the entry point index.d.ts
+// dist/project/GdcProject.d.ts:19:13 - (ae-forgotten-export) The symbol "GdcPaging" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/libs/gd-bear-model/src/base/Paging.ts
+++ b/libs/gd-bear-model/src/base/Paging.ts
@@ -1,0 +1,24 @@
+// (C) 2019 GoodData Corporation
+
+/**
+ * Objects  related to paged server API's.
+ *
+ * @public
+ */
+export namespace GdcPaging {
+    /**
+     * @public
+     */
+    export interface IBearPaging {
+        offset: number;
+        count: number;
+        limit: number;
+    }
+
+    /**
+     * @public
+     */
+    export interface IBearPagingWithTotalCount extends IBearPaging {
+        totalCount: number;
+    }
+}

--- a/libs/gd-bear-model/src/dataSets/GdcDataSets.ts
+++ b/libs/gd-bear-model/src/dataSets/GdcDataSets.ts
@@ -1,0 +1,145 @@
+// (C) 2019 GoodData Corporation
+import { GdcMetadata } from "../meta/GdcMetadata";
+
+/**
+ * @public
+ */
+export namespace GdcDataSets {
+    /**
+     * Represents the current status of CSV source.
+     *
+     * @public
+     */
+    export type DataSetLoadStatus =
+        | "RUNNING"
+        | "OK"
+        | "ERROR"
+        | "CANCELLED"
+        | "ERROR_METADATA"
+        | "REFRESHING";
+
+    /**
+     * Object wrapping info about the user that created CSV load. Contains their login and full name.
+     *
+     * @public
+     */
+    export interface IDataSetUser {
+        login: string;
+        fullName: string;
+        profileUri: string;
+    }
+
+    /**
+     * Object wrapping basic information (owner, date created, status) about a CSV Load.
+     *
+     * @public
+     */
+    export interface IDataSetLoadInfo {
+        owner: IDataSetUser;
+        status: DataSetLoadStatus;
+        created: string;
+    }
+
+    /**
+     * Represents type of LDM field created from the Dataset column.
+     *
+     * @public
+     */
+    export type DataColumnType = "ATTRIBUTE" | "FACT" | "DATE";
+
+    /**
+     * Dataset column with name, type and boolean flag whether the column
+     * needs to be skipped while data loading or not.
+     *
+     * @public
+     */
+    export interface IDataColumn {
+        column: {
+            name: string;
+            type: DataColumnType;
+            skip?: boolean;
+            format?: string;
+        };
+    }
+
+    /**
+     * Structural information about CSV header and columns. Indicates whether the CSV file
+     * contains header or not and on which row. Also contains the list of CSV columns with
+     * their names and types.
+     *
+     * @public
+     */
+    export interface IDataHeader {
+        headerRowIndex?: number;
+        columns: IDataColumn[];
+    }
+
+    /**
+     * Dataset describes a particular structure of dataset (CSV file). There may be many Loads
+     * related to a single dataset - meaning multiple files with the same structure and different data.
+     *
+     * @public
+     */
+    export interface IDataSet {
+        dataset: {
+            name: string;
+            dataHeader: IDataHeader;
+            dataSetId: string;
+            loadedRowCount: number;
+            dataSetLoadStatus: DataSetLoadStatus;
+            firstSuccessfulUpdate?: IDataSetLoadInfo;
+            lastSuccessfulUpdate?: IDataSetLoadInfo;
+            lastUpdate?: IDataSetLoadInfo;
+        };
+    }
+
+    /**
+     * @public
+     */
+    export interface IDataSetResponse {
+        datasets: {
+            items: IDataSet[];
+        };
+    }
+
+    /**
+     * TODO: SDK8 add docs
+     *
+     * @public
+     */
+    export interface IDateDataSetAttribute {
+        attributeMeta: GdcMetadata.IObjectMeta;
+        defaultDisplayFormMeta: GdcMetadata.IObjectMeta;
+        type: string;
+    }
+
+    /**
+     * TODO: SDK8 add docs
+     *
+     * @public
+     */
+    export interface IDateDataSet {
+        relevance: number;
+        availableDateAttributes?: IDateDataSetAttribute[];
+        meta: GdcMetadata.IObjectMeta;
+    }
+
+    /**
+     * TODO: SDK8 add docs
+     *
+     * @public
+     */
+    export interface IDateDataSetResponseContent {
+        dateDataSets: IDateDataSet[];
+        unavailableDateDataSetsCount?: number;
+    }
+
+    /**
+     * TODO: SDK8 add docs
+     *
+     * @public
+     */
+    export interface IDateDataSetResponse {
+        dateDataSetsResponse: IDateDataSetResponseContent;
+    }
+}

--- a/libs/gd-bear-model/src/index.ts
+++ b/libs/gd-bear-model/src/index.ts
@@ -9,6 +9,8 @@ export { GdcDashboardExport } from "./dashboard/GdcDashboardExport";
 export { GdcDashboardLayout } from "./dashboard/DashboardLayout";
 export { GdcCatalog } from "./catalog/GdcCatalog";
 export { GdcMetadata } from "./meta/GdcMetadata";
+export { GdcDataSets } from "./dataSets/GdcDataSets";
+export { GdcProject } from "./project/GdcProject";
 
 export { sanitizeDateFilters } from "./dashboard/utils";
 export { getAttributesDisplayForms } from "./visualizationObject/utils";

--- a/libs/gd-bear-model/src/project/GdcProject.ts
+++ b/libs/gd-bear-model/src/project/GdcProject.ts
@@ -1,0 +1,26 @@
+// (C) 2019 GoodData Corporation
+import { GdcPaging } from "../base/Paging";
+
+/**
+ * @public
+ */
+export namespace GdcProject {
+    export type UserProjectState = "ENABLED" | "DISABLED";
+
+    export interface IUserProject {
+        projectState: UserProjectState;
+        userState: UserProjectState;
+        projectDescription: string;
+        projectTitle: string;
+        links: {
+            self: string; // TODO use Uri type
+        };
+    }
+
+    export interface IUserProjectsResponse {
+        userProjects: {
+            items: IUserProject[];
+            paging: GdcPaging.IBearPagingWithTotalCount;
+        };
+    }
+}

--- a/libs/gd-bear-model/src/visualizationObject/GdcVisualizationObject.ts
+++ b/libs/gd-bear-model/src/visualizationObject/GdcVisualizationObject.ts
@@ -198,7 +198,7 @@ export namespace GdcVisualizationObject {
     }
 
     export interface IVisualizationObject {
-        meta: GdcMetadata.IObjectMeta;
+        meta: Partial<GdcMetadata.IObjectMeta>;
         content: IVisualizationObjectContent;
     }
 

--- a/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
+++ b/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
@@ -26,6 +26,8 @@ export class FixedLoginAndPasswordAuthProvider implements IAuthenticationProvide
     constructor(username: string, password: string);
     // (undocumented)
     authenticate(context: AuthenticationContext): Promise<AuthenticatedPrincipal>;
+    // (undocumented)
+    getCurrentPrincipal(): AuthenticatedPrincipal | undefined;
     }
 
 

--- a/libs/sdk-backend-bear/src/commonTypes.ts
+++ b/libs/sdk-backend-bear/src/commonTypes.ts
@@ -1,7 +1,10 @@
 // (C) 2019 GoodData Corporation
 import { SDK } from "@gooddata/gd-bear-client";
-import { AnalyticalBackendError } from "@gooddata/sdk-backend-spi";
+import { AnalyticalBackendError, AuthenticatedPrincipal } from "@gooddata/sdk-backend-spi";
 
-export type AsyncCall<T> = (sdk: SDK) => Promise<T>;
+export interface IAsyncCallContext {
+    principal: AuthenticatedPrincipal;
+}
+export type AsyncCall<T> = (sdk: SDK, context: IAsyncCallContext) => Promise<T>;
 export type ErrorConverter = (e: any) => AnalyticalBackendError;
 export type AuthenticatedCallGuard = <T>(call: AsyncCall<T>, errorConverter?: ErrorConverter) => Promise<T>;

--- a/libs/sdk-backend-bear/src/dataSets.ts
+++ b/libs/sdk-backend-bear/src/dataSets.ts
@@ -1,0 +1,20 @@
+// (C) 2019 GoodData Corporation
+import { IWorkspaceDataSetsService } from "@gooddata/sdk-backend-spi";
+import { IDataSet, IDateDataSet } from "@gooddata/sdk-model";
+import { AuthenticatedCallGuard } from "./commonTypes";
+import { convertDateDataSet } from "./fromSdkModel/DateDataSetConverter";
+import { convertDataSet } from "./fromSdkModel/DataSetConverter";
+
+export class BearWorkspaceDataSets implements IWorkspaceDataSetsService {
+    constructor(private readonly authCall: AuthenticatedCallGuard, public readonly workspace: string) {}
+
+    public async getDataSets(): Promise<IDataSet[]> {
+        const result = await this.authCall(sdk => sdk.catalogue.loadDataSets(this.workspace));
+        return result.map(convertDataSet);
+    }
+
+    public async getDateDataSets(): Promise<IDateDataSet[]> {
+        const result = await this.authCall(sdk => sdk.catalogue.loadDateDataSets(this.workspace, {}));
+        return result.dateDataSetsResponse.dateDataSets.map(convertDateDataSet);
+    }
+}

--- a/libs/sdk-backend-bear/src/elements.ts
+++ b/libs/sdk-backend-bear/src/elements.ts
@@ -87,7 +87,7 @@ class BearWorkspaceElementsQuery implements IElementQuery {
         const hasNextPage = serverOffset + count < total;
 
         const emptyResult: IElementQueryResult = {
-            elements: [],
+            items: [],
             limit: count,
             offset: total,
             totalCount: total,
@@ -95,7 +95,7 @@ class BearWorkspaceElementsQuery implements IElementQuery {
         };
 
         return {
-            elements: items.map((element: { element: IAttributeElement }) => element.element),
+            items: items.map((element: { element: IAttributeElement }) => element.element),
             limit: count,
             offset: serverOffset,
             totalCount: total,

--- a/libs/sdk-backend-bear/src/fromSdkModel/DataSetConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/DataSetConverter.ts
@@ -1,0 +1,9 @@
+// (C) 2019 GoodData Corporation
+import { GdcDataSets } from "@gooddata/gd-bear-model";
+import { IDataSet } from "@gooddata/sdk-model";
+
+export const convertDataSet = (dataSet: GdcDataSets.IDataSet): IDataSet => {
+    return {
+        ...dataSet,
+    };
+};

--- a/libs/sdk-backend-bear/src/fromSdkModel/DateDataSetConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/DateDataSetConverter.ts
@@ -1,0 +1,21 @@
+// (C) 2019 GoodData Corporation
+import { GdcDataSets } from "@gooddata/gd-bear-model";
+import { IDateDataSet, IDateDataSetAttribute } from "@gooddata/sdk-model";
+
+const convertDateDataSetAttribute = (attribute: GdcDataSets.IDateDataSetAttribute): IDateDataSetAttribute => {
+    return {
+        attributeId: attribute.attributeMeta.identifier!,
+        defaultDisplayFormId: attribute.defaultDisplayFormMeta.identifier!,
+        defaultDisplayFormTitle: attribute.defaultDisplayFormMeta.title,
+        granularity: attribute.type,
+    };
+};
+
+export const convertDateDataSet = (dateDataSet: GdcDataSets.IDateDataSet): IDateDataSet => {
+    return {
+        availableDateAttributes: dateDataSet.availableDateAttributes
+            ? dateDataSet.availableDateAttributes.map(convertDateDataSetAttribute)
+            : [],
+        relevance: dateDataSet.relevance,
+    };
+};

--- a/libs/sdk-backend-bear/src/fromSdkModel/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/FilterConverter.ts
@@ -1,0 +1,106 @@
+// (C) 2019 GoodData Corporation
+import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
+import {
+    IFilter,
+    isPositiveAttributeFilter,
+    IPositiveAttributeFilter,
+    filterAttributeElements,
+    isAttributeElementsByRef,
+    filterAttributeDisplayForm,
+    INegativeAttributeFilter,
+    isNegativeAttributeFilter,
+    IRelativeDateFilter,
+    isAbsoluteDateFilter,
+    IAbsoluteDateFilter,
+    isMeasureValueFilter,
+    IMeasureValueFilter,
+    measureValueFilterMeasure,
+    measureValueFilterCondition,
+    isIdentifierRef,
+    IMeasureFilter,
+    relativeDateFilterValues,
+    absoluteDateFilterValues,
+} from "@gooddata/sdk-model";
+
+const convertMeasureValueFilter = (
+    filter: IMeasureValueFilter,
+): GdcVisualizationObject.IMeasureValueFilter => {
+    const measureObjQualifier = measureValueFilterMeasure(filter);
+
+    if (isIdentifierRef(measureObjQualifier)) {
+        throw new Error("Cannot convert measure value filter for measure specified by identifier");
+    }
+
+    return {
+        measureValueFilter: {
+            measure: measureObjQualifier,
+            condition: measureValueFilterCondition(filter),
+        },
+    };
+};
+
+const convertRelativeDateFilter = (
+    filter: IRelativeDateFilter,
+): GdcVisualizationObject.IRelativeDateFilter => {
+    return {
+        relativeDateFilter: {
+            dataSet: filterAttributeDisplayForm(filter),
+            ...relativeDateFilterValues(filter),
+        },
+    };
+};
+
+const convertAbsoluteDateFilter = (
+    filter: IAbsoluteDateFilter,
+): GdcVisualizationObject.IAbsoluteDateFilter => {
+    return {
+        absoluteDateFilter: {
+            dataSet: filterAttributeDisplayForm(filter),
+            ...absoluteDateFilterValues(filter),
+        },
+    };
+};
+
+const convertNegativeAttributeFilter = (
+    filter: INegativeAttributeFilter,
+): GdcVisualizationObject.INegativeAttributeFilter => {
+    const elements = filterAttributeElements(filter);
+    return {
+        negativeAttributeFilter: {
+            displayForm: filterAttributeDisplayForm(filter),
+            notIn: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
+        },
+    };
+};
+
+const convertPositiveAttributeFilter = (
+    filter: IPositiveAttributeFilter,
+): GdcVisualizationObject.IPositiveAttributeFilter => {
+    const elements = filterAttributeElements(filter);
+    return {
+        positiveAttributeFilter: {
+            displayForm: filterAttributeDisplayForm(filter),
+            in: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
+        },
+    };
+};
+
+export const convertExtendedFilter = (filter: IFilter): GdcVisualizationObject.ExtendedFilter => {
+    if (isMeasureValueFilter(filter)) {
+        return convertMeasureValueFilter(filter);
+    } else {
+        return convertFilter(filter);
+    }
+};
+
+export const convertFilter = (filter: IMeasureFilter): GdcVisualizationObject.Filter => {
+    if (isPositiveAttributeFilter(filter)) {
+        return convertPositiveAttributeFilter(filter);
+    } else if (isNegativeAttributeFilter(filter)) {
+        return convertNegativeAttributeFilter(filter);
+    } else if (isAbsoluteDateFilter(filter)) {
+        return convertAbsoluteDateFilter(filter);
+    } else {
+        return convertRelativeDateFilter(filter);
+    }
+};

--- a/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
@@ -1,0 +1,73 @@
+// (C) 2019 GoodData Corporation
+import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
+import {
+    IInsightWithoutIdentifier,
+    insightBuckets,
+    insightVisualizationClassIdentifier,
+    IBucket,
+    AttributeOrMeasure,
+    isMeasure,
+    IAttribute,
+    attributeLocalId,
+    attributeAlias,
+    attributeAttributeDisplayFormObjRef,
+    insightTitle,
+    insightFilters,
+    insightProperties,
+} from "@gooddata/sdk-model";
+import { convertUrisToReferences } from "../toSdkModel/ReferenceConverter";
+import { serializeProperties } from "../toSdkModel/PropertiesConverter";
+import { convertExtendedFilter } from "./FilterConverter";
+import { convertMeasure } from "./MeasureConverter";
+
+const convertAttribute = (attribute: IAttribute): GdcVisualizationObject.IAttribute => {
+    return {
+        visualizationAttribute: {
+            alias: attributeAlias(attribute),
+            displayForm: attributeAttributeDisplayFormObjRef(attribute),
+            localIdentifier: attributeLocalId(attribute),
+        },
+    };
+};
+
+const convertBucketItem = (bucketItem: AttributeOrMeasure): GdcVisualizationObject.BucketItem => {
+    return isMeasure(bucketItem) ? convertMeasure(bucketItem) : convertAttribute(bucketItem);
+};
+
+const convertBucket = (bucket: IBucket): GdcVisualizationObject.IBucket => {
+    return {
+        items: bucket.items.map(convertBucketItem),
+        localIdentifier: bucket.localIdentifier,
+        totals: bucket.totals,
+    };
+};
+
+const convertInsightContent = (
+    insight: IInsightWithoutIdentifier,
+): GdcVisualizationObject.IVisualizationObjectContent => {
+    const { properties, references } = convertUrisToReferences({
+        properties: insightProperties(insight),
+        references: {},
+    });
+
+    return {
+        buckets: insightBuckets(insight).map(convertBucket),
+        visualizationClass: {
+            uri: insightVisualizationClassIdentifier(insight), // TODO this might not be an uri but an identifier...
+        },
+        filters: insightFilters(insight).map(convertExtendedFilter),
+        properties: serializeProperties(properties),
+        references,
+    };
+};
+
+export const convertInsight = (
+    insight: IInsightWithoutIdentifier,
+): GdcVisualizationObject.IVisualizationObject => {
+    return {
+        content: convertInsightContent(insight),
+        meta: {
+            title: insightTitle(insight),
+        },
+    };
+};

--- a/libs/sdk-backend-bear/src/fromSdkModel/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/MeasureConverter.ts
@@ -1,0 +1,112 @@
+// (C) 2019 GoodData Corporation
+import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
+import {
+    IMeasureDefinitionType,
+    IMeasure,
+    isSimpleMeasure,
+    IMeasureDefinition,
+    measureAlias,
+    measureFormat,
+    measureLocalId,
+    measureTitle,
+    measureAggregation,
+    measureDoesComputeRatio,
+    measureIdentifier,
+    measureUri,
+    isArithmeticMeasure,
+    measureArithmeticOperands,
+    measureArithmeticOperator,
+    IArithmeticMeasureDefinition,
+    isPoPMeasure,
+    IPoPMeasureDefinition,
+    measureMasterIdentifier,
+    measurePopAttribute,
+    isPreviousPeriodMeasure,
+    IPreviousPeriodMeasureDefinition,
+    measurePreviousPeriodDateDataSets,
+    measureFilters,
+} from "@gooddata/sdk-model";
+import { convertFilter } from "./FilterConverter";
+
+const convertPreviousPeriodMeasureDefinition = (
+    measure: IMeasure<IPreviousPeriodMeasureDefinition>,
+): GdcVisualizationObject.IPreviousPeriodMeasureDefinition => {
+    return {
+        previousPeriodMeasure: {
+            measureIdentifier: measureMasterIdentifier(measure)!,
+            dateDataSets: measurePreviousPeriodDateDataSets(measure)!,
+        },
+    };
+};
+
+const convertPoPMeasureDefinition = (
+    measure: IMeasure<IPoPMeasureDefinition>,
+): GdcVisualizationObject.IPoPMeasureDefinition => {
+    return {
+        popMeasureDefinition: {
+            measureIdentifier: measureMasterIdentifier(measure)!,
+            popAttribute: measurePopAttribute(measure)!,
+        },
+    };
+};
+
+const convertArithmeticMeasureDefinition = (
+    measure: IMeasure<IArithmeticMeasureDefinition>,
+): GdcVisualizationObject.IArithmeticMeasureDefinition => {
+    return {
+        arithmeticMeasure: {
+            measureIdentifiers: measureArithmeticOperands(measure)!,
+            operator: measureArithmeticOperator(measure)!,
+        },
+    };
+};
+
+const convertSimpleMeasureDefinition = (
+    measure: IMeasure<IMeasureDefinition>,
+): GdcVisualizationObject.IMeasureDefinition => {
+    const identifier = measureIdentifier(measure);
+    const uri = measureUri(measure);
+
+    if (!identifier && !uri) {
+        throw new Error("Measure has neither uri nor identifier.");
+    }
+
+    return {
+        measureDefinition: {
+            aggregation: measureAggregation(measure),
+            computeRatio: measureDoesComputeRatio(measure),
+            filters: (measureFilters(measure) || []).map(convertFilter),
+            item: identifier ? { identifier } : { uri: uri! },
+        },
+    };
+};
+
+const convertMeasureDefinition = (
+    measure: IMeasure<IMeasureDefinitionType>,
+): GdcVisualizationObject.IMeasureDefinitionType => {
+    if (isSimpleMeasure(measure)) {
+        return convertSimpleMeasureDefinition(measure);
+    } else if (isArithmeticMeasure(measure)) {
+        return convertArithmeticMeasureDefinition(measure);
+    } else if (isPoPMeasure(measure)) {
+        return convertPoPMeasureDefinition(measure);
+    } else if (isPreviousPeriodMeasure(measure)) {
+        return convertPreviousPeriodMeasureDefinition(measure);
+    }
+
+    throw new Error("Unknown measure type");
+};
+
+export const convertMeasure = (
+    measure: IMeasure<IMeasureDefinitionType>,
+): GdcVisualizationObject.IMeasure => {
+    return {
+        measure: {
+            alias: measureAlias(measure),
+            definition: convertMeasureDefinition(measure),
+            format: measureFormat(measure),
+            localIdentifier: measureLocalId(measure),
+            title: measureTitle(measure),
+        },
+    };
+};

--- a/libs/sdk-backend-bear/src/fromSdkModel/WorkspaceConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/WorkspaceConverter.ts
@@ -1,0 +1,11 @@
+// (C) 2019 GoodData Corporation
+import { GdcProject } from "@gooddata/gd-bear-model";
+import { IWorkspace } from "@gooddata/sdk-model";
+
+export const convertUserProject = (userProject: GdcProject.IUserProject): IWorkspace => {
+    return {
+        description: userProject.projectDescription,
+        title: userProject.projectTitle,
+        id: userProject.links.self.match(/\/gdc\/projects\/(.+)/i)![1],
+    };
+};

--- a/libs/sdk-backend-bear/src/toSdkModel/tests/ReferenceConverter.fixtures.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/tests/ReferenceConverter.fixtures.ts
@@ -1,111 +1,214 @@
 // (C) 2019 GoodData Corporation
-import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
-
-// tslint:disable:max-line-length
-
-const createFixture = (
-    properties: string,
-    references?: GdcVisualizationObject.IReferenceItems,
-): GdcVisualizationObject.IVisualizationObject => {
-    const referenceProp = references ? { references } : undefined;
-    return {
-        content: {
-            buckets: [],
-            visualizationClass: {
-                uri: "/gdc/md/foo_project/obj/8705",
-            },
-            properties,
-            ...referenceProp,
-        },
-        meta: {
-            title: "Foo",
-            category: "visualizationObject",
-            summary: "",
-            tags: "",
-            author: "",
-            contributor: "",
-            identifier: "",
-            uri: "",
-            deprecated: "0",
-            created: "",
-            isProduction: 1,
-            updated: "",
-        },
-    };
-};
+import { IConversionData } from "../ReferenceConverter";
 
 // ColorMapping fixtures
 
-export const colorMappingWithUrisAndExistingReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"/gdc/md/foo_project/obj/2210/elements?id=4436534"},{"color":{"type":"guid","value":"guid2"},"id":"/gdc/md/foo_project/obj/2210/elements?id=6340112"}],"zzCanary":true}}',
-    {
+export const colorMappingWithUrisAndExistingReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                {
+                    color: { type: "guid", value: "guid2" },
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=4436534",
+                },
+                {
+                    color: { type: "guid", value: "guid2" },
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=6340112",
+                },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {
         "5b7eff1441b24a40bce96d5698b009d3": "/gdc/md/foo_project/obj/2210/elements?id=4436534",
         "761e07c106d04474a0a509721f9a7fb5": "/gdc/md/foo_project/obj/2210/elements?id=6340112",
     },
-);
+};
 
-export const colorMappingWithUrisAndSurplusReferences = createFixture(
-    '{"controls":{"colorMapping":[{"id":"/gdc/md/foo_project/obj/2210/elements?id=4436534","color":{"type":"guid","value":"guid2"}},{"id":"/gdc/md/foo_project/obj/2210/elements?id=6340112","color":{"type":"guid","value":"guid2"}}],"zzCanary":true}}',
-    {
+export const colorMappingWithUrisAndSurplusReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                {
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=4436534",
+                    color: { type: "guid", value: "guid2" },
+                },
+                {
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=6340112",
+                    color: { type: "guid", value: "guid2" },
+                },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {
         "5b7eff1441b24a40bce96d5698b009d3": "/gdc/md/foo_project/obj/2210/elements?id=4436534",
         "761e07c106d04474a0a509721f9a7fb5": "/gdc/md/foo_project/obj/2210/elements?id=6340112",
         unused: "/gdc/md/unused",
     },
-);
+};
 
-export const colorMappingWithUrisAndNoReferences = createFixture(
-    '{"controls":{"colorMapping":[{"id":"/gdc/md/foo_project/obj/2210/elements?id=4436534","color":{"type":"guid","value":"guid2"}},{"id":"/gdc/md/foo_project/obj/2210/elements?id=6340112","color":{"type":"guid","value":"guid2"}}],"zzCanary":true}}',
-);
+export const colorMappingWithUrisAndNoReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                {
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=4436534",
+                    color: { type: "guid", value: "guid2" },
+                },
+                {
+                    id: "/gdc/md/foo_project/obj/2210/elements?id=6340112",
+                    color: { type: "guid", value: "guid2" },
+                },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {},
+};
 
-export const colorMappingWithReferencesAndExistingReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"5b7eff1441b24a40bce96d5698b009d3"},{"color":{"type":"guid","value":"guid2"},"id":"761e07c106d04474a0a509721f9a7fb5"}],"zzCanary":true}}',
-    {
+export const colorMappingWithReferencesAndExistingReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                { color: { type: "guid", value: "guid2" }, id: "5b7eff1441b24a40bce96d5698b009d3" },
+                { color: { type: "guid", value: "guid2" }, id: "761e07c106d04474a0a509721f9a7fb5" },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {
         "5b7eff1441b24a40bce96d5698b009d3": "/gdc/md/foo_project/obj/2210/elements?id=4436534",
         "761e07c106d04474a0a509721f9a7fb5": "/gdc/md/foo_project/obj/2210/elements?id=6340112",
     },
-);
+};
 
-export const colorMappingWithReferencesAndNewReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"id_0"},{"color":{"type":"guid","value":"guid2"},"id":"id_1"}],"zzCanary":true}}',
-    {
+export const colorMappingWithReferencesAndNewReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                { color: { type: "guid", value: "guid2" }, id: "id_0" },
+                { color: { type: "guid", value: "guid2" }, id: "id_1" },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {
         id_0: "/gdc/md/foo_project/obj/2210/elements?id=4436534",
         id_1: "/gdc/md/foo_project/obj/2210/elements?id=6340112",
     },
-);
+};
 
-export const colorMappingWithReferencesAndEmptyReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"measureId1"},{"color":{"type":"guid","value":"guid2"},"id":"measureId2"}],"zzCanary":true}}',
-    {},
-);
+export const colorMappingWithReferencesAndEmptyReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                { color: { type: "guid", value: "guid2" }, id: "measureId1" },
+                { color: { type: "guid", value: "guid2" }, id: "measureId2" },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {},
+};
 
-export const colorMappingWithReferencesAndNoReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"measureId1"},{"color":{"type":"guid","value":"guid2"},"id":"measureId2"}],"zzCanary":true}}',
-);
+export const colorMappingWithReferencesAndNoReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                { color: { type: "guid", value: "guid2" }, id: "measureId1" },
+                { color: { type: "guid", value: "guid2" }, id: "measureId2" },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {},
+};
 
-export const colorMappingWithReferencesAndMismatchingReferences = createFixture(
-    '{"controls":{"colorMapping":[{"color":{"type":"guid","value":"guid2"},"id":"id_0"},{"color":{"type":"guid","value":"guid2"},"id":"id_1"}],"zzCanary":true}}',
-    {
+export const colorMappingWithReferencesAndMismatchingReferences: IConversionData = {
+    properties: {
+        controls: {
+            colorMapping: [
+                { color: { type: "guid", value: "guid2" }, id: "id_0" },
+                { color: { type: "guid", value: "guid2" }, id: "id_1" },
+            ],
+            zzCanary: true,
+        },
+    },
+    references: {
         invalid: "/gdc/md/foo_project/obj/2210/elements?id=4436534",
         id_1: "/gdc/md/foo_project/obj/2210/elements?id=6340112",
     },
-);
+};
 
 // Sorting fixtures
 
-export const sortLocatorsWithUrisAndNoReferences = createFixture(
-    '{"sortItems":[{"measureSortItem":{"direction":"desc","locators":[{"attributeLocatorItem":{"attributeIdentifier":"d9f598def1e34c7aa1696f50eada43c4","element":"/gdc/md/foo_project/obj/2187/elements?id=6338473"}},{"measureLocatorItem":{"measureIdentifier":"82d062156ee74757a2f820a05744452c"}}]}}]}',
-);
+export const sortLocatorsWithUrisAndNoReferences: IConversionData = {
+    properties: {
+        sortItems: [
+            {
+                measureSortItem: {
+                    direction: "desc",
+                    locators: [
+                        {
+                            attributeLocatorItem: {
+                                attributeIdentifier: "d9f598def1e34c7aa1696f50eada43c4",
+                                element: "/gdc/md/foo_project/obj/2187/elements?id=6338473",
+                            },
+                        },
+                        { measureLocatorItem: { measureIdentifier: "82d062156ee74757a2f820a05744452c" } },
+                    ],
+                },
+            },
+        ],
+    },
+    references: {},
+};
 
-export const sortLocatorsWithUrisAndExistingReferences = createFixture(
-    '{"sortItems":[{"measureSortItem":{"direction":"desc","locators":[{"attributeLocatorItem":{"attributeIdentifier":"d9f598def1e34c7aa1696f50eada43c4","element":"/gdc/md/foo_project/obj/2187/elements?id=6338473"}},{"measureLocatorItem":{"measureIdentifier":"82d062156ee74757a2f820a05744452c"}}]}}]}',
-    {
+export const sortLocatorsWithUrisAndExistingReferences: IConversionData = {
+    properties: {
+        sortItems: [
+            {
+                measureSortItem: {
+                    direction: "desc",
+                    locators: [
+                        {
+                            attributeLocatorItem: {
+                                attributeIdentifier: "d9f598def1e34c7aa1696f50eada43c4",
+                                element: "/gdc/md/foo_project/obj/2187/elements?id=6338473",
+                            },
+                        },
+                        { measureLocatorItem: { measureIdentifier: "82d062156ee74757a2f820a05744452c" } },
+                    ],
+                },
+            },
+        ],
+    },
+    references: {
         id_0: "/gdc/md/foo_project/obj/2187/elements?id=6338473",
     },
-);
+};
 
-export const sortLocatorsWithReferencesAndNewReferences = createFixture(
-    '{"sortItems":[{"measureSortItem":{"direction":"desc","locators":[{"attributeLocatorItem":{"attributeIdentifier":"d9f598def1e34c7aa1696f50eada43c4","element":"id_0"}},{"measureLocatorItem":{"measureIdentifier":"82d062156ee74757a2f820a05744452c"}}]}}]}',
-    {
+export const sortLocatorsWithReferencesAndNewReferences: IConversionData = {
+    properties: {
+        sortItems: [
+            {
+                measureSortItem: {
+                    direction: "desc",
+                    locators: [
+                        {
+                            attributeLocatorItem: {
+                                attributeIdentifier: "d9f598def1e34c7aa1696f50eada43c4",
+                                element: "id_0",
+                            },
+                        },
+                        { measureLocatorItem: { measureIdentifier: "82d062156ee74757a2f820a05744452c" } },
+                    ],
+                },
+            },
+        ],
+    },
+    references: {
         id_0: "/gdc/md/foo_project/obj/2187/elements?id=6338473",
     },
-);
+};

--- a/libs/sdk-backend-bear/src/workspace.ts
+++ b/libs/sdk-backend-bear/src/workspace.ts
@@ -9,6 +9,7 @@ import {
     IWorkspaceStylingService,
     NotImplemented,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
 } from "@gooddata/sdk-backend-spi";
 import { BearExecution } from "./executionFactory";
 import { AuthenticatedCallGuard } from "./commonTypes";
@@ -16,6 +17,7 @@ import { BearWorkspaceMetadata } from "./metadata";
 import { BearWorkspaceStyling } from "./styling";
 import { BearWorkspaceElements } from "./elements";
 import { BearWorkspaceCatalog } from "./catalog";
+import { BearWorkspaceDataSets } from "./dataSets";
 
 export class BearWorkspace implements IAnalyticalWorkspace {
     constructor(private readonly authCall: AuthenticatedCallGuard, public readonly workspace: string) {}
@@ -42,5 +44,9 @@ export class BearWorkspace implements IAnalyticalWorkspace {
 
     public catalog(): IWorkspaceCatalog {
         return new BearWorkspaceCatalog(this.authCall, this.workspace);
+    }
+
+    public dataSets(): IWorkspaceDataSetsService {
+        return new BearWorkspaceDataSets(this.authCall, this.workspace);
     }
 }

--- a/libs/sdk-backend-bear/src/workspaces.ts
+++ b/libs/sdk-backend-bear/src/workspaces.ts
@@ -1,0 +1,69 @@
+// (C) 2019 GoodData Corporation
+import { IWorkspaceQueryFactory, IWorkspaceQuery, IWorkspaceQueryResult } from "@gooddata/sdk-backend-spi";
+import { AuthenticatedCallGuard } from "./commonTypes";
+import { convertUserProject } from "./fromSdkModel/WorkspaceConverter";
+
+export class BearWorkspaceQueryFactory implements IWorkspaceQueryFactory {
+    constructor(private readonly authCall: AuthenticatedCallGuard) {}
+
+    public forUser(userId: string): IWorkspaceQuery {
+        return new BearWorkspaceQuery(this.authCall, userId);
+    }
+
+    public forCurrentUser(): IWorkspaceQuery {
+        return new BearWorkspaceQuery(this.authCall);
+    }
+}
+
+class BearWorkspaceQuery implements IWorkspaceQuery {
+    private limit: number = 100;
+    private offset: number = 0;
+
+    constructor(private readonly authCall: AuthenticatedCallGuard, private readonly userId?: string) {}
+
+    public withLimit(limit: number): IWorkspaceQuery {
+        this.limit = limit;
+        return this;
+    }
+
+    public withOffset(offset: number): IWorkspaceQuery {
+        this.offset = offset;
+        return this;
+    }
+
+    public query(): Promise<IWorkspaceQueryResult> {
+        return this.queryWorker(this.offset, this.limit);
+    }
+
+    private async queryWorker(offset: number, limit: number): Promise<IWorkspaceQueryResult> {
+        const {
+            userProjects: { paging, items },
+        } = await this.authCall(async (sdk, { principal }) => {
+            const userId = this.userId || principal.userId;
+            return sdk.project.getProjectsWithPaging(userId, offset, limit);
+        });
+
+        const serverOffset = paging.offset;
+        const { totalCount, count } = paging;
+
+        const hasNextPage = serverOffset + count < totalCount;
+
+        const emptyResult: IWorkspaceQueryResult = {
+            items: [],
+            limit: count,
+            offset: totalCount,
+            totalCount,
+            next: () => Promise.resolve(emptyResult),
+        };
+
+        return {
+            items: items.map(convertUserProject),
+            limit: paging.limit,
+            offset: paging.offset,
+            totalCount: paging.totalCount,
+            next: hasNextPage
+                ? () => this.queryWorker(offset + count, limit)
+                : () => Promise.resolve(emptyResult),
+        };
+    }
+}

--- a/libs/sdk-backend-mockingbird/src/decoratedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/decoratedBackend/index.ts
@@ -19,6 +19,8 @@ import {
     IExportConfig,
     IDataView,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
+    IWorkspaceQueryFactory,
 } from "@gooddata/sdk-backend-spi";
 import {
     AttributeOrMeasure,
@@ -72,6 +74,10 @@ class BackendWithDecoratedServices implements IAnalyticalBackend {
     public workspace(id: string): IAnalyticalWorkspace {
         return new AnalyticalWorkspaceDecorator(this.decorated.workspace(id), this.factories);
     }
+
+    public workspaces(): IWorkspaceQueryFactory {
+        return this.decorated.workspaces();
+    }
 }
 
 class AnalyticalWorkspaceDecorator implements IAnalyticalWorkspace {
@@ -113,6 +119,10 @@ class AnalyticalWorkspaceDecorator implements IAnalyticalWorkspace {
 
     public catalog(): IWorkspaceCatalog {
         return this.decorated.catalog();
+    }
+
+    public dataSets(): IWorkspaceDataSetsService {
+        return this.decorated.dataSets();
     }
 }
 

--- a/libs/sdk-backend-mockingbird/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/dummyBackend/index.ts
@@ -21,6 +21,8 @@ import {
     NoDataError,
     NotSupported,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
+    IWorkspaceQueryFactory,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -83,6 +85,9 @@ export function dummyBackend(config: DummyBackendConfig = defaultDummyBackendCon
         },
         workspace(id: string): IAnalyticalWorkspace {
             return dummyWorkspace(id, config);
+        },
+        workspaces(): IWorkspaceQueryFactory {
+            throw new NotSupported("not supported");
         },
         authenticate(): Promise<AuthenticatedPrincipal> {
             return Promise.resolve({ userId: "dummyUser" });
@@ -172,6 +177,9 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
             throw new NotSupported("not supported");
         },
         catalog(): IWorkspaceCatalog {
+            throw new NotSupported("not supported");
+        },
+        dataSets(): IWorkspaceDataSetsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -23,6 +23,8 @@ import {
     IWorkspaceStylingService,
     NotSupported,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
+    IWorkspaceQueryFactory,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -106,6 +108,9 @@ export function legacyRecordedBackend(
         workspace(id: string): IAnalyticalWorkspace {
             return recordedWorkspace(id, index[id]);
         },
+        workspaces(): IWorkspaceQueryFactory {
+            throw new NotSupported("not yet supported");
+        },
         authenticate(): Promise<AuthenticatedPrincipal> {
             return Promise.resolve({ userId: "recordedUser" });
         },
@@ -164,6 +169,9 @@ function recordedWorkspace(
             throw new NotSupported("not supported");
         },
         catalog(): IWorkspaceCatalog {
+            throw new NotSupported("not supported");
+        },
+        dataSets(): IWorkspaceDataSetsService {
             throw new NotSupported("not supported");
         },
     };
@@ -295,6 +303,18 @@ function recordedWorkspaceMetadata(recordings: LegacyWorkspaceRecordings = {}): 
         getInsight(_id: string): Promise<IInsight> {
             throw new NotSupported("not supported");
         },
+        getInsights(_options) {
+            throw new NotSupported("not supported");
+        },
+        createInsight(_insight) {
+            throw new NotSupported("not supported");
+        },
+        updateInsight(_insight) {
+            throw new NotSupported("not supported");
+        },
+        deleteInsight(_id) {
+            throw new NotSupported("not supported");
+        },
         getVisualizationClass(_id: string): Promise<IVisualizationClass> {
             throw new NotSupported("not supported");
         },
@@ -329,7 +349,7 @@ function recordedElementQuery(objectId: string, recordings: LegacyWorkspaceRecor
         const slice = recording.slice(offset, offset + limit);
 
         const emptyResult: IElementQueryResult = {
-            elements: [],
+            items: [],
             limit,
             offset: recording.length,
             totalCount: recording.length,
@@ -339,7 +359,7 @@ function recordedElementQuery(objectId: string, recordings: LegacyWorkspaceRecor
         const hasNextPage = offset + limit < recording.length;
 
         return {
-            elements: slice,
+            items: slice,
             limit: Math.min(limit, slice.length),
             next() {
                 return hasNextPage ? queryWorker(offset + limit, limit) : Promise.resolve(emptyResult);

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -14,6 +14,8 @@ import {
     NotSupported,
     UnexpectedResponseError,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
+    IWorkspaceQueryFactory,
 } from "@gooddata/sdk-backend-spi";
 import { RecordedExecutionFactory } from "./execution";
 import { RecordingIndex, WorkspaceRecordings } from "./types";
@@ -61,6 +63,9 @@ export function recordedBackend(
 
             return recordedWorkspace(id, index[workspaceEntry]);
         },
+        workspaces(): IWorkspaceQueryFactory {
+            throw new NotSupported("not supported");
+        },
         authenticate(): Promise<AuthenticatedPrincipal> {
             return Promise.resolve({ userId: "recordedUser" });
         },
@@ -91,6 +96,9 @@ function recordedWorkspace(workspace: string, recordings: WorkspaceRecordings = 
             throw new NotSupported("not supported");
         },
         catalog(): IWorkspaceCatalog {
+            throw new NotSupported("not supported");
+        },
+        dataSets(): IWorkspaceDataSetsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -14,13 +14,17 @@ import { IAttributeElement } from '@gooddata/sdk-model';
 import { IBucket } from '@gooddata/sdk-model';
 import { ICatalogGroup } from '@gooddata/sdk-model';
 import { IColorPalette } from '@gooddata/sdk-model';
+import { IDataSet } from '@gooddata/sdk-model';
+import { IDateDataSet } from '@gooddata/sdk-model';
 import { IDimension } from '@gooddata/sdk-model';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IFilter } from '@gooddata/sdk-model';
 import { IInsight } from '@gooddata/sdk-model';
+import { IInsightWithoutIdentifier } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
 import { IMeasureExpressionToken } from '@gooddata/sdk-model';
 import { IVisualizationClass } from '@gooddata/sdk-model';
+import { IWorkspace } from '@gooddata/sdk-model';
 import { SortDirection } from '@gooddata/sdk-model';
 import { SortItem } from '@gooddata/sdk-model';
 
@@ -165,11 +169,13 @@ export interface IAnalyticalBackend {
     withAuthentication(provider: IAuthenticationProvider): IAnalyticalBackend;
     withTelemetry(componentName: string, props: object): IAnalyticalBackend;
     workspace(id: string): IAnalyticalWorkspace;
+    workspaces(): IWorkspaceQueryFactory;
 }
 
 // @public
 export interface IAnalyticalWorkspace {
     catalog(): IWorkspaceCatalog;
+    dataSets(): IWorkspaceDataSetsService;
     elements(): IElementQueryFactory;
     execution(): IExecutionFactory;
     metadata(): IWorkspaceMetadata;
@@ -199,6 +205,7 @@ export interface IAttributeDescriptor {
 // @public
 export interface IAuthenticationProvider {
     authenticate(context: AuthenticationContext): Promise<AuthenticatedPrincipal>;
+    getCurrentPrincipal(): AuthenticatedPrincipal | undefined;
 }
 
 // @public
@@ -263,17 +270,7 @@ export interface IElementQueryOptions {
 }
 
 // @public
-export interface IElementQueryResult {
-    // (undocumented)
-    readonly elements: IAttributeElement[];
-    // (undocumented)
-    readonly limit: number;
-    // (undocumented)
-    next(): Promise<IElementQueryResult>;
-    // (undocumented)
-    readonly offset: number;
-    // (undocumented)
-    readonly totalCount: number;
+export interface IElementQueryResult extends IPagedResource<IAttributeElement> {
 }
 
 // @public
@@ -309,6 +306,21 @@ export interface IExportConfig {
 export interface IExportResult {
     // (undocumented)
     uri: string;
+}
+
+// @public
+export interface IInsightQueryOptions {
+    author?: string;
+    // (undocumented)
+    limit?: number;
+    // (undocumented)
+    offset?: number;
+    // (undocumented)
+    orderBy?: "id" | "title" | "updated";
+}
+
+// @public
+export interface IInsightQueryResult extends IPagedResource<IInsight> {
 }
 
 // @public (undocumented)
@@ -364,6 +376,20 @@ export interface IMeasureGroupDescriptor {
         items: IMeasureDescriptor[];
         totalItems?: ITotalDescriptor[];
     };
+}
+
+// @public
+export interface IPagedResource<TItem> {
+    // (undocumented)
+    readonly items: TItem[];
+    // (undocumented)
+    readonly limit: number;
+    // (undocumented)
+    next(): Promise<IPagedResource<TItem>>;
+    // (undocumented)
+    readonly offset: number;
+    // (undocumented)
+    readonly totalCount: number;
 }
 
 // @public
@@ -473,15 +499,48 @@ export interface IWorkspaceCatalog {
 }
 
 // @public
+export interface IWorkspaceDataSetsService {
+    // (undocumented)
+    getDataSets(): Promise<IDataSet[]>;
+    // (undocumented)
+    getDateDataSets(): Promise<IDateDataSet[]>;
+}
+
+// @public
 export interface IWorkspaceMetadata {
+    // (undocumented)
+    createInsight(insight: IInsightWithoutIdentifier): Promise<IInsight>;
+    // (undocumented)
+    deleteInsight(id: string): Promise<void>;
     getAttributeDisplayForm(id: string): Promise<IAttributeDisplayForm>;
     // (undocumented)
     getInsight(id: string): Promise<IInsight>;
+    // (undocumented)
+    getInsights(options?: IInsightQueryOptions): Promise<IInsightQueryResult>;
     getMeasureExpressionTokens(id: string): Promise<IMeasureExpressionToken[]>;
     // (undocumented)
     getVisualizationClass(id: string): Promise<IVisualizationClass>;
     // (undocumented)
     getVisualizationClasses(): Promise<IVisualizationClass[]>;
+    // (undocumented)
+    updateInsight(insight: IInsight): Promise<IInsight>;
+}
+
+// @public
+export interface IWorkspaceQuery {
+    query(): Promise<IWorkspaceQueryResult>;
+    withLimit(limit: number): IWorkspaceQuery;
+    withOffset(offset: number): IWorkspaceQuery;
+}
+
+// @public
+export interface IWorkspaceQueryFactory {
+    forCurrentUser(): IWorkspaceQuery;
+    forUser(userId: string): IWorkspaceQuery;
+}
+
+// @public
+export interface IWorkspaceQueryResult extends IPagedResource<IWorkspace> {
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/backend/index.ts
+++ b/libs/sdk-backend-spi/src/backend/index.ts
@@ -7,6 +7,8 @@ import { IWorkspaceSettingsService } from "../featureFlags";
 import { IWorkspaceMetadata } from "../metadata";
 import { IWorkspaceStylingService } from "../styling";
 import { IWorkspaceCatalog } from "../catalog";
+import { IWorkspaceDataSetsService } from "../dataSets";
+import { IWorkspaceQueryFactory } from "../workspace";
 
 /**
  * Specifies platform agnostic configuration of an analytical backend. Only config items that make sense for
@@ -114,6 +116,11 @@ export interface IAnalyticalBackend {
      * @returns an instance that can be used to interact with the workspace
      */
     workspace(id: string): IAnalyticalWorkspace;
+
+    /**
+     * Returns service that can be used to obtain available workspaces.
+     */
+    workspaces(): IWorkspaceQueryFactory;
 }
 
 /**
@@ -158,6 +165,11 @@ export interface IAnalyticalWorkspace {
      * Returns service that can be used to query workspace catalog items - attributes, measures, facts, dates, and datasets
      */
     catalog(): IWorkspaceCatalog;
+
+    /**
+     * Returns service that can be used to query data sets and data data sets defined in this workspace.
+     */
+    dataSets(): IWorkspaceDataSetsService;
 }
 
 /**
@@ -231,6 +243,12 @@ export interface IAuthenticationProvider {
      * @param context - context in which the authentication is done
      */
     authenticate(context: AuthenticationContext): Promise<AuthenticatedPrincipal>;
+
+    /**
+     * Returns the currently authenticated principal, or undefined if not authenticated.
+     * Does not trigger authentication if no principal is available.
+     */
+    getCurrentPrincipal(): AuthenticatedPrincipal | undefined;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/dataSets/index.ts
+++ b/libs/sdk-backend-spi/src/dataSets/index.ts
@@ -1,0 +1,12 @@
+// (C) 2019 GoodData Corporation
+import { IDataSet, IDateDataSet } from "@gooddata/sdk-model";
+
+/**
+ * TODO: SDK8: add public doc
+ *
+ * @public
+ */
+export interface IWorkspaceDataSetsService {
+    getDataSets(): Promise<IDataSet[]>;
+    getDateDataSets(): Promise<IDateDataSet[]>;
+}

--- a/libs/sdk-backend-spi/src/elements/index.ts
+++ b/libs/sdk-backend-spi/src/elements/index.ts
@@ -1,5 +1,6 @@
 // (C) 2019 GoodData Corporation
 import { SortDirection, IAttributeElement } from "@gooddata/sdk-model";
+import { IPagedResource } from "../paging";
 
 /**
  * TODO: SDK8: add docs
@@ -44,11 +45,4 @@ export interface IElementQuery {
  * TODO: SDK8: add docs
  * @public
  */
-export interface IElementQueryResult {
-    readonly elements: IAttributeElement[];
-    readonly limit: number;
-    readonly offset: number;
-    readonly totalCount: number;
-
-    next(): Promise<IElementQueryResult>;
-}
+export interface IElementQueryResult extends IPagedResource<IAttributeElement> {}

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -45,7 +45,7 @@ export {
 
 export { IWorkspaceSettingsService, IWorkspaceSettings } from "./featureFlags";
 
-export { IWorkspaceMetadata } from "./metadata";
+export { IWorkspaceMetadata, IInsightQueryOptions, IInsightQueryResult } from "./metadata";
 
 export {
     IWorkspaceCatalog,
@@ -81,3 +81,9 @@ export {
     isNotAuthenticated,
     AnalyticalBackendErrorTypes,
 } from "./errors";
+
+export { IPagedResource } from "./paging";
+
+export { IWorkspaceDataSetsService } from "./dataSets";
+
+export { IWorkspaceQuery, IWorkspaceQueryFactory, IWorkspaceQueryResult } from "./workspace";

--- a/libs/sdk-backend-spi/src/metadata/index.ts
+++ b/libs/sdk-backend-spi/src/metadata/index.ts
@@ -5,7 +5,9 @@ import {
     IInsight,
     IAttributeDisplayForm,
     IMeasureExpressionToken,
+    IInsightWithoutIdentifier,
 } from "@gooddata/sdk-model";
+import { IPagedResource } from "../paging";
 
 /**
  * TODO: SDK8: add public doc
@@ -16,6 +18,10 @@ export interface IWorkspaceMetadata {
     getVisualizationClass(id: string): Promise<IVisualizationClass>;
     getVisualizationClasses(): Promise<IVisualizationClass[]>;
     getInsight(id: string): Promise<IInsight>;
+    getInsights(options?: IInsightQueryOptions): Promise<IInsightQueryResult>;
+    createInsight(insight: IInsightWithoutIdentifier): Promise<IInsight>;
+    updateInsight(insight: IInsight): Promise<IInsight>;
+    deleteInsight(id: string): Promise<void>;
     /**
      * Gets the attribute display form with the provided identifier.
      * @param id - identifier of the attribute display form to retrieve
@@ -29,3 +35,25 @@ export interface IWorkspaceMetadata {
      */
     getMeasureExpressionTokens(id: string): Promise<IMeasureExpressionToken[]>;
 }
+
+/**
+ * TODO: SDK8: add public doc
+ *
+ * @public
+ */
+export interface IInsightQueryOptions {
+    offset?: number;
+    limit?: number;
+    orderBy?: "id" | "title" | "updated";
+    /**
+     * Login of the author to filter the insights by
+     */
+    author?: string;
+}
+
+/**
+ * TODO: SDK8: add public doc
+ *
+ * @public
+ */
+export interface IInsightQueryResult extends IPagedResource<IInsight> {}

--- a/libs/sdk-backend-spi/src/paging/index.ts
+++ b/libs/sdk-backend-spi/src/paging/index.ts
@@ -1,0 +1,14 @@
+// (C) 2019 GoodData Corporation
+
+/**
+ * TODO: SDK8: add docs
+ * @public
+ */
+export interface IPagedResource<TItem> {
+    readonly items: TItem[];
+    readonly limit: number;
+    readonly offset: number;
+    readonly totalCount: number;
+
+    next(): Promise<IPagedResource<TItem>>;
+}

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -1,0 +1,58 @@
+// (C) 2019 GoodData Corporation
+import { IWorkspace } from "@gooddata/sdk-model";
+import { IPagedResource } from "../paging";
+
+/**
+ * Factory providing creating queries used to get available workspaces.
+ *
+ * @public
+ */
+export interface IWorkspaceQueryFactory {
+    /**
+     * Creates a query for workspaces available to the specified user.
+     *
+     * @param userId - id of the user to retrieve workspaces for
+     * @public
+     */
+    forUser(userId: string): IWorkspaceQuery;
+
+    /**
+     * Creates a query for workspaces available to the user currently logged in.
+     *
+     * @public
+     */
+    forCurrentUser(): IWorkspaceQuery;
+}
+
+/**
+ * Query to retrieve available worksapces.
+ *
+ * @public
+ */
+export interface IWorkspaceQuery {
+    /**
+     * Sets a limit on how many items to retrieve at once.
+     * @param limit - how many items to retrieve at most
+     *
+     * @public
+     */
+    withLimit(limit: number): IWorkspaceQuery;
+
+    /**
+     * Sets a number of items to skip.
+     * @param offset - how many items to skip
+     */
+    withOffset(offset: number): IWorkspaceQuery;
+
+    /**
+     * Executes the query and returns the result asynchronously.
+     */
+    query(): Promise<IWorkspaceQueryResult>;
+}
+
+/**
+ * Paged resource with results of a workspace query.
+ *
+ * @public
+ */
+export interface IWorkspaceQueryResult extends IPagedResource<IWorkspace> {}

--- a/libs/sdk-backend-tiger/src/backend.ts
+++ b/libs/sdk-backend-tiger/src/backend.ts
@@ -6,6 +6,8 @@ import {
     IAnalyticalWorkspace,
     IAuthenticationProvider,
     AuthenticatedPrincipal,
+    IWorkspaceQueryFactory,
+    NotImplemented,
 } from "@gooddata/sdk-backend-spi";
 import { AxiosInstance } from "axios";
 import { newAxios } from "./gd-tiger-client/axios";
@@ -103,6 +105,10 @@ export class TigerBackend implements IAnalyticalBackend {
 
     public workspace(id: string): IAnalyticalWorkspace {
         return new TigerWorkspace(this.axios, id);
+    }
+
+    public workspaces(): IWorkspaceQueryFactory {
+        throw new NotImplemented("workspaces query not yet implemented");
     }
 }
 

--- a/libs/sdk-backend-tiger/src/workspace.ts
+++ b/libs/sdk-backend-tiger/src/workspace.ts
@@ -9,6 +9,7 @@ import {
     IWorkspaceStylingService,
     NotImplemented,
     IWorkspaceCatalog,
+    IWorkspaceDataSetsService,
 } from "@gooddata/sdk-backend-spi";
 import { AxiosInstance } from "axios";
 import { TigerExecution } from "./executionFactory";
@@ -38,5 +39,9 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
 
     public catalog(): IWorkspaceCatalog {
         throw new NotImplemented("catalog service not yet implemented");
+    }
+
+    public dataSets(): IWorkspaceDataSetsService {
+        throw new NotImplemented("dataSets service not yet implemented");
     }
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public
+export function absoluteDateFilterValues(filter: IAbsoluteDateFilter): IAbsoluteDateFilterValues;
+
+// @public
 export const anyAttribute: AttributePredicate;
 
 // @public
@@ -24,6 +27,12 @@ export class ArithmeticMeasureBuilder extends MeasureBuilderBase<IArithmeticMeas
 
 // @public
 export type ArithmeticMeasureOperator = "sum" | "difference" | "multiplication" | "ratio" | "change";
+
+// @public
+export function attributeAlias(attribute: IAttribute): string | undefined;
+
+// @public
+export function attributeAttributeDisplayFormObjRef(attribute: IAttribute): ObjRef;
 
 // @public
 export class AttributeBuilder implements IAttribute {
@@ -156,6 +165,12 @@ export enum ComputeRatioRule {
 }
 
 // @public
+export type DataColumnType = "ATTRIBUTE" | "FACT" | "DATE";
+
+// @public
+export type DataSetLoadStatus = "RUNNING" | "OK" | "ERROR" | "CANCELLED" | "ERROR_METADATA" | "REFRESHING";
+
+// @public
 export const DateGranularity: {
     date: string;
     week: string;
@@ -207,6 +222,12 @@ export function emptyDef(workspace: string): IExecutionDefinition;
 export const factoryNotationFor: (data: any) => string;
 
 // @public
+export function filterAttributeDisplayForm(filter: IAbsoluteDateFilter | IRelativeDateFilter | IPositiveAttributeFilter | INegativeAttributeFilter): ObjRef;
+
+// @public
+export function filterAttributeElements(filter: IPositiveAttributeFilter | INegativeAttributeFilter): AttributeElements;
+
+// @public
 export function filterIsEmpty(filter: IAttributeFilter): boolean;
 
 // @public (undocumented)
@@ -220,6 +241,14 @@ export interface IAbsoluteDateFilter {
         from: string;
         to: string;
     };
+}
+
+// @public
+export interface IAbsoluteDateFilterValues {
+    // (undocumented)
+    from: string;
+    // (undocumented)
+    to: string;
 }
 
 // @public
@@ -384,6 +413,78 @@ export interface IComparisonCondition {
 }
 
 // @public
+export interface IDataColumn {
+    // (undocumented)
+    column: {
+        name: string;
+        type: DataColumnType;
+        skip?: boolean;
+        format?: string;
+    };
+}
+
+// @public
+export interface IDataHeader {
+    // (undocumented)
+    columns: IDataColumn[];
+    // (undocumented)
+    headerRowIndex?: number;
+}
+
+// @public
+export interface IDataSet {
+    // (undocumented)
+    dataset: {
+        name: string;
+        dataHeader: IDataHeader;
+        dataSetId: string;
+        loadedRowCount: number;
+        dataSetLoadStatus: DataSetLoadStatus;
+        firstSuccessfulUpdate?: IDataSetLoadInfo;
+        lastSuccessfulUpdate?: IDataSetLoadInfo;
+        lastUpdate?: IDataSetLoadInfo;
+    };
+}
+
+// @public
+export interface IDataSetLoadInfo {
+    // (undocumented)
+    created: string;
+    // (undocumented)
+    owner: IDataSetUser;
+    // (undocumented)
+    status: DataSetLoadStatus;
+}
+
+// @public
+export interface IDataSetUser {
+    // (undocumented)
+    fullName: string;
+    // (undocumented)
+    login: string;
+}
+
+// @public
+export interface IDateDataSet {
+    // (undocumented)
+    availableDateAttributes?: IDateDataSetAttribute[];
+    // (undocumented)
+    relevance: number;
+}
+
+// @public
+export interface IDateDataSetAttribute {
+    // (undocumented)
+    attributeId: string;
+    // (undocumented)
+    defaultDisplayFormId: string;
+    // (undocumented)
+    defaultDisplayFormTitle: string;
+    // (undocumented)
+    granularity: string;
+}
+
+// @public
 export type IDateFilter = IRelativeDateFilter | IAbsoluteDateFilter;
 
 // @public
@@ -444,6 +545,11 @@ export interface IInsight {
         properties: VisualizationProperties;
     };
 }
+
+// @public
+export type IInsightWithoutIdentifier = {
+    insight: Omit<IInsight["insight"], "identifier">;
+};
 
 // Warning: (ae-forgotten-export) The symbol "IMeasureTitle" needs to be exported by the entry point index.d.ts
 //
@@ -515,31 +621,34 @@ export interface INegativeAttributeFilter {
 }
 
 // @public
-export function insightAttributes(insight: IInsight): IAttribute[];
+export function insightAttributes(insight: IInsightWithoutIdentifier): IAttribute[];
 
 // @public
-export function insightBucket(insight: IInsight, idOrFun?: string | BucketPredicate): IBucket | undefined;
+export function insightBucket(insight: IInsightWithoutIdentifier, idOrFun?: string | BucketPredicate): IBucket | undefined;
 
 // @public
-export function insightBuckets(insight: IInsight, ...ids: string[]): IBucket[];
+export function insightBuckets(insight: IInsightWithoutIdentifier, ...ids: string[]): IBucket[];
 
 // @public
-export function insightFilters(insight: IInsight): IFilter[];
+export function insightFilters(insight: IInsightWithoutIdentifier): IFilter[];
 
 // @public
-export function insightHasAttributes(insight: IInsight): boolean;
+export function insightHasAttributes(insight: IInsightWithoutIdentifier): boolean;
 
 // @public
-export function insightHasDataDefined(insight: IInsight): boolean;
+export function insightHasDataDefined(insight: IInsightWithoutIdentifier): boolean;
 
 // @public
-export function insightHasMeasures(insight: IInsight): boolean;
+export function insightHasMeasures(insight: IInsightWithoutIdentifier): boolean;
 
 // @public
-export function insightMeasures(insight: IInsight): IMeasure[];
+export function insightId(insight: IInsight): string;
 
 // @public
-export function insightProperties(insight: IInsight): VisualizationProperties;
+export function insightMeasures(insight: IInsightWithoutIdentifier): IMeasure[];
+
+// @public
+export function insightProperties(insight: IInsightWithoutIdentifier): VisualizationProperties;
 
 // @public
 export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
@@ -548,13 +657,16 @@ export function insightSetProperties(insight: IInsight, properties?: Visualizati
 export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
 
 // @public
-export function insightSorts(insight: IInsight): SortItem[];
+export function insightSorts(insight: IInsightWithoutIdentifier): SortItem[];
 
 // @public
-export function insightTotals(insight: IInsight): ITotal[];
+export function insightTitle(insight: IInsightWithoutIdentifier): string;
 
 // @public
-export function insightVisualizationClassIdentifier(insight: IInsight): string;
+export function insightTotals(insight: IInsightWithoutIdentifier): ITotal[];
+
+// @public
+export function insightVisualizationClassIdentifier(insight: IInsightWithoutIdentifier): string;
 
 // @public (undocumented)
 export interface IObjectExpressionToken {
@@ -630,6 +742,16 @@ export interface IRelativeDateFilter {
         from: number;
         to: number;
     };
+}
+
+// @public
+export interface IRelativeDateFilterValues {
+    // (undocumented)
+    from: number;
+    // (undocumented)
+    granularity: string;
+    // (undocumented)
+    to: number;
 }
 
 // @public
@@ -790,6 +912,16 @@ export interface IVisualizationClass {
 }
 
 // @public
+export interface IWorkspace {
+    // (undocumented)
+    description: string;
+    // (undocumented)
+    id: string;
+    // (undocumented)
+    title: string;
+}
+
+// @public
 export type LocalIdRef = {
     localIdentifier: Identifier;
 };
@@ -799,6 +931,9 @@ export type LocatorItem = IAttributeLocatorItem | IMeasureLocatorItem;
 
 // @public
 export type MeasureAggregation = "sum" | "count" | "avg" | "min" | "max" | "median" | "runsum";
+
+// @public
+export function measureAggregation(measure: IMeasure): MeasureAggregation | undefined;
 
 // @public
 export function measureAlias(measure: IMeasure): string | undefined;
@@ -816,7 +951,7 @@ export class MeasureBuilder extends MeasureBuilderBase<IMeasureDefinition> {
     // (undocumented)
     aggregation: (aggregation: MeasureAggregation) => this;
     // (undocumented)
-    filters: (...filters: IMeasureFilter[]) => this;
+    filters: (...filters: (import("../filter").IPositiveAttributeFilter | import("../filter").INegativeAttributeFilter | import("../filter").IAbsoluteDateFilter | import("../filter").IRelativeDateFilter)[]) => this;
     // (undocumented)
     ratio: () => this;
 }
@@ -848,6 +983,12 @@ export function measureDisableComputeRatio(measure: IMeasure): IMeasure;
 export function measureDoesComputeRatio(measure: IMeasure): boolean;
 
 // @public
+export function measureFilters(measure: IMeasure): IMeasureFilter[] | undefined;
+
+// @public
+export function measureFormat(measure: IMeasure): string | undefined;
+
+// @public
 export const MeasureGroupIdentifier = "measureGroup";
 
 // @public
@@ -870,7 +1011,13 @@ export function measureMasterIdentifier(measure: IMeasure): string | undefined;
 export type MeasureModifications<TBuilder> = (builder: TBuilder) => TBuilder;
 
 // @public
+export function measurePopAttribute(measure: IMeasure): ObjRef | undefined;
+
+// @public
 export type MeasurePredicate = (measure: IMeasure) => boolean;
+
+// @public
+export function measurePreviousPeriodDateDataSets(measure: IMeasure): IPreviousPeriodDateDataSet[] | undefined;
 
 // @public
 export function measureTitle(measure: IMeasure): string | undefined;
@@ -880,6 +1027,12 @@ export function measureUri(measure: IMeasure): string | undefined;
 
 // @public (undocumented)
 export type MeasureValueFilterCondition = IComparisonCondition | IRangeCondition;
+
+// @public
+export function measureValueFilterCondition(filter: IMeasureValueFilter): MeasureValueFilterCondition | undefined;
+
+// @public
+export function measureValueFilterMeasure(filter: IMeasureValueFilter): ObjRefInScope;
 
 // @public
 export function modifyMeasure(measure: IMeasure<IMeasureDefinition>, modifications?: MeasureModifications<MeasureBuilder>): IMeasure<IMeasureDefinition>;
@@ -967,6 +1120,9 @@ export class PreviousPeriodMeasureBuilder extends MeasureBuilderBase<IPreviousPe
 
 // @public (undocumented)
 export type RangeConditionOperator = "BETWEEN" | "NOT_BETWEEN";
+
+// @public
+export function relativeDateFilterValues(filter: IRelativeDateFilter): IRelativeDateFilterValues;
 
 // @public (undocumented)
 export type RgbType = "rgb";

--- a/libs/sdk-model/src/attribute/index.ts
+++ b/libs/sdk-model/src/attribute/index.ts
@@ -128,6 +128,32 @@ export function attributeIdentifier(attribute: IAttribute): string | undefined {
 }
 
 /**
+ * Gets an attribute alias.
+ *
+ * @param attribute - attribute to work with
+ * @returns value of attribute alias
+ * @public
+ */
+export function attributeAlias(attribute: IAttribute): string | undefined {
+    invariant(attribute, "attribute must not be undefined");
+
+    return attribute.attribute.alias;
+}
+
+/**
+ * Gets an attribute display form object ref.
+ *
+ * @param attribute - attribute to work with
+ * @returns value of attribute display form object ref
+ * @public
+ */
+export function attributeAttributeDisplayFormObjRef(attribute: IAttribute): ObjRef {
+    invariant(attribute, "attribute must not be undefined");
+
+    return attribute.attribute.displayForm;
+}
+
+/**
  * Given list of attributes, returns first-found attribute matching the provided predicate.
  *
  * If no predicate is provided, then the function defaults to anyAttribute predicate - meaning first found attribute

--- a/libs/sdk-model/src/attribute/tests/attribute.test.ts
+++ b/libs/sdk-model/src/attribute/tests/attribute.test.ts
@@ -1,6 +1,15 @@
 // (C) 2019 GoodData Corporation
-import { attributeIdentifier, attributeLocalId, attributesFind, attributeUri, IAttribute } from "../index";
+import {
+    attributeIdentifier,
+    attributeLocalId,
+    attributesFind,
+    attributeUri,
+    IAttribute,
+    attributeAlias,
+    attributeAttributeDisplayFormObjRef,
+} from "../index";
 import { Account, Activity, ActivityType } from "../../../__mocks__/model";
+import { ObjRef } from "../../base";
 
 const UriDefinedAttribute: IAttribute = {
     attribute: {
@@ -8,6 +17,13 @@ const UriDefinedAttribute: IAttribute = {
         displayForm: {
             uri: "/gdc/uri/should/not/be/used",
         },
+    },
+};
+
+const AttributeWithAlias: IAttribute = {
+    attribute: {
+        ...Account.Default.attribute,
+        alias: "alias",
     },
 };
 
@@ -50,6 +66,52 @@ describe("attributeIdentifier", () => {
 
     it.each(Scenarios)("should %s", (_desc, input, expectedResult) => {
         expect(attributeIdentifier(input)).toBe(expectedResult);
+    });
+});
+
+describe("attributeAlias", () => {
+    const Scenarios: Array<[string, any, any]> = [
+        ["return undefined if attribute has no alias", Account.Default, undefined],
+        ["return identifier if attribute defined as such", AttributeWithAlias, "alias"],
+    ];
+
+    it.each(Scenarios)("should %s", (_desc, input, expectedResult) => {
+        expect(attributeAlias(input)).toBe(expectedResult);
+    });
+
+    it("should fail if attribute is null", () => {
+        // @ts-ignore
+        expect(() => attributeAlias(null)).toThrow();
+    });
+
+    it("should fail if attribute is undefined", () => {
+        // @ts-ignore
+        expect(() => attributeAlias(undefined)).toThrow();
+    });
+});
+
+describe("attributeAttributeDisplayFormObjRef", () => {
+    const Scenarios: Array<[string, any, ObjRef]> = [
+        ["return id ref if attribute has id ref", Account.Default, { identifier: "label.account.id" }],
+        [
+            "return uri ref if attribute defined as such",
+            UriDefinedAttribute,
+            { uri: "/gdc/uri/should/not/be/used" },
+        ],
+    ];
+
+    it.each(Scenarios)("should %s", (_desc, input, expectedResult) => {
+        expect(attributeAttributeDisplayFormObjRef(input)).toEqual(expectedResult);
+    });
+
+    it("should fail if attribute is null", () => {
+        // @ts-ignore
+        expect(() => attributeAttributeDisplayFormObjRef(null)).toThrow();
+    });
+
+    it("should fail if attribute is undefined", () => {
+        // @ts-ignore
+        expect(() => attributeAttributeDisplayFormObjRef(undefined)).toThrow();
     });
 });
 

--- a/libs/sdk-model/src/dataSet/index.ts
+++ b/libs/sdk-model/src/dataSet/index.ts
@@ -1,0 +1,84 @@
+// (C) 2019 GoodData Corporation
+
+/**
+ * Represents the current status of CSV source.
+ *
+ * @public
+ */
+export type DataSetLoadStatus = "RUNNING" | "OK" | "ERROR" | "CANCELLED" | "ERROR_METADATA" | "REFRESHING";
+
+/**
+ * Object wrapping info about the user that created CSV load. Contains their login and full name.
+ *
+ * @public
+ */
+export interface IDataSetUser {
+    login: string;
+    fullName: string;
+}
+
+/**
+ * Object wrapping basic information (owner, date created, status) about a CSV Load.
+ *
+ * @public
+ */
+export interface IDataSetLoadInfo {
+    owner: IDataSetUser;
+    status: DataSetLoadStatus;
+    created: string;
+}
+
+/**
+ * Represents type of LDM field created from the Dataset column.
+ *
+ * @public
+ */
+export type DataColumnType = "ATTRIBUTE" | "FACT" | "DATE";
+
+/**
+ * Dataset column with name, type and boolean flag whether the column
+ * needs to be skipped while data loading or not.
+ *
+ * @public
+ */
+export interface IDataColumn {
+    column: {
+        name: string;
+        type: DataColumnType;
+        skip?: boolean;
+        format?: string;
+    };
+}
+
+/**
+ * Structural information about CSV header and columns. Indicates whether the CSV file
+ * contains header or not and on which row. Also contains the list of CSV columns with
+ * their names and types.
+ *
+ * @public
+ */
+export interface IDataHeader {
+    headerRowIndex?: number;
+    columns: IDataColumn[];
+}
+
+/**
+ * Dataset describes a particular structure of dataset (CSV file). There may be many Loads
+ * related to a single dataset - meaning multiple files with the same structure and different data.
+ *
+ * @public
+ */
+export interface IDataSet {
+    dataset: {
+        name: string;
+        dataHeader: IDataHeader;
+        dataSetId: string;
+        loadedRowCount: number;
+        dataSetLoadStatus: DataSetLoadStatus;
+        firstSuccessfulUpdate?: IDataSetLoadInfo;
+        lastSuccessfulUpdate?: IDataSetLoadInfo;
+        lastUpdate?: IDataSetLoadInfo;
+    };
+}
+
+// TODO functions

--- a/libs/sdk-model/src/dateDataSet/index.ts
+++ b/libs/sdk-model/src/dateDataSet/index.ts
@@ -1,0 +1,23 @@
+// (C) 2019 GoodData Corporation
+
+/**
+ * TODO: SDK8 add docs
+ *
+ * @public
+ */
+export interface IDateDataSetAttribute {
+    granularity: string;
+    attributeId: string;
+    defaultDisplayFormId: string;
+    defaultDisplayFormTitle: string;
+}
+
+/**
+ * TODO: SDK8 add docs
+ *
+ * @public
+ */
+export interface IDateDataSet {
+    relevance: number;
+    availableDateAttributes?: IDateDataSetAttribute[];
+}

--- a/libs/sdk-model/src/filter/index.ts
+++ b/libs/sdk-model/src/filter/index.ts
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
-import { ObjRef, ObjRefInScope } from "../base";
 import isEmpty = require("lodash/isEmpty");
+import invariant from "ts-invariant";
+import { ObjRef, ObjRefInScope } from "../base";
 
 /**
  * Attribute elements specified by their URI.
@@ -353,4 +354,130 @@ function attributeElementsIsEmpty(attributeElements: AttributeElements): boolean
     }
 
     return isEmpty(attributeElements.values);
+}
+
+/**
+ * Gets attribute elements for attribute filters.
+ *
+ * @param filter - filter to work with
+ * @returns attribute elements, undefined if not available
+ * @public
+ */
+export function filterAttributeElements(
+    filter: IPositiveAttributeFilter | INegativeAttributeFilter,
+): AttributeElements;
+export function filterAttributeElements(filter: IFilter): AttributeElements | undefined {
+    if (!isAttributeFilter(filter)) {
+        return undefined;
+    }
+
+    return isPositiveAttributeFilter(filter)
+        ? filter.positiveAttributeFilter.in
+        : filter.negativeAttributeFilter.notIn;
+}
+
+/**
+ * Gets attribute display form for filter.
+ *
+ * @param filter - filter to work with
+ * @returns filter attribute display form, undefined if not available
+ * @public
+ */
+export function filterAttributeDisplayForm(
+    filter: IAbsoluteDateFilter | IRelativeDateFilter | IPositiveAttributeFilter | INegativeAttributeFilter,
+): ObjRef;
+export function filterAttributeDisplayForm(filter: IFilter): ObjRef | undefined {
+    if (isPositiveAttributeFilter(filter)) {
+        return filter.positiveAttributeFilter.displayForm;
+    }
+    if (isNegativeAttributeFilter(filter)) {
+        return filter.negativeAttributeFilter.displayForm;
+    }
+    if (isAbsoluteDateFilter(filter)) {
+        return filter.absoluteDateFilter.dataSet;
+    }
+    if (isRelativeDateFilter(filter)) {
+        return filter.relativeDateFilter.dataSet;
+    }
+    return undefined;
+}
+
+/**
+ * Represents values of an absolute filter.
+ *
+ * @public
+ */
+export interface IAbsoluteDateFilterValues {
+    from: string;
+    to: string;
+}
+
+/**
+ * Gets effective values of an absolute date filter.
+ *
+ * @param filter - date filter to work with
+ * @returns filter values
+ * @public
+ */
+export function absoluteDateFilterValues(filter: IAbsoluteDateFilter): IAbsoluteDateFilterValues {
+    invariant(filter, "filter must not be undefined");
+
+    return {
+        from: filter.absoluteDateFilter.from,
+        to: filter.absoluteDateFilter.to,
+    };
+}
+
+/**
+ * Represents values of a relative filter.
+ *
+ * @public
+ */
+export interface IRelativeDateFilterValues {
+    from: number;
+    to: number;
+    granularity: string;
+}
+
+/**
+ * Gets effective values of a relative date filter.
+ *
+ * @param filter - date filter to work with
+ * @returns filter values
+ * @public
+ */
+export function relativeDateFilterValues(filter: IRelativeDateFilter): IRelativeDateFilterValues {
+    invariant(filter, "filter must not be undefined");
+
+    return {
+        from: filter.relativeDateFilter.from,
+        to: filter.relativeDateFilter.to,
+        granularity: filter.relativeDateFilter.granularity,
+    };
+}
+
+/**
+ * Gets measure value filter measure.
+ * @param filter - measure value filter to work with
+ * @returns filter measure
+ * @public
+ */
+export function measureValueFilterMeasure(filter: IMeasureValueFilter): ObjRefInScope {
+    invariant(filter, "filter must not be undefined");
+
+    return filter.measureValueFilter.measure;
+}
+
+/**
+ * Gets measure value filter condition.
+ * @param filter - measure value filter to work with
+ * @returns filter condition
+ * @public
+ */
+export function measureValueFilterCondition(
+    filter: IMeasureValueFilter,
+): MeasureValueFilterCondition | undefined {
+    invariant(filter, "filter must not be undefined");
+
+    return filter.measureValueFilter.condition;
 }

--- a/libs/sdk-model/src/filter/tests/filter.test.ts
+++ b/libs/sdk-model/src/filter/tests/filter.test.ts
@@ -1,8 +1,40 @@
 // (C) 2019 GoodData Corporation
 
-import { Account } from "../../../__mocks__/model";
-import { newNegativeAttributeFilter, newPositiveAttributeFilter } from "../factory";
-import { filterIsEmpty } from "../index";
+import { Account, ClosedDate, Won } from "../../../__mocks__/model";
+import {
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+    newAbsoluteDateFilter,
+    newMeasureValueFilter,
+    newRelativeDateFilter,
+} from "../factory";
+import {
+    filterIsEmpty,
+    AttributeElements,
+    IFilter,
+    filterAttributeElements,
+    filterAttributeDisplayForm,
+    measureValueFilterCondition,
+    measureValueFilterMeasure,
+    absoluteDateFilterValues,
+    relativeDateFilterValues,
+} from "../index";
+import { objectRefValue, ObjRef } from "../../base";
+
+const AbsoluteDateFilter = newAbsoluteDateFilter(
+    objectRefValue(ClosedDate.MmDdYyyy.attribute.displayForm),
+    "2018",
+    "2019",
+);
+
+const RelativeDateFilter = newRelativeDateFilter(
+    objectRefValue(ClosedDate.MmDdYyyy.attribute.displayForm),
+    "GDC.time.date",
+    -6,
+    0,
+);
+
+const MeasureValueFilter = newMeasureValueFilter(Won, "EQUAL_TO", 42);
 
 describe("filterIsEmpty", () => {
     const Scenarios: Array<[boolean, string, any]> = [
@@ -15,6 +47,148 @@ describe("filterIsEmpty", () => {
     ];
 
     it.each(Scenarios)("should return %s when %s", (expectedResult, _desc, input) => {
-        expect(filterIsEmpty(input)).toBe(expectedResult);
+        expect(filterIsEmpty(input)).toEqual(expectedResult);
+    });
+});
+
+describe("filterAttributeElements", () => {
+    const Scenarios: Array<[string, IFilter | null | undefined, AttributeElements | undefined]> = [
+        ["undefined for null filter", null, undefined],
+        ["undefined for undefined filter", undefined, undefined],
+        ["undefined for date filter", AbsoluteDateFilter, undefined],
+        [
+            "empty values for positive attribute filter with empty values",
+            newPositiveAttributeFilter(Account.Name, []),
+            { values: [] },
+        ],
+        [
+            "empty values for negative attribute filter with empty values",
+            newNegativeAttributeFilter(Account.Name, []),
+            { values: [] },
+        ],
+        [
+            "proper values for positive attribute filter with non-empty values",
+            newPositiveAttributeFilter(Account.Name, ["foo"]),
+            { values: ["foo"] },
+        ],
+        [
+            "proper values for negative attribute filter with non-empty values",
+            newNegativeAttributeFilter(Account.Name, ["foo"]),
+            { values: ["foo"] },
+        ],
+    ];
+
+    it.each(Scenarios)("should return %s", (_, input, expectedResult) => {
+        expect(filterAttributeElements(input as any)).toEqual(expectedResult);
+    });
+});
+
+describe("filterAttributeDisplayForm", () => {
+    const Scenarios: Array<[string, IFilter | null | undefined, ObjRef | undefined]> = [
+        ["undefined for null filter", null, undefined],
+        ["undefined for undefined filter", undefined, undefined],
+        ["undefined for measure filter", MeasureValueFilter, undefined],
+        [
+            "attribute display form identifier for positive attribute filter",
+            newPositiveAttributeFilter(Account.Name, []),
+            Account.Name.attribute.displayForm,
+        ],
+        [
+            "attribute display form identifier for negative attribute filter",
+            newNegativeAttributeFilter(Account.Name, []),
+            Account.Name.attribute.displayForm,
+        ],
+        [
+            "attribute display form identifier for absolute date filter",
+            AbsoluteDateFilter,
+            ClosedDate.MmDdYyyy.attribute.displayForm,
+        ],
+        [
+            "attribute display form identifier for relative date filter",
+            RelativeDateFilter,
+            ClosedDate.MmDdYyyy.attribute.displayForm,
+        ],
+    ];
+
+    it.each(Scenarios)("should return %s", (_, input, expectedResult) => {
+        expect(filterAttributeDisplayForm(input as any)).toEqual(expectedResult);
+    });
+});
+
+describe("absoluteDateFilterValues", () => {
+    it("should return proper value for absolute date filter", () => {
+        expect(absoluteDateFilterValues(AbsoluteDateFilter)).toEqual({
+            from: "2018",
+            to: "2019",
+        });
+    });
+
+    it("should throw for undefined relative date filter", () => {
+        // @ts-ignore
+        expect(() => absoluteDateFilterValues(undefined)).toThrow();
+    });
+
+    it("should throw for null relative date filter", () => {
+        // @ts-ignore
+        expect(() => absoluteDateFilterValues(null)).toThrow();
+    });
+});
+
+describe("relativeDateFilterValues", () => {
+    it("should return proper value for relative date filter", () => {
+        expect(relativeDateFilterValues(RelativeDateFilter)).toEqual({
+            from: -6,
+            to: 0,
+            granularity: "GDC.time.date",
+        });
+    });
+
+    it("should throw for undefined relative date filter", () => {
+        // @ts-ignore
+        expect(() => relativeDateFilterValues(undefined)).toThrow();
+    });
+
+    it("should throw for null relative date filter", () => {
+        // @ts-ignore
+        expect(() => relativeDateFilterValues(null)).toThrow();
+    });
+});
+
+describe("measureValueFilterMeasure", () => {
+    it("should return proper value for measure value filter", () => {
+        expect(measureValueFilterMeasure(MeasureValueFilter)).toEqual({
+            localIdentifier: Won.measure.localIdentifier,
+        });
+    });
+
+    it("should throw for undefined measure value filter", () => {
+        // @ts-ignore
+        expect(() => measureValueFilterMeasure(undefined)).toThrow();
+    });
+
+    it("should throw for null measure value filter", () => {
+        // @ts-ignore
+        expect(() => measureValueFilterMeasure(null)).toThrow();
+    });
+});
+
+describe("measureValueFilterCondition", () => {
+    it("should return proper value for measure value filter", () => {
+        expect(measureValueFilterCondition(MeasureValueFilter)).toEqual({
+            comparison: {
+                operator: "EQUAL_TO",
+                value: 42,
+            },
+        });
+    });
+
+    it("should throw for undefined measure value filter", () => {
+        // @ts-ignore
+        expect(() => measureValueFilterCondition(undefined)).toThrow();
+    });
+
+    it("should throw for null measure value filter", () => {
+        // @ts-ignore
+        expect(() => measureValueFilterCondition(null)).toThrow();
     });
 });

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -10,6 +10,8 @@ export {
     attributesFind,
     attributeUri,
     attributeIdentifier,
+    attributeAlias,
+    attributeAttributeDisplayFormObjRef,
 } from "./attribute";
 
 export { newAttribute, AttributeBuilder, AttributeModifications } from "./attribute/factory";
@@ -67,6 +69,18 @@ export {
 } from "./base/sort";
 
 export {
+    DataColumnType,
+    DataSetLoadStatus,
+    IDataColumn,
+    IDataHeader,
+    IDataSet,
+    IDataSetLoadInfo,
+    IDataSetUser,
+} from "./dataSet";
+
+export { IDateDataSetAttribute, IDateDataSet } from "./dateDataSet";
+
+export {
     IAttributeElementsByRef,
     IAttributeElementsByValue,
     AttributeElements,
@@ -97,6 +111,14 @@ export {
     isComparisonCondition,
     isRangeCondition,
     filterIsEmpty,
+    filterAttributeElements,
+    filterAttributeDisplayForm,
+    IAbsoluteDateFilterValues,
+    IRelativeDateFilterValues,
+    absoluteDateFilterValues,
+    relativeDateFilterValues,
+    measureValueFilterCondition,
+    measureValueFilterMeasure,
 } from "./filter";
 
 export {
@@ -139,6 +161,11 @@ export {
     measureAlias,
     measureTitle,
     measureArithmeticOperator,
+    measureFormat,
+    measureAggregation,
+    measureFilters,
+    measurePopAttribute,
+    measurePreviousPeriodDateDataSets,
 } from "./measure";
 
 export {
@@ -224,10 +251,12 @@ export {
 
 export {
     IInsight,
+    IInsightWithoutIdentifier,
     IVisualizationClass,
     VisualizationProperties,
     IColorMappingItem,
     isInsight,
+    insightId,
     insightMeasures,
     insightHasMeasures,
     insightAttributes,
@@ -237,6 +266,7 @@ export {
     insightBuckets,
     insightSorts,
     insightBucket,
+    insightTitle,
     insightTotals,
     insightFilters,
     insightVisualizationClassIdentifier,
@@ -267,3 +297,5 @@ export {
 } from "./metadata/measure";
 
 export { factoryNotationFor } from "./objectFactoryNotation";
+
+export { IWorkspace } from "./workspace";

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -78,6 +78,16 @@ export interface IInsight {
 }
 
 /**
+ * Represents an Insight without identifier. This is useful when working with Insight that do not have any identifier yet
+ * (i.e. they have not been saved to the platform yet).
+ *
+ * @public
+ */
+export type IInsightWithoutIdentifier = {
+    insight: Omit<IInsight["insight"], "identifier">;
+};
+
+/**
  * Visualization class is essentially a descriptor for particular type of visualization - say bar chart
  * or table. Each available visualization type is described by a class stored in the metadata. The available
  * classes influence what visualizations can users select in Analytical Designer.
@@ -186,7 +196,7 @@ export function isInsight(obj: any): obj is IInsight {
  * @public
  */
 export function insightBucket(
-    insight: IInsight,
+    insight: IInsightWithoutIdentifier,
     idOrFun: string | BucketPredicate = anyBucket,
 ): IBucket | undefined {
     if (!insight) {
@@ -204,7 +214,7 @@ export function insightBucket(
  * @returns empty list if none match
  * @public
  */
-export function insightBuckets(insight: IInsight, ...ids: string[]): IBucket[] {
+export function insightBuckets(insight: IInsightWithoutIdentifier, ...ids: string[]): IBucket[] {
     if (!insight) {
         return [];
     }
@@ -223,7 +233,7 @@ export function insightBuckets(insight: IInsight, ...ids: string[]): IBucket[] {
  * @returns empty if one
  * @public
  */
-export function insightMeasures(insight: IInsight): IMeasure[] {
+export function insightMeasures(insight: IInsightWithoutIdentifier): IMeasure[] {
     if (!insight) {
         return [];
     }
@@ -238,7 +248,7 @@ export function insightMeasures(insight: IInsight): IMeasure[] {
  * @returns true if any measures, false if not
  * @public
  */
-export function insightHasMeasures(insight: IInsight): boolean {
+export function insightHasMeasures(insight: IInsightWithoutIdentifier): boolean {
     if (!insight) {
         return false;
     }
@@ -253,7 +263,7 @@ export function insightHasMeasures(insight: IInsight): boolean {
  * @returns empty if none
  * @public
  */
-export function insightAttributes(insight: IInsight): IAttribute[] {
+export function insightAttributes(insight: IInsightWithoutIdentifier): IAttribute[] {
     if (!insight) {
         return [];
     }
@@ -268,7 +278,7 @@ export function insightAttributes(insight: IInsight): IAttribute[] {
  * @returns true if any measures, false if not
  * @public
  */
-export function insightHasAttributes(insight: IInsight): boolean {
+export function insightHasAttributes(insight: IInsightWithoutIdentifier): boolean {
     if (!insight) {
         return false;
     }
@@ -284,7 +294,7 @@ export function insightHasAttributes(insight: IInsight): boolean {
  * @returns true if at least one measure or attribute, false if none
  * @public
  */
-export function insightHasDataDefined(insight: IInsight): boolean {
+export function insightHasDataDefined(insight: IInsightWithoutIdentifier): boolean {
     if (!insight) {
         return false;
     }
@@ -300,7 +310,7 @@ export function insightHasDataDefined(insight: IInsight): boolean {
  * @param insight - insight to work with
  * @public
  */
-export function insightFilters(insight: IInsight): IFilter[] {
+export function insightFilters(insight: IInsightWithoutIdentifier): IFilter[] {
     if (!insight) {
         return [];
     }
@@ -318,7 +328,7 @@ export function insightFilters(insight: IInsight): IFilter[] {
  * @returns array of valid sorts
  * @public
  */
-export function insightSorts(insight: IInsight): SortItem[] {
+export function insightSorts(insight: IInsightWithoutIdentifier): SortItem[] {
     if (!insight) {
         return [];
     }
@@ -347,7 +357,7 @@ export function insightSorts(insight: IInsight): SortItem[] {
  * @returns empty if none
  * @public
  */
-export function insightTotals(insight: IInsight): ITotal[] {
+export function insightTotals(insight: IInsightWithoutIdentifier): ITotal[] {
     if (!insight) {
         return [];
     }
@@ -362,7 +372,7 @@ export function insightTotals(insight: IInsight): ITotal[] {
  * @returns empty object is no properties
  * @public
  */
-export function insightProperties(insight: IInsight): VisualizationProperties {
+export function insightProperties(insight: IInsightWithoutIdentifier): VisualizationProperties {
     if (!insight) {
         return {};
     }
@@ -373,13 +383,39 @@ export function insightProperties(insight: IInsight): VisualizationProperties {
 /**
  * Gets visualization class identifier of an insight.
  *
- * @param insight - insight to get vis properties for
+ * @param insight - insight to get vis class identifier for
  * @public
  */
-export function insightVisualizationClassIdentifier(insight: IInsight): string {
+export function insightVisualizationClassIdentifier(insight: IInsightWithoutIdentifier): string {
     invariant(insight, "insight to get vis class identifier from must be defined");
 
     return insight.insight.visualizationClassIdentifier;
+}
+
+/**
+ * Gets the insight title
+ *
+ * @param insight - insight to title of
+ * @returns the insight title
+ * @public
+ */
+export function insightTitle(insight: IInsightWithoutIdentifier): string {
+    invariant(insight, "insight to get title from must be defined");
+
+    return insight.insight.title;
+}
+
+/**
+ * Gets the insight id
+ *
+ * @param insight - insight to get id of
+ * @returns the insight id
+ * @public
+ */
+export function insightId(insight: IInsight): string {
+    invariant(insight, "insight to get id of must be defined");
+
+    return insight.insight.identifier;
 }
 
 /**
@@ -391,7 +427,11 @@ export function insightVisualizationClassIdentifier(insight: IInsight): string {
  * @returns always new instance
  * @public
  */
-export function insightSetProperties(insight: IInsight, properties: VisualizationProperties = {}): IInsight {
+export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
+export function insightSetProperties(
+    insight: IInsightWithoutIdentifier,
+    properties: VisualizationProperties = {},
+): IInsightWithoutIdentifier {
     return {
         insight: {
             ...insight.insight,
@@ -409,7 +449,11 @@ export function insightSetProperties(insight: IInsight, properties: Visualizatio
  * @returns always new instance
  * @public
  */
-export function insightSetSorts(insight: IInsight, sorts: SortItem[] = []): IInsight {
+export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
+export function insightSetSorts(
+    insight: IInsightWithoutIdentifier,
+    sorts: SortItem[] = [],
+): IInsightWithoutIdentifier {
     return {
         insight: {
             ...insight.insight,

--- a/libs/sdk-model/src/insight/tests/insight.test.ts
+++ b/libs/sdk-model/src/insight/tests/insight.test.ts
@@ -30,6 +30,7 @@ import {
     insightHasDataDefined,
     insightHasMeasures,
     insightMeasures,
+    insightId,
 } from "../index";
 
 const MixedBucket = newBucket("bucket1", Account.Name, Won);
@@ -243,6 +244,16 @@ describe("insightProperties", () => {
 
     it.each(Scenarios)("should return %s", (_desc, insightArg, expectedResult) => {
         expect(insightProperties(insightArg)).toEqual(expectedResult);
+    });
+});
+
+describe("insightId", () => {
+    it("should return the identifier", () => {
+        expect(insightId(EmptyInsight)).toEqual("random");
+    });
+    it("should throw if the insight is undefined", () => {
+        // @ts-ignore
+        expect(() => insightId(undefined)).toThrow();
     });
 });
 

--- a/libs/sdk-model/src/measure/index.ts
+++ b/libs/sdk-model/src/measure/index.ts
@@ -429,3 +429,79 @@ export function measureTitle(measure: IMeasure): string | undefined {
 
     return measure.measure.title;
 }
+
+/**
+ * Gets measure format.
+ * @param measure - measure to get the format of
+ * @returns measure format if specified, undefined otherwise
+ * @public
+ */
+export function measureFormat(measure: IMeasure): string | undefined {
+    if (!measure) {
+        return;
+    }
+
+    return measure.measure.format;
+}
+
+/**
+ * Gets measure aggregation.
+ *
+ * @param measure - measure to get the aggregation of
+ * @returns measure aggregation if specified, undefined otherwise
+ * @public
+ */
+export function measureAggregation(measure: IMeasure): MeasureAggregation | undefined {
+    if (!isSimpleMeasure(measure)) {
+        return undefined;
+    }
+
+    return measure.measure.definition.measureDefinition.aggregation;
+}
+
+/**
+ * Gets measure filters.
+ *
+ * @param measure - measure to get the filters of
+ * @returns measure filters if specified, undefined otherwise
+ * @public
+ */
+export function measureFilters(measure: IMeasure): IMeasureFilter[] | undefined {
+    if (!isSimpleMeasure(measure)) {
+        return undefined;
+    }
+
+    return measure.measure.definition.measureDefinition.filters;
+}
+
+/**
+ * Gets measure popAttribute.
+ *
+ * @param measure - measure to get the popAttribute of
+ * @returns measure popAttribute if specified, undefined otherwise
+ * @public
+ */
+export function measurePopAttribute(measure: IMeasure): ObjRef | undefined {
+    if (!isPoPMeasure(measure)) {
+        return undefined;
+    }
+
+    return measure.measure.definition.popMeasureDefinition.popAttribute;
+}
+
+/**
+ * Gets measure previous period date data sets.
+ *
+ * @param measure - measure to get the previous period date data sets of
+ * @returns measure previous period date data sets if specified, undefined otherwise
+ * @public
+ */
+export function measurePreviousPeriodDateDataSets(
+    measure: IMeasure,
+): IPreviousPeriodDateDataSet[] | undefined {
+    if (!isPreviousPeriodMeasure(measure)) {
+        return undefined;
+    }
+
+    return measure.measure.definition.previousPeriodMeasure.dateDataSets;
+}

--- a/libs/sdk-model/src/measure/tests/measure.test.ts
+++ b/libs/sdk-model/src/measure/tests/measure.test.ts
@@ -12,12 +12,24 @@ import {
     measureArithmeticOperator,
     measureAlias,
     measureTitle,
+    measureFormat,
+    measureAggregation,
+    measurePopAttribute,
+    measurePreviousPeriodDateDataSets,
+    IPreviousPeriodDateDataSet,
+    measureFilters,
 } from "../index";
+import { ObjRef } from "../../base";
+import { newPositiveAttributeFilter } from "../../filter/factory";
+import { IFilter } from "../../filter";
 
 const SimpleMeasureWithIdentifier = Won;
 const SimpleMeasureWithRatio = modifyMeasure(Won, m => m.ratio());
 const SimpleMeasureWithUri = modifyMeasure(Won);
 SimpleMeasureWithUri.measure.definition.measureDefinition.item = { uri: "/uri" };
+const SimpleMeasureWithFilters = modifyMeasure(Won, m =>
+    m.filters(newPositiveAttributeFilter("myAttribute", ["foo"])),
+);
 
 const ArithmeticMeasure = newArithmeticMeasure([Won, Velocity.Min], "sum");
 const PopMeasure = newPopMeasure(measureLocalId(Won), "myPopAttribute");
@@ -139,11 +151,97 @@ describe("measureTitle", () => {
     const Scenarios: Array<[string, any, string | undefined]> = [
         ["undefined if measure is undefined", undefined, undefined],
         ["undefined if measure is null", null, undefined],
-        ["undefined for measure without alias", SimpleMeasureWithIdentifier, undefined],
+        ["undefined for measure without title", SimpleMeasureWithIdentifier, undefined],
         ["title value when defined", MeasureWithTitle, "customTitle"],
     ];
 
     it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
         expect(measureTitle(measureArg)).toEqual(expectedResult);
+    });
+});
+
+describe("measureFormat", () => {
+    const MeasureWithFormat = modifyMeasure(SimpleMeasureWithIdentifier, m => m.format("customFormat"));
+    const Scenarios: Array<[string, any, string | undefined]> = [
+        ["undefined if measure is undefined", undefined, undefined],
+        ["undefined if measure is null", null, undefined],
+        ["undefined for measure without format", SimpleMeasureWithIdentifier, undefined],
+        ["format value when defined", MeasureWithFormat, "customFormat"],
+    ];
+
+    it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
+        expect(measureFormat(measureArg)).toEqual(expectedResult);
+    });
+});
+
+describe("measureAggregation", () => {
+    const MeasureWithAggregation = modifyMeasure(SimpleMeasureWithIdentifier, m => m.aggregation("median"));
+    const Scenarios: Array<[string, any, string | undefined]> = [
+        ["undefined if measure is undefined", undefined, undefined],
+        ["undefined if measure is null", null, undefined],
+        ["undefined for measure without aggregation", SimpleMeasureWithIdentifier, undefined],
+        ["aggregation value when defined", MeasureWithAggregation, "median"],
+    ];
+
+    it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
+        expect(measureAggregation(measureArg)).toEqual(expectedResult);
+    });
+});
+
+describe("measureFilters", () => {
+    const Scenarios: Array<[string, any, IFilter[] | undefined]> = [
+        ["undefined if measure is undefined", undefined, undefined],
+        ["undefined if measure is null", null, undefined],
+        ["undefined for measure without filters", SimpleMeasureWithIdentifier, undefined],
+        [
+            "filter values when defined",
+            SimpleMeasureWithFilters,
+            [
+                {
+                    positiveAttributeFilter: {
+                        displayForm: { identifier: "myAttribute" },
+                        in: { values: ["foo"] },
+                    },
+                },
+            ],
+        ],
+    ];
+
+    it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
+        expect(measureFilters(measureArg)).toEqual(expectedResult);
+    });
+});
+
+describe("measurePopAttribute", () => {
+    const Scenarios: Array<[string, any, ObjRef | undefined]> = [
+        ["undefined if measure is undefined", undefined, undefined],
+        ["undefined if measure is null", null, undefined],
+        ["undefined for measure without PoP attribute", SimpleMeasureWithIdentifier, undefined],
+        ["PoP attribute value when defined", PopMeasure, { identifier: "myPopAttribute" }],
+    ];
+
+    it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
+        expect(measurePopAttribute(measureArg)).toEqual(expectedResult);
+    });
+});
+
+describe("measurePreviousPeriodDateDataSets", () => {
+    const Scenarios: Array<[string, any, IPreviousPeriodDateDataSet[] | undefined]> = [
+        ["undefined if measure is undefined", undefined, undefined],
+        ["undefined if measure is null", null, undefined],
+        [
+            "undefined for measure without previous period date data sets",
+            SimpleMeasureWithIdentifier,
+            undefined,
+        ],
+        [
+            "previous period date data set values when defined",
+            PreviousPeriodMeasure,
+            [{ dataSet: { identifier: "dataSet" }, periodsAgo: 1 }],
+        ],
+    ];
+
+    it.each(Scenarios)("should return %s", (_desc, measureArg, expectedResult) => {
+        expect(measurePreviousPeriodDateDataSets(measureArg)).toEqual(expectedResult);
     });
 });

--- a/libs/sdk-model/src/workspace/index.ts
+++ b/libs/sdk-model/src/workspace/index.ts
@@ -1,0 +1,12 @@
+// (C) 2019 GoodData Corporation
+
+/**
+ * Workspace represents a set of related data, insights and so on.
+ *
+ * @public
+ */
+export interface IWorkspace {
+    id: string;
+    title: string;
+    description: string;
+}

--- a/libs/sdk-ui-tests/tests/api-regression/charts/__snapshots__/headline.test.tsx.snap
+++ b/libs/sdk-ui-tests/tests/api-regression/charts/__snapshots__/headline.test.tsx.snap
@@ -69,6 +69,7 @@ Object {
       "withAuthentication": [Function],
       "withTelemetry": [Function],
       "workspace": [Function],
+      "workspaces": [Function],
     },
     "factories": Object {
       "execution": [Function],
@@ -175,6 +176,7 @@ Object {
       "withAuthentication": [Function],
       "withTelemetry": [Function],
       "workspace": [Function],
+      "workspaces": [Function],
     },
     "factories": Object {
       "execution": [Function],
@@ -277,6 +279,7 @@ Object {
       "withAuthentication": [Function],
       "withTelemetry": [Function],
       "workspace": [Function],
+      "workspaces": [Function],
     },
     "factories": Object {
       "execution": [Function],
@@ -379,6 +382,7 @@ Object {
       "withAuthentication": [Function],
       "withTelemetry": [Function],
       "workspace": [Function],
+      "workspaces": [Function],
     },
     "factories": Object {
       "execution": [Function],

--- a/libs/sdk-ui/src/filters/AttributeElements/AttributeElements.tsx
+++ b/libs/sdk-ui/src/filters/AttributeElements/AttributeElements.tsx
@@ -75,7 +75,7 @@ export class AttributeElements extends React.PureComponent<IAttributeElementsPro
                 validElements: {
                     ...state.validElements,
                     ...moreItems,
-                    elements: [...state.validElements.elements, ...moreItems.elements],
+                    items: [...state.validElements.items, ...moreItems.items],
                 },
             }));
         } catch (error) {

--- a/libs/sdk-ui/src/filters/AttributeElements/tests/AttributeElements.test.tsx
+++ b/libs/sdk-ui/src/filters/AttributeElements/tests/AttributeElements.test.tsx
@@ -29,8 +29,8 @@ describe("AttributeElements", () => {
 
         expect(children).toHaveBeenCalledTimes(2);
         expect(children.mock.calls[1][0].isLoading).toEqual(false);
-        expect(children.mock.calls[1][0].validElements.elements.length).toEqual(8);
-        expect(children.mock.calls[1][0].validElements.elements[0].title).toEqual("DELETE");
+        expect(children.mock.calls[1][0].validElements.items.length).toEqual(8);
+        expect(children.mock.calls[1][0].validElements.items[0].title).toEqual("DELETE");
     });
 
     it("should load more attribute elements using the loadMore function", async () => {
@@ -40,16 +40,16 @@ describe("AttributeElements", () => {
         await waitForAsync();
 
         expect(children.mock.calls[1][0].isLoading).toEqual(false);
-        expect(children.mock.calls[1][0].validElements.elements.length).toEqual(1);
-        expect(children.mock.calls[1][0].validElements.elements[0].title).toEqual("DELETE");
+        expect(children.mock.calls[1][0].validElements.items.length).toEqual(1);
+        expect(children.mock.calls[1][0].validElements.items[0].title).toEqual("DELETE");
 
         await children.mock.calls[1][0].loadMore();
 
         expect(children.mock.calls[2][0].isLoading).toEqual(true);
 
         expect(children.mock.calls[3][0].isLoading).toEqual(false);
-        expect(children.mock.calls[3][0].validElements.elements.length).toEqual(2);
-        expect(children.mock.calls[3][0].validElements.elements[1].title).toEqual("GET");
+        expect(children.mock.calls[3][0].validElements.items.length).toEqual(2);
+        expect(children.mock.calls[3][0].validElements.items[1].title).toEqual("GET");
     });
 
     it("should load different attribute when identifier prop changes", async () => {
@@ -63,7 +63,7 @@ describe("AttributeElements", () => {
 
         expect(children).toHaveBeenCalledTimes(2);
         expect(children.mock.calls[1][0].isLoading).toEqual(false);
-        expect(children.mock.calls[1][0].validElements.elements[0].title).toEqual("DELETE");
+        expect(children.mock.calls[1][0].validElements.items[0].title).toEqual("DELETE");
 
         wrapper.setProps({ identifier: anotherIdentifier });
 
@@ -71,6 +71,6 @@ describe("AttributeElements", () => {
 
         const lastCallArguments = children.mock.calls[children.mock.calls.length - 1][0];
         expect(lastCallArguments.isLoading).toEqual(false);
-        expect(lastCallArguments.validElements.elements[0].title).toEqual("100");
+        expect(lastCallArguments.validElements.items[0].title).toEqual("100");
     });
 });

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
@@ -4,12 +4,13 @@ import { IAttributeElement } from "@gooddata/sdk-model";
 import Dropdown, { DropdownButton } from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import { string as stringUtils } from "@gooddata/js-utils";
 import { IValidElementsResponse } from "@gooddata/gd-bear-client";
-import { IAnalyticalBackend, IElementQueryResult } from "@gooddata/sdk-backend-spi";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import * as classNames from "classnames";
 
 import { AttributeDropdownBody } from "./AttributeDropdownBody";
 import { VISIBLE_ITEMS_COUNT } from "./AttributeDropdownList";
-import { mergeElementQueryResults, EmptyListItem } from "./mergeElementQueryResults";
+import { mergeElementQueryResults } from "./mergeElementQueryResults";
+import { IElementQueryResultWithEmptyItems, EmptyListItem } from "./types";
 
 export interface IValidElementsItem {
     uri: string;
@@ -42,7 +43,7 @@ export interface IAttributeDropdownStateItem {
 }
 
 export interface IAttributeDropdownState {
-    validElements?: IElementQueryResult;
+    validElements?: IElementQueryResultWithEmptyItems;
     selectedItems: IAttributeElement[];
     isInverted: boolean;
     isLoading: boolean;
@@ -99,7 +100,7 @@ export class AttributeDropdown extends React.PureComponent<IAttributeDropdownPro
     public getElements = async () => {
         const { offset, limit, validElements } = this.state;
 
-        const currentElements = validElements ? validElements.elements : [];
+        const currentElements = validElements ? validElements.items : [];
 
         const isQueryOutOfBounds = offset + limit > currentElements.length;
         const isMissingDataInWindow = currentElements
@@ -200,15 +201,14 @@ export class AttributeDropdown extends React.PureComponent<IAttributeDropdownPro
     private renderDropdownBody() {
         const { selectedItems, isInverted, error, isLoading, validElements } = this.state;
 
-        const shouldDisableApplyButton =
-            error || isLoading || (validElements && !validElements.elements.length);
-        const hasTriedToLoadData = validElements && validElements.elements;
+        const shouldDisableApplyButton = error || isLoading || (validElements && !validElements.items.length);
+        const hasTriedToLoadData = validElements && validElements.items;
 
         return (
             <AttributeDropdownBody
                 error={error}
                 isLoading={!hasTriedToLoadData && isLoading}
-                items={validElements ? validElements.elements : []}
+                items={validElements ? validElements.items : []}
                 isInverted={isInverted}
                 onRangeChange={this.onRangeChange}
                 selectedItems={selectedItems}

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdownBody.tsx
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdownBody.tsx
@@ -4,9 +4,10 @@ import { IAttributeElement } from "@gooddata/sdk-model";
 
 import { AttributeDropdownList } from "./AttributeDropdownList";
 import { AttributeDropdownButtons } from "./AttributeDropdownButtons";
+import { AttributeListItem } from "./types";
 
 interface IAttributeDropdownBodyProps {
-    items: IAttributeElement[];
+    items: AttributeListItem[];
     totalCount: number;
     selectedItems: IAttributeElement[];
     isInverted: boolean;

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
@@ -6,6 +6,7 @@ import { IAttributeElement } from "@gooddata/sdk-model";
 import InvertableList from "@gooddata/goodstrap/lib/List/InvertableList";
 
 import { AttributeFilterItem } from "./AttributeFilterItem";
+import { AttributeListItem } from "./types";
 
 const ITEM_HEIGHT = 28;
 const LIST_WIDTH = 208;
@@ -37,7 +38,7 @@ const ListNoResults = () => {
 };
 
 interface IAttributeDropdownListProps {
-    items: IAttributeElement[];
+    items: AttributeListItem[];
     totalCount: number;
     selectedItems: IAttributeElement[];
     isInverted: boolean;

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/mergeElementQueryResults.ts
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/mergeElementQueryResults.ts
@@ -1,37 +1,35 @@
 // (C) 2019 GoodData Corporation
 import { IElementQueryResult } from "@gooddata/sdk-backend-spi";
-
-export const emptyListItem = { empty: true };
-export type EmptyListItem = typeof emptyListItem;
+import { IElementQueryResultWithEmptyItems, emptyListItem } from "./types";
 
 export function mergeElementQueryResults(
-    currentElements: IElementQueryResult,
+    currentElements: IElementQueryResultWithEmptyItems,
     newElements: IElementQueryResult,
-): IElementQueryResult {
-    const mergedElements = currentElements ? [...currentElements.elements] : [];
-    const currentLength = mergedElements.length;
+): IElementQueryResultWithEmptyItems {
+    const mergedItems = currentElements ? [...currentElements.items] : [];
+    const currentLength = mergedItems.length;
 
     // make sure the array has sufficient length for new elements
     // in case they are added "beyond" the current last item
     // otherwise splice would overwrite wrong indices
-    const newLength = Math.max(currentLength, newElements.offset + newElements.elements.length);
-    if (newLength > mergedElements.length) {
-        mergedElements.length = newLength;
+    const newLength = Math.max(currentLength, newElements.offset + newElements.items.length);
+    if (newLength > mergedItems.length) {
+        mergedItems.length = newLength;
     }
 
     // fill the hole we might have created with dummy objects
     // because the underlying list throws on undefined members
     const holeLength = newElements.offset - currentLength;
     if (holeLength > 0) {
-        mergedElements.splice(currentLength, holeLength, ...new Array(holeLength).fill({ ...emptyListItem }));
+        mergedItems.splice(currentLength, holeLength, ...new Array(holeLength).fill({ ...emptyListItem }));
     }
 
     // insert the newly loaded items at their corresponding places
-    mergedElements.splice(newElements.offset, newElements.elements.length, ...newElements.elements);
+    mergedItems.splice(newElements.offset, newElements.items.length, ...newElements.items);
 
     return {
         ...currentElements,
         ...newElements,
-        elements: mergedElements,
+        items: mergedItems,
     };
 }

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/tests/mergeElementQueryResults.test.ts
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/tests/mergeElementQueryResults.test.ts
@@ -1,14 +1,15 @@
 // (C) 2019 GoodData Corporation
 import { IElementQueryResult } from "@gooddata/sdk-backend-spi";
 
-import { mergeElementQueryResults, emptyListItem } from "../mergeElementQueryResults";
+import { mergeElementQueryResults } from "../mergeElementQueryResults";
+import { emptyListItem } from "../types";
 
 describe("mergeElementQueryResults", () => {
     it("should handle empty current elements", () => {
         const current: IElementQueryResult | undefined = undefined;
 
         const incoming: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -29,7 +30,7 @@ describe("mergeElementQueryResults", () => {
 
     it("should handle appending to empty current elements", () => {
         const current: IElementQueryResult = {
-            elements: [],
+            items: [],
             limit: 1,
             next: jest.fn(),
             offset: 0,
@@ -37,7 +38,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const incoming: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -58,7 +59,7 @@ describe("mergeElementQueryResults", () => {
 
     it("should handle appending to non-empty current elements without a hole", () => {
         const current: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -71,7 +72,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const incoming: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Bar",
                     uri: "some/uri",
@@ -84,7 +85,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const expected: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -107,7 +108,7 @@ describe("mergeElementQueryResults", () => {
 
     it("should handle appending to non-empty current elements with a hole", () => {
         const current: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -120,7 +121,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const incoming: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Bar",
                     uri: "some/uri",
@@ -133,7 +134,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const expected = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -159,7 +160,7 @@ describe("mergeElementQueryResults", () => {
 
     it("should handle overwriting non-empty current elements", () => {
         const current: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Foo",
                     uri: "some/uri",
@@ -172,7 +173,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const incoming: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Bar",
                     uri: "some/uri",
@@ -185,7 +186,7 @@ describe("mergeElementQueryResults", () => {
         };
 
         const expected: IElementQueryResult = {
-            elements: [
+            items: [
                 {
                     title: "Bar",
                     uri: "some/uri",

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/types.ts
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeDropdown/types.ts
@@ -1,0 +1,9 @@
+// (C) 2019 GoodData Corporation
+import { IPagedResource } from "@gooddata/sdk-backend-spi";
+import { IAttributeElement } from "@gooddata/sdk-model";
+
+export const emptyListItem = { empty: true };
+export type EmptyListItem = typeof emptyListItem;
+export type AttributeListItem = IAttributeElement | EmptyListItem;
+
+export type IElementQueryResultWithEmptyItems = IPagedResource<AttributeListItem>;


### PR DESCRIPTION
This PR adds several SPI resources as needed by AD:

* resource for available Workspaces
* resource for manipulating Insights
* resource for available data sets
* reosurce for available date data sets

Also, reference handling was made more reusable and AttributeDropdown types more precise.

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
