### PR TITLE
RELATED: RAIL-2171 properly map tiger elements options

### DIFF
--- a/libs/sdk-backend-spi/src/workspace/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/elements/index.ts
@@ -30,7 +30,7 @@ export interface IElementQueryOptions {
     uris?: string[];
 
     /**
-     * TO-DO what is this doing?
+     * If true, the `filter` prop will behave negatively - i.e. it will not include items matching the `filter` value.
      */
     complement?: boolean;
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/elements/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/elements/index.ts
@@ -61,15 +61,19 @@ class TigerWorkspaceElementsQuery implements IElementQuery {
             throw new UnexpectedError("Tiger backend does not allow referencing objects by URI");
         }
 
-        const mergedOptions = { ...options, limit, offset };
-
-        const response = await this.authCall(sdk =>
-            sdk.labelElements.processElementsRequest({
-                ...mergedOptions,
-                workspace: this.workspace,
+        const response = await this.authCall(sdk => {
+            const elementsRequest: Parameters<typeof sdk.labelElements.processElementsRequest>[0] = {
+                ...(options?.complement && { complementFilter: options.complement }),
+                ...(options?.filter && { patternFilter: options.filter }),
+                ...(options?.order && { sortOrder: options.order === "asc" ? "ASC" : "DESC" }),
+                limit,
+                offset,
                 label: ref.identifier,
-            }),
-        );
+                workspace: this.workspace,
+            };
+
+            return sdk.labelElements.processElementsRequest(elementsRequest);
+        });
 
         const { paging, elements } = response.data;
         const { count, total, offset: serverOffset } = paging;


### PR DESCRIPTION
The options in tiger are a bit different and the mapping
from the SPI options was missing.

Also, docs for one of the options were derived from the corresponding
tiger option docs.

JIRA: RAIL-2171

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
