### PR TITLE
RELATED: RAIL-1977 - Ensure all code depends on base public API

### DIFF
--- a/libs/sdk-ui/.dependency-cruiser.js
+++ b/libs/sdk-ui/.dependency-cruiser.js
@@ -208,7 +208,7 @@ options = {
             },
             to: {
                 path:
-                    "src/base/(constants|context|errors|factory|hoc|interfaces|promise|simple|translations|typings)",
+                    "src/base/(constants|errors|headerMatching|helpers|interfaces|localization|measureTitles|react|typings|vis)",
             },
         },
         {

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -6,6 +6,7 @@
 
 export { DefaultColorPalette } from "./constants/colorPalette";
 export { BucketNames } from "./constants/bucketNames";
+export { visualizationIsBetaWarning } from "./helpers/logging";
 
 /*
  * Error handling
@@ -40,7 +41,7 @@ export { wrapDisplayName } from "./react/wrapDisplayName";
  */
 
 export { ILocale, DefaultLocale } from "./localization/Locale";
-export { getTranslation } from "./localization/IntlStore";
+export { getTranslation, getIntl } from "./localization/IntlStore";
 export { IntlWrapper, IIntlWrapperProps, messagesMap } from "./localization/IntlWrapper";
 export {
     TranslationsProvider,
@@ -94,9 +95,48 @@ export {
     IExtendedExportConfig,
     IDrillableItemPushData,
     IColorAssignment,
+    DrillableItemType,
+    IColorsData,
 } from "./vis/Events";
-export { OnFiredDrillEvent, IDrillableItem } from "./vis/DrillEvents";
-export { VisualizationTypes, VisualizationEnvironment, ChartType } from "./vis/visualizationTypes";
+export {
+    OnFiredDrillEvent,
+    IDrillableItem,
+    DrillEventIntersectionElementHeader,
+    IDrillableItemIdentifier,
+    IDrillableItemUri,
+    IDrillConfig,
+    IDrillEvent,
+    IDrillEventCallback,
+    IDrillEventContext,
+    IDrillEventContextGroup,
+    IDrillEventContextHeadline,
+    IDrillEventContextPoint,
+    IDrillEventContextTable,
+    IDrillEventContextXirr,
+    IDrillEventIntersectionElement,
+    IDrillIntersectionAttributeItem,
+    IDrillPoint,
+    isDrillableItemIdentifier,
+    isDrillableItemUri,
+    isDrillIntersectionAttributeItem,
+    IHighchartsCategoriesTree,
+    IHighchartsParentTick,
+} from "./vis/DrillEvents";
+export {
+    convertDrillableItemsToPredicates,
+    isSomeHeaderPredicateMatched,
+    getDrillIntersection,
+    fireDrillEvent,
+} from "./vis/drilling";
+export {
+    VisualizationTypes,
+    VisualizationEnvironment,
+    ChartType,
+    VisType,
+    HeadlineElementType,
+    getVisualizationType,
+    ChartElementType,
+} from "./vis/visualizationTypes";
 export { Subtract } from "./typings/subtract";
 export { OverTimeComparisonType, OverTimeComparisonTypes } from "./interfaces/OverTimeComparison";
 export { CatalogHelper } from "./helpers/CatalogHelper";

--- a/libs/sdk-ui/src/base/localization/IntlStore.ts
+++ b/libs/sdk-ui/src/base/localization/IntlStore.ts
@@ -29,7 +29,7 @@ const messagesMap = {
 
 const intlStore = {};
 
-function getIntl(locale: ILocale = DefaultLocale): IntlShape {
+export function getIntl(locale: ILocale = DefaultLocale): IntlShape {
     let usedLocale = locale;
     if (isEmpty(locale)) {
         usedLocale = DefaultLocale;
@@ -47,8 +47,3 @@ export function getTranslation(translationId: string, locale: ILocale, values = 
     const intl = getIntl(locale);
     return intl.formatMessage({ id: translationId, defaultMessage: translationId }, values);
 }
-
-export default {
-    getIntl,
-    getTranslation,
-};

--- a/libs/sdk-ui/src/base/localization/test/IntlStore.test.ts
+++ b/libs/sdk-ui/src/base/localization/test/IntlStore.test.ts
@@ -1,27 +1,27 @@
 // (C) 2007-2019 GoodData Corporation
-import IntlStore from "../IntlStore";
 import { DefaultLocale, ILocale } from "../Locale";
+import { getIntl, getTranslation } from "../IntlStore";
 
 describe("IntlStore", () => {
     describe("getIntl", () => {
         it("should return intlProvider for default locale (en-US)", () => {
-            const intl = IntlStore.getIntl();
+            const intl = getIntl();
 
             expect(intl.locale).toEqual(DefaultLocale);
         });
 
         it("should return specific locale from supported list of localizations", () => {
-            const intl = IntlStore.getIntl("de-DE");
+            const intl = getIntl("de-DE");
             expect(intl.locale).toEqual("de-DE");
         });
 
         it("should return default locale when locale is null", () => {
-            const intl = IntlStore.getIntl(null);
+            const intl = getIntl(null);
             expect(intl.locale).toEqual(DefaultLocale);
         });
 
         it("should return default locale when locale is undefined", () => {
-            const intl = IntlStore.getIntl(undefined);
+            const intl = getIntl(undefined);
             expect(intl.locale).toEqual(DefaultLocale);
         });
     });
@@ -42,14 +42,14 @@ describe("IntlStore", () => {
 
             it("should return message in en-US", () => {
                 localizations.forEach(locale => {
-                    const result = IntlStore.getTranslation("visualizations.more", locale);
+                    const result = getTranslation("visualizations.more", locale);
                     expect(result).toBeTruthy();
                 });
             });
 
             it("should return message in en-US with replaced placeholders for values", () => {
                 localizations.forEach(locale => {
-                    const result = IntlStore.getTranslation("gs.list.limitExceeded", locale, {
+                    const result = getTranslation("gs.list.limitExceeded", locale, {
                         limit: 42,
                     });
                     expect(result).toBeTruthy();
@@ -61,7 +61,7 @@ describe("IntlStore", () => {
         it("should return default message in production environment when translationId was not found", () => {
             process.env.NODE_ENV = "production";
 
-            const result = IntlStore.getTranslation("unknown_id", "fr-FR");
+            const result = getTranslation("unknown_id", "fr-FR");
             expect(result).toEqual("unknown_id");
 
             process.env.NODE_ENV = "test";

--- a/libs/sdk-ui/src/base/measureTitles/ArithmeticMeasureTitleFactory.ts
+++ b/libs/sdk-ui/src/base/measureTitles/ArithmeticMeasureTitleFactory.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
-import IntlStore from "../localization/IntlStore";
+import { getTranslation } from "../localization/IntlStore";
 import { IArithmeticMeasureTitleProps, IMeasureTitleProps } from "./MeasureTitle";
 import { ILocale } from "../localization/Locale";
 
@@ -93,6 +93,6 @@ export class ArithmeticMeasureTitleFactory {
     }
 
     private translateKey(localizationKey: string, values: any): string {
-        return IntlStore.getTranslation(localizationKey, this.locale, values);
+        return getTranslation(localizationKey, this.locale, values);
     }
 }

--- a/libs/sdk-ui/src/base/measureTitles/DerivedMeasureTitleSuffixFactory.ts
+++ b/libs/sdk-ui/src/base/measureTitles/DerivedMeasureTitleSuffixFactory.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
-import IntlStore from "../localization/IntlStore";
+import { getTranslation } from "../localization/IntlStore";
 import { OverTimeComparisonType, OverTimeComparisonTypes } from "../interfaces/OverTimeComparison";
 import { ILocale } from "../localization/Locale";
 
@@ -45,6 +45,6 @@ export class DerivedMeasureTitleSuffixFactory {
     }
 
     private translateKey(localizationKey: string): string {
-        return IntlStore.getTranslation(localizationKey, this.locale);
+        return getTranslation(localizationKey, this.locale);
     }
 }

--- a/libs/sdk-ui/src/charts/_base/withChart.tsx
+++ b/libs/sdk-ui/src/charts/_base/withChart.tsx
@@ -3,8 +3,7 @@ import * as React from "react";
 import compose = require("lodash/flowRight");
 import { IChartDefinition, getCoreChartProps } from "../_commons/chartDefinition";
 import { IBucketChartProps, ICoreChartProps } from "../chartProps";
-import { withContexts } from "../../base/react/withContexts";
-import { wrapDisplayName } from "../../base/react/wrapDisplayName";
+import { withContexts, wrapDisplayName } from "../../base";
 
 /**
  * Hoc that transforms incoming props to BaseChart props according to chart definition

--- a/libs/sdk-ui/src/charts/_commons/defaultProps.ts
+++ b/libs/sdk-ui/src/charts/_commons/defaultProps.ts
@@ -1,9 +1,7 @@
 // (C) 2019 GoodData Corporation
 import noop = require("lodash/noop");
-import { ErrorComponent } from "../../base/react/ErrorComponent";
-import { LoadingComponent } from "../../base/react/LoadingComponent";
+import { ErrorComponent, LoadingComponent, defaultErrorHandler } from "../../base";
 import { ICoreChartProps } from "../chartProps";
-import { defaultErrorHandler } from "../../base";
 
 export const defaultCoreChartProps: Partial<ICoreChartProps> = {
     execution: undefined,

--- a/libs/sdk-ui/src/charts/funnelChart/CoreFunnelChart.tsx
+++ b/libs/sdk-ui/src/charts/funnelChart/CoreFunnelChart.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import * as React from "react";
-import { visualizationIsBetaWarning } from "../../base/helpers/logging";
+import { visualizationIsBetaWarning } from "../../base";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../chartProps";
 

--- a/libs/sdk-ui/src/charts/headline/internal/Headline.tsx
+++ b/libs/sdk-ui/src/charts/headline/internal/Headline.tsx
@@ -2,7 +2,7 @@
 import ResponsiveText from "@gooddata/goodstrap/lib/ResponsiveText/ResponsiveText";
 import * as classNames from "classnames";
 import * as React from "react";
-import { HeadlineElementType } from "../../../base/vis/visualizationTypes";
+import { HeadlineElementType } from "../../../base";
 import { IChartConfig } from "../../../highcharts";
 import { IFormattedHeadlineDataItem, IHeadlineData, IHeadlineDataItem } from "../Headlines";
 import { formatItemValue, formatPercentageValue } from "./utils/HeadlineDataItemUtils";

--- a/libs/sdk-ui/src/charts/headline/internal/HeadlineTransformation.tsx
+++ b/libs/sdk-ui/src/charts/headline/internal/HeadlineTransformation.tsx
@@ -2,10 +2,14 @@
 import { IDataView } from "@gooddata/sdk-backend-spi";
 import * as React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import { convertDrillableItemsToPredicates, fireDrillEvent } from "../../../base/vis/drilling";
 import { IChartConfig } from "../../../highcharts";
-import { IDrillableItem, IDrillEventCallback } from "../../../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../../../base/headerMatching/HeaderPredicate";
+import {
+    IHeaderPredicate,
+    IDrillableItem,
+    IDrillEventCallback,
+    convertDrillableItemsToPredicates,
+    fireDrillEvent,
+} from "../../../base";
 import Headline, { IHeadlineFiredDrillEventItemContext } from "./Headline";
 import {
     applyDrillableItems,

--- a/libs/sdk-ui/src/charts/headline/internal/utils/HeadlineTransformationUtils.ts
+++ b/libs/sdk-ui/src/charts/headline/internal/utils/HeadlineTransformationUtils.ts
@@ -6,14 +6,15 @@ import isNumber = require("lodash/isNumber");
 import { DataValue, DataViewFacade, IDataView, IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 import * as invariant from "invariant";
 import { IntlShape } from "react-intl";
-import { HeadlineElementType, VisualizationTypes } from "../../../../base/vis/visualizationTypes";
-import { isSomeHeaderPredicateMatched } from "../../../../base/vis/drilling";
 import {
     IDrillEvent,
     IDrillEventContextHeadline,
     IDrillEventIntersectionElement,
-} from "../../../../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../../../../base/headerMatching/HeaderPredicate";
+    IHeaderPredicate,
+    isSomeHeaderPredicateMatched,
+    HeadlineElementType,
+    VisualizationTypes,
+} from "../../../../base";
 import { IHeadlineData, IHeadlineDataItem } from "../../Headlines";
 import { Identifier } from "@gooddata/sdk-model";
 

--- a/libs/sdk-ui/src/charts/xirr/internal/XirrTransformation.tsx
+++ b/libs/sdk-ui/src/charts/xirr/internal/XirrTransformation.tsx
@@ -2,10 +2,14 @@
 import * as React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import noop = require("lodash/noop");
-import { convertDrillableItemsToPredicates, fireDrillEvent } from "../../../base/vis/drilling";
 import { IChartConfig } from "../../../highcharts";
-import { IDrillableItem, IDrillEventCallback } from "../../../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../../../base/headerMatching/HeaderPredicate";
+import {
+    IDrillableItem,
+    IDrillEventCallback,
+    IHeaderPredicate,
+    convertDrillableItemsToPredicates,
+    fireDrillEvent,
+} from "../../../base";
 import { getHeadlineData, applyDrillableItems, buildDrillEventData } from "./utils/XirrTransformationUtils";
 import { IDataView } from "@gooddata/sdk-backend-spi";
 import Headline, { IHeadlineFiredDrillEventItemContext } from "../../headline/internal/Headline";

--- a/libs/sdk-ui/src/charts/xirr/internal/utils/XirrTransformationUtils.ts
+++ b/libs/sdk-ui/src/charts/xirr/internal/utils/XirrTransformationUtils.ts
@@ -7,13 +7,14 @@ import { Identifier } from "@gooddata/sdk-model";
 
 import { calculateXirr } from "./calculateXirr";
 import {
+    VisualizationTypes,
+    HeadlineElementType,
     IDrillEvent,
     IDrillEventIntersectionElement,
     IDrillEventContextXirr,
-} from "../../../../base/vis/DrillEvents";
-import { VisualizationTypes, HeadlineElementType } from "../../../../base/vis/visualizationTypes";
-import { isSomeHeaderPredicateMatched } from "../../../../base/vis/drilling";
-import { IHeaderPredicate } from "../../../../base/headerMatching/HeaderPredicate";
+    isSomeHeaderPredicateMatched,
+    IHeaderPredicate,
+} from "../../../../base";
 import { IHeadlineData } from "../../../headline/Headlines";
 
 export interface IXirrExecutionData {

--- a/libs/sdk-ui/src/execution/Executor.tsx
+++ b/libs/sdk-ui/src/execution/Executor.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { DataViewFacade, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { withExecution } from "./withExecution";
-import { WithLoadingResult } from "../base/react/withLoading";
+import { WithLoadingResult } from "../base";
 
 /**
  * TODO: SDK8: add docs

--- a/libs/sdk-ui/src/execution/withExecution.ts
+++ b/libs/sdk-ui/src/execution/withExecution.ts
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import { DataViewFacade, IPreparedExecution } from "@gooddata/sdk-backend-spi";
-import { withLoading, WithLoadingResult, IWithLoadingEvents } from "../base/react/withLoading";
+import { withLoading, WithLoadingResult, IWithLoadingEvents } from "../base";
 
 /**
  * TODO: SDK8: add docs

--- a/libs/sdk-ui/src/filters/AttributeFilter/AttributeFilter.tsx
+++ b/libs/sdk-ui/src/filters/AttributeFilter/AttributeFilter.tsx
@@ -18,9 +18,8 @@ import {
 } from "@gooddata/sdk-model";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
-import { IntlWrapper } from "../../base/localization/IntlWrapper";
 import { AttributeDropdown } from "./AttributeDropdown/AttributeDropdown";
-import { defaultErrorHandler, OnError } from "../../base";
+import { defaultErrorHandler, OnError, IntlWrapper } from "../../base";
 
 interface IAttributeFilterProps {
     backend: IAnalyticalBackend;

--- a/libs/sdk-ui/src/filters/DateFilter/DateFilterCore.tsx
+++ b/libs/sdk-ui/src/filters/DateFilter/DateFilterCore.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import Dropdown from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import MediaQuery from "react-responsive";
 import { ExtendedDateFilters, IExtendedDateFilterErrors } from "./interfaces/ExtendedDateFilters";
-import { IntlWrapper } from "../../base/localization/IntlWrapper";
+import { IntlWrapper } from "../../base";
 import * as MediaQueries from "./constants/MediaQueries";
 import { DateFilterButtonLocalized } from "./DateFilterButtonLocalized/DateFilterButtonLocalized";
 import { DateFilterBody } from "./DateFilterBody/DateFilterBody";

--- a/libs/sdk-ui/src/filters/DateFilter/utils/Translations/DateFilterTitle.ts
+++ b/libs/sdk-ui/src/filters/DateFilter/utils/Translations/DateFilterTitle.ts
@@ -1,8 +1,7 @@
 // (C) 2019 GoodData Corporation
 import capitalize = require("lodash/capitalize");
 import isEqual = require("lodash/isEqual");
-import { ILocale } from "../../../../base";
-import IntlStore from "../../../../base/localization/IntlStore";
+import { ILocale, getIntl } from "../../../../base";
 import { granularityIntlCodes } from "../../constants/i18n";
 import { IMessageTranslator, IDateTranslator, IDateAndMessageTranslator } from "./Translators";
 import { convertPlatformDateStringToDate } from "../DateConversions";
@@ -185,7 +184,7 @@ const getDateFilterRepresentationByFilterType = (
  * @returns {string} Representation of the filter (e.g. "My preset", "From 2 weeks ago to 1 week ahead")
  */
 export const getDateFilterTitle = (filter: ExtendedDateFilters.DateFilterOption, locale: ILocale): string => {
-    const translator = IntlStore.getIntl(locale);
+    const translator = getIntl(locale);
 
     return getDateFilterRepresentationByFilterType(filter, translator);
 };
@@ -226,7 +225,7 @@ export const getDateFilterRepresentation = (
     filter: ExtendedDateFilters.DateFilterOption,
     locale: ILocale,
 ): string => {
-    const translator = IntlStore.getIntl(locale);
+    const translator = getIntl(locale);
 
     return getDateFilterRepresentationUsingTranslator(filter, translator);
 };

--- a/libs/sdk-ui/src/filters/MeasureValueFilter/Dropdown.tsx
+++ b/libs/sdk-ui/src/filters/MeasureValueFilter/Dropdown.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { IntlWrapper } from "../../base/localization/IntlWrapper";
+import { IntlWrapper } from "../../base";
 import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { DropdownButton as DefaultDropdownButton } from "./DropdownButton";
 import { DropdownBody } from "./DropdownBody";

--- a/libs/sdk-ui/src/filters/MeasureValueFilter/DropdownBody.tsx
+++ b/libs/sdk-ui/src/filters/MeasureValueFilter/DropdownBody.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import Button from "@gooddata/goodstrap/lib/Button/Button";
 
-import { IntlWrapper } from "../../base/localization/IntlWrapper";
+import { IntlWrapper } from "../../base";
 import OperatorDropdown from "./OperatorDropdown";
 import RangeInput from "./RangeInput";
 import ComparisonInput from "./ComparisonInput";

--- a/libs/sdk-ui/src/highcharts/Config.ts
+++ b/libs/sdk-ui/src/highcharts/Config.ts
@@ -1,6 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
-import { VisType } from "../base/vis/visualizationTypes";
 import {
     ColorAxisOptions,
     DataLabelsOptionsObject,
@@ -10,7 +9,7 @@ import {
     SVGDOMElement,
 } from "./chart/highcharts/highchartsEntryPoint";
 import { IColor, IColorPalette } from "@gooddata/sdk-model";
-import { IHeaderPredicate, IColorAssignment } from "../base";
+import { IHeaderPredicate, IColorAssignment, VisType } from "../base";
 export { DefaultColorPalette } from "../base";
 
 export type PositionType = "left" | "right" | "top" | "bottom" | "auto";

--- a/libs/sdk-ui/src/highcharts/Visualization.tsx
+++ b/libs/sdk-ui/src/highcharts/Visualization.tsx
@@ -2,8 +2,7 @@
 import { IDataView } from "@gooddata/sdk-backend-spi";
 import * as invariant from "invariant";
 import * as React from "react";
-import { IDrillableItem, OnFiredDrillEvent } from "../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../base/headerMatching/HeaderPredicate";
+import { IDrillableItem, OnFiredDrillEvent, IHeaderPredicate } from "../base";
 import ChartTransformation, { renderHighCharts } from "./chart/ChartTransformation";
 import Highcharts from "./chart/highcharts/highchartsEntryPoint";
 import { IChartConfig } from "./Config";

--- a/libs/sdk-ui/src/highcharts/chart/ChartTransformation.tsx
+++ b/libs/sdk-ui/src/highcharts/chart/ChartTransformation.tsx
@@ -3,9 +3,12 @@ import { IDataView } from "@gooddata/sdk-backend-spi";
 import * as invariant from "invariant";
 import * as React from "react";
 
-import { convertDrillableItemsToPredicates } from "../../base/vis/drilling";
-import { IDrillableItem, OnFiredDrillEvent } from "../../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../../base/headerMatching/HeaderPredicate";
+import {
+    convertDrillableItemsToPredicates,
+    IDrillableItem,
+    OnFiredDrillEvent,
+    IHeaderPredicate,
+} from "../../base";
 import { OnLegendReady } from "../../charts/chartProps";
 import { IChartConfig, IChartOptions } from "../Config";
 import { ILegendOptions } from "../typings/legend";

--- a/libs/sdk-ui/src/highcharts/chart/HighChartsRenderer.tsx
+++ b/libs/sdk-ui/src/highcharts/chart/HighChartsRenderer.tsx
@@ -16,7 +16,7 @@ import Chart, { IChartProps } from "./Chart";
 import Legend, { ILegendProps } from "./legend/Legend";
 import { TOP, LEFT, BOTTOM, RIGHT } from "./legend/PositionTypes";
 import { isPieOrDonutChart, isOneOfTypes } from "../utils/common";
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../base";
 import { IChartConfig } from "../Config";
 import Highcharts from "./highcharts/highchartsEntryPoint";
 import { alignChart } from "./highcharts/helpers";

--- a/libs/sdk-ui/src/highcharts/chart/chartOptions/comboChartOptions.ts
+++ b/libs/sdk-ui/src/highcharts/chart/chartOptions/comboChartOptions.ts
@@ -4,9 +4,8 @@ import get = require("lodash/get");
 import cloneDeep = require("lodash/cloneDeep");
 import { DataViewFacade, IMeasureGroupDescriptor, IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 import { IBucket, AttributeOrMeasure } from "@gooddata/sdk-model";
-import { BucketNames } from "../../../base";
+import { BucketNames, VisualizationTypes } from "../../../base";
 import { IChartConfig, ISeriesItem } from "../../Config";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
 import { isLineChart } from "../../utils/common";
 import { NORMAL_STACK } from "../highcharts/getOptionalStackingConfiguration";
 

--- a/libs/sdk-ui/src/highcharts/chart/chartOptionsBuilder.ts
+++ b/libs/sdk-ui/src/highcharts/chart/chartOptionsBuilder.ts
@@ -12,7 +12,15 @@ import {
 import * as cx from "classnames";
 import * as invariant from "invariant";
 
-import { BucketNames } from "../../base";
+import {
+    BucketNames,
+    VisType,
+    VisualizationTypes,
+    getDrillIntersection,
+    isSomeHeaderPredicateMatched,
+    IHeaderPredicate,
+    IMappingHeader,
+} from "../../base";
 import { ViewByAttributesLimit } from "../../charts/_commons/limits";
 import {
     PARENT_ATTRIBUTE_INDEX,
@@ -21,13 +29,9 @@ import {
     VIEW_BY_DIMENSION_INDEX,
 } from "../constants/dimensions";
 import { HEATMAP_DATA_POINTS_LIMIT, PIE_CHART_LIMIT } from "../constants/limits";
-import { VisType, VisualizationTypes } from "../../base/vis/visualizationTypes";
-import { getDrillIntersection, isSomeHeaderPredicateMatched } from "../../base/vis/drilling";
 
 import { findAttributeInDimension, findMeasureGroupInDimensions } from "../utils/executionResultHelper";
 import { IUnwrappedAttributeHeadersWithItems } from "../utils/types";
-import { IHeaderPredicate } from "../../base/headerMatching/HeaderPredicate";
-import { IMappingHeader } from "../../base/headerMatching/MappingHeader";
 
 import {
     IAxis,

--- a/libs/sdk-ui/src/highcharts/chart/colorFactory.ts
+++ b/libs/sdk-ui/src/highcharts/chart/colorFactory.ts
@@ -10,10 +10,9 @@ import {
     IColorPaletteItem,
 } from "@gooddata/sdk-model";
 import { DataViewFacade, IMeasureDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { VisualizationTypes, IMappingHeader, IColorAssignment } from "../../base";
 import { findMeasureGroupInDimensions } from "../utils/executionResultHelper";
 import { DefaultColorPalette, IColorMapping } from "../Config";
-import { IMappingHeader } from "../../base/headerMatching/MappingHeader";
 
 import {
     DEFAULT_HEATMAP_BLUE_COLOR,
@@ -28,7 +27,6 @@ import { isBubbleChart, isHeatmap, isOneOfTypes, isScatterPlot, isTreemap } from
 import isEqual = require("lodash/isEqual");
 import range = require("lodash/range");
 import uniqBy = require("lodash/uniqBy");
-import { IColorAssignment } from "../../base/vis/Events";
 
 export interface IColorStrategy {
     getColorByIndex(index: number): string;

--- a/libs/sdk-ui/src/highcharts/chart/events/setupDrilldownToParentAttribute.ts
+++ b/libs/sdk-ui/src/highcharts/chart/events/setupDrilldownToParentAttribute.ts
@@ -4,12 +4,7 @@ import partial = require("lodash/partial");
 import Highcharts from "../highcharts/highchartsEntryPoint";
 import { styleVariables } from "../../styles/variables";
 import { tickLabelClick } from "../../utils/drilldownEventing";
-import { ChartType } from "../../../base/vis/visualizationTypes";
-import {
-    IDrillConfig,
-    IHighchartsCategoriesTree,
-    IHighchartsParentTick,
-} from "../../../base/vis/DrillEvents";
+import { ChartType, IDrillConfig, IHighchartsCategoriesTree, IHighchartsParentTick } from "../../../base";
 import { IHighchartsPointObject } from "../../utils/isGroupHighchartsDrillEvent";
 
 function getDDPointsInParentTick(axis: any, tick: IHighchartsParentTick): IHighchartsPointObject[] {

--- a/libs/sdk-ui/src/highcharts/chart/highChartsCreators.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highChartsCreators.ts
@@ -2,7 +2,7 @@
 import get = require("lodash/get");
 import merge = require("lodash/merge");
 import * as invariant from "invariant";
-import { IDrillConfig } from "../../base/vis/DrillEvents";
+import { VisualizationTypes, IDrillConfig } from "../../base";
 import { getCommonConfiguration } from "./highcharts/commonConfiguration";
 
 import { stringifyChartTypes } from "../utils/common";
@@ -22,7 +22,6 @@ import { getTreemapConfiguration } from "./highcharts/treemapConfiguration";
 import { getFunnelConfiguration } from "./highcharts/funnelConfiguration";
 import { getHeatmapConfiguration } from "./highcharts/heatmapConfiguration";
 import { getBubbleConfiguration } from "./highcharts/bubbleConfiguration";
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
 import { IExecutionDefinition } from "@gooddata/sdk-model";
 
 const chartConfigurationMap = {

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/comboConfiguration.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/comboConfiguration.ts
@@ -2,9 +2,8 @@
 import { MAX_POINT_WIDTH } from "./commonConfiguration";
 import { LINE_WIDTH } from "./lineConfiguration";
 import { IChartConfig } from "../../Config";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
 import { isLineChart } from "../../utils/common";
-import { BucketNames } from "../../../base";
+import { BucketNames, VisualizationTypes } from "../../../base";
 import { bucketIsEmpty, bucketsFind, IExecutionDefinition } from "@gooddata/sdk-model";
 import get = require("lodash/get");
 

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/commonConfiguration.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/commonConfiguration.ts
@@ -4,7 +4,7 @@ import get = require("lodash/get");
 import invoke = require("lodash/invoke");
 import isEmpty = require("lodash/isEmpty");
 import set = require("lodash/set");
-import { IDrillConfig } from "../../../base/vis/DrillEvents";
+import { IDrillConfig } from "../../../base";
 import { IHighchartsAxisExtend } from "../../HighchartsExtend";
 import { styleVariables } from "../../styles/variables";
 import { isOneOfTypes } from "../../utils/common";

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/customConfiguration.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/customConfiguration.ts
@@ -17,7 +17,7 @@ import * as cx from "classnames";
 
 import { styleVariables } from "../../styles/variables";
 import { supportedDualAxesChartTypes, supportedTooltipFollowPointerChartTypes } from "../chartOptionsBuilder";
-import { ChartType, VisualizationTypes } from "../../../base/vis/visualizationTypes";
+import { IDrillConfig, ChartType, VisualizationTypes } from "../../../base";
 import {
     IAxis,
     IChartConfig,
@@ -51,7 +51,6 @@ import {
 } from "./helpers";
 
 import getOptionalStackingConfiguration from "./getOptionalStackingConfiguration";
-import { IDrillConfig } from "../../../base/vis/DrillEvents";
 import { getZeroAlignConfiguration } from "./getZeroAlignConfiguration";
 import { canComboChartBeStackedInPercent } from "../chartOptions/comboChartOptions";
 import { getAxisNameConfiguration } from "./getAxisNameConfiguration";

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/getOptionalStackingConfiguration.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/getOptionalStackingConfiguration.ts
@@ -24,7 +24,7 @@ import {
     isComboChart,
     isLineChart,
 } from "../../utils/common";
-import { IDrillConfig } from "../../../base/vis/DrillEvents";
+import { IDrillConfig } from "../../../base";
 import { canComboChartBeStackedInPercent } from "../chartOptions/comboChartOptions";
 import { isPrimaryYAxis } from "../../utils/isPrimaryYAxis";
 

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/helpers.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/helpers.ts
@@ -14,7 +14,7 @@ import min = require("lodash/min");
 import max = require("lodash/max");
 import isNil = require("lodash/isNil");
 
-import { VisualizationTypes, VisType } from "../../../base/vis/visualizationTypes";
+import { VisualizationTypes, VisType } from "../../../base";
 import { isBarChart } from "../../utils/common";
 import { ISeriesItem, ISeriesDataItem, IChartConfig, ChartAlignTypes } from "../../Config";
 import { BOTTOM, MIDDLE, TOP } from "../../constants/alignments";

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/autohideColumnLabels.ts
@@ -31,7 +31,7 @@ import {
     hasShape,
     hasLabelInside,
 } from "../../dataLabelsHelpers";
-import { VisualizationTypes } from "../../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../../base";
 import {
     IPointData,
     IAxisConfig,

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/autohideLabels.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/autohideLabels/autohideLabels.ts
@@ -2,7 +2,7 @@
 import { getChartType } from "../../helpers";
 
 import { getDataLabelsGdcVisible, minimizeDataLabel, hideDataLabel } from "../../dataLabelsHelpers";
-import { VisualizationTypes } from "../../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../../base";
 import { autohideColumnLabels, handleColumnLabelsOutsideChart } from "./autohideColumnLabels";
 import { autohideBarLabels, handleBarLabelsOutsideChart } from "./autohideBarLabels";
 import autohidePieLabels from "./autohidePieLabels";

--- a/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/dataLabelsColors.ts
+++ b/libs/sdk-ui/src/highcharts/chart/highcharts/plugins/dataLabelsColors.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import flatMap = require("lodash/flatMap");
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../base";
 import { getChartType, getVisibleSeries, isStacked, getShapeAttributes } from "../helpers";
 
 import { getDataLabelAttributes } from "../dataLabelsHelpers";

--- a/libs/sdk-ui/src/highcharts/chart/legend/Legend.tsx
+++ b/libs/sdk-ui/src/highcharts/chart/legend/Legend.tsx
@@ -5,14 +5,9 @@ import * as cx from "classnames";
 import isEmpty = require("lodash/isEmpty");
 import FluidLegend from "./FluidLegend";
 import StaticLegend from "./StaticLegend";
-import { ChartType } from "../../../base/vis/visualizationTypes";
 import { isComboChart, isHeatmap } from "../../utils/common";
 import HeatmapLegend from "./HeatmapLegend";
-import { IntlWrapper } from "../../../base/localization/IntlWrapper";
-import {
-    IntlTranslationsProvider,
-    ITranslationsComponentProps,
-} from "../../../base/localization/TranslationsProvider";
+import { ChartType, IntlWrapper, IntlTranslationsProvider, ITranslationsComponentProps } from "../../../base";
 import { getComboChartSeries, transformToDualAxesSeries } from "./helpers";
 
 export interface ILegendProps {

--- a/libs/sdk-ui/src/highcharts/chart/legend/helpers.ts
+++ b/libs/sdk-ui/src/highcharts/chart/legend/helpers.ts
@@ -11,7 +11,7 @@ import { LEFT, RIGHT, TOP, BOTTOM } from "./PositionTypes";
 import { formatLegendLabel, isAreaChart, isOneOfTypes, isTreemap } from "../../utils/common";
 import { supportedDualAxesChartTypes } from "../chartOptionsBuilder";
 import { ISeriesItem } from "../../Config";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../base";
 
 export const RESPONSIVE_ITEM_MIN_WIDTH = 200;
 export const RESPONSIVE_VISIBLE_ROWS = 2;

--- a/libs/sdk-ui/src/highcharts/chart/legend/legendBuilder.ts
+++ b/libs/sdk-ui/src/highcharts/chart/legend/legendBuilder.ts
@@ -12,7 +12,7 @@ import {
     isScatterPlot,
     isTreemap,
 } from "../../utils/common";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../base";
 import { ILegendOptions, LegendOptionsItemType, DEFAULT_LEGEND_CONFIG } from "../../typings/legend";
 import { supportedDualAxesChartTypes } from "../chartOptionsBuilder";
 import { isStackedChart } from "./helpers";

--- a/libs/sdk-ui/src/highcharts/constants/label.ts
+++ b/libs/sdk-ui/src/highcharts/constants/label.ts
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import Highcharts from "../chart/highcharts/highchartsEntryPoint";
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../base";
 
 export const WHITE_LABEL: Highcharts.CSSObject = {
     color: "#ffffff",

--- a/libs/sdk-ui/src/highcharts/utils/common.ts
+++ b/libs/sdk-ui/src/highcharts/utils/common.ts
@@ -2,12 +2,11 @@
 import clone = require("lodash/clone");
 import get = require("lodash/get");
 import includes = require("lodash/includes");
-// (C) 2007-2019 GoodData Corporation
 import isNil = require("lodash/isNil");
 import setWith = require("lodash/setWith");
 import { numberFormat } from "@gooddata/numberjs";
 
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../base";
 import { IChartOptions, ISeriesItem } from "../Config";
 
 // lodash/fp does not provide typings

--- a/libs/sdk-ui/src/highcharts/utils/drilldownEventing.ts
+++ b/libs/sdk-ui/src/highcharts/utils/drilldownEventing.ts
@@ -9,8 +9,6 @@ import {
     getVisualizationType,
     VisType,
     VisualizationTypes,
-} from "../../base/vis/visualizationTypes";
-import {
     IDrillConfig,
     IDrillEvent,
     IDrillEventContext,
@@ -18,7 +16,7 @@ import {
     IDrillEventContextPoint,
     IDrillPoint,
     OnFiredDrillEvent,
-} from "../../base/vis/DrillEvents";
+} from "../../base";
 import Highcharts from "../chart/highcharts/highchartsEntryPoint";
 import { isComboChart, isHeatmap, isTreemap } from "./common";
 import { IHighchartsPointObject, isGroupHighchartsDrillEvent } from "./isGroupHighchartsDrillEvent";

--- a/libs/sdk-ui/src/highcharts/utils/dualAxis.ts
+++ b/libs/sdk-ui/src/highcharts/utils/dualAxis.ts
@@ -2,8 +2,7 @@
 import { DataViewFacade } from "@gooddata/sdk-backend-spi";
 import { measureLocalId } from "@gooddata/sdk-model";
 import { IChartConfig } from "../Config";
-import { BucketNames } from "../../base";
-import { VisType } from "../../base/vis/visualizationTypes";
+import { BucketNames, VisType } from "../../base";
 import { isComboChart } from "./common";
 import get = require("lodash/get");
 

--- a/libs/sdk-ui/src/highcharts/utils/isGroupHighchartsDrillEvent.ts
+++ b/libs/sdk-ui/src/highcharts/utils/isGroupHighchartsDrillEvent.ts
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import Highcharts from "../chart/highcharts/highchartsEntryPoint";
-import { IDrillEventIntersectionElement } from "../../base/vis/DrillEvents";
+import { IDrillEventIntersectionElement } from "../../base";
 
 export interface IHighchartsPointObject extends Highcharts.Point {
     drillIntersection: IDrillEventIntersectionElement[];

--- a/libs/sdk-ui/src/index.ts
+++ b/libs/sdk-ui/src/index.ts
@@ -1,16 +1,14 @@
 // (C) 2007-2019 GoodData Corporation
 import "./polyfills";
-import * as VisEvents from "./base/vis/Events";
 // import { ICommonVisualizationProps } from "./_defunct/to_delete/VisualizationLoadingHOC";
 import { Kpi } from "./kpi/Kpi";
 // import { Visualization } from "./_defunct/uri/Visualization";
 // import { Execute } from "./execution/Execute";
-import { IDrillableItem } from "./base/vis/DrillEvents";
 import { withExecution } from "./execution/withExecution";
 import { Executor } from "./execution/Executor";
 // tslint:disable-next-line:no-duplicate-imports
 
-export { Kpi, Executor, withExecution, IDrillableItem, VisEvents };
+export { Kpi, Executor, withExecution };
 
 // new exports
 

--- a/libs/sdk-ui/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui/src/insightView/InsightView.tsx
@@ -30,9 +30,17 @@ import { PluggableTreemap } from "../internal/components/pluggableVisualizations
 import { PluggableFunnelChart } from "../internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart";
 import { PluggableXirr } from "../internal/components/pluggableVisualizations/xirr/PluggableXirr";
 import { ExecutionFactoryWithPresetFilters } from "./ExecutionFactoryWithPresetFilters";
-import { ErrorComponent, IErrorProps } from "../base/react/ErrorComponent";
-import { LoadingComponent, ILoadingProps } from "../base/react/LoadingComponent";
-import { GoodDataSdkError, fillMissingTitles, DefaultLocale, ILocale, withContexts } from "../base";
+import {
+    GoodDataSdkError,
+    fillMissingTitles,
+    DefaultLocale,
+    ILocale,
+    withContexts,
+    LoadingComponent,
+    ILoadingProps,
+    ErrorComponent,
+    IErrorProps,
+} from "../base";
 
 const VisualizationsCatalog = {
     bar: PluggableBarChart,

--- a/libs/sdk-ui/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui/src/internal/components/BaseVisualization.tsx
@@ -1,9 +1,14 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import * as uuid from "uuid";
-import { IDrillableItem } from "../../base/vis/DrillEvents";
-import * as VisEvents from "../../base/vis/Events";
-import { VisualizationEnvironment } from "../../base/vis/visualizationTypes";
+import {
+    IDrillableItem,
+    VisualizationEnvironment,
+    OnError,
+    OnExportReady,
+    OnLoadingChanged,
+    ILocale,
+} from "../../base";
 import {
     IBucketItem,
     IFeatureFlags,
@@ -20,7 +25,7 @@ import { PluggableLineChart } from "./pluggableVisualizations/lineChart/Pluggabl
 import { PluggableAreaChart } from "./pluggableVisualizations/areaChart/PluggableAreaChart";
 import { PluggablePieChart } from "./pluggableVisualizations/pieChart/PluggablePieChart";
 import { PluggableDonutChart } from "./pluggableVisualizations/donutChart/PluggableDonutChart";
-// import { PluggablePivotTable } from "../../_defunct/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable";
+import { PluggablePivotTable } from "./pluggableVisualizations/pivotTable/PluggablePivotTable";
 import { PluggableHeadline } from "./pluggableVisualizations/headline/PluggableHeadline";
 import { PluggableScatterPlot } from "./pluggableVisualizations/scatterPlot/PluggableScatterPlot";
 import { PluggableComboChartDeprecated } from "./pluggableVisualizations/comboChart/PluggableComboChartDeprecated";
@@ -34,7 +39,6 @@ import isEqual = require("lodash/isEqual");
 import isEmpty = require("lodash/isEmpty");
 import noop = require("lodash/noop");
 import omit = require("lodash/omit");
-import { ILocale } from "../../base/localization/Locale";
 
 // visualization catalogue - add your new visualization here
 const VisualizationsCatalog = {
@@ -44,7 +48,7 @@ const VisualizationsCatalog = {
     area: PluggableAreaChart,
     pie: PluggablePieChart,
     donut: PluggableDonutChart,
-    // table: PluggablePivotTable,
+    table: PluggablePivotTable,
     headline: PluggableHeadline,
     scatter: PluggableScatterPlot,
     bubble: PluggableBubbleChart,
@@ -70,9 +74,9 @@ export interface IBaseVisualizationProps extends IVisCallbacks {
     visualizationsCatalog?: object;
     newDerivedBucketItems?: IBucketItem[];
     referencePoint?: IReferencePoint;
-    onError: VisEvents.OnError;
-    onExportReady: VisEvents.OnExportReady;
-    onLoadingChanged: VisEvents.OnLoadingChanged;
+    onError: OnError;
+    onExportReady: OnExportReady;
+    onLoadingChanged: OnLoadingChanged;
     isMdObjectValid?: boolean;
     backend: IAnalyticalBackend;
     onExtendedReferencePointChanged?(): void;

--- a/libs/sdk-ui/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
+++ b/libs/sdk-ui/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItem.tsx
@@ -6,7 +6,7 @@ import ColoredItemContent from "./ColoredItemContent";
 import ColorDropdown from "../colorDropdown/ColorDropdown";
 import { IColoredItem, IColoredItemDropdownItem } from "../../../../interfaces/Colors";
 import { isMeasureDescriptor, isResultAttributeHeader } from "@gooddata/sdk-backend-spi";
-import { IMappingHeader } from "../../../../../base/headerMatching/MappingHeader";
+import { IMappingHeader } from "../../../../../base";
 
 export interface IColoredItemProps {
     colorPalette: IColorPalette;

--- a/libs/sdk-ui/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
+++ b/libs/sdk-ui/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { DefaultLocale } from "../../../base";
-import { ChartType } from "../../../base/vis/visualizationTypes";
+import { DefaultLocale, ChartType } from "../../../base";
 
 import { IFeatureFlags, IReferences, IVisualizationProperties } from "../../interfaces/Visualization";
 import { IColorConfiguration } from "../../interfaces/Colors";

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -1,8 +1,7 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import { render } from "react-dom";
-import { BucketNames } from "../../../../base";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
 import { render } from "react-dom";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../base";
 import cloneDeep = require("lodash/cloneDeep");
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { COLUMN_BAR_CHART_UICONFIG } from "../../../constants/uiConfig";

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
@@ -18,7 +18,7 @@ import {
     limitNumberOfMeasuresInBuckets,
 } from "../../../utils/bucketHelper";
 
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { METRIC, BUCKETS } from "../../../constants/bucket";
 import { removeSort } from "../../../utils/sort";
 import { setBubbleChartUiConfig } from "../../../utils/uiConfigHelpers/bubbleChartUiConfigHelper";
@@ -26,7 +26,6 @@ import { DEFAULT_BUBBLE_CHART_CONFIG } from "../../../constants/uiConfig";
 import { BUBBLE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import BubbleChartConfigurationPanel from "../../configurationPanels/BubbleChartConfigurationPanel";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableBubbleChart extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -5,7 +5,7 @@ import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { COLUMN_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import { COLUMN_BAR_CHART_UICONFIG } from "../../../constants/uiConfig";
 import { IVisConstruct, IUiConfig } from "../../../interfaces/Visualization";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../base";
 
 export class PluggableColumnChart extends PluggableColumnBarCharts {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -3,7 +3,7 @@ import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
 import without = require("lodash/without");
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import {
@@ -47,7 +47,6 @@ import {
     PROPERTY_CONTROLS_PRIMARY_CHART_TYPE,
     PROPERTY_CONTROLS_SECONDARY_CHART_TYPE,
 } from "../../../constants/properties";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 import { getMasterMeasuresCount } from "../../../utils/bucketRules";
 import { isLineChart, isAreaChart } from "../../../../highcharts";
 

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
@@ -5,7 +5,7 @@ import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
 import without = require("lodash/without");
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import {
@@ -33,7 +33,6 @@ import { setComboChartUiConfigDeprecated } from "../../../utils/uiConfigHelpers/
 import { removeSort } from "../../../utils/sort";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 import { COMBO_CHART_UICONFIG_DEPRECATED } from "../../../constants/uiConfig";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableComboChartDeprecated extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/donutChart/PluggableDonutChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/donutChart/PluggableDonutChart.tsx
@@ -3,7 +3,7 @@ import { IVisConstruct, IReferencePoint, IExtendedReferencePoint } from "../../.
 
 import { PluggablePieChart } from "../pieChart/PluggablePieChart";
 import { setDonutChartUiConfig } from "../../../utils/uiConfigHelpers/donutChartUiConfigHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../base";
 
 export class PluggableDonutChart extends PluggablePieChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
@@ -12,7 +12,7 @@ import {
 import { PluggablePieChart } from "../pieChart/PluggablePieChart";
 import { setFunnelChartUiConfig } from "../../../utils/uiConfigHelpers/funnelChartUiConfigHelper";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../../../base";
 
 export class PluggableFunnelChart extends PluggablePieChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -7,7 +7,7 @@ import { IntlShape } from "react-intl";
 import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 
-import { BucketNames } from "../../../../base";
+import { BucketNames, DefaultLocale, ILocale } from "../../../../base";
 import { updateConfigWithSettings } from "../../../../highcharts";
 import { METRIC } from "../../../constants/bucket";
 
@@ -54,7 +54,6 @@ import {
 import { CoreHeadline } from "../../../../charts/headline/CoreHeadline";
 import { IInsight, insightProperties, insightHasDataDefined } from "@gooddata/sdk-model";
 import { IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";
-import { DefaultLocale, ILocale } from "../../../../base/localization/Locale";
 import { unmountComponentsAtNodes } from "../../../utils/domHelper";
 
 export class PluggableHeadline extends AbstractPluggableVisualization {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -6,7 +6,7 @@ import set = require("lodash/set");
 import tail = require("lodash/tail");
 import includes = require("lodash/includes");
 
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import { IReferencePoint, IExtendedReferencePoint, IVisConstruct } from "../../../interfaces/Visualization";
@@ -29,7 +29,6 @@ import HeatMapConfigurationPanel from "../../configurationPanels/HeatMapConfigur
 
 import { BUCKETS, ATTRIBUTE, DATE } from "../../../constants/bucket";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableHeatmap extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { render } from "react-dom";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
@@ -38,7 +38,6 @@ import {
 } from "../../../utils/propertiesHelper";
 import { LINE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableLineChart extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -4,7 +4,7 @@ import React = require("react");
 import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 
 import {
     IVisConstruct,
@@ -38,7 +38,6 @@ import {
 import { setPieChartUiConfig } from "../../../utils/uiConfigHelpers/pieChartUiConfigHelper";
 import { removeSort } from "../../../utils/sort";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 import { IChartConfig, TOP } from "../../../../highcharts";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
 

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -12,8 +12,14 @@ import { IntlShape } from "react-intl";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 
-import * as VisEvents from "../../../../base/vis/Events";
-import { BucketNames } from "../../../../base";
+import {
+    BucketNames,
+    IExportFunction,
+    VisualizationEnvironment,
+    VisualizationTypes,
+    DefaultLocale,
+    ILocale,
+} from "../../../../base";
 import {
     IBucketFilter,
     IBucketItem,
@@ -41,7 +47,6 @@ import { createInternalIntl } from "../../../utils/internalIntlProvider";
 import { DEFAULT_PIVOT_TABLE_UICONFIG } from "../../../constants/uiConfig";
 import { AbstractPluggableVisualization } from "../AbstractPluggableVisualization";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationEnvironment, VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 import { CorePivotTable } from "../../../../pivotTable/CorePivotTable";
 import { generateDimensions } from "../../../utils/dimensions";
 import {
@@ -66,7 +71,6 @@ import {
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import { createSorts } from "../../../utils/sort";
 import { ICorePivotTableProps } from "../../../../pivotTable/types";
-import { DefaultLocale, ILocale } from "../../../../base/localization/Locale";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
 import { unmountComponentsAtNodes } from "../../../utils/domHelper";
 
@@ -451,7 +455,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         }
     }
 
-    protected onExportReady(exportResult: VisEvents.IExportFunction) {
+    protected onExportReady(exportResult: IExportFunction) {
         const { onExportReady } = this.callbacks;
         if (onExportReady) {
             onExportReady(exportResult);

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
@@ -18,7 +18,7 @@ import {
     limitNumberOfMeasuresInBuckets,
 } from "../../../utils/bucketHelper";
 
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { METRIC, BUCKETS } from "../../../constants/bucket";
 import { removeSort } from "../../../utils/sort";
 import { setScatterPlotUiConfig } from "../../../utils/uiConfigHelpers/scatterPlotUiConfigHelper";
@@ -26,7 +26,6 @@ import { DEFAULT_SCATTERPLOT_UICONFIG } from "../../../constants/uiConfig";
 import ScatterPlotConfigurationPanel from "../../configurationPanels/ScatterPlotConfigurationPanel";
 import { SCATTERPLOT_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableScatterPlot extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -7,7 +7,7 @@ import set = require("lodash/set");
 import tail = require("lodash/tail");
 import isEmpty = require("lodash/isEmpty");
 
-import { BucketNames } from "../../../../base";
+import { BucketNames, VisualizationTypes } from "../../../../base";
 import { IReferencePoint, IExtendedReferencePoint, IVisConstruct } from "../../../interfaces/Visualization";
 import { configurePercent, configureOverTimeComparison } from "../../../utils/bucketConfig";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
@@ -36,7 +36,6 @@ import {
 import { setTreemapUiConfig } from "../../../utils/uiConfigHelpers/treemapUiConfigHelper";
 import { removeSort } from "../../../utils/sort";
 import { getReferencePointWithSupportedProperties } from "../../../utils/propertiesHelper";
-import { VisualizationTypes } from "../../../../base/vis/visualizationTypes";
 
 export class PluggableTreemap extends PluggableBaseChart {
     constructor(props: IVisConstruct) {

--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
@@ -47,10 +47,9 @@ import {
     MeasureGroupIdentifier,
 } from "@gooddata/sdk-model";
 import { IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";
-import { DefaultLocale, ILocale } from "../../../../base/localization/Locale";
 import { unmountComponentsAtNodes } from "../../../utils/domHelper";
 import { CoreXirr } from "../../../../charts/xirr/CoreXirr";
-import { BucketNames } from "../../../../base";
+import { BucketNames, DefaultLocale, ILocale } from "../../../../base";
 
 export class PluggableXirr extends AbstractPluggableVisualization {
     protected configPanelElement: string;

--- a/libs/sdk-ui/src/internal/constants/axis.ts
+++ b/libs/sdk-ui/src/internal/constants/axis.ts
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { VisualizationTypes } from "../../base";
 
 export const AXIS = {
     PRIMARY: "primary",

--- a/libs/sdk-ui/src/internal/interfaces/Colors.ts
+++ b/libs/sdk-ui/src/internal/interfaces/Colors.ts
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
-import { IMappingHeader } from "../../base";
+import { IMappingHeader, IColorAssignment } from "../../base";
 import { IRgbColorValue, IColor, IColorPaletteItem } from "@gooddata/sdk-model";
-import { IColorAssignment } from "../../base/vis/Events";
 
 export interface IColoredItem {
     colorItem: IColor;

--- a/libs/sdk-ui/src/internal/utils/colors.ts
+++ b/libs/sdk-ui/src/internal/utils/colors.ts
@@ -9,11 +9,10 @@ import compact = require("lodash/compact");
 
 import { IVisualizationProperties } from "../interfaces/Visualization";
 import { IColorConfiguration, IColoredItem } from "../interfaces/Colors";
-import * as MappingHeader from "../../base/headerMatching/MappingHeader";
 import { ColorUtils } from "../../highcharts";
 import { IMeasureDescriptor, isMeasureDescriptor, isResultAttributeHeader } from "@gooddata/sdk-backend-spi";
 import { IColor, IColorMappingItem, isColorFromPalette, isRgbColor } from "@gooddata/sdk-model";
-import { IColorAssignment } from "../../base/vis/Events";
+import { IColorAssignment, IMappingHeader } from "../../base";
 
 function getItemName(item: IColoredItem): string {
     let name = "";
@@ -84,7 +83,7 @@ function mergeColorMappingToProperties(properties: IVisualizationProperties, id:
 
 export function getProperties(
     properties: IVisualizationProperties,
-    item: MappingHeader.IMappingHeader,
+    item: IMappingHeader,
     color: IColor,
 ): IVisualizationProperties {
     if (isMeasureDescriptor(item)) {

--- a/libs/sdk-ui/src/internal/utils/dimensions.ts
+++ b/libs/sdk-ui/src/internal/utils/dimensions.ts
@@ -12,8 +12,7 @@ import {
     MeasureGroupIdentifier,
 } from "@gooddata/sdk-model";
 import { ViewByAttributesLimit } from "../../charts";
-import { BucketNames } from "../../base";
-import { VisType, VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { BucketNames, VisType, VisualizationTypes } from "../../base";
 
 export function getPivotTableDimensions(insight: IInsight): IDimension[] {
     const row = insightBucket(insight, BucketNames.ATTRIBUTE);

--- a/libs/sdk-ui/src/internal/utils/drillablePredicates.ts
+++ b/libs/sdk-ui/src/internal/utils/drillablePredicates.ts
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
-import * as HeaderPredicateFactory from "../../base/headerMatching/HeaderPredicateFactory";
-import { IHeaderPredicate } from "../../base/headerMatching/HeaderPredicate";
+import { IHeaderPredicate, HeaderPredicates } from "../../base";
 import isArray = require("lodash/isArray");
 import uniq = require("lodash/uniq");
 
@@ -62,11 +61,9 @@ export async function convertPostMessageToDrillablePredicates(
     //  will call the factory with 3 args (value, index and all values)
 
     return [
-        ...simpleUris.map(uri => HeaderPredicateFactory.uriMatch(uri)),
-        ...simpleIdentifiers.map(identifier => HeaderPredicateFactory.identifierMatch(identifier)),
-        ...composedFromUris.map(uri => HeaderPredicateFactory.composedFromUri(uri)),
-        ...composedFromIdentifiers.map(identifier =>
-            HeaderPredicateFactory.composedFromIdentifier(identifier),
-        ),
+        ...simpleUris.map(uri => HeaderPredicates.uriMatch(uri)),
+        ...simpleIdentifiers.map(identifier => HeaderPredicates.identifierMatch(identifier)),
+        ...composedFromUris.map(uri => HeaderPredicates.composedFromUri(uri)),
+        ...composedFromIdentifiers.map(identifier => HeaderPredicates.composedFromIdentifier(identifier)),
     ];
 }

--- a/libs/sdk-ui/src/internal/utils/sort.ts
+++ b/libs/sdk-ui/src/internal/utils/sort.ts
@@ -23,9 +23,7 @@ import {
     sortEntityIds,
     SortItem,
 } from "@gooddata/sdk-model";
-import { BucketNames } from "../../base";
-
-import { VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { BucketNames, VisualizationTypes } from "../../base";
 import { SORT_DIR_ASC, SORT_DIR_DESC } from "../constants/sort";
 import { IBucketItem, IBucketOfFun, IExtendedReferencePoint } from "../interfaces/Visualization";
 

--- a/libs/sdk-ui/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
+++ b/libs/sdk-ui/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
@@ -5,7 +5,7 @@ import set = require("lodash/set");
 import forEach = require("lodash/forEach");
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "../../../base/";
+import { BucketNames, VisualizationTypes } from "../../../base/";
 import {
     IExtendedReferencePoint,
     IBucketOfFun,
@@ -37,7 +37,6 @@ import * as columnStackIcon from "../../assets/column/bucket-title-stack.svg";
 import * as barMeasuresIcon from "../../assets/bar/bucket-title-measures.svg";
 import * as barViewIcon from "../../assets/bar/bucket-title-view.svg";
 import * as barStackIcon from "../../assets/bar/bucket-title-stack.svg";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
 
 function setBaseChartBucketWarningMessages(
     referencePoint: IExtendedReferencePoint,

--- a/libs/sdk-ui/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
+++ b/libs/sdk-ui/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
@@ -4,7 +4,7 @@ import set = require("lodash/set");
 import get = require("lodash/get");
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "../../../base/";
+import { BucketNames, ChartType, VisualizationTypes } from "../../../base/";
 import { IBucketOfFun, IExtendedReferencePoint, IUiConfig } from "../../interfaces/Visualization";
 import { BUCKETS } from "../../constants/bucket";
 import { getTranslation } from "../translations";
@@ -27,7 +27,6 @@ import {
     PROPERTY_CONTROLS_SECONDARY_CHART_TYPE,
 } from "../../constants/properties";
 import { UICONFIG } from "../../constants/uiConfig";
-import { ChartType, VisualizationTypes } from "../../../base/vis/visualizationTypes";
 import { isLineChart } from "../../../highcharts";
 
 const { COLUMN, LINE, AREA } = VisualizationTypes;

--- a/libs/sdk-ui/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelperDeprecated.ts
+++ b/libs/sdk-ui/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelperDeprecated.ts
@@ -3,7 +3,7 @@ import cloneDeep = require("lodash/cloneDeep");
 import set = require("lodash/set");
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "../../../base/";
+import { BucketNames, ChartType } from "../../../base/";
 import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 import { BUCKETS } from "../../constants/bucket";
 import { setBucketTitles } from "../bucketHelper";
@@ -15,7 +15,6 @@ import * as columnMeasureIcon from "../../assets/combo/bucket-title-measures-col
 import * as columnLineIcon from "../../assets/combo/bucket-title-view-column-line.svg";
 
 import { UICONFIG } from "../../constants/uiConfig";
-import { ChartType } from "../../../base/vis/visualizationTypes";
 
 export function setComboChartUiConfigDeprecated(
     referencePoint: IExtendedReferencePoint,

--- a/libs/sdk-ui/src/internal/utils/uiConfigHelpers/headlineUiConfigHelper.ts
+++ b/libs/sdk-ui/src/internal/utils/uiConfigHelpers/headlineUiConfigHelper.ts
@@ -4,7 +4,7 @@ import get = require("lodash/get");
 import set = require("lodash/set");
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "../../../base/";
+import { BucketNames, VisualizationTypes } from "../../../base/";
 import { IBucketOfFun, IUiConfig, IReferencePoint } from "../../interfaces/Visualization";
 import { DEFAULT_HEADLINE_UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
@@ -16,7 +16,6 @@ import { getTranslation } from "./../translations";
 
 import * as headlineMeasuresIcon from "../../assets/headline/bucket-title-measures.svg";
 import * as headlineSecondaryMeasuresIcon from "../../assets/headline/bucket-title-secondary-measures.svg";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
 
 export function getDefaultHeadlineUiConfig(): IUiConfig {
     return cloneDeep(DEFAULT_HEADLINE_UICONFIG);

--- a/libs/sdk-ui/src/internal/utils/uiConfigHelpers/xirrUiConfigHelper.ts
+++ b/libs/sdk-ui/src/internal/utils/uiConfigHelpers/xirrUiConfigHelper.ts
@@ -4,15 +4,12 @@ import get = require("lodash/get");
 import set = require("lodash/set");
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "../../../base/";
+import { BucketNames, VisualizationTypes } from "../../../base/";
 import { IReferencePoint, IUiConfig, ICustomError, IBucketOfFun } from "../../interfaces/Visualization";
 import { DEFAULT_XIRR_UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
-
 import { hasNoMeasures, hasNoAttribute } from "../bucketRules";
-
 import { setBucketTitles, getItemsCount } from "../bucketHelper";
-import { VisualizationTypes } from "../../../base/vis/visualizationTypes";
 
 export const getDefaultXirrUiConfig = (): IUiConfig => cloneDeep(DEFAULT_XIRR_UICONFIG);
 

--- a/libs/sdk-ui/src/internal/utils/visualizationsHelper.ts
+++ b/libs/sdk-ui/src/internal/utils/visualizationsHelper.ts
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import includes = require("lodash/includes");
-import { ChartType, VisualizationTypes } from "../../base/vis/visualizationTypes";
+import { ChartType, VisualizationTypes } from "../../base";
 
 const openAsReportSupportingVisualizations: ChartType[] = [
     VisualizationTypes.COLUMN,

--- a/libs/sdk-ui/src/kpi/Kpi.tsx
+++ b/libs/sdk-ui/src/kpi/Kpi.tsx
@@ -3,16 +3,13 @@ import * as React from "react";
 import { IAnalyticalBackend, DataViewFacade } from "@gooddata/sdk-backend-spi";
 import { IMeasure, IFilter } from "@gooddata/sdk-model";
 import { ISeparators } from "@gooddata/numberjs";
-import { ILoadingProps, LoadingComponent } from "../base/react/LoadingComponent";
-import { IErrorProps } from "../base/react/ErrorComponent";
 import { Executor, IExecutorProps } from "../execution/Executor";
 import { FormattedNumber } from "./FormattedNumber";
 import { KpiError } from "./KpiError";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import { IntlWrapper } from "../base/localization/IntlWrapper";
 import get = require("lodash/get");
 import isNil = require("lodash/isNil");
-import { withContexts } from "../base/react/withContexts";
+import { withContexts, IntlWrapper, ILoadingProps, LoadingComponent, IErrorProps } from "../base";
 //
 // Internals
 //

--- a/libs/sdk-ui/src/kpi/KpiError.tsx
+++ b/libs/sdk-ui/src/kpi/KpiError.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import * as React from "react";
-import { IErrorProps } from "../base/react/ErrorComponent";
+import { IErrorProps } from "../base";
 
 /**
  * TODO: SDK8: add docs

--- a/libs/sdk-ui/src/pivotTable/CorePivotTable.tsx
+++ b/libs/sdk-ui/src/pivotTable/CorePivotTable.tsx
@@ -25,22 +25,28 @@ import * as CustomEvent from "custom-event";
 import * as React from "react";
 
 import "../../styles/css/pivotTable.css";
-import { VisualizationTypes } from "../base/vis/visualizationTypes";
 import { getScrollbarWidth } from "./impl/domUtils";
 import {
+    convertError,
+    ErrorCodes,
+    GoodDataSdkError,
+    IErrorDescriptors,
+    newErrorMapping,
+    VisualizationTypes,
     convertDrillableItemsToPredicates,
     getDrillIntersection,
     isSomeHeaderPredicateMatched,
-} from "../base/vis/drilling";
-import {
     IDrillEvent,
     IDrillEventContextTable,
     IDrillEventIntersectionElement,
-} from "../base/vis/DrillEvents";
-import { IHeaderPredicate } from "../base/headerMatching/HeaderPredicate";
-import { IMappingHeader } from "../base/headerMatching/MappingHeader";
-import { ErrorComponent } from "../base/react/ErrorComponent";
-import { LoadingComponent } from "../base/react/LoadingComponent";
+    IMappingHeader,
+    ErrorComponent,
+    LoadingComponent,
+    IHeaderPredicate,
+    IDrillableItemPushData,
+    IExportFunction,
+    IExtendedExportConfig,
+} from "../base";
 import { getUpdatedColumnTotals } from "./impl/aggregationsMenuHelper";
 import ApiWrapper from "./impl/agGridApiWrapper";
 import {
@@ -86,8 +92,6 @@ import {
 import { getCellClassNames, getMeasureCellFormattedValue, getMeasureCellStyle } from "./impl/tableCell";
 
 import { ICorePivotTableProps, IMenuAggregationClickConfig } from "./types";
-import { convertError, ErrorCodes, GoodDataSdkError, IErrorDescriptors, newErrorMapping } from "../base";
-import { IDrillableItemPushData, IExportFunction, IExtendedExportConfig } from "../base/vis/Events";
 import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import isEqual = require("lodash/isEqual");

--- a/libs/sdk-ui/src/pivotTable/PivotTable.tsx
+++ b/libs/sdk-ui/src/pivotTable/PivotTable.tsx
@@ -15,13 +15,13 @@ import {
 } from "@gooddata/sdk-model";
 import { ICorePivotTableProps, IPivotTableBucketProps, IPivotTableProps } from "./types";
 import omit = require("lodash/omit");
-import { IntlWrapper } from "../base/localization/IntlWrapper";
 import {
     IntlTranslationsProvider,
     ITranslationsComponentProps,
     withContexts,
     Subtract,
     BucketNames,
+    IntlWrapper,
 } from "../base";
 import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
 

--- a/libs/sdk-ui/src/pivotTable/impl/RowLoadingElement.tsx
+++ b/libs/sdk-ui/src/pivotTable/impl/RowLoadingElement.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 import { ICellRendererParams } from "ag-grid-community";
 import * as React from "react";
-import { LoadingComponent } from "../../base/react/LoadingComponent";
+import { LoadingComponent } from "../../base";
 
 /**
  * This component is passed to AG-Grid and will be used to render loading indicator on row-level

--- a/libs/sdk-ui/src/pivotTable/impl/agGridData.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridData.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import { IntlShape } from "react-intl";
 
-import { IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { IMappingHeader } from "../../base";
 import { getIdsFromUri, getSubtotalStyles, getTreeLeaves } from "./agGridUtils";
 import {
     FIELD_SEPARATOR,

--- a/libs/sdk-ui/src/pivotTable/impl/agGridDrilling.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridDrilling.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 
-import { getMappingHeaderUri, IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { getMappingHeaderUri, IMappingHeader } from "../../base";
 import { getIdsFromUri } from "./agGridUtils";
 import { COLUMN_ATTRIBUTE_COLUMN, MEASURE_COLUMN, ROW_ATTRIBUTE_COLUMN } from "./agGridConst";
 import { ColDef } from "ag-grid-community";

--- a/libs/sdk-ui/src/pivotTable/impl/agGridHeaders.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridHeaders.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 
-import { getMappingHeaderName, IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { getMappingHeaderName, IMappingHeader } from "../../base";
 import { getIdsFromUri, getTreeLeaves } from "./agGridUtils";
 import {
     COLUMN_GROUPING_DELIMITER,

--- a/libs/sdk-ui/src/pivotTable/impl/agGridTypes.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridTypes.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
-import { IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { IMappingHeader } from "../../base";
 import { CellEvent, ColDef, GridOptions } from "ag-grid-community";
 import { DataViewFacade } from "@gooddata/sdk-backend-spi";
 import { ITotal, SortDirection } from "@gooddata/sdk-model";

--- a/libs/sdk-ui/src/pivotTable/impl/agGridUtils.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridUtils.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import { ICellRendererParams } from "ag-grid-community";
-import { getMappingHeaderUri, IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { getMappingHeaderUri, IMappingHeader } from "../../base";
 import {
     DOT_PLACEHOLDER,
     FIELD_SEPARATOR,

--- a/libs/sdk-ui/src/pivotTable/impl/tableCell.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/tableCell.ts
@@ -2,7 +2,7 @@
 import * as classNames from "classnames";
 import { colors2Object, ISeparators, numberFormat } from "@gooddata/numberjs";
 
-import { IMappingHeader } from "../../base/headerMatching/MappingHeader";
+import { IMappingHeader } from "../../base";
 
 import {
     isAttributeCell,

--- a/libs/sdk-ui/src/pivotTable/types.ts
+++ b/libs/sdk-ui/src/pivotTable/types.ts
@@ -2,7 +2,7 @@
 import { ISeparators } from "@gooddata/numberjs";
 import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { AttributeOrMeasure, IAttribute, IFilter, ITotal, SortItem, TotalType } from "@gooddata/sdk-model";
-import { IVisualizationCallbacks, IVisualizationProps } from "../base/vis/VisualizationProps";
+import { IVisualizationCallbacks, IVisualizationProps } from "../base";
 import { WrappedComponentProps } from "react-intl";
 
 export interface IMenu {


### PR DESCRIPTION
There were still some files where dependencies were on particular files in the src/base instead of its public API. Found and fixed those.

I thought this was fixed previously but due to invalid rules in dep cruiser, some (100+) slipped through.
