### PR TITLE
BUGFIX: RAIL-2181 fix date conversion in DateFilter

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/utils/DateConversions.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/DateConversions.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 import * as moment from "moment";
 import isString = require("lodash/isString");
 import isDate = require("lodash/isDate");
@@ -25,11 +25,16 @@ export const convertPlatformDateStringToDate = (
      *   local time is "2019-11-28T06:00:00 GTM+0600"
      *   after converting the local time will be "2019-11-28T00:00:00 GTM+0600"
      */
-    const localTimeOffsetValue = getTimeOffsetInMilliseconds();
-    const localTimeValue = new Date(platformDate).getTime() + localTimeOffsetValue;
+    const convertedDate = new Date(platformDate);
+    const localTimeOffsetValue = getTimeOffsetInMilliseconds(convertedDate);
+    const localTimeValue = convertedDate.getTime() + localTimeOffsetValue;
 
     return new Date(localTimeValue);
 };
 
-export const getTimeOffsetInMilliseconds = (): number =>
-    new Date().getTimezoneOffset() * NUM_OF_MILISECONDS_IN_MINUTE;
+/**
+ * Returns the timezone offset in milliseconds for the given date.
+ * @param when when to return the offset for. This is important because of DST - the offset changes during the year.
+ */
+const getTimeOffsetInMilliseconds = (when: Date): number =>
+    when.getTimezoneOffset() * NUM_OF_MILISECONDS_IN_MINUTE;


### PR DESCRIPTION
The problem was that the local time offset was taken for today,
not for the date we are working with.
These are very different if today is DST and the given date is not
or vice versa.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
