### PR TITLE
RELATED: RAIL-1848 - Bump pnpm to 4.5.0 (release candidate)

### DIFF
--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -34,7 +34,7 @@
     },
     "typings": "dist/index.d.ts",
     "dependencies": {
-        "@gooddata/goodstrap": "~65.0.0",
+        "@gooddata/goodstrap": "^65.0.0",
         "@gooddata/js-utils": "^3.4.0",
         "@gooddata/numberjs": "^3.2.3",
         "@gooddata/sdk-backend-spi": "^8.0.0-alpha.0",

--- a/rush.json
+++ b/rush.json
@@ -26,7 +26,7 @@
      * Specify one of: "pnpmVersion", "npmVersion", or "yarnVersion".  See the Rush documentation
      * for details about these alternatives.
      */
-    "pnpmVersion": "4.3.3",
+    "pnpmVersion": "4.5.0-6",
 
     // "npmVersion": "4.5.0",
     // "yarnVersion": "1.9.4",


### PR DESCRIPTION
-  pnpm had a bug in 4.x line where it would sometimes ignore versions in the lock file
-  this manifested itself lately after breaking change in goodstrap (minor version :))
-  it led to 'rush install' install latest minor that was not in lockfile
-  breakage on both workstation and CI happened
-  with 4.5.0 the problem is gone
-  given the severity of the issue, i'm upgrading pnpm to latest RC
