### PR TITLE
RELATED: RAIL-1896 add convertInsight function

### DIFF
--- a/libs/sdk-backend-bear/src/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-bear/src/catalog/availableItemsFactory.ts
@@ -17,7 +17,7 @@ import {
     convertDateDataset,
     isCompatibleCatalogItemType,
 } from "../toSdkModel/CatalogConverter";
-import { convertInsight } from "../fromSdkModel/InsightConverter";
+import { convertInsightDefinition } from "../fromSdkModel/InsightConverter";
 import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
 import { IUriMappings } from "./types";
 import { BearWorkspaceCatalogWithAvailableItems } from "./catalogWithAvailableItems";
@@ -98,7 +98,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
                 ],
             },
         };
-        const visualizationObject = convertInsight(insight || itemsInsight);
+        const visualizationObject = convertInsightDefinition(insight || itemsInsight);
 
         // loadItemDescriptionObjects + loadDateDataSets consumes only visualizationObject with specified uris
         // so map identifiers to uris

--- a/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/fromSdkModel/InsightConverter.ts
@@ -14,6 +14,10 @@ import {
     insightTitle,
     insightFilters,
     insightProperties,
+    insightId,
+    insightUri,
+    insightIsLocked,
+    IInsight,
 } from "@gooddata/sdk-model";
 import { convertUrisToReferences } from "../toSdkModel/ReferenceConverter";
 import { serializeProperties } from "../toSdkModel/PropertiesConverter";
@@ -63,11 +67,26 @@ const convertInsightContent = (
     };
 };
 
-export const convertInsight = (insight: IInsightDefinition): GdcVisualizationObject.IVisualizationObject => {
+export const convertInsightDefinition = (
+    insight: IInsightDefinition,
+): GdcVisualizationObject.IVisualizationObject => {
     return {
         content: convertInsightContent(insight),
         meta: {
             title: insightTitle(insight),
+        },
+    };
+};
+
+export const convertInsight = (insight: IInsight): GdcVisualizationObject.IVisualizationObject => {
+    const convertedDefinition = convertInsightDefinition(insight);
+    return {
+        content: convertedDefinition.content,
+        meta: {
+            ...convertedDefinition.meta,
+            identifier: insightId(insight),
+            uri: insightUri(insight),
+            locked: insightIsLocked(insight),
         },
     };
 };

--- a/libs/sdk-backend-bear/src/metadata/index.ts
+++ b/libs/sdk-backend-bear/src/metadata/index.ts
@@ -18,7 +18,7 @@ import { AuthenticatedCallGuard } from "../commonTypes";
 import { convertVisualizationClass } from "../toSdkModel/VisualizationClassConverter";
 import { convertVisualization } from "../toSdkModel/VisualizationConverter";
 import { tokenizeExpression, getTokenValuesOfType } from "./measureExpressionTokens";
-import { convertInsight } from "../fromSdkModel/InsightConverter";
+import { convertInsightDefinition, convertInsight } from "../fromSdkModel/InsightConverter";
 import { convertObjectMeta } from "../toSdkModel/MetaConverter";
 import { objRefToUri } from "../utils/api";
 
@@ -118,7 +118,9 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
 
     public createInsight = async (insight: IInsightDefinition): Promise<IInsight> => {
         return this.authCall(sdk =>
-            sdk.md.saveVisualization(this.workspace, { visualizationObject: convertInsight(insight) }),
+            sdk.md.saveVisualization(this.workspace, {
+                visualizationObject: convertInsightDefinition(insight),
+            }),
         );
     };
 
@@ -136,7 +138,7 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
     };
 
     public openInsightAsReport = async (insight: IInsightDefinition): Promise<string> => {
-        const visualizationObject = convertInsight(insight);
+        const visualizationObject = convertInsightDefinition(insight);
         return this.authCall(sdk =>
             sdk.md.openVisualizationAsReport(this.workspace, { visualizationObject }),
         );


### PR DESCRIPTION
This splits convertInsight to two functions:
one for IInsightDefinition and other for IInsight.
The latter now transfers things like uri and identifier.

JIRA: RAIL-1896

<!--

Description of changes.

-->

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
