### PR TITLE
RELATED: RAIL-2121 - Fix error handling when obtaining color palette in bear client

### DIFF
--- a/libs/gd-bear-client/src/xhr.ts
+++ b/libs/gd-bear-client/src/xhr.ts
@@ -90,6 +90,8 @@ export function originPackageHeaders({ name, version }: IPackageHeaders) {
 export class ApiError extends Error {
     constructor(message: string, public cause: any) {
         super(message);
+
+        Object.setPrototypeOf(this, new.target.prototype);
     }
 }
 
@@ -110,19 +112,19 @@ export class ApiResponse<T = any> {
         this.responseBody = responseBody;
     }
 
-    get data() {
+    get data(): T {
         try {
             return JSON.parse(this.responseBody) as T;
         } catch (error) {
-            throw new Error("Cannot parse responseBody!");
+            throw new Error("Cannot parse responseBody.");
         }
     }
 
-    public getData() {
+    public getData(): T {
         try {
             return JSON.parse(this.responseBody) as T;
         } catch (error) {
-            throw new Error("Cannot parse responseBody!");
+            throw new Error("Cannot parse responseBody.");
         }
     }
 


### PR DESCRIPTION
-  getData() was not throwing errors before RAIL-1909; it does now
-  color palette was not ready for this
-  fixed ApiError extension of Error
-  added catches to getColor* methods
-  added and corrected tests

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
