### PR TITLE
Handle catalog load for types: ["dateDataset"]

### DIFF
--- a/libs/sdk-backend-bear/src/toSdkModel/CatalogConverter.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/CatalogConverter.ts
@@ -17,6 +17,9 @@ import { convertObjectMeta } from "./MetaConverter";
 export type CompatibleCatalogItemType = Exclude<CatalogItemType, "dateDataset">;
 export type CompatibleCatalogItem = Exclude<CatalogItem, ICatalogDateDataset>;
 
+export const isCompatibleCatalogItemType = (type: CatalogItemType): type is CompatibleCatalogItemType =>
+    type !== "dateDataset";
+
 const bearItemTypeByCatalogItemType: {
     [catalogItemType in CompatibleCatalogItemType]: GdcCatalog.CatalogItemType;
 } = {


### PR DESCRIPTION
In case types === ["dateDataset"] the loadItems was called with types: [].
This caused the call to backend to fail.
This change splits the load method a bit to make it manageable
and handles this case by skipping the loadItems call if not needed.

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

[Check PR owner responsibilities](https://confluence.intgdc.com/display/Development/Code-reviews#Code-reviews-Ownerresponsibilities)

TBD

# PR Checklist

-   [ ] Verify code changes ([Checklist](https://confluence.intgdc.com/display/Development/Code-reviews+checklist), [Best practices](https://confluence.intgdc.com/display/Development/Code-reviews+best+practices))
-   [ ] [Verify pull-request formalities](https://confluence.intgdc.com/display/Development/Code-reviews)
-   [ ] Migration guide (for major changes) is mentioned in [CHANGELOG.md](../blob/master/CHANGELOG.md).

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
