### PR TITLE
RELATED: RAIL-1896 fix insight saving and updating-related logic

### DIFF
--- a/libs/gd-bear-client/src/metadata.ts
+++ b/libs/gd-bear-client/src/metadata.ts
@@ -872,8 +872,9 @@ export class MetadataModule {
         projectId: string,
         visualizationUri: string,
         visualization: GdcVisualizationObject.IVisualization,
-    ) {
-        return this.updateObject(projectId, visualizationUri, {
+    ): Promise<{ uri: string }> {
+        const objectId = visualizationUri.split("/").slice(-1)[0];
+        return this.updateObject(projectId, objectId, {
             visualizationObject: visualization.visualizationObject,
         });
     }
@@ -921,12 +922,12 @@ export class MetadataModule {
      * @experimental
      * @method updateObject
      * @param {String} projectId
-     * @param {String} visualizationUri
+     * @param {String} objectId
      * @param {String} obj object definition
      */
-    public updateObject(projectId: string, visualizationUri: string, obj: any) {
+    public updateObject(projectId: string, objectId: string, obj: any) {
         return this.xhr
-            .put(`/gdc/md/${projectId}/obj/${visualizationUri}`, {
+            .put(`/gdc/md/${projectId}/obj/${objectId}`, {
                 body: obj,
             })
             .then((r: ApiResponse) => r.getData());


### PR DESCRIPTION
* Fixes updateObject API spec (better parameter name)
* Fixes updateInsight and createInsight implementations
  * They really return IInsight now
  * They convert visualization class URL <-> URI properly

JIRA: RAIL-1896
---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
