### PR TITLE
RAIL-1850: Make validate scripts run without errors

### DIFF
--- a/libs/gd-bear-client/package.json
+++ b/libs/gd-bear-client/package.json
@@ -29,8 +29,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "repository": "https://github.com/gooddata/gooddata-ui-sdk/tree/master/libs/gd-bear-client",
     "dependencies": {

--- a/libs/gd-bear-model/package.json
+++ b/libs/gd-bear-model/package.json
@@ -14,8 +14,8 @@
         "test-ci": "JEST_JUNIT_OUTPUT=./ci/results/test-results.xml jest --config jest.ci.js",
         "tslint": "tslint -p . -t verbose $npm_package_config_tslint",
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
-        "validate": "tsc --noEmit && npm run tslint",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci",
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci",
         "prettier-check": "prettier --check 'src/**/*.ts'",
         "prettier-write": "prettier --write 'src/**/*.ts'"
     },

--- a/libs/gd-bear-model/src/executeAfm/tests/GdcExecuteAFM.fixtures.ts
+++ b/libs/gd-bear-model/src/executeAfm/tests/GdcExecuteAFM.fixtures.ts
@@ -1,3 +1,4 @@
+// (C) 2019 GoodData Corporation
 import { GdcExecuteAFM as AFM } from "../GdcExecuteAFM";
 
 export const expressionFilter: AFM.CompatibilityFilter = {

--- a/libs/sdk-backend-bear/package.json
+++ b/libs/sdk-backend-bear/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/gd-bear-client": "^8.0.0-alpha.0",

--- a/libs/sdk-backend-mockingbird/package.json
+++ b/libs/sdk-backend-mockingbird/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/sdk-backend-spi": "^8.0.0-alpha.0",

--- a/libs/sdk-backend-spi/package.json
+++ b/libs/sdk-backend-spi/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/sdk-model": "^8.0.0-alpha.0",

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/sdk-backend-spi": "^8.0.0-alpha.0",

--- a/libs/sdk-model/package.json
+++ b/libs/sdk-model/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "lodash": "^4.17.15",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -25,8 +25,8 @@
         "write-exec-defs": "GDC_STORE_DEFS=\"../../tools/reference-workspace/src/recordings/executions/uiTestScenarios\" jest --config \"smoke-and-capture.config.js\" --watchAll=false",
         "prettier-check": "prettier --check '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check",
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check",
         "storybook": "npm run build && start-storybook -p 9001 -c .storybook",
         "build-storybook": "npm run build && build-storybook -c .storybook -o dist-storybook",
         "test-storybook": "npm run build && test-storybook"

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -28,8 +28,8 @@
         "prettier-check": "prettier --check '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "check-circular-deps": "madge --circular --extensions ts ./src",
-        "validate": "tsc --noEmit -p tsconfig.build.json && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit -p tsconfig.build.json && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "typings": "dist/index.d.ts",
     "dependencies": {

--- a/libs/sdk-ui/src/base/translations/TranslationsProvider.tsx
+++ b/libs/sdk-ui/src/base/translations/TranslationsProvider.tsx
@@ -10,7 +10,7 @@ export interface ITranslationsProviderProps {
 export interface ITranslationsComponentProps {
     numericSymbols: string[];
     emptyHeaderString: string;
-    intl: InjectedIntl
+    intl: InjectedIntl;
 }
 
 export class TranslationsProvider extends React.PureComponent<
@@ -20,7 +20,7 @@ export class TranslationsProvider extends React.PureComponent<
         const props: ITranslationsComponentProps = {
             numericSymbols: this.getNumericSymbols(),
             emptyHeaderString: this.getEmptyHeaderString(),
-            intl: this.props.intl
+            intl: this.props.intl,
         };
         return this.props.children(props);
     }

--- a/libs/sdk-ui/src/pivotTable/impl/HeaderCell.tsx
+++ b/libs/sdk-ui/src/pivotTable/impl/HeaderCell.tsx
@@ -1,12 +1,12 @@
 // (C) 2007-2018 GoodData Corporation
-import { DataViewFacade } from '@gooddata/sdk-backend-spi';
+import { DataViewFacade } from "@gooddata/sdk-backend-spi";
 import * as React from "react";
 import * as classNames from "classnames";
 
 import { IMenu, IMenuAggregationClickConfig } from "../types";
 import { IOnOpenedChangeParams } from "../menu/MenuSharedTypes";
 import AggregationsMenu from "./AggregationsMenu";
-import { ITotal, SortDirection } from '@gooddata/sdk-model';
+import { ITotal, SortDirection } from "@gooddata/sdk-model";
 
 export type AlignPositions = "left" | "right" | "center";
 export const ALIGN_LEFT = "left";

--- a/libs/sdk-ui/src/pivotTable/impl/agGridDataSourceUtils.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridDataSourceUtils.ts
@@ -1,8 +1,8 @@
 // (C) 2019 GoodData Corporation
-import { GridApi } from 'ag-grid-community';
-import ApiWrapper from './agGridApiWrapper';
-import { IGridTotalsRow } from './agGridTypes';
-import isEqual = require('lodash/isEqual');
+import { GridApi } from "ag-grid-community";
+import ApiWrapper from "./agGridApiWrapper";
+import { IGridTotalsRow } from "./agGridTypes";
+import isEqual = require("lodash/isEqual");
 
 export const areTotalsChanged = (gridApi: GridApi, newTotals: IGridTotalsRow[]) => {
     const currentTotalsCount = gridApi.getPinnedBottomRowCount();

--- a/libs/sdk-ui/tslint.json
+++ b/libs/sdk-ui/tslint.json
@@ -1,5 +1,8 @@
 {
     "extends": ["../../tslint.json"],
+    "linterOptions": {
+        "exclude": ["stories/**"]
+    },
     "rules": {
         "member-ordering": false
     }

--- a/skel/sdk-skel-ts/package.json
+++ b/skel/sdk-skel-ts/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "lodash": "^4.17.15"

--- a/skel/sdk-skel-tsx/package.json
+++ b/skel/sdk-skel-tsx/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "typings": "dist/index.d.ts",
     "dependencies": {

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -28,8 +28,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/gd-bear-client": "^8.0.0-alpha.0",

--- a/tools/mock-handling/package.json
+++ b/tools/mock-handling/package.json
@@ -29,8 +29,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check",
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check",
         "playlist-generator": "ts-node ./src/playListGenerator.ts"
     },
     "dependencies": {

--- a/tools/reference-workspace/package.json
+++ b/tools/reference-workspace/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "@gooddata/sdk-backend-spi": "^8.0.0-alpha.0",

--- a/tools/schema-gen/package.json
+++ b/tools/schema-gen/package.json
@@ -26,8 +26,8 @@
         "tslint-ci": "mkdir -p ./ci/results && tslint -p . -t checkstyle -o ./ci/results/tslint-results.xml $npm_package_config_tslint",
         "prettier-check": "prettier --check '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,test}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
-        "validate": "tsc --noEmit && npm run tslint && npm run prettier-check",
-        "validate-ci": "tsc --noEmit && npm run tslint-ci && npm run prettier-check"
+        "validate": "tsc -p tsconfig.build.json --noEmit && npm run tslint && npm run prettier-check",
+        "validate-ci": "tsc -p tsconfig.build.json --noEmit && npm run tslint-ci && npm run prettier-check"
     },
     "dependencies": {
         "lodash": "^4.17.15",


### PR DESCRIPTION
-  Ensure validate uses tsconfig.build.json when compiling sources
   This resolves compilation errors in projects that employ baseUrl
   & paths for source-level linking to other projects.

   Otherwise what happens is that a compilation of project with
   stricter tsconfig compiles sources from project with looser
   config => leading to compile errors.

-  Unified validate scripts across all projects

-  sdk-ui/stories are ignored in tslint; they are in process of
   transformation into sdk-ui-tests; necessary package dependencies in
   sdk-ui are no longer present => leading to tslint errors

-  prettier-formatted 3 files in sdk-ui that slipped through the radar,
   likely due to broken pre-commit hook in the past.
