### PR TITLE
RELATED: RAIL-2121 switch PluggableVisualizations to IInsightDefinition

### DIFF
--- a/libs/sdk-backend-mockingbird/src/decoratedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/decoratedBackend/index.ts
@@ -33,7 +33,7 @@ import {
     IDimension,
     IExecutionDefinition,
     IFilter,
-    IInsight,
+    IInsightDefinition,
     SortItem,
 } from "@gooddata/sdk-model";
 
@@ -172,7 +172,7 @@ export class DecoratedExecutionFactory implements IExecutionFactory {
         return this.wrap(this.decorated.forBuckets(buckets, filters));
     }
 
-    public forInsight(insight: IInsight, filters?: IFilter[]): IPreparedExecution {
+    public forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution {
         return this.wrap(this.decorated.forInsight(insight, filters));
     }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -43,7 +43,7 @@ export abstract class AbstractExecutionFactory implements IExecutionFactory {
     // (undocumented)
     abstract forDefinition(def: IExecutionDefinition): IPreparedExecution;
     // (undocumented)
-    forInsight(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
+    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
     // (undocumented)
     abstract forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
     // (undocumented)
@@ -320,7 +320,7 @@ export interface IElementQueryResult extends IPagedResource<IAttributeElement> {
 export interface IExecutionFactory {
     forBuckets(buckets: IBucket[], filters?: IFilter[]): IPreparedExecution;
     forDefinition(def: IExecutionDefinition): IPreparedExecution;
-    forInsight(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
+    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
     forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
     forItems(items: AttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution;
 }

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -4,7 +4,7 @@ import {
     IBucket,
     IDimension,
     IFilter,
-    IInsight,
+    IInsightDefinition,
     SortItem,
     IExecutionDefinition,
     DimensionGenerator,
@@ -86,7 +86,7 @@ export interface IExecutionFactory {
      * @param insight - insight to create execution for, must have buckets which must have some attributes or measures in them
      * @param filters - optional, may not be provided
      */
-    forInsight(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
+    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
 
     /**
      * Prepares new execution for an insight specified by reference =\> a link. This function is asynchronous as
@@ -98,7 +98,7 @@ export interface IExecutionFactory {
      * and not do any 'freeform' execution.
      *
      * The contract is that prepared executions created by this method MUST be executable and MUST come with
-     * pre-filled dimensions greated using the `defaultDimensionsGenerator` provided by the
+     * pre-filled dimensions created using the `defaultDimensionsGenerator` provided by the
      * `@gooddata/sdk-model` package.
      *
      * @param uri - link to insight
@@ -139,7 +139,7 @@ export abstract class AbstractExecutionFactory implements IExecutionFactory {
         return this.forDefinition(def);
     }
 
-    public forInsight(insight: IInsight, filters?: IFilter[]): IPreparedExecution {
+    public forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution {
         const def = defWithDimensions(
             newDefForInsight(this.workspace, insight, filters),
             defaultDimensionsGenerator,

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -855,10 +855,10 @@ export type InsightModifications = (builder: InsightDefinitionBuilder) => Insigh
 export function insightProperties(insight: IInsightDefinition): VisualizationProperties;
 
 // @public
-export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
+export function insightSetProperties<T extends IInsightDefinition>(insight: T, properties?: VisualizationProperties): T;
 
 // @public
-export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
+export function insightSetSorts<T extends IInsightDefinition>(insight: T, sorts?: SortItem[]): T;
 
 // @public
 export function insightSorts(insight: IInsightDefinition): SortItem[];
@@ -1367,7 +1367,7 @@ export const newDataSetMetadataObject: (ref: ObjRef, modifications?: BuilderModi
 export function newDefForBuckets(workspace: string, buckets: IBucket[], filters?: IFilter[]): IExecutionDefinition;
 
 // @public
-export function newDefForInsight(workspace: string, insight: IInsight, filters?: IFilter[]): IExecutionDefinition;
+export function newDefForInsight(workspace: string, insight: IInsightDefinition, filters?: IFilter[]): IExecutionDefinition;
 
 // @public
 export function newDefForItems(workspace: string, items: AttributeOrMeasure[], filters?: IFilter[]): IExecutionDefinition;

--- a/libs/sdk-model/src/execution/executionDefinition/factory.ts
+++ b/libs/sdk-model/src/execution/executionDefinition/factory.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import { attributeLocalId, isAttribute } from "../attribute";
 import {
     IDimension,
@@ -11,7 +11,7 @@ import { SortItem } from "../base/sort";
 import { AttributeOrMeasure, bucketAttributes, bucketMeasures, IBucket } from "../buckets";
 import { bucketsAttributes, bucketsIsEmpty, bucketsMeasures } from "../buckets/bucketArray";
 import { IFilter } from "../filter";
-import { IInsight, insightBuckets, insightFilters, insightSorts } from "../../insight";
+import { insightBuckets, insightFilters, insightSorts, IInsightDefinition } from "../../insight";
 import { isMeasure } from "../measure";
 import {
     defSetDimensions,
@@ -128,7 +128,7 @@ export function newDefForBuckets(
  */
 export function newDefForInsight(
     workspace: string,
-    insight: IInsight,
+    insight: IInsightDefinition,
     filters: IFilter[] = [],
 ): IExecutionDefinition {
     invariant(workspace, "workspace to create exec def for must be specified");

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -463,19 +463,19 @@ export function insightIsLocked(insight: IInsightDefinition): boolean {
  * @returns always new instance
  * @public
  */
-export function insightSetProperties(insight: IInsight, properties?: VisualizationProperties): IInsight;
-export function insightSetProperties(
-    insight: IInsightDefinition,
+export function insightSetProperties<T extends IInsightDefinition>(
+    insight: T,
     properties: VisualizationProperties = {},
-): IInsightDefinition {
+): T {
     invariant(insight, "insight must be specified");
 
+    // tslint:disable-next-line: no-object-literal-type-assertion
     return {
         insight: {
             ...insight.insight,
             properties,
         },
-    };
+    } as T;
 }
 
 /**
@@ -487,16 +487,16 @@ export function insightSetProperties(
  * @returns always new instance
  * @public
  */
-export function insightSetSorts(insight: IInsight, sorts?: SortItem[]): IInsight;
-export function insightSetSorts(insight: IInsightDefinition, sorts: SortItem[] = []): IInsightDefinition {
+export function insightSetSorts<T extends IInsightDefinition>(insight: T, sorts: SortItem[] = []): T {
     invariant(insight, "insight must be specified");
 
+    // tslint:disable-next-line: no-object-literal-type-assertion
     return {
         insight: {
             ...insight.insight,
             sorts,
         },
-    };
+    } as T;
 }
 
 //

--- a/libs/sdk-ui-ext/src/insightView/ExecutionFactoryWithPresetFilters.ts
+++ b/libs/sdk-ui-ext/src/insightView/ExecutionFactoryWithPresetFilters.ts
@@ -1,9 +1,9 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import {
     AttributeOrMeasure,
     IBucket,
     IFilter,
-    IInsight,
+    IInsightDefinition,
     defWithFilters,
     IExecutionDefinition,
 } from "@gooddata/sdk-model";
@@ -24,7 +24,7 @@ export class ExecutionFactoryWithPresetFilters implements IExecutionFactory {
     public forBuckets = (buckets: IBucket[], filters: IFilter[] = []): IPreparedExecution => {
         return this.factory.forBuckets(buckets, [...this.presetFilters, ...filters]);
     };
-    public forInsight = (insight: IInsight, filters: IFilter[] = []): IPreparedExecution => {
+    public forInsight = (insight: IInsightDefinition, filters: IFilter[] = []): IPreparedExecution => {
         return this.factory.forInsight(insight, [...this.presetFilters, ...filters]);
     };
     public forInsightByRef = (uri: string, filters: IFilter[] = []): Promise<IPreparedExecution> => {

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import { IAnalyticalBackend, IExecutionFactory } from "@gooddata/sdk-backend-spi";
-import { IInsight, insightProperties, IVisualizationClass, visClassUrl } from "@gooddata/sdk-model";
+import { IInsightDefinition, insightProperties, IVisualizationClass, visClassUrl } from "@gooddata/sdk-model";
 import * as React from "react";
 import { render } from "react-dom";
 import * as uuid from "uuid";
@@ -35,7 +35,7 @@ import omit = require("lodash/omit");
 export interface IBaseVisualizationProps extends IVisCallbacks {
     backend: IAnalyticalBackend;
     projectId: string;
-    insight: IInsight;
+    insight: IInsightDefinition;
     config?: IGdcConfig;
     visualizationClass: IVisualizationClass;
     environment?: VisualizationEnvironment;

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BubbleChartConfigurationPanel.tsx
@@ -20,7 +20,7 @@ import {
     BUBBLE_ARROW_OFFSET_X,
     BUBBLE_ARROW_OFFSET_Y,
 } from "../../constants/bubble";
-import { bucketsIsEmpty, IInsight, insightBuckets } from "@gooddata/sdk-model";
+import { bucketsIsEmpty, IInsightDefinition, insightBuckets } from "@gooddata/sdk-model";
 import { BucketNames } from "@gooddata/sdk-ui";
 
 export default class BubbleChartConfigurationPanel extends ConfigurationPanelContent {
@@ -177,6 +177,6 @@ export default class BubbleChartConfigurationPanel extends ConfigurationPanelCon
     }
 }
 
-function hasTertiaryMeasures(insight: IInsight): boolean {
+function hasTertiaryMeasures(insight: IInsightDefinition): boolean {
     return !bucketsIsEmpty(insightBuckets(insight, BucketNames.TERTIARY_MEASURES));
 }

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
@@ -7,7 +7,7 @@ import { IColorConfiguration } from "../../interfaces/Colors";
 import ColorsSection from "../configurationControls/colors/ColorsSection";
 import LegendSection from "../configurationControls/legend/LegendSection";
 import { InternalIntlWrapper } from "../../utils/internalIntlProvider";
-import { IInsight, insightHasMeasures } from "@gooddata/sdk-model";
+import { IInsightDefinition, insightHasMeasures } from "@gooddata/sdk-model";
 import noop = require("lodash/noop");
 import { getMeasuresFromMdObject } from "../../utils/bucketHelper";
 
@@ -20,7 +20,7 @@ export interface IConfigurationPanelContentProps {
     type?: ChartType;
     isError?: boolean;
     isLoading?: boolean;
-    insight?: IInsight;
+    insight?: IInsightDefinition;
     featureFlags?: IFeatureFlags;
     axis?: string;
     pushData?(data: any): void;

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
@@ -19,7 +19,7 @@ import {
 import LabelSubsection from "../configurationControls/axis/LabelSubsection";
 import { AxisType } from "../../interfaces/AxisType";
 import { noRowsAndHasOneMeasure, noColumnsAndHasOneMeasure } from "../../utils/bucketHelper";
-import { IInsight, insightBuckets } from "@gooddata/sdk-model";
+import { IInsightDefinition, insightBuckets } from "@gooddata/sdk-model";
 
 export default class HeatMapConfigurationPanel extends ConfigurationPanelContent {
     protected renderConfigurationPanel() {
@@ -137,7 +137,7 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
         };
     }
 
-    private isAxisDisabled(controlsDisabled: boolean, axis: AxisType, insight: IInsight): boolean {
+    private isAxisDisabled(controlsDisabled: boolean, axis: AxisType, insight: IInsightDefinition): boolean {
         const isAxisDisabled =
             axis === "xaxis"
                 ? noColumnsAndHasOneMeasure(insightBuckets(insight))

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BaseChartConfigurationPanel.test.tsx
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { IAttribute, IInsight, IMeasure } from "@gooddata/sdk-model";
+import { IAttribute, IInsightDefinition, IMeasure } from "@gooddata/sdk-model";
 import * as React from "react";
 import { shallow } from "enzyme";
 import { insightWithSingleAttribute } from "../../../tests/mocks/testMocks";
@@ -66,15 +66,13 @@ describe("BaseChartConfigurationPanel", () => {
         };
 
         it("should render configuration panel with enabled name sections in single axis chart", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",
@@ -103,15 +101,13 @@ describe("BaseChartConfigurationPanel", () => {
         });
 
         it("should render configuration panel with enabled name sections in dual axis chart", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",
@@ -151,15 +147,13 @@ describe("BaseChartConfigurationPanel", () => {
         });
 
         it("should render configuration panel with enabled X axis name section and disabled Y axis name section in single axis chart", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",
@@ -188,15 +182,13 @@ describe("BaseChartConfigurationPanel", () => {
         });
 
         it("should render configuration panel with disabled X axis name section and disabled Y axis name section in group-category chart", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BubbleChartConfigurationPanel.test.tsx
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { IInsight, newMeasure } from "@gooddata/sdk-model";
+import { IInsightDefinition, newMeasure } from "@gooddata/sdk-model";
 import { shallow } from "enzyme";
 import * as React from "react";
 import { DefaultLocale, VisualizationTypes } from "@gooddata/sdk-ui";
@@ -9,14 +9,14 @@ import ConfigSection from "../../configurationControls/ConfigSection";
 import BubbleChartConfigurationPanel from "../BubbleChartConfigurationPanel";
 import { IConfigurationPanelContentProps } from "../ConfigurationPanelContent";
 
-describe("BubbleChartconfigurationPanel", () => {
+describe("BubbleChartConfigurationPanel", () => {
     function createComponent(props: IConfigurationPanelContentProps) {
         return shallow<IConfigurationPanelContentProps, null>(<BubbleChartConfigurationPanel {...props} />, {
             lifecycleExperimental: true,
         });
     }
 
-    function newInsight(measureBucket: string): IInsight {
+    function newInsight(measureBucket: string): IInsightDefinition {
         return {
             insight: {
                 title: "My Insight",
@@ -24,8 +24,6 @@ describe("BubbleChartconfigurationPanel", () => {
                 filters: [],
                 visualizationUrl: "vc",
                 properties: {},
-                identifier: "id",
-                uri: "test",
                 buckets: [
                     {
                         localIdentifier: measureBucket,
@@ -100,15 +98,13 @@ describe("BubbleChartconfigurationPanel", () => {
         };
 
         it("should render configuration panel with enabled name sections", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",
@@ -163,16 +159,14 @@ describe("BubbleChartconfigurationPanel", () => {
         });
 
         it("should render configuration panel with disabled name sections", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
-                    buckets: [] as any,
+                    buckets: [],
                 },
             };
 
@@ -191,15 +185,13 @@ describe("BubbleChartconfigurationPanel", () => {
         });
 
         it("should render configuration panel with enabled X axis name section and disabled Y axis name section", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/ScatterPlotConfigurationPanel.test.tsx
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { IInsight, newMeasure } from "@gooddata/sdk-model";
+import { IInsightDefinition, newMeasure } from "@gooddata/sdk-model";
 import * as React from "react";
 import { shallow } from "enzyme";
 import { insightWithSingleAttribute } from "../../../tests/mocks/testMocks";
@@ -20,7 +20,7 @@ describe("ScatterPlotConfigurationPanel", () => {
         });
     }
 
-    function newInsight(measureBucket: string): IInsight {
+    function newInsight(measureBucket: string): IInsightDefinition {
         return {
             insight: {
                 title: "My Insight",
@@ -28,8 +28,6 @@ describe("ScatterPlotConfigurationPanel", () => {
                 filters: [],
                 visualizationUrl: "vc",
                 properties: {},
-                identifier: "id",
-                uri: "test",
                 buckets: [
                     {
                         localIdentifier: measureBucket,
@@ -58,15 +56,13 @@ describe("ScatterPlotConfigurationPanel", () => {
         };
 
         it("should render configuration panel with enabled name sections", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
                     buckets: [
                         {
                             localIdentifier: "measures",
@@ -121,16 +117,14 @@ describe("ScatterPlotConfigurationPanel", () => {
         });
 
         it("should render configuration panel with disabled name sections", () => {
-            const insight: IInsight = {
+            const insight: IInsightDefinition = {
                 insight: {
                     title: "My Insight",
                     sorts: [],
                     filters: [],
                     visualizationUrl: "vc",
                     properties: {},
-                    identifier: "id",
-                    uri: "test",
-                    buckets: [] as any,
+                    buckets: [],
                 },
             };
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -14,7 +14,7 @@ import {
     PluggableVisualizationErrorCodes,
 } from "../../interfaces/Visualization";
 import { findDerivedBucketItem, hasDerivedBucketItems, isDerivedBucketItem } from "../../utils/bucketHelper";
-import { IInsight, insightHasDataDefined, insightProperties } from "@gooddata/sdk-model";
+import { IInsightDefinition, insightHasDataDefined, insightProperties } from "@gooddata/sdk-model";
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import {
     DefaultLocale,
@@ -54,7 +54,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      * Insight that is currently rendered by the pluggable visualization. This field is set during
      * every call to {@link update} and will remain the same until the next update() call.
      */
-    protected currentInsight: IInsight;
+    protected currentInsight: IInsightDefinition;
     protected visualizationProperties: IVisualizationProperties;
     protected supportedPropertiesList: string[];
     protected propertiesMeta: any;
@@ -104,7 +104,11 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      * @param insight
      * @param executionFactory
      */
-    public update(options: IVisProps, insight: IInsight, executionFactory: IExecutionFactory): void {
+    public update(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ): void {
         this.updateInstanceProperties(options, insight);
 
         let shouldRenderVisualization: boolean;
@@ -136,7 +140,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
     protected updateInstanceProperties(
         // @ts-ignore
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
     ) {
         const visualizationProperties = insightProperties(insight);
 
@@ -156,7 +160,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      * @returns when true is returned (default), visualization will be rendered, when false is returned no rendering is done
      * @throws error - if anything is thrown, visualization will not be rendered and the exception will be passed via onError callback
      */
-    protected checkBeforeRender(insight: IInsight): boolean {
+    protected checkBeforeRender(insight: IInsightDefinition): boolean {
         if (!insightHasDataDefined(insight)) {
             throw new GoodDataSdkError(PluggableVisualizationErrorCodes.EMPTY_AFM);
         }
@@ -174,7 +178,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      */
     protected abstract renderVisualization(
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ): void;
 
@@ -184,7 +188,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      *
      * @param insight - insight that is rendered
      */
-    protected abstract renderConfigurationPanel(insight: IInsight): void;
+    protected abstract renderConfigurationPanel(insight: IInsightDefinition): void;
 
     //
     // Callback delegates

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 import get = require("lodash/get");
 import set = require("lodash/set");
-import { bucketsItems, IInsight, insightBuckets } from "@gooddata/sdk-model";
+import { bucketsItems, IInsightDefinition, insightBuckets } from "@gooddata/sdk-model";
 import { BucketNames } from "@gooddata/sdk-ui";
 import { AXIS } from "../../constants/axis";
 import { BUCKETS } from "../../constants/bucket";
@@ -112,6 +112,6 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
     }
 }
 
-function haveManyViewItems(insight: IInsight): boolean {
+function haveManyViewItems(insight: IInsightDefinition): boolean {
     return bucketsItems(insightBuckets(insight, BucketNames.VIEW)).length > 1;
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { bucketsItems, IInsight, insightBuckets } from "@gooddata/sdk-model";
+import { bucketsItems, IInsightDefinition, insightBuckets } from "@gooddata/sdk-model";
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import * as React from "react";
 import { render } from "react-dom";
@@ -61,7 +61,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return cloneDeep(DEFAULT_AREA_UICONFIG);
     }
 
-    protected updateInstanceProperties(options: IVisProps, insight: IInsight) {
+    protected updateInstanceProperties(options: IVisProps, insight: IInsightDefinition) {
         super.updateInstanceProperties(options, insight);
 
         this.updateCustomSupportedProperties(insight);
@@ -117,7 +117,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return AREA_CHART_SUPPORTED_PROPERTIES;
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <LineChartBasedConfigurationPanel
@@ -138,7 +138,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
         }
     }
 
-    private updateCustomSupportedProperties(insight: IInsight): void {
+    private updateCustomSupportedProperties(insight: IInsightDefinition): void {
         if (bucketsItems(insightBuckets(insight, BucketNames.VIEW)).length > 1) {
             this.addSupportedProperties(OPTIONAL_STACKING_PROPERTIES);
             this.setCustomControlsProperties({

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -2,6 +2,7 @@
 import * as React from "react";
 import { render } from "react-dom";
 import { VisualizationTypes } from "@gooddata/sdk-ui";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 import cloneDeep = require("lodash/cloneDeep");
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { COLUMN_BAR_CHART_UICONFIG } from "../../../constants/uiConfig";
@@ -9,7 +10,6 @@ import { IVisConstruct, IUiConfig } from "../../../interfaces/Visualization";
 import { BAR_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import BarChartConfigurationPanel from "../../configurationPanels/BarChartConfigurationPanel";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
-import { IInsight } from "@gooddata/sdk-model";
 
 export class PluggableBarChart extends PluggableColumnBarCharts {
     constructor(props: IVisConstruct) {
@@ -30,7 +30,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         return BAR_CHART_SUPPORTED_PROPERTIES[this.axis || AXIS.DUAL] || [];
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BarChartConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -4,7 +4,7 @@ import {
     bucketsIsEmpty,
     IColorMappingItem,
     IDimension,
-    IInsight,
+    IInsightDefinition,
     insightBuckets,
     insightHasMeasures,
     insightMeasures,
@@ -188,7 +188,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         return stacks;
     }
 
-    protected checkBeforeRender(insight: IInsight): boolean {
+    protected checkBeforeRender(insight: IInsightDefinition): boolean {
         super.checkBeforeRender(insight);
 
         if (!insightHasMeasures(insight)) {
@@ -200,7 +200,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
 
     protected renderVisualization(
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ) {
         const { dimensions = { height: undefined }, custom = {}, locale, config } = options;
@@ -254,7 +254,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         });
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BaseChartConfigurationPanel
@@ -276,7 +276,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         }
     }
 
-    protected getDimensions(insight: IInsight): IDimension[] {
+    protected getDimensions(insight: IInsightDefinition): IDimension[] {
         return generateDimensions(insight, this.type);
     }
 
@@ -361,7 +361,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         };
     }
 
-    private getSupportedControls(insight: IInsight) {
+    private getSupportedControls(insight: IInsightDefinition) {
         let supportedControls = cloneDeep(get(this.visualizationProperties, "controls", {}));
         const defaultControls = getSupportedPropertiesControls(
             this.defaultControlsProperties,
@@ -392,7 +392,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         };
     }
 
-    private getLegendPosition(controlProperties: IVisualizationProperties, insight: IInsight) {
+    private getLegendPosition(controlProperties: IVisualizationProperties, insight: IInsightDefinition) {
         const legendPosition = get(controlProperties, "legend.position", "auto");
 
         if (legendPosition === "auto") {
@@ -407,17 +407,20 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 }
 
-function isStacked(insight: IInsight): boolean {
+function isStacked(insight: IInsightDefinition): boolean {
     return !bucketsIsEmpty(insightBuckets(insight, BucketNames.STACK, BucketNames.SEGMENT));
 }
 
-function areAllMeasuresOnSingleAxis(insight: IInsight, secondaryYAxis: IAxisConfig): boolean {
+function areAllMeasuresOnSingleAxis(insight: IInsightDefinition, secondaryYAxis: IAxisConfig): boolean {
     const measureCount = insightMeasures(insight).length;
     const numberOfMeasureOnSecondaryAxis = secondaryYAxis.measures?.length ?? 0;
     return numberOfMeasureOnSecondaryAxis === 0 || measureCount === numberOfMeasureOnSecondaryAxis;
 }
 
-function canSortStackTotalValue(insight: IInsight, supportedControls: IVisualizationProperties): boolean {
+function canSortStackTotalValue(
+    insight: IInsightDefinition,
+    supportedControls: IVisualizationProperties,
+): boolean {
     const stackMeasures = get(supportedControls, "stackMeasures", false);
     const secondaryAxis: IAxisConfig = get(supportedControls, "secondary_yaxis", { measures: [] });
     const allMeasuresOnSingleAxis = areAllMeasuresOnSingleAxis(insight, secondaryAxis);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/insightIntrospection.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/insightIntrospection.ts
@@ -1,11 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
-import { bucketItems, IInsight, insightBucket } from "@gooddata/sdk-model";
+import { bucketItems, IInsightDefinition, insightBucket } from "@gooddata/sdk-model";
 import { BucketNames } from "@gooddata/sdk-ui";
 import { isBarChart, isScatterPlot, isBubbleChart } from "@gooddata/sdk-ui-charts";
 import { IVisualizationProperties } from "../../../interfaces/Visualization";
 import get = require("lodash/get");
 
-export function countBucketItems(insight: IInsight) {
+export function countBucketItems(insight: IInsightDefinition) {
     if (!insight) {
         return {
             viewByItemCount: 0,
@@ -25,7 +25,11 @@ export function countBucketItems(insight: IInsight) {
     };
 }
 
-export function countItemsOnAxes(type: string, controls: IVisualizationProperties, insight: IInsight) {
+export function countItemsOnAxes(
+    type: string,
+    controls: IVisualizationProperties,
+    insight: IInsightDefinition,
+) {
     const isBarChartType = isBarChart(type);
 
     const { viewByItemCount, measureItemCount, secondaryMeasureItemCount } = countBucketItems(insight);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.test.tsx
@@ -9,7 +9,7 @@ import * as referencePointMocks from "../../../../tests/mocks/referencePointMock
 import * as uiConfigMocks from "../../../../tests/mocks/uiConfigMocks";
 import BaseChartConfigurationPanel from "../../../configurationPanels/BaseChartConfigurationPanel";
 import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
-import { IInsight, insightSetProperties } from "@gooddata/sdk-model";
+import { IInsightDefinition, insightSetProperties } from "@gooddata/sdk-model";
 import noop = require("lodash/noop");
 
 describe("PluggableBaseChart", () => {
@@ -40,7 +40,7 @@ describe("PluggableBaseChart", () => {
         return new PluggableBaseChart(props);
     }
 
-    function dummyConfigurationRenderer(insight: IInsight) {
+    function dummyConfigurationRenderer(insight: IInsightDefinition) {
         const properties = {};
 
         return (

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/insightIntrospection.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/insightIntrospection.test.ts
@@ -1,17 +1,15 @@
 // (C) 2019-2020 GoodData Corporation
 
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 import { BucketNames } from "@gooddata/sdk-ui";
 import { countBucketItems, countItemsOnAxes } from "../insightIntrospection";
 import { IVisualizationProperties } from "../../../../interfaces/Visualization";
 
 describe("countItemsOnAxesInMdObject", () => {
     it("should return number of items in buckets", () => {
-        const insight: IInsight = {
+        const insight: IInsightDefinition = {
             insight: {
                 filters: [],
-                identifier: "insight",
-                uri: "test",
                 properties: {},
                 sorts: [],
                 title: "My Insight",
@@ -34,11 +32,9 @@ describe("countItemsOnAxesInMdObject", () => {
 
 describe("countItemsOnAxes", () => {
     it("should return number of items on axes of column chart", () => {
-        const insight: IInsight = {
+        const insight: IInsightDefinition = {
             insight: {
                 filters: [],
-                identifier: "insight",
-                uri: "test",
                 properties: {},
                 sorts: [],
                 title: "My Insight",
@@ -63,11 +59,9 @@ describe("countItemsOnAxes", () => {
     });
 
     it("should return number of items on axes of bar chart", () => {
-        const insight: IInsight = {
+        const insight: IInsightDefinition = {
             insight: {
                 filters: [],
-                identifier: "insight",
-                uri: "test",
                 properties: {},
                 sorts: [],
                 title: "My Insight",
@@ -92,11 +86,9 @@ describe("countItemsOnAxes", () => {
     });
 
     it("should return number of items on axes of combo chart", () => {
-        const insight: IInsight = {
+        const insight: IInsightDefinition = {
             insight: {
                 filters: [],
-                identifier: "insight",
-                uri: "test",
                 properties: {},
                 sorts: [],
                 title: "My Insight",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
@@ -25,7 +25,7 @@ import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep = require("lodash/cloneDeep");
 import includes = require("lodash/includes");
 import set = require("lodash/set");
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggableBubbleChart extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -120,7 +120,7 @@ export class PluggableBubbleChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <BubbleChartConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -1,7 +1,7 @@
 // (C) 2019 GoodData Corporation
 
 import { IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";
-import { bucketIsEmpty, IInsight, insightBucket, insightHasDataDefined } from "@gooddata/sdk-model";
+import { bucketIsEmpty, IInsightDefinition, insightBucket, insightHasDataDefined } from "@gooddata/sdk-model";
 
 import { BucketNames, GoodDataSdkError } from "@gooddata/sdk-ui";
 import { CoreHeadline, updateConfigWithSettings } from "@gooddata/sdk-ui-charts";
@@ -114,7 +114,7 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected checkBeforeRender(insight: IInsight): boolean {
+    protected checkBeforeRender(insight: IInsightDefinition): boolean {
         super.checkBeforeRender(insight);
 
         const measureBucket = insightBucket(insight, BucketNames.MEASURES);
@@ -128,7 +128,7 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
 
     protected renderVisualization(
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ) {
         if (!insightHasDataDefined(insight)) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -28,7 +28,7 @@ import cloneDeep = require("lodash/cloneDeep");
 import includes = require("lodash/includes");
 import set = require("lodash/set");
 import tail = require("lodash/tail");
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggableHeatmap extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -95,7 +95,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <HeatMapConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -38,7 +38,7 @@ import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggableLineChart extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -127,7 +127,7 @@ export class PluggableLineChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <LineChartBasedConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -40,7 +40,7 @@ import cloneDeep = require("lodash/cloneDeep");
 import get = require("lodash/get");
 import set = require("lodash/set");
 import React = require("react");
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggablePieChart extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -108,7 +108,7 @@ export class PluggablePieChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <PieChartConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -14,7 +14,7 @@ import {
     IAttributeSortItem,
     IBucket,
     IDimension,
-    IInsight,
+    IInsightDefinition,
     IMeasureSortItem,
     insightBuckets,
     insightHasDataDefined,
@@ -340,7 +340,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
     protected renderVisualization(
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ) {
         if (!insightHasDataDefined(insight)) {
@@ -433,7 +433,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         }
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             const properties: IVisualizationProperties = get(
                 this.visualizationProperties,
@@ -463,7 +463,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         }
     }
 
-    protected getDimensions(insight: IInsight): IDimension[] {
+    protected getDimensions(insight: IInsightDefinition): IDimension[] {
         return generateDimensions(insight, VisualizationTypes.TABLE);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
@@ -25,7 +25,7 @@ import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep = require("lodash/cloneDeep");
 import includes = require("lodash/includes");
 import set = require("lodash/set");
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggableScatterPlot extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -103,7 +103,7 @@ export class PluggableScatterPlot extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <ScatterPlotConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/AbstractPluggableVisualization.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/AbstractPluggableVisualization.test.tsx
@@ -3,7 +3,7 @@ import { IVisProps } from "../../../interfaces/Visualization";
 import { AbstractPluggableVisualization } from "../AbstractPluggableVisualization";
 import { BucketNames } from "@gooddata/sdk-ui";
 import * as referencePointMocks from "../../../tests/mocks/referencePointMocks";
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import { DummyVisConstruct } from "./visConstruct.fixture";
 
@@ -21,13 +21,13 @@ describe("AbstractPluggableVisualization", () => {
             return;
         }
 
-        protected renderConfigurationPanel(_insight: IInsight): void {
+        protected renderConfigurationPanel(_insight: IInsightDefinition): void {
             return;
         }
 
         protected renderVisualization(
             _options: IVisProps,
-            _insight: IInsight,
+            _insight: IInsightDefinition,
             _executionFactory: IExecutionFactory,
         ): void {
             return;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -35,7 +35,7 @@ import { removeSort } from "../../../utils/sort";
 import { setTreemapUiConfig } from "../../../utils/uiConfigHelpers/treemapUiConfigHelper";
 import TreeMapConfigurationPanel from "../../configurationPanels/TreeMapConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 
 export class PluggableTreemap extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -103,7 +103,7 @@ export class PluggableTreemap extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    protected renderConfigurationPanel(insight: IInsight) {
+    protected renderConfigurationPanel(insight: IInsightDefinition) {
         if (document.querySelector(this.configPanelElement)) {
             render(
                 <TreeMapConfigurationPanel

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
@@ -5,7 +5,7 @@ import {
     attributeLocalId,
     bucketAttributes,
     IDimension,
-    IInsight,
+    IInsightDefinition,
     insightBucket,
     MeasureGroupIdentifier,
     newDimension,
@@ -89,7 +89,7 @@ export class PluggableXirr extends AbstractPluggableVisualization {
 
     protected renderVisualization(
         options: IVisProps,
-        insight: IInsight,
+        insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ) {
         const { locale, custom = {}, config } = options;
@@ -135,7 +135,7 @@ export class PluggableXirr extends AbstractPluggableVisualization {
         }
     }
 
-    private getXirrDimensions(insight: IInsight): IDimension[] {
+    private getXirrDimensions(insight: IInsightDefinition): IDimension[] {
         const attribute = insightBucket(insight, BucketNames.ATTRIBUTE);
 
         if (attribute && attribute.items.length) {

--- a/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
@@ -14,7 +14,7 @@ import { AbstractPluggableVisualization } from "../pluggableVisualizations/Abstr
 import { VisualizationTypes, IDrillableItem } from "@gooddata/sdk-ui";
 import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
 import { CatalogViaTypeToClassMap, IVisualizationCatalog } from "../VisualizationCatalog";
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import { DummyVisConstruct } from "../pluggableVisualizations/tests/visConstruct.fixture";
 
@@ -30,13 +30,13 @@ class DummyClass extends AbstractPluggableVisualization {
         return;
     }
 
-    protected renderConfigurationPanel(_insight: IInsight): void {
+    protected renderConfigurationPanel(_insight: IInsightDefinition): void {
         return;
     }
 
     protected renderVisualization(
         _options: IVisProps,
-        _insight: IInsight,
+        _insight: IInsightDefinition,
         _executionFactory: IExecutionFactory,
     ): void {
         return;

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
 import { IAnalyticalBackend, IExecutionFactory } from "@gooddata/sdk-backend-spi";
-import { IColorPalette, IInsight, ITotal, VisualizationProperties } from "@gooddata/sdk-model";
+import { IColorPalette, IInsightDefinition, ITotal, VisualizationProperties } from "@gooddata/sdk-model";
 import {
     ChartType,
     IDrillableItem,
@@ -291,7 +291,7 @@ export interface IVisualization {
      * @param insight - new state of insight
      * @param executionFactory - execution factory to use when triggering calculation on backend
      */
-    update(props: IVisProps, insight: IInsight, executionFactory: IExecutionFactory): void;
+    update(props: IVisProps, insight: IInsightDefinition, executionFactory: IExecutionFactory): void;
 
     unmount(): void;
 

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/testMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/testMocks.ts
@@ -1,14 +1,14 @@
 // (C) 2019-2020 GoodData Corporation
 import { BucketNames } from "@gooddata/sdk-ui";
-import { IInsight, IVisualizationClass, newAttribute } from "@gooddata/sdk-model";
+import { IInsightDefinition, IVisualizationClass, newAttribute } from "@gooddata/sdk-model";
 
 //
-// Test insights
+// Test insight definitions
 //
 
 export const EMPTY_TITLE = "empty_title";
 
-export const emptyInsight: IInsight = {
+export const emptyInsight: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [],
@@ -16,12 +16,10 @@ export const emptyInsight: IInsight = {
         sorts: [],
         properties: {},
         title: "Empty insight",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const dummyInsight: IInsight = {
+export const dummyInsight: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -34,12 +32,10 @@ export const dummyInsight: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single attribute",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithStacking: IInsight = {
+export const insightWithStacking: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -91,12 +87,10 @@ export const insightWithStacking: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single attribute",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasureAndTwoViewBy: IInsight = {
+export const insightWithSingleMeasureAndTwoViewBy: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -147,12 +141,10 @@ export const insightWithSingleMeasureAndTwoViewBy: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with two viewby attributes",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithTwoMeasuresAndViewBy: IInsight = {
+export const insightWithTwoMeasuresAndViewBy: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -207,12 +199,10 @@ export const insightWithTwoMeasuresAndViewBy: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with two viewby attributes",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithTwoMeasuresAndTwoViewBy: IInsight = {
+export const insightWithTwoMeasuresAndTwoViewBy: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -275,12 +265,10 @@ export const insightWithTwoMeasuresAndTwoViewBy: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with two viewby attributes",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasure: IInsight = {
+export const insightWithSingleMeasure: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -306,12 +294,10 @@ export const insightWithSingleMeasure: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleSecondaryMeasure: IInsight = {
+export const insightWithSingleSecondaryMeasure: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -337,12 +323,10 @@ export const insightWithSingleSecondaryMeasure: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasureAndViewBy: IInsight = {
+export const insightWithSingleMeasureAndViewBy: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -381,12 +365,10 @@ export const insightWithSingleMeasureAndViewBy: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasureAndViewByAndStack: IInsight = {
+export const insightWithSingleMeasureAndViewByAndStack: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -438,12 +420,10 @@ export const insightWithSingleMeasureAndViewByAndStack: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasureAndStack: IInsight = {
+export const insightWithSingleMeasureAndStack: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -482,12 +462,10 @@ export const insightWithSingleMeasureAndStack: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleAttribute: IInsight = {
+export const insightWithSingleAttribute: IInsightDefinition = {
     insight: {
         visualizationUrl: "column",
         buckets: [
@@ -509,12 +487,10 @@ export const insightWithSingleAttribute: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithNoMeasureAndOneAttribute: IInsight = {
+export const insightWithNoMeasureAndOneAttribute: IInsightDefinition = {
     insight: {
         visualizationUrl: "table",
         buckets: [
@@ -536,12 +512,10 @@ export const insightWithNoMeasureAndOneAttribute: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with no measure and one attribute",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithSingleMeasureAndOneAttribute: IInsight = {
+export const insightWithSingleMeasureAndOneAttribute: IInsightDefinition = {
     insight: {
         visualizationUrl: "table",
         buckets: [
@@ -580,12 +554,10 @@ export const insightWithSingleMeasureAndOneAttribute: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with single measure and one attribute",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 
-export const insightWithNoMeasureAndOneColumn: IInsight = {
+export const insightWithNoMeasureAndOneColumn: IInsightDefinition = {
     insight: {
         visualizationUrl: "table",
         buckets: [
@@ -607,8 +579,6 @@ export const insightWithNoMeasureAndOneColumn: IInsight = {
         sorts: [],
         properties: {},
         title: "Dummy insight with no measure and one column",
-        identifier: "myIdentifier",
-        uri: "/gdc/md/mockproject/obj/123",
     },
 };
 

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -50,7 +50,7 @@ import {
     bucketsFind,
     bucketsMeasures,
     IBucket,
-    IInsight,
+    IInsightDefinition,
     insightBuckets,
     isSimpleMeasure,
     ITotal,
@@ -410,7 +410,7 @@ export function getUniqueAttributes(buckets: IBucketOfFun[]) {
     return uniqBy(attributes, attribute => get(attribute, "attribute"));
 }
 
-export function getMeasuresFromMdObject(insight: IInsight) {
+export function getMeasuresFromMdObject(insight: IInsightDefinition) {
     if (!insight) {
         return [];
     }

--- a/libs/sdk-ui-ext/src/internal/utils/dimensions.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/dimensions.ts
@@ -5,7 +5,7 @@ import {
     bucketAttributes,
     bucketIsEmpty,
     IDimension,
-    IInsight,
+    IInsightDefinition,
     insightAttributes,
     insightBucket,
     insightTotals,
@@ -14,7 +14,7 @@ import {
 import { BucketNames, VisType, VisualizationTypes } from "@gooddata/sdk-ui";
 import { ViewByAttributesLimit } from "@gooddata/sdk-ui-charts";
 
-export function getPivotTableDimensions(insight: IInsight): IDimension[] {
+export function getPivotTableDimensions(insight: IInsightDefinition): IDimension[] {
     const row = insightBucket(insight, BucketNames.ATTRIBUTE);
     const columns = insightBucket(insight, BucketNames.COLUMNS);
     const measures = insightBucket(insight, BucketNames.MEASURES);
@@ -38,7 +38,7 @@ export function getPivotTableDimensions(insight: IInsight): IDimension[] {
     ];
 }
 
-function getPieOrDonutDimensions(insight: IInsight): IDimension[] {
+function getPieOrDonutDimensions(insight: IInsightDefinition): IDimension[] {
     const viewBy = insightBucket(insight, BucketNames.VIEW);
 
     if (viewBy && !bucketIsEmpty(viewBy)) {
@@ -62,7 +62,7 @@ function getPieOrDonutDimensions(insight: IInsight): IDimension[] {
     ];
 }
 
-function getBarDimensions(insight: IInsight): IDimension[] {
+function getBarDimensions(insight: IInsightDefinition): IDimension[] {
     const viewBy = insightBucket(insight, BucketNames.VIEW);
     const viewByAttributes = viewBy ? bucketAttributes(viewBy) : [];
     const stack = insightBucket(insight, BucketNames.STACK);
@@ -88,7 +88,7 @@ function getBarDimensions(insight: IInsight): IDimension[] {
     ];
 }
 
-function getAreaDimensions(insight: IInsight): IDimension[] {
+function getAreaDimensions(insight: IInsightDefinition): IDimension[] {
     const viewBucket = insightBucket(insight, BucketNames.VIEW);
     const viewByAttributes = viewBucket ? bucketAttributes(viewBucket) : [];
     const stackBucket = insightBucket(insight, BucketNames.STACK);
@@ -129,7 +129,7 @@ function getAreaDimensions(insight: IInsight): IDimension[] {
     ];
 }
 
-function getLineDimensions(insight: IInsight): IDimension[] {
+function getLineDimensions(insight: IInsightDefinition): IDimension[] {
     const trend = insightBucket(insight, BucketNames.TREND);
     const trendAttributes = trend ? bucketAttributes(trend) : [];
     const segment = insightBucket(insight, BucketNames.SEGMENT);
@@ -159,7 +159,7 @@ export function getHeadlinesDimensions(): IDimension[] {
     return [{ itemIdentifiers: [MeasureGroupIdentifier] }];
 }
 
-function getScatterDimensions(insight: IInsight): IDimension[] {
+function getScatterDimensions(insight: IInsightDefinition): IDimension[] {
     const attribute = insightBucket(insight, BucketNames.ATTRIBUTE);
 
     if (attribute && !bucketIsEmpty(attribute)) {
@@ -184,11 +184,11 @@ function getScatterDimensions(insight: IInsight): IDimension[] {
 }
 
 // Heatmap
-export function getHeatmapDimensionsFromMdObj(insight: IInsight): IDimension[] {
+export function getHeatmapDimensionsFromMdObj(insight: IInsightDefinition): IDimension[] {
     return getHeatmapDimensionsFromBuckets(insight);
 }
 
-export function getHeatmapDimensionsFromBuckets(insight: IInsight): IDimension[] {
+export function getHeatmapDimensionsFromBuckets(insight: IInsightDefinition): IDimension[] {
     const view = insightBucket(insight, BucketNames.VIEW);
     const viewAttributes = view ? bucketAttributes(view) : [];
     const stack = insightBucket(insight, BucketNames.STACK);
@@ -214,7 +214,7 @@ export function getHeatmapDimensionsFromBuckets(insight: IInsight): IDimension[]
     ];
 }
 
-function getBubbleDimensions(insight: IInsight): IDimension[] {
+function getBubbleDimensions(insight: IInsightDefinition): IDimension[] {
     const view = insightBucket(insight, BucketNames.VIEW);
     const viewAttributes = view ? bucketAttributes(view) : [];
     const stack = insightBucket(insight, BucketNames.STACK);
@@ -252,7 +252,7 @@ function getBubbleDimensions(insight: IInsight): IDimension[] {
  * @param type:VisType - visualization type string
  * @internal
  */
-export function generateDimensions(insight: IInsight, type: VisType): IDimension[] {
+export function generateDimensions(insight: IInsightDefinition, type: VisType): IDimension[] {
     switch (type) {
         case VisualizationTypes.TABLE: {
             return getPivotTableDimensions(insight);
@@ -296,7 +296,7 @@ export function generateDimensions(insight: IInsight, type: VisType): IDimension
     return [];
 }
 
-export function generateStackedDimensions(insight: IInsight): IDimension[] {
+export function generateStackedDimensions(insight: IInsightDefinition): IDimension[] {
     const viewBucket = insightBucket(insight, BucketNames.ATTRIBUTE);
     const viewAttributes = viewBucket ? bucketAttributes(viewBucket) : [];
     const stackAttribute = bucketAttribute(insightBucket(insight, BucketNames.STACK));
@@ -312,7 +312,7 @@ export function generateStackedDimensions(insight: IInsight): IDimension[] {
 }
 
 // for LineChart, AreaChart, BarChart, ColumnChart
-export function generateDefaultDimensions(insight: IInsight): IDimension[] {
+export function generateDefaultDimensions(insight: IInsightDefinition): IDimension[] {
     return [
         {
             itemIdentifiers: [MeasureGroupIdentifier],
@@ -324,7 +324,7 @@ export function generateDefaultDimensions(insight: IInsight): IDimension[] {
 }
 
 // for ScatterPlot and BubbleChart
-export function generateDefaultDimensionsForPointsCharts(insight: IInsight): IDimension[] {
+export function generateDefaultDimensionsForPointsCharts(insight: IInsightDefinition): IDimension[] {
     return [
         {
             itemIdentifiers: insightAttributes(insight).map(attributeLocalId),
@@ -336,7 +336,7 @@ export function generateDefaultDimensionsForPointsCharts(insight: IInsight): IDi
 }
 
 // for PieChart, DonutChart
-export const generateDefaultDimensionsForRoundChart = (insight: IInsight): IDimension[] => {
+export const generateDefaultDimensionsForRoundChart = (insight: IInsightDefinition): IDimension[] => {
     const attributes = insightAttributes(insight);
 
     if (attributes.length === 0) {
@@ -361,15 +361,15 @@ export const generateDefaultDimensionsForRoundChart = (insight: IInsight): IDime
 };
 
 // Treemap
-export function getTreemapDimensionsFromMdObj(insight: IInsight): IDimension[] {
+export function getTreemapDimensionsFromMdObj(insight: IInsightDefinition): IDimension[] {
     return getTreemapDimensionsFromBuckets(insight);
 }
 
-export function getTreemapDimensionsFromBuckets(insight: IInsight): IDimension[] {
+export function getTreemapDimensionsFromBuckets(insight: IInsightDefinition): IDimension[] {
     return getTreemapDimensionsFromAFM(insight);
 }
 
-export function getTreemapDimensionsFromAFM(insight: IInsight): IDimension[] {
+export function getTreemapDimensionsFromAFM(insight: IInsightDefinition): IDimension[] {
     const attributes = insightAttributes(insight);
 
     if (attributes.length === 1) {

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -10,7 +10,7 @@ import {
     bucketAttributes,
     IAttributeSortItem,
     IBucket,
-    IInsight,
+    IInsightDefinition,
     IMeasure,
     insightBucket,
     insightMeasures,
@@ -54,7 +54,7 @@ export function getAttributeSortItem(
     return attributeSortItem;
 }
 
-function getDefaultTableSort(insight: IInsight): SortItem[] {
+function getDefaultTableSort(insight: IInsightDefinition): SortItem[] {
     const rowBucket = insightBucket(insight, BucketNames.ATTRIBUTE);
     const rowAttributes = rowBucket ? bucketAttributes(rowBucket) : [];
 
@@ -74,7 +74,10 @@ function getDefaultTableSort(insight: IInsight): SortItem[] {
     return [];
 }
 
-function getDefaultBarChartSort(insight: IInsight, canSortStackTotalValue: boolean = false): SortItem[] {
+function getDefaultBarChartSort(
+    insight: IInsightDefinition,
+    canSortStackTotalValue: boolean = false,
+): SortItem[] {
     const measures = insightMeasures(insight);
     const viewBucket = insightBucket(insight, BucketNames.VIEW);
     const stackBucket = insightBucket(insight, BucketNames.STACK);
@@ -121,7 +124,7 @@ export function getDefaultTreemapSortFromBuckets(
     return [];
 }
 
-export function getDefaultTreemapSort(insight: IInsight): SortItem[] {
+export function getDefaultTreemapSort(insight: IInsightDefinition): SortItem[] {
     return getDefaultTreemapSortFromBuckets(
         insightBucket(insight, BucketNames.VIEW),
         insightBucket(insight, BucketNames.SEGMENT),
@@ -129,10 +132,10 @@ export function getDefaultTreemapSort(insight: IInsight): SortItem[] {
     );
 }
 
-// Consider disolving this function into individual components
+// Consider dissolving this function into individual components
 export function createSorts(
     type: string,
-    insight: IInsight,
+    insight: IInsightDefinition,
     canSortStackTotalValue: boolean = false,
 ): SortItem[] {
     switch (type) {

--- a/libs/sdk-ui-ext/src/internal/utils/tests/dimensions.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/dimensions.test.ts
@@ -10,7 +10,7 @@ import {
 import {
     bucketsFind,
     IBucket,
-    IInsight,
+    IInsightDefinition,
     insightBucket,
     insightBuckets,
     ITotal,
@@ -19,8 +19,9 @@ import {
 } from "@gooddata/sdk-model";
 import { ReferenceRecordings } from "@gooddata/reference-workspace";
 
-const singleMeasureInsight = ReferenceRecordings.Insights.Headline.SingleMeasure.obj as IInsight;
-const singleAttributeInsight = ReferenceRecordings.Insights.PivotTable.SingleAttribute.obj as IInsight;
+const singleMeasureInsight = ReferenceRecordings.Insights.Headline.SingleMeasure.obj as IInsightDefinition;
+const singleAttributeInsight = ReferenceRecordings.Insights.PivotTable.SingleAttribute
+    .obj as IInsightDefinition;
 const insightWithProperties = insightSetProperties(singleMeasureInsight, {
     controls: { xaxis: { visible: true } },
 });
@@ -32,7 +33,7 @@ const insightWithProperties = insightSetProperties(singleMeasureInsight, {
  * different recorded insights and verifying dimensionality.
  */
 
-function getVisualizationBucket(newVis: IInsight, bucketName: string): IBucket {
+function getVisualizationBucket(newVis: IInsightDefinition, bucketName: string): IBucket {
     const buckets = insightBuckets(newVis);
     let bucket = bucketsFind(buckets, bucketName);
 
@@ -44,7 +45,7 @@ function getVisualizationBucket(newVis: IInsight, bucketName: string): IBucket {
     return bucket;
 }
 
-function addMeasure(visualization: IInsight, index: number): IInsight {
+function addMeasure(visualization: IInsightDefinition, index: number): IInsightDefinition {
     const newVis = cloneDeep(visualization);
     const measure = {
         measure: {
@@ -66,7 +67,11 @@ function addMeasure(visualization: IInsight, index: number): IInsight {
     return newVis;
 }
 
-function addAttribute(visualization: IInsight, index: number, bucketName: string): IInsight {
+function addAttribute(
+    visualization: IInsightDefinition,
+    index: number,
+    bucketName: string,
+): IInsightDefinition {
     const newVis = cloneDeep(visualization);
     const attribute = {
         attribute: {
@@ -83,7 +88,11 @@ function addAttribute(visualization: IInsight, index: number, bucketName: string
     return newVis;
 }
 
-function addTotals(visualization: IInsight, bucketName: string, newTotals: ITotal[]): IInsight {
+function addTotals(
+    visualization: IInsightDefinition,
+    bucketName: string,
+    newTotals: ITotal[],
+): IInsightDefinition {
     const newVis = cloneDeep(visualization);
 
     const bucket = getVisualizationBucket(newVis, bucketName);
@@ -99,11 +108,9 @@ function addTotals(visualization: IInsight, bucketName: string, newTotals: ITota
     return newVis;
 }
 
-function newInsight(buckets: IBucket[]): IInsight {
+function newInsight(buckets: IBucket[]): IInsightDefinition {
     return {
         insight: {
-            identifier: "test",
-            uri: "test",
             title: "no name",
             visualizationUrl: "classId",
             buckets,


### PR DESCRIPTION
There is no reason for PluggableVisualizations to need to know
whether the insight they work with has been persisted or not.

JIRA: RAIL-2121

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
