### PR TITLE
RELATED: RAIL-1896 fix PivotTable intl

### DIFF
--- a/libs/sdk-ui-tests/tests/api-regression/pivotTable/pivotTable.test.tsx
+++ b/libs/sdk-ui-tests/tests/api-regression/pivotTable/pivotTable.test.tsx
@@ -9,7 +9,7 @@ import { ReactWrapper } from "enzyme";
 import flatMap = require("lodash/flatMap");
 
 function tablePropsExtractor(wrapper: ReactWrapper): any {
-    const child = wrapper.find("CorePivotTable");
+    const child = wrapper.find("CorePivotTablePure");
 
     return child.props();
 }

--- a/libs/sdk-ui/src/pivotTable/CorePivotTable.tsx
+++ b/libs/sdk-ui/src/pivotTable/CorePivotTable.tsx
@@ -23,6 +23,7 @@ import { AgGridReact } from "ag-grid-react";
 import * as classNames from "classnames";
 import * as CustomEvent from "custom-event";
 import * as React from "react";
+import { injectIntl } from "react-intl";
 
 import "../../styles/css/pivotTable.css";
 import {
@@ -46,6 +47,7 @@ import {
     newErrorMapping,
     VisualizationTypes,
     ILoadingState,
+    IntlWrapper,
 } from "../base";
 import { getUpdatedColumnTotals } from "./impl/aggregationsMenuHelper";
 import ApiWrapper from "./impl/agGridApiWrapper";
@@ -117,7 +119,7 @@ export const WATCHING_TABLE_RENDERED_MAX_TIME = 15000;
  *
  * @internal
  */
-export class CorePivotTable extends React.Component<ICorePivotTableProps, ICorePivotTableState> {
+export class CorePivotTablePure extends React.Component<ICorePivotTableProps, ICorePivotTableState> {
     public static defaultProps: Partial<ICorePivotTableProps> = {
         locale: "en-US",
         drillableItems: [],
@@ -998,3 +1000,11 @@ export class CorePivotTable extends React.Component<ICorePivotTableProps, ICoreP
         return target.classList.contains("ag-header-cell-resize");
     }
 }
+
+const CorePivotTableWithIntl = injectIntl(CorePivotTablePure);
+
+export const CorePivotTable: React.FC<ICorePivotTableProps> = props => (
+    <IntlWrapper locale={props.locale}>
+        <CorePivotTableWithIntl {...props} />
+    </IntlWrapper>
+);

--- a/libs/sdk-ui/src/pivotTable/PivotTable.tsx
+++ b/libs/sdk-ui/src/pivotTable/PivotTable.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2018 GoodData Corporation
 import * as React from "react";
-import { CorePivotTable } from "./CorePivotTable";
+import { CorePivotTablePure } from "./CorePivotTable";
 import {
     attributeLocalId,
     bucketAttributes,
@@ -103,7 +103,7 @@ class RenderPivotTable extends React.Component<IPivotTableProps> {
                 <IntlTranslationsProvider>
                     {(translationProps: ITranslationsComponentProps) => {
                         return (
-                            <CorePivotTable
+                            <CorePivotTablePure
                                 {...corePivotProps}
                                 intl={translationProps.intl}
                                 execution={execution}

--- a/libs/sdk-ui/src/pivotTable/tests/CorePivotTable.test.tsx
+++ b/libs/sdk-ui/src/pivotTable/tests/CorePivotTable.test.tsx
@@ -5,7 +5,7 @@ import { createIntlMock } from "../../base/localization/intlUtils";
 import noop = require("lodash/noop");
 
 import {
-    CorePivotTable,
+    CorePivotTablePure,
     WATCHING_TABLE_RENDERED_INTERVAL,
     WATCHING_TABLE_RENDERED_MAX_TIME,
 } from "../CorePivotTable";
@@ -28,12 +28,12 @@ describe("CorePivotTable", () => {
         customProps: Partial<ICorePivotTableProps> = {},
         execution: IPreparedExecution = singleMeasureExec,
     ) {
-        return mount(<CorePivotTable execution={execution} intl={intl} {...customProps} />);
+        return mount(<CorePivotTablePure execution={execution} intl={intl} {...customProps} />);
     }
 
     function getTableInstance(customProps: Partial<ICorePivotTableProps> = {}) {
         const wrapper = renderComponent(customProps);
-        const table = wrapper.find(CorePivotTable);
+        const table = wrapper.find(CorePivotTablePure);
         return table.instance() as any;
     }
 


### PR DESCRIPTION
We have to explicitly use the base IntlWrapper.
It is done implicitly for other vis types by the LoadingHOC.

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
