### PR TITLE
RELATED: RAIL-1977 - Rename and refactor InsightWithoutIdentifier

### DIFF
--- a/libs/sdk-backend-bear/src/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-bear/src/catalog/availableItemsFactory.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import {
     IWorkspaceCatalogAvailableItemsFactory,
     IWorkspaceCatalogWithAvailableItemsFactoryOptions,
@@ -9,7 +9,7 @@ import {
     ICatalogGroup,
     ICatalogDateDataset,
     AttributeOrMeasure,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
 } from "@gooddata/sdk-model";
 import { AuthenticatedCallGuard } from "../commonTypes";
 import {
@@ -74,7 +74,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
         return this.withOptions({ items });
     }
 
-    public forInsight(insight: IInsightWithoutIdentifier): IWorkspaceCatalogAvailableItemsFactory {
+    public forInsight(insight: IInsightDefinition): IWorkspaceCatalogAvailableItemsFactory {
         return this.withOptions({ insight });
     }
 
@@ -89,7 +89,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
             (type): type is CompatibleCatalogItemType => type !== "dateDataset",
         );
         const bearTypes = compatibleBearItemTypes.map(convertItemType);
-        const itemsInsight: IInsightWithoutIdentifier = {
+        const itemsInsight: IInsightDefinition = {
             insight: {
                 title: "",
                 filters: [],

--- a/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
@@ -1,7 +1,7 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
 import {
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
     insightBuckets,
     insightVisualizationClassUri,
     IBucket,
@@ -43,7 +43,7 @@ const convertBucket = (bucket: IBucket): GdcVisualizationObject.IBucket => {
 };
 
 const convertInsightContent = (
-    insight: IInsightWithoutIdentifier,
+    insight: IInsightDefinition,
 ): GdcVisualizationObject.IVisualizationObjectContent => {
     const { properties, references } = convertUrisToReferences({
         properties: insightProperties(insight),
@@ -63,9 +63,7 @@ const convertInsightContent = (
     };
 };
 
-export const convertInsight = (
-    insight: IInsightWithoutIdentifier,
-): GdcVisualizationObject.IVisualizationObject => {
+export const convertInsight = (insight: IInsightDefinition): GdcVisualizationObject.IVisualizationObject => {
     return {
         content: convertInsightContent(insight),
         meta: {

--- a/libs/sdk-backend-bear/src/metadata/index.ts
+++ b/libs/sdk-backend-bear/src/metadata/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import flow from "lodash/flow";
 import map from "lodash/fp/map";
 import uniq from "lodash/fp/uniq";
@@ -10,7 +10,7 @@ import {
     IInsight,
     IAttributeDisplayForm,
     IMeasureExpressionToken,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
     insightId,
 } from "@gooddata/sdk-model";
 import { AuthenticatedCallGuard } from "../commonTypes";
@@ -92,7 +92,7 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
         };
     };
 
-    public createInsight = async (insight: IInsightWithoutIdentifier): Promise<IInsight> => {
+    public createInsight = async (insight: IInsightDefinition): Promise<IInsight> => {
         return this.authCall(sdk =>
             sdk.md.saveVisualization(this.workspace, { visualizationObject: convertInsight(insight) }),
         );
@@ -111,7 +111,7 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
         await this.authCall(sdk => sdk.md.deleteVisualization(uri));
     };
 
-    public openInsightAsReport = async (insight: IInsightWithoutIdentifier): Promise<string> => {
+    public openInsightAsReport = async (insight: IInsightDefinition): Promise<string> => {
         const visualizationObject = convertInsight(insight);
         return this.authCall(sdk =>
             sdk.md.openVisualizationAsReport(this.workspace, { visualizationObject }),

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/metadata.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/metadata.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 
 import {
     IInsightQueryOptions,
@@ -12,7 +12,7 @@ import {
     IVisualizationClass,
     IMeasureExpressionToken,
     IAttributeDisplayForm,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
 } from "@gooddata/sdk-model";
 import { RecordingIndex } from "./types";
 import { identifierToRecording } from "./utils";
@@ -54,7 +54,7 @@ export class RecordedMetadata implements IWorkspaceMetadata {
         throw new NotSupported("not supported");
     }
 
-    public createInsight(_: IInsightWithoutIdentifier): Promise<IInsight> {
+    public createInsight(_: IInsightDefinition): Promise<IInsight> {
         throw new NotSupported("not supported");
     }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -23,7 +23,7 @@ import { IDimension } from '@gooddata/sdk-model';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IFilter } from '@gooddata/sdk-model';
 import { IInsight } from '@gooddata/sdk-model';
-import { IInsightWithoutIdentifier } from '@gooddata/sdk-model';
+import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
 import { IMeasureExpressionToken } from '@gooddata/sdk-model';
 import { IVisualizationClass } from '@gooddata/sdk-model';
@@ -476,7 +476,7 @@ export interface IWorkspaceCatalog extends IWorkspaceCatalogMethods {
 // @public
 export interface IWorkspaceCatalogAvailableItemsFactory extends IWorkspaceCatalogFactoryMethods<IWorkspaceCatalogAvailableItemsFactory, IWorkspaceCatalogWithAvailableItemsFactoryOptions> {
     // (undocumented)
-    forInsight(insight: IInsightWithoutIdentifier): IWorkspaceCatalogAvailableItemsFactory;
+    forInsight(insight: IInsightDefinition): IWorkspaceCatalogAvailableItemsFactory;
     // (undocumented)
     forItems(items: AttributeOrMeasure[]): IWorkspaceCatalogAvailableItemsFactory;
     // (undocumented)
@@ -550,7 +550,7 @@ export interface IWorkspaceCatalogWithAvailableItems extends IWorkspaceCatalogMe
 // @public
 export interface IWorkspaceCatalogWithAvailableItemsFactoryOptions extends IWorkspaceCatalogFactoryOptions {
     // (undocumented)
-    insight?: IInsightWithoutIdentifier;
+    insight?: IInsightDefinition;
     // (undocumented)
     items?: AttributeOrMeasure[];
 }
@@ -564,7 +564,7 @@ export interface IWorkspaceDatasetsService {
 // @public
 export interface IWorkspaceMetadata {
     // (undocumented)
-    createInsight(insight: IInsightWithoutIdentifier): Promise<IInsight>;
+    createInsight(insight: IInsightDefinition): Promise<IInsight>;
     // (undocumented)
     deleteInsight(id: string): Promise<void>;
     getAttributeDisplayForm(id: string): Promise<IAttributeDisplayForm>;

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -1,11 +1,11 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 
 import {
     IVisualizationClass,
     IInsight,
     IAttributeDisplayForm,
     IMeasureExpressionToken,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
 } from "@gooddata/sdk-model";
 import { IPagedResource } from "../../common/paging";
 
@@ -19,7 +19,7 @@ export interface IWorkspaceMetadata {
     getVisualizationClasses(): Promise<IVisualizationClass[]>;
     getInsight(id: string): Promise<IInsight>;
     getInsights(options?: IInsightQueryOptions): Promise<IInsightQueryResult>;
-    createInsight(insight: IInsightWithoutIdentifier): Promise<IInsight>;
+    createInsight(insight: IInsightDefinition): Promise<IInsight>;
     updateInsight(insight: IInsight): Promise<IInsight>;
     deleteInsight(id: string): Promise<void>;
     /**

--- a/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import {
     CatalogItemType,
     CatalogItem,
@@ -8,7 +8,7 @@ import {
     ICatalogFact,
     AttributeOrMeasure,
     ICatalogDateDataset,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
 } from "@gooddata/sdk-model";
 
 /**
@@ -30,7 +30,7 @@ export interface IWorkspaceCatalogFactoryOptions {
  */
 export interface IWorkspaceCatalogWithAvailableItemsFactoryOptions extends IWorkspaceCatalogFactoryOptions {
     items?: AttributeOrMeasure[];
-    insight?: IInsightWithoutIdentifier;
+    insight?: IInsightDefinition;
 }
 
 /**
@@ -54,7 +54,7 @@ export interface IWorkspaceCatalogAvailableItemsFactory
         IWorkspaceCatalogWithAvailableItemsFactoryOptions
     > {
     forItems(items: AttributeOrMeasure[]): IWorkspaceCatalogAvailableItemsFactory;
-    forInsight(insight: IInsightWithoutIdentifier): IWorkspaceCatalogAvailableItemsFactory;
+    forInsight(insight: IInsightDefinition): IWorkspaceCatalogAvailableItemsFactory;
     load(): Promise<IWorkspaceCatalogWithAvailableItems>;
 }
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -545,11 +545,16 @@ export interface IGroupableCatalogItemBase extends ICatalogItemBase {
 }
 
 // @public
-export interface IInsight {
-    // (undocumented)
+export type IInsight = IInsightDefinition & {
     insight: {
         identifier: string;
         uri?: string;
+    };
+};
+
+// @public
+export type IInsightDefinition = {
+    insight: {
         title: string;
         visualizationClassUri: string;
         buckets: IBucket[];
@@ -557,11 +562,6 @@ export interface IInsight {
         sorts: SortItem[];
         properties: VisualizationProperties;
     };
-}
-
-// @public
-export type IInsightWithoutIdentifier = {
-    insight: Omit<IInsight["insight"], "identifier">;
 };
 
 // @public
@@ -642,34 +642,34 @@ export interface INegativeAttributeFilter {
 }
 
 // @public
-export function insightAttributes(insight: IInsightWithoutIdentifier): IAttribute[];
+export function insightAttributes(insight: IInsightDefinition): IAttribute[];
 
 // @public
-export function insightBucket(insight: IInsightWithoutIdentifier, idOrFun?: string | BucketPredicate): IBucket | undefined;
+export function insightBucket(insight: IInsightDefinition, idOrFun?: string | BucketPredicate): IBucket | undefined;
 
 // @public
-export function insightBuckets(insight: IInsightWithoutIdentifier, ...ids: string[]): IBucket[];
+export function insightBuckets(insight: IInsightDefinition, ...ids: string[]): IBucket[];
 
 // @public
-export function insightFilters(insight: IInsightWithoutIdentifier): IFilter[];
+export function insightFilters(insight: IInsightDefinition): IFilter[];
 
 // @public
-export function insightHasAttributes(insight: IInsightWithoutIdentifier): boolean;
+export function insightHasAttributes(insight: IInsightDefinition): boolean;
 
 // @public
-export function insightHasDataDefined(insight: IInsightWithoutIdentifier): boolean;
+export function insightHasDataDefined(insight: IInsightDefinition): boolean;
 
 // @public
-export function insightHasMeasures(insight: IInsightWithoutIdentifier): boolean;
+export function insightHasMeasures(insight: IInsightDefinition): boolean;
 
 // @public
 export function insightId(insight: IInsight): string;
 
 // @public
-export function insightMeasures(insight: IInsightWithoutIdentifier): IMeasure[];
+export function insightMeasures(insight: IInsightDefinition): IMeasure[];
 
 // @public
-export function insightProperties(insight: IInsightWithoutIdentifier): VisualizationProperties;
+export function insightProperties(insight: IInsightDefinition): VisualizationProperties;
 
 // @public
 export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
@@ -678,16 +678,16 @@ export function insightSetProperties(insight: IInsight, properties?: Visualizati
 export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
 
 // @public
-export function insightSorts(insight: IInsightWithoutIdentifier): SortItem[];
+export function insightSorts(insight: IInsightDefinition): SortItem[];
 
 // @public
-export function insightTitle(insight: IInsightWithoutIdentifier): string;
+export function insightTitle(insight: IInsightDefinition): string;
 
 // @public
-export function insightTotals(insight: IInsightWithoutIdentifier): ITotal[];
+export function insightTotals(insight: IInsightDefinition): ITotal[];
 
 // @public
-export function insightVisualizationClassUri(insight: IInsightWithoutIdentifier): string;
+export function insightVisualizationClassUri(insight: IInsightDefinition): string;
 
 // @public (undocumented)
 export interface IObjectExpressionToken {

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 
 export {
     IAttribute,
@@ -242,7 +242,7 @@ export {
 
 export {
     IInsight,
-    IInsightWithoutIdentifier,
+    IInsightDefinition,
     IVisualizationClass,
     VisualizationProperties,
     IColorMappingItem,

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import isEmpty = require("lodash/isEmpty");
 import intersection = require("lodash/intersection");
 import { SortEntityIds, sortEntityIds, SortItem } from "../execution/base/sort";
@@ -26,7 +26,7 @@ import { IColor } from "../colors";
  *
  * @public
  */
-export interface IInsight {
+export type IInsight = IInsightDefinition & {
     insight: {
         /**
          * Unique identifier of the Insight
@@ -37,7 +37,16 @@ export interface IInsight {
          * Link to the insight.
          */
         uri?: string;
+    };
+};
 
+/**
+ * Insight definition specifies what and how should be visualized by an insight.
+ *
+ * @public
+ */
+export type IInsightDefinition = {
+    insight: {
         /**
          * User-assigned title of this insight
          */
@@ -75,16 +84,6 @@ export interface IInsight {
          */
         properties: VisualizationProperties;
     };
-}
-
-/**
- * Represents an Insight without identifier. This is useful when working with Insight that do not have any identifier yet
- * (i.e. they have not been saved to the platform yet).
- *
- * @public
- */
-export type IInsightWithoutIdentifier = {
-    insight: Omit<IInsight["insight"], "identifier">;
 };
 
 /**
@@ -196,7 +195,7 @@ export function isInsight(obj: any): obj is IInsight {
  * @public
  */
 export function insightBucket(
-    insight: IInsightWithoutIdentifier,
+    insight: IInsightDefinition,
     idOrFun: string | BucketPredicate = anyBucket,
 ): IBucket | undefined {
     invariant(insight, "insight must be specified");
@@ -212,7 +211,7 @@ export function insightBucket(
  * @returns empty list if none match
  * @public
  */
-export function insightBuckets(insight: IInsightWithoutIdentifier, ...ids: string[]): IBucket[] {
+export function insightBuckets(insight: IInsightDefinition, ...ids: string[]): IBucket[] {
     invariant(insight, "insight must be specified");
 
     if (isEmpty(ids)) {
@@ -229,7 +228,7 @@ export function insightBuckets(insight: IInsightWithoutIdentifier, ...ids: strin
  * @returns empty if one
  * @public
  */
-export function insightMeasures(insight: IInsightWithoutIdentifier): IMeasure[] {
+export function insightMeasures(insight: IInsightDefinition): IMeasure[] {
     invariant(insight, "insight must be specified");
 
     return bucketsMeasures(insight.insight.buckets);
@@ -242,7 +241,7 @@ export function insightMeasures(insight: IInsightWithoutIdentifier): IMeasure[] 
  * @returns true if any measures, false if not
  * @public
  */
-export function insightHasMeasures(insight: IInsightWithoutIdentifier): boolean {
+export function insightHasMeasures(insight: IInsightDefinition): boolean {
     invariant(insight, "insight must be specified");
 
     return insightMeasures(insight).length > 0;
@@ -255,7 +254,7 @@ export function insightHasMeasures(insight: IInsightWithoutIdentifier): boolean 
  * @returns empty if none
  * @public
  */
-export function insightAttributes(insight: IInsightWithoutIdentifier): IAttribute[] {
+export function insightAttributes(insight: IInsightDefinition): IAttribute[] {
     invariant(insight, "insight must be specified");
 
     return bucketsAttributes(insight.insight.buckets);
@@ -268,7 +267,7 @@ export function insightAttributes(insight: IInsightWithoutIdentifier): IAttribut
  * @returns true if any measures, false if not
  * @public
  */
-export function insightHasAttributes(insight: IInsightWithoutIdentifier): boolean {
+export function insightHasAttributes(insight: IInsightDefinition): boolean {
     invariant(insight, "insight must be specified");
 
     return insightAttributes(insight).length > 0;
@@ -282,7 +281,7 @@ export function insightHasAttributes(insight: IInsightWithoutIdentifier): boolea
  * @returns true if at least one measure or attribute, false if none
  * @public
  */
-export function insightHasDataDefined(insight: IInsightWithoutIdentifier): boolean {
+export function insightHasDataDefined(insight: IInsightDefinition): boolean {
     invariant(insight, "insight must be specified");
 
     return (
@@ -296,7 +295,7 @@ export function insightHasDataDefined(insight: IInsightWithoutIdentifier): boole
  * @param insight - insight to work with
  * @public
  */
-export function insightFilters(insight: IInsightWithoutIdentifier): IFilter[] {
+export function insightFilters(insight: IInsightDefinition): IFilter[] {
     invariant(insight, "insight must be specified");
 
     return insight.insight.filters;
@@ -312,7 +311,7 @@ export function insightFilters(insight: IInsightWithoutIdentifier): IFilter[] {
  * @returns array of valid sorts
  * @public
  */
-export function insightSorts(insight: IInsightWithoutIdentifier): SortItem[] {
+export function insightSorts(insight: IInsightDefinition): SortItem[] {
     invariant(insight, "insight must be specified");
 
     const attributeIds = insightAttributes(insight).map(attributeLocalId);
@@ -339,7 +338,7 @@ export function insightSorts(insight: IInsightWithoutIdentifier): SortItem[] {
  * @returns empty if none
  * @public
  */
-export function insightTotals(insight: IInsightWithoutIdentifier): ITotal[] {
+export function insightTotals(insight: IInsightDefinition): ITotal[] {
     invariant(insight, "insight must be specified");
 
     return bucketsTotals(insight.insight.buckets);
@@ -352,7 +351,7 @@ export function insightTotals(insight: IInsightWithoutIdentifier): ITotal[] {
  * @returns empty object is no properties
  * @public
  */
-export function insightProperties(insight: IInsightWithoutIdentifier): VisualizationProperties {
+export function insightProperties(insight: IInsightDefinition): VisualizationProperties {
     invariant(insight, "insight must be specified");
 
     return insight.insight.properties;
@@ -364,7 +363,7 @@ export function insightProperties(insight: IInsightWithoutIdentifier): Visualiza
  * @param insight - insight to get vis class URI for
  * @public
  */
-export function insightVisualizationClassUri(insight: IInsightWithoutIdentifier): string {
+export function insightVisualizationClassUri(insight: IInsightDefinition): string {
     invariant(insight, "insight to get vis class URI from must be defined");
 
     return insight.insight.visualizationClassUri;
@@ -377,7 +376,7 @@ export function insightVisualizationClassUri(insight: IInsightWithoutIdentifier)
  * @returns the insight title
  * @public
  */
-export function insightTitle(insight: IInsightWithoutIdentifier): string {
+export function insightTitle(insight: IInsightDefinition): string {
     invariant(insight, "insight to get title from must be defined");
 
     return insight.insight.title;
@@ -407,9 +406,9 @@ export function insightId(insight: IInsight): string {
  */
 export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
 export function insightSetProperties(
-    insight: IInsightWithoutIdentifier,
+    insight: IInsightDefinition,
     properties: VisualizationProperties = {},
-): IInsightWithoutIdentifier {
+): IInsightDefinition {
     invariant(insight, "insight must be specified");
 
     return {
@@ -430,10 +429,7 @@ export function insightSetProperties(
  * @public
  */
 export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
-export function insightSetSorts(
-    insight: IInsightWithoutIdentifier,
-    sorts: SortItem[] = [],
-): IInsightWithoutIdentifier {
+export function insightSetSorts(insight: IInsightDefinition, sorts: SortItem[] = []): IInsightDefinition {
     invariant(insight, "insight must be specified");
 
     return {


### PR DESCRIPTION
-  Minor rename/move/split refactor
-  InsightWithoutIdentifier is now called InsightDefinition
-  This contains everything that defines what and how to visualize
-  The IInsight then adds persistence related identifiers on top of that
