### PR TITLE
RELATED: RAIL-1896 do not unwrap attribute in attributeMapping

### DIFF
--- a/libs/gd-bear-client/src/execution/experimental-executions.ts
+++ b/libs/gd-bear-client/src/execution/experimental-executions.ts
@@ -107,11 +107,11 @@ function isDerived(measure: any) {
 }
 
 function getAttrTypeFromMap(dfUri: string, attributesMap: any) {
-    return get(get(attributesMap, [dfUri], {}), ["attribute", "content", "type"]);
+    return get(attributesMap, [dfUri, "attribute", "content", "type"]);
 }
 
 function getAttrUriFromMap(dfUri: string, attributesMap: any) {
-    return get(get(attributesMap, [dfUri], {}), ["attribute", "meta", "uri"]);
+    return get(attributesMap, [dfUri, "attribute", "meta", "uri"]);
 }
 
 function isAttrFilterNegative(attributeFilter: any) {

--- a/libs/sdk-backend-bear/src/catalog/factory.ts
+++ b/libs/sdk-backend-bear/src/catalog/factory.ts
@@ -110,7 +110,7 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
                         ...acc,
                         attributeByUri: {
                             ...acc.attributeByUri,
-                            [el.attribute.meta.uri]: el.attribute,
+                            [el.attribute.meta.uri]: el,
                         },
                     };
                 }

--- a/libs/sdk-backend-bear/src/catalog/types.ts
+++ b/libs/sdk-backend-bear/src/catalog/types.ts
@@ -6,7 +6,7 @@ import { ICatalogMeasure } from "@gooddata/sdk-model";
  * @internal
  */
 export interface IAttributeByKey {
-    [key: string]: GdcMetadata.IAttribute;
+    [key: string]: GdcMetadata.IWrappedAttribute;
 }
 
 /**


### PR DESCRIPTION
There is lots of non-trivial logic and tests depending on
attribute not being unwrapped there (e.g. loading of missing attributes),
so the unwrapping was removed.

Also, a glorious "get" inception was removed.

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
