### PR TITLE
RELATED: RAIL-2035 - Enable referencing objects by type+id

### DIFF
--- a/libs/sdk-backend-bear/src/fromSdkModel/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/FilterConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
 import {
     IFilter,
@@ -21,6 +21,7 @@ import {
     relativeDateFilterValues,
     absoluteDateFilterValues,
 } from "@gooddata/sdk-model";
+import { toBearRef } from "../utils/ObjRefConverter";
 
 const convertMeasureValueFilter = (
     filter: IMeasureValueFilter,
@@ -44,7 +45,7 @@ const convertRelativeDateFilter = (
 ): GdcVisualizationObject.IRelativeDateFilter => {
     return {
         relativeDateFilter: {
-            dataSet: filterAttributeDisplayForm(filter),
+            dataSet: toBearRef(filterAttributeDisplayForm(filter)),
             ...relativeDateFilterValues(filter),
         },
     };
@@ -55,7 +56,7 @@ const convertAbsoluteDateFilter = (
 ): GdcVisualizationObject.IAbsoluteDateFilter => {
     return {
         absoluteDateFilter: {
-            dataSet: filterAttributeDisplayForm(filter),
+            dataSet: toBearRef(filterAttributeDisplayForm(filter)),
             ...absoluteDateFilterValues(filter),
         },
     };
@@ -67,7 +68,7 @@ const convertNegativeAttributeFilter = (
     const elements = filterAttributeElements(filter);
     return {
         negativeAttributeFilter: {
-            displayForm: filterAttributeDisplayForm(filter),
+            displayForm: toBearRef(filterAttributeDisplayForm(filter)),
             notIn: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
         },
     };
@@ -79,7 +80,7 @@ const convertPositiveAttributeFilter = (
     const elements = filterAttributeElements(filter);
     return {
         positiveAttributeFilter: {
-            displayForm: filterAttributeDisplayForm(filter),
+            displayForm: toBearRef(filterAttributeDisplayForm(filter)),
             in: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
         },
     };

--- a/libs/sdk-backend-bear/src/fromSdkModel/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/MeasureConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
 import {
     IMeasureDefinitionType,
@@ -25,8 +25,19 @@ import {
     IPreviousPeriodMeasureDefinition,
     measurePreviousPeriodDateDataSets,
     measureFilters,
+    IPreviousPeriodDateDataSet,
 } from "@gooddata/sdk-model";
+import { toBearRef } from "../utils/ObjRefConverter";
 import { convertFilter, shouldFilterBeIncluded } from "./FilterConverter";
+
+const convertPreviousPeriodDataSet = (
+    dataSet: IPreviousPeriodDateDataSet,
+): GdcVisualizationObject.IPreviousPeriodDateDataSet => {
+    return {
+        dataSet: toBearRef(dataSet.dataSet),
+        periodsAgo: dataSet.periodsAgo,
+    };
+};
 
 const convertPreviousPeriodMeasureDefinition = (
     measure: IMeasure<IPreviousPeriodMeasureDefinition>,
@@ -34,7 +45,7 @@ const convertPreviousPeriodMeasureDefinition = (
     return {
         previousPeriodMeasure: {
             measureIdentifier: measureMasterIdentifier(measure)!,
-            dateDataSets: measurePreviousPeriodDateDataSets(measure)!,
+            dateDataSets: measurePreviousPeriodDateDataSets(measure)!.map(convertPreviousPeriodDataSet),
         },
     };
 };
@@ -45,7 +56,7 @@ const convertPoPMeasureDefinition = (
     return {
         popMeasureDefinition: {
             measureIdentifier: measureMasterIdentifier(measure)!,
-            popAttribute: measurePopAttribute(measure)!,
+            popAttribute: toBearRef(measurePopAttribute(measure)!),
         },
     };
 };

--- a/libs/sdk-backend-bear/src/toAfm/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/toAfm/FilterConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { GdcExecuteAFM } from "@gooddata/gd-bear-model";
 import {
     filterIsEmpty,
@@ -13,14 +13,28 @@ import {
     isMeasureValueFilter,
     isPositiveAttributeFilter,
 } from "@gooddata/sdk-model";
+import { toBearRef, toScopedBearRef } from "../utils/ObjRefConverter";
 
 function convertAttributeFilter(filter: IAttributeFilter): GdcExecuteAFM.FilterItem | null {
     if (!isPositiveAttributeFilter(filter)) {
         if (filterIsEmpty(filter)) {
             return null;
         }
+
+        return {
+            negativeAttributeFilter: {
+                displayForm: toBearRef(filter.negativeAttributeFilter.displayForm),
+                notIn: filter.negativeAttributeFilter.notIn,
+            },
+        };
     }
-    return filter;
+
+    return {
+        positiveAttributeFilter: {
+            displayForm: toBearRef(filter.positiveAttributeFilter.displayForm),
+            in: filter.positiveAttributeFilter.in,
+        },
+    };
 }
 
 export function convertAbsoluteDateFilter(filter: IAbsoluteDateFilter): GdcExecuteAFM.FilterItem | null {
@@ -32,7 +46,7 @@ export function convertAbsoluteDateFilter(filter: IAbsoluteDateFilter): GdcExecu
 
     return {
         absoluteDateFilter: {
-            dataSet: absoluteDateFilter.dataSet,
+            dataSet: toBearRef(absoluteDateFilter.dataSet),
             from: String(absoluteDateFilter.from),
             to: String(absoluteDateFilter.to),
         },
@@ -48,7 +62,7 @@ export function convertRelativeDateFilter(filter: IRelativeDateFilter): GdcExecu
 
     return {
         relativeDateFilter: {
-            dataSet: relativeDateFilter.dataSet,
+            dataSet: toBearRef(relativeDateFilter.dataSet),
             granularity: relativeDateFilter.granularity,
             from: Number(relativeDateFilter.from),
             to: Number(relativeDateFilter.to),
@@ -63,7 +77,12 @@ export function convertMeasureValueFilter(
         return null;
     }
 
-    return filter;
+    return {
+        measureValueFilter: {
+            measure: toScopedBearRef(filter.measureValueFilter.measure),
+            condition: filter.measureValueFilter.condition,
+        },
+    };
 }
 
 export function convertFilter(filter: IFilter): GdcExecuteAFM.ExtendedFilter | null {

--- a/libs/sdk-backend-bear/src/toAfm/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/toAfm/MeasureConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import {
     IArithmeticMeasureDefinition,
     IMeasure,
@@ -13,6 +13,7 @@ import {
 } from "@gooddata/sdk-model";
 import { GdcExecuteAFM } from "@gooddata/gd-bear-model";
 import { convertMeasureFilter } from "./FilterConverter";
+import { toBearRef } from "../utils/ObjRefConverter";
 import compact = require("lodash/compact");
 import get = require("lodash/get");
 
@@ -69,7 +70,7 @@ function convertSimpleMeasureDefinition(
 
     return {
         measure: {
-            item: measureDefinition.item,
+            item: toBearRef(measureDefinition.item),
             ...filtersProp,
             ...aggregationProp,
             ...computeRatioProp,
@@ -82,7 +83,7 @@ function convertPopMeasureDefinition(definition: IPoPMeasureDefinition): GdcExec
     return {
         popMeasure: {
             measureIdentifier: popMeasureDefinition.measureIdentifier,
-            popAttribute: popMeasureDefinition.popAttribute,
+            popAttribute: toBearRef(popMeasureDefinition.popAttribute),
         },
     };
 }
@@ -95,7 +96,7 @@ function convertPreviousPeriodMeasureDefinition(
         previousPeriodMeasure: {
             measureIdentifier: previousPeriodMeasure.measureIdentifier,
             dateDataSets: previousPeriodMeasure.dateDataSets.map(dateDataSet => ({
-                dataSet: dateDataSet.dataSet,
+                dataSet: toBearRef(dateDataSet.dataSet),
                 periodsAgo: dateDataSet.periodsAgo,
             })),
         },

--- a/libs/sdk-backend-bear/src/toAfm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-bear/src/toAfm/tests/FilterConverter.test.ts
@@ -1,4 +1,4 @@
-// // (C) 2020 GoodData Corporation
+// (C) 2020 GoodData Corporation
 import {
     convertAbsoluteDateFilter,
     convertRelativeDateFilter,

--- a/libs/sdk-backend-bear/src/toAfm/toAfmResultSpec.ts
+++ b/libs/sdk-backend-bear/src/toAfm/toAfmResultSpec.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import compact = require("lodash/compact");
 import isEmpty = require("lodash/isEmpty");
 import { GdcExecuteAFM } from "@gooddata/gd-bear-model";
@@ -15,12 +15,13 @@ import {
     totalIsNative,
     IExecutionDefinition,
 } from "@gooddata/sdk-model";
+import { toBearRef } from "../utils/ObjRefConverter";
 
 function convertAttribute(attribute: IAttribute, idx: number): GdcExecuteAFM.IAttribute {
     const alias = attribute.attribute.alias;
     const aliasProp = alias ? { alias } : {};
     return {
-        displayForm: attribute.attribute.displayForm,
+        displayForm: toBearRef(attribute.attribute.displayForm),
         localIdentifier: attribute.attribute.localIdentifier || `a${idx + 1}`,
         ...aliasProp,
     };

--- a/libs/sdk-backend-bear/src/utils/ObjRefConverter.ts
+++ b/libs/sdk-backend-bear/src/utils/ObjRefConverter.ts
@@ -1,0 +1,33 @@
+// (C) 2007-2020 GoodData Corporation
+
+import { isLocalIdRef, isUriRef, ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
+
+/**
+ * Converts reference into a format acceptable by the bear backend. URI references are left as-is, while
+ * the identifier references have the object type (if any) stripped.
+ *
+ * @param ref - reference
+ * @internal
+ */
+export function toBearRef(ref: ObjRef): ObjRef {
+    if (isUriRef(ref)) {
+        return ref;
+    }
+
+    return { identifier: ref.identifier };
+}
+
+/**
+ * Converts scoped reference into a format acceptable by the bear backend. URI references are left as-is, scoped
+ * references are left as is, while the identifier references have the object type (if any) stripped.
+ *
+ * @param ref - reference
+ * @internal
+ */
+export function toScopedBearRef(ref: ObjRefInScope): ObjRefInScope {
+    if (isLocalIdRef(ref)) {
+        return ref;
+    }
+
+    return toBearRef(ref);
+}

--- a/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
@@ -1,22 +1,37 @@
 // (C) 2007-2020 GoodData Corporation
 
 import { NotSupported } from "@gooddata/sdk-backend-spi";
-import { isUriRef, ObjRef } from "@gooddata/sdk-model";
+import { isUriRef, ObjectType, ObjRef } from "@gooddata/sdk-model";
 import { ExecuteAFM } from "../gd-tiger-model/ExecuteAFM";
 import ObjQualifier = ExecuteAFM.ObjQualifier;
 import ILocalIdentifierQualifier = ExecuteAFM.ILocalIdentifierQualifier;
 
-type ObjectTypes = "fact" | "label" | "dateDataSet";
+type TigerObjectTypes = "metric" | "fact" | "attribute" | "label" | "dataSet";
 
-function toObjQualifier(ref: ObjRef, type: ObjectTypes): ObjQualifier {
+// TODO: get rid of the defaultValue, tiger should explode if ref is not provided correctly
+function toTigerObjectType(value: ObjectType | undefined, defaultValue: TigerObjectTypes): TigerObjectTypes {
+    if (!value) {
+        return defaultValue;
+    }
+
+    if (value === "measure") {
+        return "metric";
+    } else if (value === "displayForm") {
+        return "label";
+    }
+
+    return value;
+}
+
+function toObjQualifier(ref: ObjRef, defaultValue: TigerObjectTypes): ObjQualifier {
     if (isUriRef(ref)) {
-        throw new NotSupported(`Tiger backend does not allow specifying ${type} by URI`);
+        throw new NotSupported(`Tiger backend does not allow referencing objects by URI.`);
     }
 
     return {
         identifier: {
             id: ref.identifier,
-            type,
+            type: toTigerObjectType(ref.type, defaultValue),
         },
     };
 }
@@ -39,7 +54,7 @@ export function toDisplayFormQualifier(ref: ObjRef): ObjQualifier {
  * @internal
  */
 export function toDateDataSetQualifier(ref: ObjRef): ObjQualifier {
-    return toObjQualifier(ref, "dateDataSet");
+    return toObjQualifier(ref, "dataSet");
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": "2019-08-06",
@@ -25,7 +25,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": -11,
@@ -41,7 +41,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": 5,
@@ -59,7 +59,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": -3,
@@ -75,7 +75,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": 25,
@@ -91,7 +91,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": 50,
@@ -107,7 +107,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": 2,
@@ -123,7 +123,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": "2019-08-06",
@@ -176,7 +176,7 @@ Object {
     "dataSet": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dateDataSet",
+        "type": "dataSet",
       },
     },
     "from": 20,

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
@@ -64,7 +64,7 @@ Object {
           "dataSet": Object {
             "identifier": Object {
               "id": "bar",
-              "type": "dateDataSet",
+              "type": "dataSet",
             },
           },
           "periodsAgo": 3,
@@ -263,7 +263,7 @@ Object {
             "dataSet": Object {
               "identifier": Object {
                 "id": "closed",
-                "type": "dateDataSet",
+                "type": "dataSet",
               },
             },
             "from": "2019-08-06",
@@ -275,7 +275,7 @@ Object {
             "dataSet": Object {
               "identifier": Object {
                 "id": "closed",
-                "type": "dateDataSet",
+                "type": "dataSet",
               },
             },
             "from": 5,
@@ -298,4 +298,4 @@ Object {
 
 exports[`measure converter should throw an error when measure definition is not supported 1`] = `"The measure definition is not supported: {}"`;
 
-exports[`measure converter should throw an error when toObjQualifier gets an URI ref 1`] = `"Tiger backend does not allow specifying dateDataSet by URI"`;
+exports[`measure converter should throw an error when toObjQualifier gets an URI ref 1`] = `"Tiger backend does not allow referencing objects by URI."`;

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -502,6 +502,7 @@ export type Identifier = string;
 
 // @public
 export type IdentifierRef = {
+    type?: ObjectType;
     identifier: Identifier;
 };
 
@@ -521,7 +522,7 @@ export const idMatchBucket: (id: string) => BucketPredicate;
 export const idMatchMeasure: (id: string) => MeasurePredicate;
 
 // @public
-export function idRef(identifier: Identifier): IdentifierRef;
+export function idRef(identifier: Identifier, type?: ObjectType): IdentifierRef;
 
 // @public
 export interface IExecutionDefinition {
@@ -1201,14 +1202,19 @@ export function newTotal(type: TotalType, measureOrId: IMeasure | string, attrib
 // @public
 export function newTwoDimensional(dim1Input: DimensionItem[], dim2Input: DimensionItem[]): IDimension[];
 
-// @public
-export function objectRefValue(objRef: ObjRef | ObjRefInScope): string;
+// @public (undocumented)
+export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dataSet";
 
 // @public
 export type ObjRef = UriRef | IdentifierRef;
 
 // @public
 export type ObjRefInScope = ObjRef | LocalIdRef;
+
+// Warning: (ae-internal-missing-underscore) The name "objRefToString" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function objRefToString(objRef: ObjRef | ObjRefInScope): string;
 
 // @public
 export class PoPMeasureBuilder extends MeasureBuilderBase<IPoPMeasureDefinition> {

--- a/libs/sdk-model/src/execution/attribute/factory.ts
+++ b/libs/sdk-model/src/execution/attribute/factory.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import identity = require("lodash/identity");
 import { IAttribute } from "./index";
-import { ObjRef, objectRefValue, Identifier, isObjRef } from "../base";
+import { ObjRef, objRefToString, Identifier, isObjRef } from "../base";
 import { idRef } from "../base/factory";
 
 /**
@@ -20,7 +20,7 @@ export class AttributeBuilder implements IAttribute {
     constructor(displayForm: ObjRef) {
         this.attribute = {
             displayForm,
-            localIdentifier: `a_${objectRefValue(displayForm)}`,
+            localIdentifier: `a_${objRefToString(displayForm)}`,
         };
     }
 

--- a/libs/sdk-model/src/execution/base/factory.ts
+++ b/libs/sdk-model/src/execution/base/factory.ts
@@ -1,13 +1,17 @@
 // (C) 2020 GoodData Corporation
-import { Identifier, Uri, IdentifierRef, UriRef, LocalIdRef } from ".";
+import { Identifier, Uri, IdentifierRef, UriRef, LocalIdRef, ObjectType } from ".";
 
 /**
- * Creates an IdentifierRef from an identifier
+ * Creates an IdentifierRef from object identifier and optionally the object type.
+ *
+ * @remarks see {@link IdentifierRef} for more information about identifier references
+ *
  * @param identifier - identifier to use
+ * @param type - referenced object type
  * @public
  */
-export function idRef(identifier: Identifier): IdentifierRef {
-    return { identifier };
+export function idRef(identifier: Identifier, type?: ObjectType): IdentifierRef {
+    return type ? { identifier, type } : { identifier };
 }
 
 /**

--- a/libs/sdk-model/src/execution/base/tests/objectRef.test.ts
+++ b/libs/sdk-model/src/execution/base/tests/objectRef.test.ts
@@ -1,24 +1,24 @@
 // (C) 2019-2020 GoodData Corporation
-import { objectRefValue, ObjRef, ObjRefInScope, areObjRefsEqual } from "../index";
+import { objRefToString, ObjRef, ObjRefInScope, areObjRefsEqual } from "../index";
 
-describe("objectRefValue", () => {
+describe("objRefToString", () => {
     const Scenarios: Array<[string, ObjRef, string | undefined]> = [
         ["return uri for UriRef", { uri: "/uri" }, "/uri"],
         ["return identifier of IdentifierRef", { identifier: "id" }, "id"],
     ];
 
     it.each(Scenarios)("should %s", (_desc, input, expected) => {
-        expect(objectRefValue(input)).toEqual(expected);
+        expect(objRefToString(input)).toEqual(expected);
     });
 
     it("should throw if input null", () => {
         // @ts-ignore
-        expect(() => objectRefValue(null)).toThrow();
+        expect(() => objRefToString(null)).toThrow();
     });
 
     it("should throw if input undefined", () => {
         // @ts-ignore
-        expect(() => objectRefValue(undefined)).toThrow();
+        expect(() => objRefToString(undefined)).toThrow();
     });
 });
 
@@ -39,10 +39,34 @@ describe("areObjRefsEqual", () => {
             { identifier: "/identifier" },
         ],
         [
+            true,
+            "identifier, identifier, same value",
+            { identifier: "/identifier", type: "attribute" },
+            { identifier: "/identifier", type: "attribute" },
+        ],
+        [
             false,
             "identifier, identifier, different value",
             { identifier: "/identifier1" },
             { identifier: "/identifier2" },
+        ],
+        [
+            false,
+            "identifier, identifier, different value same obj type",
+            { identifier: "/identifier1", type: "attribute" },
+            { identifier: "/identifier2", type: "attribute" },
+        ],
+        [
+            false,
+            "identifier, identifier, different obj types",
+            { identifier: "/identifier1", type: "fact" },
+            { identifier: "/identifier1", type: "attribute" },
+        ],
+        [
+            false,
+            "identifier, identifier, one is missing obj type",
+            { identifier: "/identifier1" },
+            { identifier: "/identifier1", type: "attribute" },
         ],
         [
             true,

--- a/libs/sdk-model/src/execution/filter/filterMerge.ts
+++ b/libs/sdk-model/src/execution/filter/filterMerge.ts
@@ -1,5 +1,5 @@
-// (C) 2019 GoodData Corporation
-import { objectRefValue } from "../base";
+// (C) 2019-2020 GoodData Corporation
+import { objRefToString } from "../base";
 import {
     IAttributeFilter,
     IDateFilter,
@@ -16,21 +16,21 @@ import invariant from "ts-invariant";
 
 function filterObjectRef(filter: IFilter): string {
     if (isMeasureValueFilter(filter)) {
-        return objectRefValue(filter.measureValueFilter.measure);
+        return objRefToString(filter.measureValueFilter.measure);
     }
 
     if (isDateFilter(filter)) {
         if (isAbsoluteDateFilter(filter)) {
-            return objectRefValue(filter.absoluteDateFilter.dataSet);
+            return objRefToString(filter.absoluteDateFilter.dataSet);
         }
-        return objectRefValue(filter.relativeDateFilter.dataSet);
+        return objRefToString(filter.relativeDateFilter.dataSet);
     }
 
     if (isPositiveAttributeFilter(filter)) {
-        return objectRefValue(filter.positiveAttributeFilter.displayForm);
+        return objRefToString(filter.positiveAttributeFilter.displayForm);
     }
 
-    return objectRefValue(filter.negativeAttributeFilter.displayForm);
+    return objRefToString(filter.negativeAttributeFilter.displayForm);
 }
 
 type FilterByType = {
@@ -68,6 +68,11 @@ function separateFiltersByType(filters: IFilter[]): FilterByType {
  *   -  filters from the addedFilters list override filters in the original list
  *
  * TODO: we seem to be missing the original logic that was cleaning up filters if the new filter was ALL_TIME?
+ *
+ * TODO: this logic is not in the right place; filter merging needs to be done by backend implementation
+ *  to be able to correctly identify objects being filtered on - regardless of how they are referenced. this
+ *  function will return bogus if one filter references say display form by URI and the other references
+ *  the same display form by identifier.
  *
  * @param originalFilters - original filters to merge with
  * @param addedFilters - new filters to add on top of original

--- a/libs/sdk-model/src/execution/measure/factory.ts
+++ b/libs/sdk-model/src/execution/measure/factory.ts
@@ -14,7 +14,7 @@ import {
     measureIdentifier,
     measureLocalId,
 } from "./index";
-import { Identifier, ObjRef, isObjRef, objectRefValue } from "../base";
+import { Identifier, ObjRef, isObjRef, objRefToString } from "../base";
 import { IMeasureFilter } from "../filter";
 import { idRef } from "../base/factory";
 
@@ -96,7 +96,7 @@ export class MeasureBuilder extends MeasureBuilderBase<IMeasureDefinition> {
                     item: measureOrRef,
                 },
             };
-            const refValue = objectRefValue(measureOrRef);
+            const refValue = objRefToString(measureOrRef);
             this.measure.localIdentifier = `m_${refValue}`;
             this.measureId = refValue;
         } else {

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -25,6 +25,7 @@ export {
 } from "./ldm/attributeDisplayForm";
 
 export {
+    ObjectType,
     Identifier,
     Uri,
     UriRef,
@@ -34,7 +35,7 @@ export {
     ObjRefInScope,
     isUriRef,
     isIdentifierRef,
-    objectRefValue,
+    objRefToString,
     isLocalIdRef,
     areObjRefsEqual,
     isObjRef,


### PR DESCRIPTION
-  Expanded ObjRef to include optional type
-  Added / expanded docs
-  Bear backend strips the type (if any) from ObjRef (in execute afm & in vis object)
-  Tiger backend keeps the type, it may transform to different value to match nomenclature
-  Tiger backend will fall back to default type if one not provided by caller