### PR TITLE
RELATED: RAIL-1896 Only use row attributes for default table sorting

### DIFF
--- a/libs/sdk-ui/src/internal/mocks/testMocks.ts
+++ b/libs/sdk-ui/src/internal/mocks/testMocks.ts
@@ -522,6 +522,104 @@ export const insightWithSingleAttribute: IInsight = {
     },
 };
 
+export const insightWithNoMeasureAndOneAttribute: IInsight = {
+    insight: {
+        visualizationUrl: "table",
+        buckets: [
+            {
+                localIdentifier: BucketNames.ATTRIBUTE,
+                items: [
+                    {
+                        attribute: {
+                            localIdentifier: "a1",
+                            displayForm: {
+                                uri: "/gdc/md/project/obj/1028",
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
+        filters: [],
+        sorts: [],
+        properties: {},
+        title: "Dummy insight with no measure and one attribute",
+        identifier: "myIdentifier",
+        uri: "/gdc/md/mockproject/obj/123",
+    },
+};
+
+export const insightWithSingleMeasureAndOneAttribute: IInsight = {
+    insight: {
+        visualizationUrl: "table",
+        buckets: [
+            {
+                localIdentifier: BucketNames.MEASURES,
+                items: [
+                    {
+                        measure: {
+                            localIdentifier: "m1",
+                            definition: {
+                                measureDefinition: {
+                                    item: {
+                                        uri: "/gdc/md/project/obj/1279",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                localIdentifier: BucketNames.ATTRIBUTE,
+                items: [
+                    {
+                        attribute: {
+                            localIdentifier: "a1",
+                            displayForm: {
+                                uri: "/gdc/md/project/obj/1028",
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
+        filters: [],
+        sorts: [],
+        properties: {},
+        title: "Dummy insight with single measure and one attribute",
+        identifier: "myIdentifier",
+        uri: "/gdc/md/mockproject/obj/123",
+    },
+};
+
+export const insightWithNoMeasureAndOneColumn: IInsight = {
+    insight: {
+        visualizationUrl: "table",
+        buckets: [
+            {
+                localIdentifier: BucketNames.COLUMNS,
+                items: [
+                    {
+                        attribute: {
+                            localIdentifier: "a1",
+                            displayForm: {
+                                uri: "/gdc/md/project/obj/1028",
+                            },
+                        },
+                    },
+                ],
+            },
+        ],
+        filters: [],
+        sorts: [],
+        properties: {},
+        title: "Dummy insight with no measure and one column",
+        identifier: "myIdentifier",
+        uri: "/gdc/md/mockproject/obj/123",
+    },
+};
+
 //
 // Visualization classes
 //

--- a/libs/sdk-ui/src/internal/utils/sort.ts
+++ b/libs/sdk-ui/src/internal/utils/sort.ts
@@ -12,7 +12,6 @@ import {
     IBucket,
     IInsight,
     IMeasure,
-    insightAttributes,
     insightBucket,
     insightMeasures,
     insightSorts,
@@ -56,10 +55,11 @@ export function getAttributeSortItem(
 }
 
 function getDefaultTableSort(insight: IInsight): SortItem[] {
-    const attributes = insightAttributes(insight);
+    const rowBucket = insightBucket(insight, BucketNames.ATTRIBUTE);
+    const rowAttributes = rowBucket ? bucketAttributes(rowBucket) : [];
 
-    if (attributes.length > 0) {
-        return [newAttributeSort(attributes[0], SORT_DIR_ASC)];
+    if (rowAttributes.length > 0) {
+        return [newAttributeSort(rowAttributes[0], SORT_DIR_ASC)];
     }
 
     const measures = insightMeasures(insight);

--- a/libs/sdk-ui/src/internal/utils/tests/sort.test.ts
+++ b/libs/sdk-ui/src/internal/utils/tests/sort.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import cloneDeep = require("lodash/cloneDeep");
 import { BucketNames } from "../../../base";
 import {
@@ -16,14 +16,15 @@ import { SORT_DIR_ASC, SORT_DIR_DESC } from "../../constants/sort";
 import { ATTRIBUTE, FILTERS, METRIC } from "../../constants/bucket";
 import {
     emptyInsight,
-    insightWithNoMeasureAndTwoViewBy,
     insightWithSingleMeasure,
     insightWithSingleMeasureAndStack,
     insightWithSingleMeasureAndTwoViewBy,
     insightWithSingleMeasureAndViewBy,
     insightWithSingleMeasureAndViewByAndStack,
     insightWithTwoMeasuresAndTwoViewBy,
-    insightWithTwoMeasuresAndViewBy,
+    insightWithSingleMeasureAndOneAttribute,
+    insightWithNoMeasureAndOneAttribute,
+    insightWithNoMeasureAndOneColumn,
 } from "../../mocks/testMocks";
 import {
     IAttributeSortItem,
@@ -74,7 +75,7 @@ Object.freeze(referencePoint);
 describe("createSorts", () => {
     describe("default sorting", () => {
         describe("table", () => {
-            it("should sort by first attribute ASC", () => {
+            it("should sort by first row attribute ASC", () => {
                 const expectedSorts: SortItem[] = [
                     {
                         attributeSortItem: {
@@ -83,10 +84,10 @@ describe("createSorts", () => {
                         },
                     },
                 ];
-                expect(createSorts("table", insightWithNoMeasureAndTwoViewBy)).toEqual(expectedSorts);
+                expect(createSorts("table", insightWithNoMeasureAndOneAttribute)).toEqual(expectedSorts);
             });
 
-            it("should sort by first attribute ASC if there are some measures", () => {
+            it("should sort by first row attribute ASC if there are some measures", () => {
                 const expectedSorts: SortItem[] = [
                     {
                         attributeSortItem: {
@@ -95,10 +96,10 @@ describe("createSorts", () => {
                         },
                     },
                 ];
-                expect(createSorts("table", insightWithTwoMeasuresAndViewBy)).toEqual(expectedSorts);
+                expect(createSorts("table", insightWithSingleMeasureAndOneAttribute)).toEqual(expectedSorts);
             });
 
-            it("should sort by first measure DESC if there are no attributes", () => {
+            it("should sort by first measure DESC if there are no row attributes", () => {
                 const expectedSort: SortItem[] = [
                     {
                         measureSortItem: {
@@ -114,6 +115,11 @@ describe("createSorts", () => {
                     },
                 ];
                 expect(createSorts("table", insightWithSingleMeasure)).toEqual(expectedSort);
+            });
+
+            it("should not sort by column attribute", () => {
+                const expectedSorts: SortItem[] = [];
+                expect(createSorts("table", insightWithNoMeasureAndOneColumn)).toEqual(expectedSorts);
             });
         });
 


### PR DESCRIPTION
Only the row attributes should be considered for
default table sorting, not column ones

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
