### PR TITLE
RELATED: RAIL-1896 Fix query string array serialization format

### DIFF
--- a/common/changes/@gooddata/gd-bear-client/dho-rail-1896-query-string-serialization_2020-01-08-14-37.json
+++ b/common/changes/@gooddata/gd-bear-client/dho-rail-1896-query-string-serialization_2020-01-08-14-37.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/gd-bear-client",
+            "comment": "fix querystring serialization array format",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/gd-bear-client",
+    "email": "dan.homola@gooddata.com"
+}

--- a/libs/gd-bear-client/src/execution/execute-afm.ts
+++ b/libs/gd-bear-client/src/execution/execute-afm.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import invariant from "invariant";
 import qs from "qs";
 import range from "lodash/range";
@@ -7,6 +7,7 @@ import { GdcExecution, GdcExecuteAFM } from "@gooddata/gd-bear-model";
 
 import { XhrModule } from "../xhr";
 import { convertExecutionToJson } from "./execute-afm.convert";
+import { stringify } from "../utils/queryString";
 
 export const DEFAULT_LIMIT = 1000;
 
@@ -279,7 +280,7 @@ export function replaceLimitAndOffsetInUri(oldUri: string, limit: number[], offs
         offset: offset.join(","),
     };
 
-    return uriPart + qs.stringify(query, { addQueryPrefix: true });
+    return uriPart + stringify(query, { addQueryPrefix: true });
 }
 
 export function getNextOffset(limit: number[], offset: number[], total: number[]): number[] {

--- a/libs/gd-bear-client/src/metadata.ts
+++ b/libs/gd-bear-client/src/metadata.ts
@@ -1,11 +1,10 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
 import get from "lodash/get";
 import chunk from "lodash/chunk";
 import flatten from "lodash/flatten";
 import pick from "lodash/pick";
 import pickBy from "lodash/pickBy";
-import qs from "qs";
 import { GdcExecuteAFM, GdcVisualizationObject, GdcMetadata } from "@gooddata/gd-bear-model";
 import { getIn, handlePolling, queryString } from "./util";
 import { ApiResponse, ApiResponseError, XhrModule } from "./xhr";
@@ -15,6 +14,7 @@ import {
     SortDirection,
     IGetObjectsByQueryWithPagingResponse,
 } from "./interfaces";
+import { stringify } from "./utils/queryString";
 
 export interface IValidElementsOptions {
     limit?: number;
@@ -220,7 +220,7 @@ export class MetadataModule {
         options: IGetObjectsByQueryOptions,
     ): Promise<IGetObjectsByQueryWithPagingResponse<T>> {
         const getTotalCount = options && options.getTotalCount ? 1 : 0;
-        const uri = `/gdc/md/${projectId}/objects/query?${qs.stringify({ ...options, getTotalCount })}`;
+        const uri = `/gdc/md/${projectId}/objects/query?${stringify({ ...options, getTotalCount })}`;
         return this.xhr
             .get(uri)
             .then((r: ApiResponse) => r.getData())

--- a/libs/gd-bear-client/src/project.ts
+++ b/libs/gd-bear-client/src/project.ts
@@ -1,10 +1,10 @@
-// (C) 2007-2019 GoodData Corporation
-import qs from "qs";
+// (C) 2007-2020 GoodData Corporation
 import { getIn, handlePolling, getAllPagesByOffsetLimit } from "./util";
 import { ITimezone, IColor, IColorPalette, IFeatureFlags } from "./interfaces";
 import { IStyleSettingsResponse, IFeatureFlagsResponse } from "./apiResponsesInterfaces";
 import { XhrModule, ApiResponse } from "./xhr";
 import { GdcProject } from "@gooddata/gd-bear-model";
+import { stringify } from "./utils/queryString";
 
 const DEFAULT_PALETTE = [
     { r: 0x2b, g: 0x6b, b: 0xae },
@@ -129,7 +129,7 @@ export class ProjectModule {
             projectStates: "ENABLED",
             userState: "ENABLED",
         };
-        const uri = `/gdc/internal/projects/?${qs.stringify(mergedOptions)}`;
+        const uri = `/gdc/internal/projects/?${stringify(mergedOptions)}`;
         return this.xhr.get(uri).then(res => res.getData());
     }
 

--- a/libs/gd-bear-client/src/utils/queryString.ts
+++ b/libs/gd-bear-client/src/utils/queryString.ts
@@ -1,0 +1,10 @@
+// (C) 2020 GoodData Corporation
+import qs from "qs";
+
+/**
+ * Stringifies an object to query string. Makes sure arrays are serialized as comma separated, otherwise bear backend does not understand it.
+ * @param obj - object to stringify
+ * @param options - additional qs.stringify options
+ */
+export const stringify = (obj: any, options?: qs.IStringifyOptions): string =>
+    qs.stringify(obj, { ...options, arrayFormat: "comma" });

--- a/libs/gd-bear-client/src/xhr.ts
+++ b/libs/gd-bear-client/src/xhr.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import set from "lodash/set";
@@ -6,7 +6,7 @@ import defaults from "lodash/defaults";
 import merge from "lodash/merge";
 import result from "lodash/result";
 import { name as pkgName, version as pkgVersion } from "../package.json";
-import * as qs from "qs";
+import { stringify } from "./utils/queryString";
 
 /**
  * Ajax wrapper around GDC authentication mechanisms, SST and TT token handling and polling.
@@ -230,7 +230,7 @@ export class XhrModule {
         const { data, ...restSettings } = settings;
         let urlWithParams = url;
         if (data) {
-            urlWithParams = `${url}?${qs.stringify(data)}`;
+            urlWithParams = `${url}?${stringify(data)}`;
         }
         return this.ajax<T>(urlWithParams, merge({ method: "GET" }, restSettings)).then(response =>
             response.getData(),


### PR DESCRIPTION
Bear backend does not understand the qs's default
array format (x[0]=y&x[1]=z).
We need to use comma separated format (x=y&x=z).

JIRA: RAIL-1896

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).
