### PR TITLE
RELATED: RAIL-1896 avoid null access in mergeColorMappingToProperties

### DIFF
--- a/libs/sdk-ui/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -329,7 +329,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 
     protected handleConfirmedColorMapping(data: any) {
-        const pushData: any = get(this.callbacks, "pushData", noop);
+        const { pushData = noop } = this.callbacks;
         const resultingData = data;
         this.colors = data.colors;
 
@@ -365,7 +365,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 
     protected handlePushData = (data: any) => {
-        const pushData = get(this.callbacks, "pushData", noop) as any;
+        const { pushData = noop } = this.callbacks;
 
         const resultingData = data;
         if (data.colors) {

--- a/libs/sdk-ui/src/internal/utils/colors.ts
+++ b/libs/sdk-ui/src/internal/utils/colors.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import get = require("lodash/get");
 import set = require("lodash/set");
 import isEqual = require("lodash/isEqual");
@@ -72,7 +72,7 @@ function mergeColorMappingToProperties(properties: IVisualizationProperties, id:
         },
     ];
 
-    const previousColorMapping = get(properties, "controls.colorMapping", []);
+    const previousColorMapping = get(properties, ["controls", "colorMapping"]) || [];
 
     const mergedMapping = compact(uniqBy([...colorMapping, ...previousColorMapping], "id"));
     const newProperties = cloneDeep(properties);


### PR DESCRIPTION
lodash.get(x, "path", []) returns null if x.path === null,
not [] as it would seem.
This led to unexpected null value in mergeColorMappingToProperties.

Also, access to getData in PlugabbleBaseChart was reimplemented
without lodash.get to retain type information.

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
