### PR TITLE
RELATED: RAIL-1850 - Fix pivot table measure header alignment regression

### DIFF
--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -42,6 +42,11 @@ $header-cell-resize-width: 20px;
             &::after {
                 display: none;
             }
+
+            &,
+            .ag-react-container {
+                width: 100%;
+            }
         }
 
         .ag-header {


### PR DESCRIPTION
-  this happened after upgrade to latest ag-grid
-  before: measure cell header aligned to the right
-  after: measure cell header aligned to the left
-  for some reason the ag-react-container does not have 100% effective
   width.. before we had 100% space in the cell and within this justified
   the content; now the container had just space for the name of the measure

PS: I don't know if this is the best way to fix this. My CSS knowledge is very basic.