### PR TITLE
Fix pluggable pivot table drilling

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -222,7 +222,8 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
     };
 
     protected onDrill = (event: IDrillEvent) => {
-        this.callbacks.onDrill?.(event);
+        // in case onDrill is not specified, default to always firing drill events
+        return this.callbacks.onDrill ? this.callbacks.onDrill(event) : true;
     };
 
     //


### PR DESCRIPTION
As the CorePivotTable is checking the output of the onDrill function
before it decides whether to fire the event, we need to return
the value in teh onDrill in AbstractPluggableVisualization.
Moreover, CorePivotTable onDrill defaults to always true, but now that
we always provide a callback when used from PluggablePivotTable
this default is ignored. Hence we need to default to returning true
and make the drilling explicitly opt-out (which it was implicitly anyway).

JIRA: RAIL-2121

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
