### PR TITLE
Make visualization converter more lenient to URIs

### DIFF
--- a/libs/sdk-backend-bear/src/toSdkModel/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/VisualizationConverter.ts
@@ -17,15 +17,18 @@ import omit = require("lodash/omit");
 import { GdcVisualizationObject } from "@gooddata/gd-bear-model";
 import { convertReferencesToUris } from "./ReferenceConverter";
 import { deserializeProperties, serializeProperties } from "./PropertiesConverter";
-import { isUri } from "@gooddata/gd-bear-client";
+
+// we use more lenient uri "detection" here because the one in bear-client makes some legacy data fail
+// as the objId is not always just a number
+const isUriLike = (value: string): boolean => /\/gdc\/md\/\S+\/obj\/\S+/.test(value);
 
 const convertAttributeElements = (items: string[]): AttributeElements => {
     if (!items.length) {
         return { values: [] }; // TODO is this OK or we want to throw?
     }
-    // we assume that all the items either use uris, or values, not both, since there no way of representing the mixed variant
+    // we assume that all the items either use uris, or values, not both, since there is no way of representing the mixed variant
     const first = items[0];
-    return isUri(first) ? { uris: items } : { values: items };
+    return isUriLike(first) ? { uris: items } : { values: items };
 };
 
 const convertFilter = (filter: GdcVisualizationObject.ExtendedFilter): IFilter | null => {


### PR DESCRIPTION
We need to relax the URI regex in visualization converter in bear backend.
Some of the data we use can have URIs
like /gdc/md/projectId/obj/not-number.
Although this should not be encouraged, we need to support it here.

JIRA: RAIL-2121

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
