### PR TITLE
RELATED: RAIL-2275 add missing pivot table drilling CSS class

### DIFF
--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -236,6 +236,16 @@ $header-cell-resize-width: 20px;
             overflow: auto !important;
             border-top: none;
         }
+
+        .gd-cell-drillable {
+            font-weight: bold;
+            color: $gd-color-text;
+            cursor: pointer;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The gd-cell-drillable class was missing as it is in the legacy table styles in SDK7.

JIRA: RAIL-2275

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
