### PR TITLE
RELATED: RAIL-2273 add getReferencedObjects function

### DIFF
--- a/libs/gd-bear-model/api/gd-bear-model.api.md
+++ b/libs/gd-bear-model/api/gd-bear-model.api.md
@@ -1235,6 +1235,17 @@ export namespace GdcMetadata {
         uri: string;
     }
     // (undocumented)
+    export interface IDataSet extends IMetadataObject {
+        // (undocumented)
+        attributes: Uri[];
+        // (undocumented)
+        dataLoadingColumns: Uri[];
+        // (undocumented)
+        facts: Uri[];
+        // (undocumented)
+        mode: string;
+    }
+    // (undocumented)
     export interface IFact extends IMetadataObject {
         // (undocumented)
         content: any;
@@ -1392,6 +1403,8 @@ export namespace GdcMetadata {
     // (undocumented)
     export function isAttributeDisplayForm(obj: any): obj is IAttributeDisplayForm;
     // (undocumented)
+    export function isDataSet(obj: any): obj is IDataSet;
+    // (undocumented)
     export function isFact(obj: any): obj is IFact;
     // (undocumented)
     export function isKpiAlert(obj: any): obj is IKpiAlert;
@@ -1401,6 +1414,8 @@ export namespace GdcMetadata {
     export function isWrappedAttribute(obj: any): obj is IWrappedAttribute;
     // (undocumented)
     export function isWrappedAttributeDisplayForm(obj: any): obj is IWrappedAttributeDisplayForm;
+    // (undocumented)
+    export function isWrappedDataSet(obj: any): obj is IWrappedDataSet;
     // (undocumented)
     export function isWrappedFact(obj: any): obj is IWrappedFact;
     // (undocumented)
@@ -1489,6 +1504,11 @@ export namespace GdcMetadata {
         };
     }
     // (undocumented)
+    export interface IWrappedDataSet {
+        // (undocumented)
+        dataSet: IDataSet;
+    }
+    // (undocumented)
     export interface IWrappedFact {
         // (undocumented)
         fact: IFact;
@@ -1512,11 +1532,11 @@ export namespace GdcMetadata {
 // @public (undocumented)
 export namespace GdcMetadataObject {
     // (undocumented)
-    export type IObject = GdcMetadata.IAttribute | GdcMetadata.IMetric | GdcMetadata.IFact | GdcMetadata.IAttributeDisplayForm | GdcMetadata.IKpiAlert | GdcDashboard.IAnalyticalDashboard | GdcDashboardExport.IFilterContext | GdcScheduledMail.IScheduledMail | GdcProjectDashboard.IProjectDashboard | GdcExtendedDateFilters.IDateFilterConfig | GdcVisualizationWidget.IVisualizationWidget | GdcVisualizationObject.IVisualizationObject;
+    export type IObject = GdcMetadata.IAttribute | GdcMetadata.IMetric | GdcMetadata.IFact | GdcMetadata.IAttributeDisplayForm | GdcMetadata.IKpiAlert | GdcMetadata.IDataSet | GdcDashboard.IAnalyticalDashboard | GdcDashboardExport.IFilterContext | GdcScheduledMail.IScheduledMail | GdcProjectDashboard.IProjectDashboard | GdcExtendedDateFilters.IDateFilterConfig | GdcVisualizationWidget.IVisualizationWidget | GdcVisualizationObject.IVisualizationObject;
     // (undocumented)
     export function unwrapMetadataObject(object: WrappedObject): IObject;
     // (undocumented)
-    export type WrappedObject = GdcMetadata.IWrappedAttribute | GdcMetadata.IWrappedMetric | GdcMetadata.IWrappedFact | GdcMetadata.IWrappedAttributeDisplayForm | GdcMetadata.IWrappedKpiAlert | GdcDashboard.IWrappedAnalyticalDashboard | GdcDashboardExport.IWrappedFilterContext | GdcScheduledMail.IWrappedScheduledMail | GdcProjectDashboard.IWrappedProjectDashboard | GdcExtendedDateFilters.IWrappedDateFilterConfig | GdcVisualizationWidget.IWrappedVisualizationWidget | GdcVisualizationObject.IVisualizationObjectResponse;
+    export type WrappedObject = GdcMetadata.IWrappedAttribute | GdcMetadata.IWrappedMetric | GdcMetadata.IWrappedFact | GdcMetadata.IWrappedAttributeDisplayForm | GdcMetadata.IWrappedKpiAlert | GdcMetadata.IWrappedDataSet | GdcDashboard.IWrappedAnalyticalDashboard | GdcDashboardExport.IWrappedFilterContext | GdcScheduledMail.IWrappedScheduledMail | GdcProjectDashboard.IWrappedProjectDashboard | GdcExtendedDateFilters.IWrappedDateFilterConfig | GdcVisualizationWidget.IWrappedVisualizationWidget | GdcVisualizationObject.IVisualizationObjectResponse;
 }
 
 // @public

--- a/libs/gd-bear-model/src/meta/GdcMetadata.ts
+++ b/libs/gd-bear-model/src/meta/GdcMetadata.ts
@@ -126,6 +126,13 @@ export namespace GdcMetadata {
         };
     }
 
+    export interface IDataSet extends IMetadataObject {
+        attributes: Uri[];
+        dataLoadingColumns: Uri[];
+        facts: Uri[];
+        mode: string;
+    }
+
     export interface IWrappedAttribute {
         attribute: IAttribute;
     }
@@ -144,6 +151,10 @@ export namespace GdcMetadata {
 
     export interface IWrappedKpiAlert {
         kpiAlert: IKpiAlert;
+    }
+
+    export interface IWrappedDataSet {
+        dataSet: IDataSet;
     }
 
     export interface IWrappedAttributeElement {
@@ -363,10 +374,18 @@ export namespace GdcMetadata {
     }
 
     export function isKpiAlert(obj: any): obj is IKpiAlert {
-        return !isEmpty(obj) && (obj as IAttribute).meta.category === "kpiAlert";
+        return !isEmpty(obj) && (obj as IKpiAlert).meta.category === "kpiAlert";
     }
 
     export function isWrappedKpiAlert(obj: any): obj is IWrappedKpiAlert {
         return !isEmpty(obj) && obj.hasOwnProperty("kpiAlert");
+    }
+
+    export function isDataSet(obj: any): obj is IDataSet {
+        return !isEmpty(obj) && (obj as IDataSet).meta.category === "dataSet";
+    }
+
+    export function isWrappedDataSet(obj: any): obj is IWrappedDataSet {
+        return !isEmpty(obj) && obj.hasOwnProperty("dataSet");
     }
 }

--- a/libs/gd-bear-model/src/meta/GdcMetadataObject.ts
+++ b/libs/gd-bear-model/src/meta/GdcMetadataObject.ts
@@ -21,6 +21,7 @@ export namespace GdcMetadataObject {
         | GdcMetadata.IFact
         | GdcMetadata.IAttributeDisplayForm
         | GdcMetadata.IKpiAlert
+        | GdcMetadata.IDataSet
         | GdcDashboard.IAnalyticalDashboard
         | GdcDashboardExport.IFilterContext
         | GdcScheduledMail.IScheduledMail
@@ -35,6 +36,7 @@ export namespace GdcMetadataObject {
         | GdcMetadata.IWrappedFact
         | GdcMetadata.IWrappedAttributeDisplayForm
         | GdcMetadata.IWrappedKpiAlert
+        | GdcMetadata.IWrappedDataSet
         | GdcDashboard.IWrappedAnalyticalDashboard
         | GdcDashboardExport.IWrappedFilterContext
         | GdcScheduledMail.IWrappedScheduledMail

--- a/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
@@ -1,10 +1,18 @@
 // (C) 2019-2020 GoodData Corporation
+import flatMap from "lodash/fp/flatMap";
 import flow from "lodash/flow";
 import filter from "lodash/fp/filter";
 import map from "lodash/fp/map";
 import sortBy from "lodash/fp/sortBy";
+import union from "lodash/union";
+import uniqBy from "lodash/fp/uniqBy";
 import { IInsightQueryOptions, IInsightQueryResult, IWorkspaceInsights } from "@gooddata/sdk-backend-spi";
-import { GdcVisualizationClass, GdcVisualizationObject } from "@gooddata/gd-bear-model";
+import {
+    GdcVisualizationClass,
+    GdcVisualizationObject,
+    GdcMetadata,
+    GdcMetadataObject,
+} from "@gooddata/gd-bear-model";
 import {
     IVisualizationClass,
     IInsightDefinition,
@@ -12,12 +20,35 @@ import {
     ObjRef,
     insightVisualizationUrl,
     IInsight,
+    ObjectType,
+    IMetadataObject,
+    insightUri,
 } from "@gooddata/sdk-model";
 import { convertVisualizationClass } from "../../../toSdkModel/VisualizationClassConverter";
 import { convertVisualization } from "../../../toSdkModel/VisualizationConverter";
 import { convertInsightDefinition, convertInsight } from "../../../fromSdkModel/InsightConverter";
 import { objRefToUri } from "../../../fromObjRef/api";
 import { BearAuthenticatedCallGuard } from "../../../types";
+import { getObjectIdFromUri } from "../../../utils/api";
+import { convertMetadataObject } from "../../../toSdkModel/MetaConverter";
+
+const objectTypeToObjectCategory = (
+    type: Exclude<ObjectType, "insight" | "tag">,
+): GdcMetadata.ObjectCategory => {
+    switch (type) {
+        case "displayForm":
+            return "attributeDisplayForm";
+        case "measure":
+            return "metric";
+        default:
+            return type;
+    }
+};
+
+const objectTypesWithLinkToDataset: Array<Exclude<ObjectType, "insight" | "tag">> = ["fact", "attribute"];
+const objectCategoriesWithLinkToDataset: GdcMetadata.ObjectCategory[] = objectTypesWithLinkToDataset.map(
+    objectTypeToObjectCategory,
+);
 
 export class BearWorkspaceInsights implements IWorkspaceInsights {
     constructor(private readonly authCall: BearAuthenticatedCallGuard, public readonly workspace: string) {}
@@ -160,6 +191,70 @@ export class BearWorkspaceInsights implements IWorkspaceInsights {
         return this.authCall(sdk =>
             sdk.md.openVisualizationAsReport(this.workspace, { visualizationObject }),
         );
+    };
+
+    public getReferencedObjects = async (
+        insight: IInsight,
+        types: Array<Exclude<ObjectType, "insight" | "tag">> = [
+            "attribute",
+            "dataSet",
+            "displayForm",
+            "fact",
+            "measure",
+        ],
+    ): Promise<IMetadataObject[]> => {
+        const uri = insightUri(insight);
+        const objectId = getObjectIdFromUri(uri);
+
+        // if the user wants dataSets we have to objects with links to dataSets as well to be able to reach the dataSets
+        const relevantTypes =
+            types && types.includes("dataSet")
+                ? union<Exclude<ObjectType, "insight" | "tag">>(types, objectTypesWithLinkToDataset)
+                : types;
+
+        const { entries: allDirectObjects } = await this.authCall(sdk =>
+            sdk.xhr.getParsed<{ entries: GdcMetadata.IObjectXrefEntry[] }>(
+                `/gdc/md/${this.workspace}/using2/${objectId}?types=${relevantTypes
+                    .map(objectTypeToObjectCategory)
+                    .join(",")}`,
+            ),
+        );
+
+        // get datasets from everything if needed
+        const datasetMetas = types.includes("dataSet") ? await this.getDatasets(allDirectObjects) : [];
+
+        // we have to actually get the full objects because of the isProduction which is not available on the meta objects
+        const objectUrisToObtain = [...allDirectObjects, ...datasetMetas].map(meta => meta.link);
+        const objects = await this.authCall(sdk => sdk.md.getObjects(this.workspace, objectUrisToObtain));
+
+        return objects
+            .map(obj => convertMetadataObject(GdcMetadataObject.unwrapMetadataObject(obj)))
+            .filter(obj => types.includes(obj.type)); // filter out items we might have needed to load but the type of which the user did not request
+    };
+
+    // gets all datasets referenced by the given objects
+    private getDatasets = async (
+        objects: GdcMetadata.IObjectXrefEntry[],
+    ): Promise<GdcMetadata.IObjectXrefEntry[]> => {
+        // only some object types will have a reference to a dataSet, so no need to load other object types
+        const itemsWithDataset = objects.filter(i =>
+            objectCategoriesWithLinkToDataset.includes(i.category as GdcMetadata.ObjectCategory),
+        );
+
+        const datasetResponses = await Promise.all(
+            itemsWithDataset.map(item =>
+                this.authCall(sdk =>
+                    sdk.xhr.getParsed<{ entries: GdcMetadata.IObjectXrefEntry[] }>(
+                        `/gdc/md/${this.workspace}/usedby2/${getObjectIdFromUri(item.link)}?types=dataSet`,
+                    ),
+                ),
+            ),
+        );
+
+        return flow(
+            flatMap((response: { entries: GdcMetadata.IObjectXrefEntry[] }) => response.entries),
+            uniqBy((dataSet: GdcMetadata.IObjectXrefEntry) => dataSet.identifier),
+        )(datasetResponses);
     };
 
     private getVisualizationClassByUrl = async (url: string): Promise<IVisualizationClass | undefined> => {

--- a/libs/sdk-backend-bear/src/toSdkModel/MetaConverter.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/MetaConverter.ts
@@ -10,6 +10,7 @@ import {
     newMeasureMetadataObject,
     IMetadataObject,
     ObjectType,
+    newDataSetMetadataObject,
 } from "@gooddata/sdk-model";
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 
@@ -21,6 +22,7 @@ export const convertMetadataObject = (obj: GdcMetadataObject.IObject): MetadataO
             .title(obj.meta.title)
             .description(obj.meta.summary)
             .id(obj.meta.identifier)
+            .production(obj.meta.isProduction === 1)
             .uri(obj.meta.uri);
 
     if (GdcMetadata.isAttribute(obj)) {
@@ -38,6 +40,8 @@ export const convertMetadataObject = (obj: GdcMetadataObject.IObject): MetadataO
         );
     } else if (GdcMetadata.isFact(obj)) {
         return newFactMetadataObject(ref, f => f.modify(commonModifications));
+    } else if (GdcMetadata.isDataSet(obj)) {
+        return newDataSetMetadataObject(ref, ds => ds.modify(commonModifications));
     }
 
     throw new UnexpectedError(

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/insights.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/insights.ts
@@ -18,6 +18,8 @@ import {
     isUriRef,
     visClassId,
     visClassUri,
+    ObjectType,
+    IMetadataObject,
 } from "@gooddata/sdk-model";
 import { InsightRecording, RecordingIndex } from "./types";
 import { identifierToRecording, RecordingPager } from "./utils";
@@ -124,6 +126,14 @@ export class RecordedInsights implements IWorkspaceInsights {
     public async getVisualizationClasses(): Promise<IVisualizationClass[]> {
         return this.visClasses;
     }
+
+    public getReferencedObjects = async (
+        _insight: IInsight,
+        _types?: Array<Exclude<ObjectType, "insight" | "tag">>,
+    ): Promise<IMetadataObject[]> => {
+        // return empty array for now
+        return [];
+    };
 
     private async getVisualizationClassByUri(uri: string): Promise<IVisualizationClass> {
         const result = this.visClasses.find(visClass => visClassUri(visClass) === uri);

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -29,6 +29,7 @@ import { IMetadataObject } from '@gooddata/sdk-model';
 import { IVisualizationClass } from '@gooddata/sdk-model';
 import { IWorkspace } from '@gooddata/sdk-model';
 import { IWorkspacePermissions } from '@gooddata/sdk-model';
+import { ObjectType } from '@gooddata/sdk-model';
 import { ObjRef } from '@gooddata/sdk-model';
 import { SortDirection } from '@gooddata/sdk-model';
 import { SortItem } from '@gooddata/sdk-model';
@@ -863,6 +864,7 @@ export interface IWorkspaceInsights {
     deleteInsight(ref: ObjRef): Promise<void>;
     getInsight(ref: ObjRef): Promise<IInsight>;
     getInsights(options?: IInsightQueryOptions): Promise<IInsightQueryResult>;
+    getReferencedObjects(insight: IInsight, types?: Array<Exclude<ObjectType, "insight" | "tag">>): Promise<IMetadataObject[]>;
     getVisualizationClass(ref: ObjRef): Promise<IVisualizationClass>;
     getVisualizationClasses(): Promise<IVisualizationClass[]>;
     updateInsight(insight: IInsight): Promise<IInsight>;

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -1,6 +1,13 @@
 // (C) 2019-2020 GoodData Corporation
 
-import { IVisualizationClass, IInsight, IInsightDefinition, ObjRef } from "@gooddata/sdk-model";
+import {
+    IVisualizationClass,
+    IInsight,
+    IInsightDefinition,
+    ObjRef,
+    IMetadataObject,
+    ObjectType,
+} from "@gooddata/sdk-model";
 import { IPagedResource } from "../../common/paging";
 
 /**
@@ -64,6 +71,17 @@ export interface IWorkspaceInsights {
      * @returns promise of undefined
      */
     deleteInsight(ref: ObjRef): Promise<void>;
+
+    /**
+     * Get all metadata objects referenced by a given insight.
+     *
+     * @param insight - insight to get referenced objects for
+     * @param types - optional array of object types to include
+     */
+    getReferencedObjects(
+        insight: IInsight,
+        types?: Array<Exclude<ObjectType, "insight" | "tag">>,
+    ): Promise<IMetadataObject[]>;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -11,6 +11,8 @@ import {
     IInsightDefinition,
     ObjRef,
     objRefToString,
+    ObjectType,
+    IMetadataObject,
 } from "@gooddata/sdk-model";
 import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToUri } from "../../../fromObjRef";
@@ -85,5 +87,13 @@ export class TigerWorkspaceInsights implements IWorkspaceInsights {
         ref: ObjRef,
     ): Promise<void> => {
         return this.authCall(async () => undefined);
+    };
+
+    public getReferencedObjects = async (
+        _insight: IInsight,
+        _types?: Array<Exclude<ObjectType, "insight" | "tag">>,
+    ): Promise<IMetadataObject[]> => {
+        // return empty array for now
+        return this.authCall(async () => []);
     };
 }


### PR DESCRIPTION
This function allows us to get all the objects referenced by a given Insight.
This is properly implemented only on bear for the time being.

Also, convertMetadataObject now correctly uses the isProduction flag.

JIRA: RAIL-2273

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
