### PR TITLE
TRIVIAL: fix rush config of exmamples

### DIFF
--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -12,7 +12,7 @@
   {
     "definitionName": "lockStepVersion",
     "policyName": "sdk",
-    "version": "8.0.0-alpha.62",
+    "version": "8.0.0-alpha.63",
     "nextBump": "prerelease"
   }
   // {

--- a/rush.json
+++ b/rush.json
@@ -454,7 +454,6 @@
             "packageName": "@gooddata/sdk-examples",
             "projectFolder": "examples/sdk-examples",
             "reviewCategory": "examples",
-            "versionPolicyName": "sdk",
             "shouldPublish": false
         }
         // {


### PR DESCRIPTION
Turns out you cannot set versionPolicyName and shouldPublish at the same time.
This blocked the release of alpha 63 which was only released partially.
To fix it, I manually bumped the last released version in version-policies.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
