### PR TITLE
RELATED: RAIL-2121 add bear legacy function for drilling sanitization

### DIFF
--- a/libs/sdk-backend-bear/src/backend/drillingPostMessageData/index.ts
+++ b/libs/sdk-backend-bear/src/backend/drillingPostMessageData/index.ts
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import { IUriIdentifierPair } from "@gooddata/gd-bear-client/lib/metadata";
-import { IPostMessageData, isPostMessageData } from "@gooddata/sdk-model";
+import { IDrillingActivationPostMessageData } from "@gooddata/sdk-model";
 import compact = require("lodash/compact");
 import includes = require("lodash/includes");
 import isArray = require("lodash/isArray");
@@ -21,23 +21,20 @@ const getUriFromPairByIdentifier = (
 /**
  * @internal
  */
-export const sanitizeDrillingPostMessageData = async (
+export const sanitizeDrillingActivationPostMessageData = async (
     workspace: string,
-    postMessageData: IPostMessageData,
+    postMessageData: IDrillingActivationPostMessageData,
     idToUriConverter: (workspace: string, identifiers: string[]) => Promise<IUriIdentifierPair[]>,
-): Promise<IPostMessageData> => {
+): Promise<IDrillingActivationPostMessageData> => {
     const { uris, identifiers, composedFrom } = postMessageData;
 
     const simpleUris = isArray(uris) ? uris : [];
     const simpleIdentifiers = isArray(identifiers) ? identifiers : [];
 
-    const composedFromUris =
-        isPostMessageData(postMessageData) && isArray(composedFrom!.uris) ? composedFrom!.uris : [];
+    const composedFromUris = composedFrom?.uris && isArray(composedFrom.uris) ? composedFrom.uris : [];
 
     const composedFromIdentifiers =
-        isPostMessageData(postMessageData) && isArray(composedFrom!.identifiers)
-            ? composedFrom!.identifiers
-            : [];
+        composedFrom?.identifiers && isArray(composedFrom.identifiers) ? composedFrom.identifiers : [];
 
     const allIdentifiers = uniq([...simpleIdentifiers, ...composedFromIdentifiers]);
 

--- a/libs/sdk-backend-bear/src/backend/drillingPostMessageData/tests/index.test.ts
+++ b/libs/sdk-backend-bear/src/backend/drillingPostMessageData/tests/index.test.ts
@@ -1,7 +1,7 @@
 // (C) 2020 GoodData Corporation
 import { IUriIdentifierPair } from "@gooddata/gd-bear-client/lib/metadata";
-import { sanitizeDrillingPostMessageData } from "..";
-import { IPostMessageData } from "@gooddata/sdk-model";
+import { sanitizeDrillingActivationPostMessageData } from "..";
+import { IDrillingActivationPostMessageData } from "@gooddata/sdk-model";
 
 describe("sanitizeDrillingPostMessageData", () => {
     const mockIdToUriConverter = async (
@@ -15,7 +15,11 @@ describe("sanitizeDrillingPostMessageData", () => {
             }),
         );
 
-    const testCases: Array<[string, IPostMessageData, IPostMessageData]> = [
+    const testCases: Array<[
+        string,
+        IDrillingActivationPostMessageData,
+        IDrillingActivationPostMessageData,
+    ]> = [
         [
             "not convert uris",
             {
@@ -124,7 +128,7 @@ describe("sanitizeDrillingPostMessageData", () => {
         ],
     ];
     it.each(testCases)("should %s", async (_, input, expected) => {
-        const actual = await sanitizeDrillingPostMessageData("", input, mockIdToUriConverter);
+        const actual = await sanitizeDrillingActivationPostMessageData("", input, mockIdToUriConverter);
         expect(actual).toEqual(expected);
     });
 });

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -18,7 +18,7 @@ import {
     NoopAuthProvider,
     IUserService,
 } from "@gooddata/sdk-backend-spi";
-import { IInsight, IPostMessageData } from "@gooddata/sdk-model";
+import { IInsight, IDrillingActivationPostMessageData } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import defaultTo = require("lodash/defaultTo");
 import isEmpty = require("lodash/isEmpty");
@@ -28,7 +28,7 @@ import { BearWorkspaceQueryFactory } from "./workspaces";
 import { BearUserService } from "./user";
 import { convertInsight } from "../fromSdkModel/InsightConverter";
 import { GdcUser } from "@gooddata/gd-bear-model";
-import { sanitizeDrillingPostMessageData } from "./drillingPostMessageData";
+import { sanitizeDrillingActivationPostMessageData } from "./drillingPostMessageData";
 
 const CAPABILITIES: BackendCapabilities = {
     canCalculateTotals: true,
@@ -73,10 +73,10 @@ type BearLegacyFunctions = {
     ajaxSetup?(setup: any): void;
     log?(uri: string, logMessages: string[]): Promise<any>;
     updateProfileCurrentWorkspace?(workspace: string, profileSetting: GdcUser.IProfileSetting): Promise<void>;
-    sanitizeDrillingPostMessageData?(
+    sanitizeDrillingActivationPostMessageData?(
         workspace: string,
-        postMessageData: IPostMessageData,
-    ): Promise<IPostMessageData>;
+        postMessageData: IDrillingActivationPostMessageData,
+    ): Promise<IDrillingActivationPostMessageData>;
 };
 
 /**
@@ -162,9 +162,12 @@ export class BearBackend implements IAnalyticalBackend {
                     );
                 },
 
-                sanitizeDrillingPostMessageData: (workspace, postMessageData) =>
-                    sanitizeDrillingPostMessageData(workspace, postMessageData, (workspace, identifiers) =>
-                        this.authApiCall(sdk => sdk.md.getUrisFromIdentifiers(workspace, identifiers)),
+                sanitizeDrillingActivationPostMessageData: (workspace, postMessageData) =>
+                    sanitizeDrillingActivationPostMessageData(
+                        workspace,
+                        postMessageData,
+                        (workspace, identifiers) =>
+                            this.authApiCall(sdk => sdk.md.getUrisFromIdentifiers(workspace, identifiers)),
                     ),
             };
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -633,6 +633,13 @@ export const idMatchMeasure: (id: string) => MeasurePredicate;
 export function idRef(identifier: Identifier, type?: ObjectType): IdentifierRef;
 
 // @public
+export interface IDrillingActivationPostMessageData {
+    composedFrom?: IDrillingActivationPostMessageData;
+    identifiers?: string[];
+    uris?: string[];
+}
+
+// @public
 export interface IExecutionDefinition {
     // (undocumented)
     readonly attributes: IAttribute[];
@@ -903,11 +910,6 @@ export interface IPositiveAttributeFilter {
     };
 }
 
-// @public (undocumented)
-export interface IPostMessageData extends ISimplePostMessageData {
-    composedFrom?: ISimplePostMessageData;
-}
-
 // @public
 export interface IPreviousPeriodDateDataSet {
     // (undocumented)
@@ -1042,12 +1044,6 @@ export function isDimension(obj: any): obj is IDimension;
 // @public
 export function isIdentifierRef(obj: any): obj is IdentifierRef;
 
-// @public (undocumented)
-export interface ISimplePostMessageData {
-    identifiers?: string[];
-    uris?: string[];
-}
-
 // @public
 export function isInsight(obj: any): obj is IInsight;
 
@@ -1083,9 +1079,6 @@ export function isPoPMeasureDefinition(obj: any): obj is IPoPMeasureDefinition;
 
 // @public
 export function isPositiveAttributeFilter(obj: any): obj is IPositiveAttributeFilter;
-
-// @public (undocumented)
-export function isPostMessageData(item: any): item is IPostMessageData;
 
 // @public
 export function isPreviousPeriodMeasure(obj: any): obj is IMeasure<IPreviousPeriodMeasureDefinition>;

--- a/libs/sdk-model/src/embedding/postMessage.ts
+++ b/libs/sdk-model/src/embedding/postMessage.ts
@@ -1,9 +1,11 @@
 // (C) 2020 GoodData Corporation
 
 /**
+ * Data of the postMessage message used to activate drilling on specific measures and/or attributes.
+ *
  * @public
  */
-export interface ISimplePostMessageData {
+export interface IDrillingActivationPostMessageData {
     /**
      * URI of attribute or measure that should be drillable.
      */
@@ -13,22 +15,10 @@ export interface ISimplePostMessageData {
      * Identifier of attribute or measure that should be drillable.
      */
     identifiers?: string[];
-}
 
-/**
- * @public
- */
-export interface IPostMessageData extends ISimplePostMessageData {
     /**
      * Optionally specifies drilling on measures that are composed from other measures - by listing uris or
      * identifiers of components.
      */
-    composedFrom?: ISimplePostMessageData;
-}
-
-/**
- * @public
- */
-export function isPostMessageData(item: any): item is IPostMessageData {
-    return (item as IPostMessageData).composedFrom !== undefined;
+    composedFrom?: IDrillingActivationPostMessageData;
 }

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -8,7 +8,7 @@ export {
     builderFactory,
 } from "./base/builder";
 
-export { IPostMessageData, ISimplePostMessageData, isPostMessageData } from "./embedding/postMessage";
+export { IDrillingActivationPostMessageData } from "./embedding/postMessage";
 
 export {
     IAttribute,

--- a/libs/sdk-ui-ext/src/internal/utils/drillablePredicates.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/drillablePredicates.ts
@@ -1,6 +1,6 @@
 // (C) 2019-2020 GoodData Corporation
 import { IHeaderPredicate, HeaderPredicates } from "@gooddata/sdk-ui";
-import { IPostMessageData, isPostMessageData } from "@gooddata/sdk-model";
+import { IDrillingActivationPostMessageData } from "@gooddata/sdk-model";
 import isArray = require("lodash/isArray");
 import uniq = require("lodash/uniq");
 
@@ -13,20 +13,17 @@ import uniq = require("lodash/uniq");
  * @internal
  */
 export async function convertPostMessageToDrillablePredicates(
-    postMessageData: IPostMessageData,
+    postMessageData: IDrillingActivationPostMessageData,
 ): Promise<IHeaderPredicate[]> {
     const { uris, identifiers, composedFrom } = postMessageData;
 
     const simpleUris = isArray(uris) ? uniq(uris) : [];
     const simpleIdentifiers = isArray(identifiers) ? uniq(identifiers) : [];
 
-    const composedFromUris =
-        isPostMessageData(postMessageData) && isArray(composedFrom.uris) ? uniq(composedFrom.uris) : [];
+    const composedFromUris = composedFrom?.uris && isArray(composedFrom.uris) ? uniq(composedFrom.uris) : [];
 
     const composedFromIdentifiers =
-        isPostMessageData(postMessageData) && isArray(composedFrom.identifiers)
-            ? uniq(composedFrom.identifiers)
-            : [];
+        composedFrom?.identifiers && isArray(composedFrom.identifiers) ? uniq(composedFrom.identifiers) : [];
 
     // note: not passing factory function to maps to make testing assertions simpler (passing factory fun-as-is
     //  will call the factory with 3 args (value, index and all values)

--- a/libs/sdk-ui-ext/src/internal/utils/tests/drillablePredicates.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/drillablePredicates.test.ts
@@ -1,7 +1,8 @@
 // (C) 2019-2020 GoodData Corporation
-import { IPostMessageData, convertPostMessageToDrillablePredicates } from "../drillablePredicates";
+import { convertPostMessageToDrillablePredicates } from "../drillablePredicates";
 import SpyInstance = jest.SpyInstance;
 import { IHeaderPredicate, HeaderPredicates } from "@gooddata/sdk-ui";
+import { IDrillingActivationPostMessageData } from "@gooddata/sdk-model";
 
 describe("convertPostMessageToDrillablePredicates", () => {
     let uriMatchSpy: SpyInstance;
@@ -31,7 +32,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return predicates for combination of uris and identifiers", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             uris: ["/foo", "/measure"],
             identifiers: ["bar", "baz"],
         };
@@ -49,7 +50,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return deduplicated predicates", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             uris: ["/common", "/common"],
             identifiers: ["common", "common"],
         };
@@ -63,7 +64,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return no predicates when no identifiers and uris provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             uris: [],
             identifiers: [],
         };
@@ -95,7 +96,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return composedFromUri predicates when composed uri provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             identifiers: [],
             uris: [],
             composedFrom: {
@@ -111,7 +112,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return composedFromUri predicate even when composed unresolvable uri provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             identifiers: [],
             uris: [],
             composedFrom: {
@@ -128,7 +129,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return composedFromIdentifier predicates when composed identifiers provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             identifiers: [],
             uris: [],
             composedFrom: {
@@ -144,7 +145,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return predicates when composed uri and identifiers provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             identifiers: [],
             uris: [],
             composedFrom: {
@@ -165,7 +166,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
 
     // tslint:disable-next-line:max-line-length
     it("should return deduplicated predicates when composed uris and identifiers provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             identifiers: [],
             uris: [],
             composedFrom: {
@@ -187,7 +188,7 @@ describe("convertPostMessageToDrillablePredicates", () => {
     });
 
     it("should return deduplicated predicates when all input uris and identifiers provided", async () => {
-        const data: IPostMessageData = {
+        const data: IDrillingActivationPostMessageData = {
             uris: ["/foo", "/common", "/common"],
             identifiers: ["bar", "baz", "common", "common"],
             composedFrom: {


### PR DESCRIPTION
This function is used to convert drilling post message data
to a form that the bear backend will understand properly.

JIRA: RAIL-2121

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
