### PR TITLE
BUGFIX: 	RAIL-1896 - Fix ag-grid integration in PivotTable

### DIFF
--- a/libs/sdk-ui/src/pivotTable/impl/ColumnGroupHeader.tsx
+++ b/libs/sdk-ui/src/pivotTable/impl/ColumnGroupHeader.tsx
@@ -10,7 +10,7 @@ import { IMenu, IMenuAggregationClickConfig } from "../types";
 import HeaderCell, { ALIGN_LEFT } from "./HeaderCell";
 
 export interface IProps extends IHeaderGroupParams {
-    menu?: IMenu;
+    menu?: () => IMenu;
     getColumnTotals: () => ITotal[];
     getDataView: () => DataViewFacade;
     onMenuAggregationClick: (config: IMenuAggregationClickConfig) => void;
@@ -37,7 +37,7 @@ export default class ColumnGroupHeader extends React.Component<IProps> {
                 enableSorting={false}
                 menuPosition={ALIGN_LEFT}
                 textAlign={ALIGN_LEFT}
-                menu={showMenu ? menu : null}
+                menu={showMenu ? menu() : null}
                 onMenuAggregationClick={this.props.onMenuAggregationClick}
                 colId={columnGroupDef.field}
                 getColumnTotals={this.props.getColumnTotals}

--- a/libs/sdk-ui/src/pivotTable/impl/ColumnHeader.tsx
+++ b/libs/sdk-ui/src/pivotTable/impl/ColumnHeader.tsx
@@ -11,7 +11,7 @@ import HeaderCell, { ALIGN_LEFT, ALIGN_RIGHT } from "./HeaderCell";
 import { ITotal, SortDirection } from "@gooddata/sdk-model";
 
 export interface IColumnHeaderProps extends IHeaderParams {
-    menu?: IMenu;
+    menu?: () => IMenu;
     getColumnTotals?: () => ITotal[];
     getDataView?: () => DataViewFacade;
     onMenuAggregationClick?: (config: IMenuAggregationClickConfig) => void;
@@ -72,7 +72,7 @@ class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHeaderStat
                 defaultSortDirection={this.getDefaultSortDirection()}
                 onSortClick={this.onSortRequested}
                 onMenuAggregationClick={this.props.onMenuAggregationClick}
-                menu={menu}
+                menu={menu()}
                 colId={column.getColDef().field}
                 getColumnTotals={this.props.getColumnTotals}
                 getDataView={this.props.getDataView}

--- a/libs/sdk-ui/src/pivotTable/impl/agGridUtils.ts
+++ b/libs/sdk-ui/src/pivotTable/impl/agGridUtils.ts
@@ -1,4 +1,6 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
+import { IExecutionResult, isMeasureGroupDescriptor, isTotalDescriptor } from "@gooddata/sdk-backend-spi";
+import { IDimension } from "@gooddata/sdk-model";
 import { ICellRendererParams } from "ag-grid-community";
 import { getMappingHeaderUri, IMappingHeader } from "../../base";
 import {
@@ -11,8 +13,6 @@ import {
     ROW_TOTAL,
 } from "./agGridConst";
 import { IGridHeader } from "./agGridTypes";
-import { IExecutionResult, isTotalDescriptor, isMeasureGroupDescriptor } from "@gooddata/sdk-backend-spi";
-import { IDimension, defFingerprint, IExecutionDefinition } from "@gooddata/sdk-model";
 import escape = require("lodash/escape");
 
 /*
@@ -164,8 +164,4 @@ export function getSubtotalStyles(dimension: IDimension): string[] {
 
     // Grand total (first) has no styles
     return [null, ...subtotalStyles];
-}
-
-export function generateAgGridComponentKey(def: IExecutionDefinition, rendererId: number): string {
-    return `agGridKey-${defFingerprint(def)}-${rendererId}`;
 }

--- a/libs/sdk-ui/src/pivotTable/impl/tests/ColumnHeader.test.tsx
+++ b/libs/sdk-ui/src/pivotTable/impl/tests/ColumnHeader.test.tsx
@@ -26,6 +26,7 @@ const getColumnHeader = (props = {}, { type = "MEASURE_COLUMN", colGroupId = "a_
         reactContainer: null,
         showColumnMenu: jest.fn(),
         setSort: jest.fn(),
+        menu: jest.fn(),
         ...props,
     };
 


### PR DESCRIPTION
-  We were not using AgGridReact correctly;
-  We were forcing refresh of headers using complete re-render of ag-grid, by
   changing the key of the AgGridReact component
-  After the pivot table changes & refactor last year, for some reason this started producing react render errors (https://reactjs.org/docs/error-decoder.html/?invariant=170)
-  The exact root cause is not 100% clear BUT it is certain that it was being triggered
   by the change of key
-  This key funny stuff was in place to force re-render of the table headers after menu is added or removed from our PivotTable props
-  There is a cleaner, ag-grid native way to do this: use gridApi.refreshHeaders()
-  The prereq for this to work is making sure that our ColumGroupHeader and ColumnHeader renderers
   can always obtain the latest version of the menu settings from the props
-  To achieve this, menu config is obtained indirectly using a function passed to the renderers
   at the time gridOptions are created
-  This goes in line with how the actual menus and submenus obtain total values
