### PR TITLE
RAIL-2093 Add support for loading single dashboard

### DIFF
--- a/libs/gd-bear-model/api/gd-bear-model.api.md
+++ b/libs/gd-bear-model/api/gd-bear-model.api.md
@@ -263,6 +263,10 @@ export namespace GdcDashboardLayout {
         title: string;
     }
     // (undocumented)
+    export function isFluidLayout(obj: any): obj is IFluidLayout;
+    // (undocumented)
+    export function isLayoutWidget(obj: any): obj is IPersistedWidget;
+    // (undocumented)
     export type Layout = IFluidLayout;
     // (undocumented)
     export type LayoutContent = Widget | Layout;
@@ -1145,7 +1149,7 @@ export namespace GdcFilterContext {
     // (undocumented)
     export function isWrappedFilterContext(obj: any): obj is IWrappedFilterContext;
     // (undocumented)
-    export function isWrappedTempFilterContext(obj: any): obj is IWrappedFilterContext;
+    export function isWrappedTempFilterContext(obj: any): obj is IWrappedTempFilterContext;
     export interface ITempFilterContext {
         // (undocumented)
         created: Timestamp;
@@ -1214,6 +1218,15 @@ export namespace GdcKpi {
         projectDashboard: string;
         // (undocumented)
         projectDashboardTab: string;
+    }
+    // (undocumented)
+    export function isKpi(obj: any): obj is IKPI;
+    // (undocumented)
+    export function isWrappedKpi(obj: any): obj is IWrappedKPI;
+    // (undocumented)
+    export interface IWrappedKPI {
+        // (undocumented)
+        kpi: IKPI;
     }
 }
 
@@ -1568,11 +1581,11 @@ export namespace GdcMetadata {
 // @public (undocumented)
 export namespace GdcMetadataObject {
     // (undocumented)
-    export type IObject = GdcMetadata.IAttribute | GdcMetadata.IMetric | GdcMetadata.IFact | GdcMetadata.IAttributeDisplayForm | GdcMetadata.IKpiAlert | GdcMetadata.IDataSet | GdcMetadata.IPrompt | GdcDashboard.IAnalyticalDashboard | GdcFilterContext.IFilterContext | GdcScheduledMail.IScheduledMail | GdcProjectDashboard.IProjectDashboard | GdcExtendedDateFilters.IDateFilterConfig | GdcVisualizationWidget.IVisualizationWidget | GdcVisualizationObject.IVisualizationObject;
+    export type IObject = GdcMetadata.IAttribute | GdcMetadata.IMetric | GdcMetadata.IFact | GdcMetadata.IAttributeDisplayForm | GdcMetadata.IKpiAlert | GdcMetadata.IDataSet | GdcMetadata.IPrompt | GdcDashboard.IAnalyticalDashboard | GdcFilterContext.IFilterContext | GdcFilterContext.ITempFilterContext | GdcKpi.IKPI | GdcScheduledMail.IScheduledMail | GdcProjectDashboard.IProjectDashboard | GdcExtendedDateFilters.IDateFilterConfig | GdcVisualizationWidget.IVisualizationWidget | GdcVisualizationObject.IVisualizationObject;
     // (undocumented)
     export function unwrapMetadataObject(object: WrappedObject): IObject;
     // (undocumented)
-    export type WrappedObject = GdcMetadata.IWrappedAttribute | GdcMetadata.IWrappedMetric | GdcMetadata.IWrappedFact | GdcMetadata.IWrappedAttributeDisplayForm | GdcMetadata.IWrappedKpiAlert | GdcMetadata.IWrappedDataSet | GdcMetadata.IWrappedPrompt | GdcDashboard.IWrappedAnalyticalDashboard | GdcFilterContext.IWrappedFilterContext | GdcScheduledMail.IWrappedScheduledMail | GdcProjectDashboard.IWrappedProjectDashboard | GdcExtendedDateFilters.IWrappedDateFilterConfig | GdcVisualizationWidget.IWrappedVisualizationWidget | GdcVisualizationObject.IVisualizationObjectResponse;
+    export type WrappedObject = GdcMetadata.IWrappedAttribute | GdcMetadata.IWrappedMetric | GdcMetadata.IWrappedFact | GdcMetadata.IWrappedAttributeDisplayForm | GdcMetadata.IWrappedKpiAlert | GdcMetadata.IWrappedDataSet | GdcMetadata.IWrappedPrompt | GdcDashboard.IWrappedAnalyticalDashboard | GdcFilterContext.IWrappedFilterContext | GdcFilterContext.IWrappedTempFilterContext | GdcKpi.IWrappedKPI | GdcScheduledMail.IWrappedScheduledMail | GdcProjectDashboard.IWrappedProjectDashboard | GdcExtendedDateFilters.IWrappedDateFilterConfig | GdcVisualizationWidget.IWrappedVisualizationWidget | GdcVisualizationObject.IVisualization;
 }
 
 // @public
@@ -2382,6 +2395,8 @@ export namespace GdcVisualizationObject {
     export function isRangeCondition(condition: MeasureValueFilterCondition): condition is IRangeCondition;
     // (undocumented)
     export function isRelativeDateFilter(filter: DateFilter): filter is IRelativeDateFilter;
+    // (undocumented)
+    export function isVisualization(obj: any): obj is IVisualization;
     // (undocumented)
     export interface ITotal {
         // (undocumented)

--- a/libs/gd-bear-model/src/dashboard/GdcDashboardLayout.ts
+++ b/libs/gd-bear-model/src/dashboard/GdcDashboardLayout.ts
@@ -1,5 +1,6 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { GdcVisualizationObject } from "../visualizationObject/GdcVisualizationObject";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * @public
@@ -57,5 +58,13 @@ export namespace GdcDashboardLayout {
 
     export interface ISectionDescription {
         description: string;
+    }
+
+    export function isFluidLayout(obj: any): obj is IFluidLayout {
+        return !isEmpty(obj) && !!(obj as IFluidLayout).fluidLayout;
+    }
+
+    export function isLayoutWidget(obj: any): obj is IPersistedWidget {
+        return !isEmpty(obj) && !!(obj as IPersistedWidget).widget;
     }
 }

--- a/libs/gd-bear-model/src/filterContext/GdcFilterContext.ts
+++ b/libs/gd-bear-model/src/filterContext/GdcFilterContext.ts
@@ -82,7 +82,7 @@ export namespace GdcFilterContext {
         );
     }
 
-    export function isWrappedTempFilterContext(obj: any): obj is IWrappedFilterContext {
-        return !isEmpty(obj) && (obj as IWrappedFilterContext).hasOwnProperty("tempFilterContext");
+    export function isWrappedTempFilterContext(obj: any): obj is IWrappedTempFilterContext {
+        return !isEmpty(obj) && (obj as IWrappedTempFilterContext).hasOwnProperty("tempFilterContext");
     }
 }

--- a/libs/gd-bear-model/src/kpi/GdcKpi.ts
+++ b/libs/gd-bear-model/src/kpi/GdcKpi.ts
@@ -1,6 +1,7 @@
 // (C) 2020 GoodData Corporation
 import { GdcMetadata } from "../meta/GdcMetadata";
 import { GdcExtendedDateFilters } from "../extendedDateFilters/GdcExtendedDateFilters";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * @public
@@ -9,6 +10,10 @@ export namespace GdcKpi {
     export interface IKPI {
         meta: GdcMetadata.IObjectMeta;
         content: IKpiContentWithoutComparison | IKpiContentWithComparison;
+    }
+
+    export interface IWrappedKPI {
+        kpi: IKPI;
     }
 
     export interface IKpiContentBase {
@@ -38,4 +43,12 @@ export namespace GdcKpi {
     export type IKpiComparisonTypeNoComparison = "none";
     export type IKpiComparisonTypeComparison = "previousPeriod" | "lastYear";
     export type IKpiComparisonDirection = "growIsGood" | "growIsBad";
+
+    export function isKpi(obj: any): obj is IKPI {
+        return !isEmpty(obj) && (obj as IKPI).meta.category === "kpi";
+    }
+
+    export function isWrappedKpi(obj: any): obj is IWrappedKPI {
+        return !isEmpty(obj) && !!(obj as IWrappedKPI).kpi;
+    }
 }

--- a/libs/gd-bear-model/src/meta/GdcMetadataObject.ts
+++ b/libs/gd-bear-model/src/meta/GdcMetadataObject.ts
@@ -10,6 +10,7 @@ import { GdcProjectDashboard } from "../projectDashboard/GdcProjectDashboard";
 import { GdcExtendedDateFilters } from "../extendedDateFilters/GdcExtendedDateFilters";
 import { GdcVisualizationWidget } from "../visualizationWidget/GdcVisualizationWidget";
 import { GdcVisualizationObject } from "../visualizationObject/GdcVisualizationObject";
+import { GdcKpi } from "../kpi/GdcKpi";
 
 /**
  * @public
@@ -25,6 +26,8 @@ export namespace GdcMetadataObject {
         | GdcMetadata.IPrompt
         | GdcDashboard.IAnalyticalDashboard
         | GdcFilterContext.IFilterContext
+        | GdcFilterContext.ITempFilterContext
+        | GdcKpi.IKPI
         | GdcScheduledMail.IScheduledMail
         | GdcProjectDashboard.IProjectDashboard
         | GdcExtendedDateFilters.IDateFilterConfig
@@ -41,11 +44,13 @@ export namespace GdcMetadataObject {
         | GdcMetadata.IWrappedPrompt
         | GdcDashboard.IWrappedAnalyticalDashboard
         | GdcFilterContext.IWrappedFilterContext
+        | GdcFilterContext.IWrappedTempFilterContext
+        | GdcKpi.IWrappedKPI
         | GdcScheduledMail.IWrappedScheduledMail
         | GdcProjectDashboard.IWrappedProjectDashboard
         | GdcExtendedDateFilters.IWrappedDateFilterConfig
         | GdcVisualizationWidget.IWrappedVisualizationWidget
-        | GdcVisualizationObject.IVisualizationObjectResponse;
+        | GdcVisualizationObject.IVisualization;
 
     export function unwrapMetadataObject(object: WrappedObject): IObject {
         const unwrappedObject: IObject = flow(values, first)(object);

--- a/libs/gd-bear-model/src/visualizationObject/GdcVisualizationObject.ts
+++ b/libs/gd-bear-model/src/visualizationObject/GdcVisualizationObject.ts
@@ -222,6 +222,10 @@ export namespace GdcVisualizationObject {
         visualizationObject: IVisualizationObject;
     }
 
+    export function isVisualization(obj: any): obj is IVisualization {
+        return !isEmpty(obj) && (obj as IVisualization).visualizationObject !== undefined;
+    }
+
     export function isMeasure(bucketItem: IMeasure | IAttribute): bucketItem is IMeasure {
         return !isEmpty(bucketItem) && (bucketItem as IMeasure).measure !== undefined;
     }

--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -7,24 +7,67 @@ import {
     NotSupported,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
+import { GdcDashboard, GdcMetadata, GdcFilterContext } from "@gooddata/gd-bear-model";
 
 import { BearAuthenticatedCallGuard } from "../../../types";
-import { convertListedDashboard } from "../../../toSdkModel/DashboardConverter";
+import {
+    convertListedDashboard,
+    convertDashboard,
+    BearDashboardDependency,
+} from "../../../toSdkModel/DashboardConverter";
+import { objRefToUri } from "../../../fromObjRef/api";
+
+type DashboardDependencyCategory = Extract<
+    GdcMetadata.ObjectCategory,
+    "kpi" | "visualizationWidget" | "filterContext"
+>;
+
+const DASHBOARD_DEPENDENCIES_TYPES: DashboardDependencyCategory[] = [
+    "kpi",
+    "visualizationWidget",
+    "filterContext",
+];
 
 export class BearWorkspaceDashboards implements IWorkspaceDashboards {
     constructor(private readonly authCall: BearAuthenticatedCallGuard, public readonly workspace: string) {}
 
-    public async getDashboards(): Promise<IListedDashboard[]> {
+    public getDashboards = async (): Promise<IListedDashboard[]> => {
         const dashboardsObjectLinks = await this.authCall(sdk =>
             sdk.md.getAnalyticalDashboards(this.workspace),
         );
         const dashboards = dashboardsObjectLinks.map(convertListedDashboard);
         return dashboards;
-    }
+    };
 
-    public async getDashboard(_dashboardRef: ObjRef, _filterContextRef?: ObjRef): Promise<IDashboard> {
-        throw new NotSupported("not supported");
-    }
+    public getDashboard = async (dashboardRef: ObjRef, filterContextRef?: ObjRef): Promise<IDashboard> => {
+        const [dashboardUri, filterContextUri] = await Promise.all([
+            objRefToUri(dashboardRef, this.workspace, this.authCall),
+            filterContextRef ? objRefToUri(filterContextRef, this.workspace, this.authCall) : undefined,
+        ]);
+
+        const [bearDashboard, bearDependencies, bearFilterContext] = await Promise.all([
+            this.authCall(sdk =>
+                sdk.md.getObjectDetails<GdcDashboard.IWrappedAnalyticalDashboard>(dashboardUri),
+            ),
+            this.loadDashboardDependencies(dashboardUri),
+            filterContextUri
+                ? this.authCall(sdk =>
+                      sdk.md.getObjectDetails<
+                          GdcFilterContext.IWrappedFilterContext | GdcFilterContext.IWrappedTempFilterContext
+                      >(dashboardUri),
+                  )
+                : undefined,
+        ]);
+
+        if (bearFilterContext) {
+            bearDashboard.analyticalDashboard.content.filterContext = filterContextUri;
+            bearDependencies.push(bearFilterContext);
+        }
+
+        const sdkDashboard = convertDashboard(bearDashboard, bearDependencies);
+
+        return sdkDashboard;
+    };
 
     public async createDashboard(_dashboard: IDashboardDefinition): Promise<IDashboard> {
         throw new NotSupported("not supported");
@@ -37,4 +80,19 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboards {
     public async deleteDashboard(_dashboardRef: ObjRef): Promise<void> {
         throw new NotSupported("not supported");
     }
+
+    private loadDashboardDependencies = async (dashboardUri: string) => {
+        const dependenciesObjectLinks = await this.authCall(sdk =>
+            sdk.md.getObjectUsing(this.workspace, dashboardUri, {
+                types: DASHBOARD_DEPENDENCIES_TYPES,
+                nearest: false,
+            }),
+        );
+        const dependenciesUris = dependenciesObjectLinks.map(objectLink => objectLink.link);
+        const dependenciesMetadataObjects = await this.authCall(sdk =>
+            sdk.md.getObjects<BearDashboardDependency>(this.workspace, dependenciesUris),
+        );
+
+        return dependenciesMetadataObjects;
+    };
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/metadata/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/metadata/index.ts
@@ -19,7 +19,12 @@ import {
 import { getTokenValuesOfType, tokenizeExpression } from "./measureExpressionTokens";
 import { objRefToUri } from "../../../fromObjRef/api";
 import { BearAuthenticatedCallGuard } from "../../../types";
-import { convertMetadataObject, convertMetadataObjectXrefEntry } from "../../../toSdkModel/MetaConverter";
+import {
+    convertMetadataObject,
+    convertMetadataObjectXrefEntry,
+    SupportedMetadataObject,
+    SupportedWrappedMetadataObject,
+} from "../../../toSdkModel/MetaConverter";
 import { getObjectIdFromUri } from "../../../utils/api";
 
 export class BearWorkspaceMetadata implements IWorkspaceMetadata {
@@ -91,9 +96,11 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
             ...allExpressionElementAttributeUris,
         ]);
         const allExpressionWrappedObjects = await this.authCall(sdk =>
-            sdk.md.getObjects(this.workspace, allExpressionUris),
+            sdk.md.getObjects<SupportedWrappedMetadataObject>(this.workspace, allExpressionUris),
         );
-        const allExpressionObjects = allExpressionWrappedObjects.map(GdcMetadataObject.unwrapMetadataObject);
+        const allExpressionObjects = allExpressionWrappedObjects.map(
+            GdcMetadataObject.unwrapMetadataObject,
+        ) as SupportedMetadataObject[];
         const allExpressionElements = await Promise.all(
             expressionElementUris.map(elementUri =>
                 this.authCall(sdk => sdk.md.getAttributeElementDefaultDisplayFormValue(elementUri)),

--- a/libs/sdk-backend-bear/src/toSdkModel/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/DashboardConverter.ts
@@ -1,8 +1,40 @@
 // (C) 2019-2020 GoodData Corporation
 
-import { GdcMetadata } from "@gooddata/gd-bear-model";
+import {
+    GdcMetadata,
+    GdcDashboard,
+    GdcFilterContext,
+    GdcVisualizationWidget,
+    GdcKpi,
+    GdcDashboardLayout,
+    GdcVisualizationObject,
+    GdcExtendedDateFilters,
+} from "@gooddata/gd-bear-model";
 import { uriRef } from "@gooddata/sdk-model";
-import { IListedDashboard } from "@gooddata/sdk-backend-spi";
+import {
+    IListedDashboard,
+    IDashboard,
+    IWidget,
+    IFilterContext,
+    FilterContextItem,
+    IDashboardAttributeFilter,
+    IDashboardDateFilter,
+    Layout,
+    IFluidLayoutColumn,
+    IFluidLayoutRow,
+    IDateFilterConfig,
+    IDashboardAddedPresets,
+    ITempFilterContext,
+    isWidget,
+} from "@gooddata/sdk-backend-spi";
+
+type DashboardDependency = IWidget | IFilterContext | ITempFilterContext;
+
+export type BearDashboardDependency =
+    | GdcVisualizationWidget.IWrappedVisualizationWidget
+    | GdcKpi.IWrappedKPI
+    | GdcFilterContext.IWrappedFilterContext
+    | GdcFilterContext.IWrappedTempFilterContext;
 
 export const convertListedDashboard = (dashboardLink: GdcMetadata.IObjectLink): IListedDashboard => ({
     ref: uriRef(dashboardLink.link),
@@ -13,3 +45,249 @@ export const convertListedDashboard = (dashboardLink: GdcMetadata.IObjectLink): 
     updated: dashboardLink.updated!,
     created: dashboardLink.created!,
 });
+
+const convertLayoutColumn = (
+    column: GdcDashboardLayout.IFluidLayoutColumn,
+    widgetDependencies: IWidget[],
+): IFluidLayoutColumn => {
+    const { content } = column;
+    if (GdcDashboardLayout.isLayoutWidget(content)) {
+        const widget = widgetDependencies.find(dep => {
+            const { qualifier } = content.widget;
+            if (GdcVisualizationObject.isObjUriQualifier(qualifier)) {
+                return qualifier.uri === dep.uri;
+            }
+            return qualifier.identifier === dep.identifier;
+        }) as IWidget;
+
+        return {
+            ...column,
+            content: {
+                widget,
+            },
+        };
+    }
+    return {
+        ...column,
+        content: convertLayout(content!, widgetDependencies),
+    };
+};
+
+const convertLayoutRow = (
+    row: GdcDashboardLayout.IFluidLayoutRow,
+    widgetDependencies: IWidget[],
+): IFluidLayoutRow => {
+    return {
+        ...row,
+        columns: row.columns.map(column => convertLayoutColumn(column, widgetDependencies)),
+    };
+};
+
+const convertLayout = (layout: GdcDashboardLayout.Layout, widgetDependencies: IWidget[]): Layout => {
+    const {
+        fluidLayout: { rows },
+        fluidLayout,
+    } = layout;
+    const convertedLayout: Layout = {
+        fluidLayout: {
+            ...fluidLayout,
+            rows: rows.map(row => convertLayoutRow(row, widgetDependencies)),
+        },
+    };
+    return convertedLayout;
+};
+
+const convertDateFilterConfigAddedPresets = (
+    addPresets: GdcExtendedDateFilters.IDashboardAddedPresets,
+): IDashboardAddedPresets => {
+    const { absolutePresets = [], relativePresets = [] } = addPresets;
+    const convertedPresets: IDashboardAddedPresets = {
+        absolutePresets: absolutePresets.map(preset => ({ ...preset, type: "absolutePreset" })),
+        relativePresets: relativePresets.map(preset => ({ ...preset, type: "relativePreset" })),
+    };
+    return convertedPresets;
+};
+
+const convertDateFilterConfig = (
+    dateFilterConfig: GdcExtendedDateFilters.IDashboardDateFilterConfig,
+): IDateFilterConfig => {
+    const { filterName, mode, addPresets, hideGranularities, hideOptions } = dateFilterConfig;
+
+    return {
+        filterName,
+        mode,
+        addPresets: addPresets && convertDateFilterConfigAddedPresets(addPresets),
+        hideGranularities,
+        hideOptions,
+    };
+};
+
+export const convertDashboard = (
+    dashboard: GdcDashboard.IWrappedAnalyticalDashboard,
+    dependencies: BearDashboardDependency[],
+): IDashboard => {
+    const sdkDependencies = dependencies.map(convertDashboardDependency);
+    const widgets = sdkDependencies.filter(isWidget);
+
+    const {
+        meta: { summary, created, updated, identifier, uri, title },
+        content: { layout, filterContext, dateFilterConfig },
+    } = dashboard.analyticalDashboard;
+
+    const convertedDashboard: IDashboard = {
+        title,
+        description: summary,
+
+        identifier,
+        uri,
+        ref: uriRef(uri),
+
+        created: created!,
+        updated: updated!,
+
+        scheduledMails: [], // TODO: https://jira.intgdc.com/browse/RAIL-2220
+
+        dateFilterConfig: dateFilterConfig && convertDateFilterConfig(dateFilterConfig),
+
+        filterContext: sdkDependencies.find(dep => dep.uri === filterContext) as IFilterContext,
+        layout: layout && convertLayout(layout, widgets),
+    };
+
+    return convertedDashboard;
+};
+
+const convertVisualizationWidget = (widget: GdcVisualizationWidget.IWrappedVisualizationWidget): IWidget => {
+    const {
+        visualizationWidget: {
+            content: { visualization },
+            meta: { identifier, uri, title, summary },
+        },
+    } = widget;
+
+    const convertedWidget: IWidget = {
+        type: "insight",
+        ref: uriRef(uri),
+        identifier,
+        uri,
+        title,
+        description: summary,
+        insight: uriRef(visualization),
+        drills: [], // (drill to dashboard, or insight) TODO: https://jira.intgdc.com/browse/RAIL-2199
+        alerts: [], // not yet supported for insight widgets
+    };
+
+    return convertedWidget;
+};
+
+const convertKpi = (widget: GdcKpi.IWrappedKPI): IWidget => {
+    const {
+        kpi: {
+            content: { metric },
+            meta: { identifier, uri, title, summary },
+        },
+    } = widget;
+
+    const convertedWidget: IWidget = {
+        type: "kpi",
+        ref: uriRef(uri),
+        identifier,
+        uri,
+        title,
+        description: summary,
+        insight: uriRef(metric),
+        drills: [], // (drills to old dashboards) - TODO: https://jira.intgdc.com/browse/RAIL-2199
+        alerts: [], // TODO: https://jira.intgdc.com/browse/RAIL-2218
+    };
+
+    return convertedWidget;
+};
+
+const convertFilterContextItem = (
+    filterContextItem: GdcFilterContext.FilterContextItem,
+): FilterContextItem => {
+    if (GdcFilterContext.isAttributeFilter(filterContextItem)) {
+        const {
+            attributeFilter: { attributeElements, displayForm, negativeSelection },
+        } = filterContextItem;
+
+        const convertedFilterContextItem: IDashboardAttributeFilter = {
+            attributeFilter: {
+                attributeElements: attributeElements.map(uriRef),
+                displayForm: uriRef(displayForm),
+                negativeSelection,
+            },
+        };
+
+        return convertedFilterContextItem;
+    }
+    const {
+        dateFilter: { granularity, type, attribute, dataSet, from, to },
+    } = filterContextItem;
+    const convertedFilterContextItem: IDashboardDateFilter = {
+        dateFilter: {
+            granularity,
+            type,
+            from,
+            to,
+        },
+    };
+    if (attribute) {
+        convertedFilterContextItem.dateFilter.attribute = uriRef(attribute);
+    }
+    if (dataSet) {
+        convertedFilterContextItem.dateFilter.dataSet = uriRef(dataSet);
+    }
+
+    return convertedFilterContextItem;
+};
+
+const convertFilterContext = (filterContext: GdcFilterContext.IWrappedFilterContext): IFilterContext => {
+    const {
+        filterContext: {
+            content: { filters },
+            meta: { identifier, uri, summary, title },
+        },
+    } = filterContext;
+
+    const convertedFilterContext: IFilterContext = {
+        description: summary,
+        identifier,
+        uri,
+        ref: uriRef(uri),
+        title,
+        filters: filters.map(convertFilterContextItem),
+    };
+
+    return convertedFilterContext;
+};
+
+const convertTempFilterContext = (
+    filterContext: GdcFilterContext.IWrappedTempFilterContext,
+): ITempFilterContext => {
+    const {
+        tempFilterContext: { created, filters, uri },
+    } = filterContext;
+
+    const convertedTempFilterContext: ITempFilterContext = {
+        uri,
+        ref: uriRef(uri),
+        filters: filters.map(convertFilterContextItem),
+        created,
+    };
+
+    return convertedTempFilterContext;
+};
+
+export const convertDashboardDependency = (dependency: BearDashboardDependency): DashboardDependency => {
+    if (GdcVisualizationWidget.isWrappedVisualizationWidget(dependency)) {
+        return convertVisualizationWidget(dependency);
+    } else if (GdcKpi.isWrappedKpi(dependency)) {
+        return convertKpi(dependency);
+    } else if (GdcFilterContext.isWrappedFilterContext(dependency)) {
+        return convertFilterContext(dependency);
+    } else if (GdcFilterContext.isWrappedTempFilterContext(dependency)) {
+        return convertTempFilterContext(dependency);
+    }
+
+    throw new Error(`No converter for the dashboard dependency!`);
+};

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -231,11 +231,11 @@ export interface IAuthenticationProvider {
 }
 
 // @alpha
-export type IDashboard = IDashboardDefinition & {
+export interface IDashboard extends IDashboardDefinition {
+    readonly identifier: string;
     readonly ref: ObjRef;
     readonly uri: string;
-    readonly identifier: string;
-};
+}
 
 // @public
 export interface IDashboardAddedPresets {
@@ -280,12 +280,11 @@ export interface IDashboardDefinition {
     readonly created: string;
     readonly dateFilterConfig?: IDateFilterConfig;
     readonly description: string;
-    readonly filterContext: IFilterContext[];
-    readonly layout: Layout;
+    readonly filterContext: IFilterContext | ITempFilterContext;
+    readonly layout?: Layout;
     readonly scheduledMails: IScheduledMail[];
     readonly title: string;
     readonly updated: string;
-    readonly widgets: IWidget[];
 }
 
 // @public
@@ -425,9 +424,14 @@ export interface IExtendedDateFilterErrors {
 }
 
 // @alpha
-export type IFilterContext = IFilterContextDefinition & {
+export interface IFilterContext extends IFilterContextDefinition {
+    // (undocumented)
+    readonly identifier: string;
+    // (undocumented)
     readonly ref: ObjRef;
-};
+    // (undocumented)
+    readonly uri: string;
+}
 
 // @alpha
 export interface IFilterContextDefinition {
@@ -490,7 +494,7 @@ export interface IInsightQueryResult extends IPagedResource<IInsight> {
 
 // @alpha
 export interface ILayoutWidget {
-    widget: ObjRef;
+    widget: IWidget;
 }
 
 // @alpha
@@ -722,6 +726,23 @@ export function isUnexpectedError(obj: any): obj is UnexpectedError;
 // @public
 export function isUnexpectedResponseError(obj: any): obj is UnexpectedResponseError;
 
+// @alpha
+export function isWidget(obj: any): obj is IWidget;
+
+// @alpha
+export interface ITempFilterContext extends ITempFilterContextDefinition {
+    // (undocumented)
+    readonly ref: ObjRef;
+    // (undocumented)
+    readonly uri: string;
+}
+
+// @alpha
+export interface ITempFilterContextDefinition {
+    readonly created: string;
+    readonly filters: FilterContextItem[];
+}
+
 // @public
 export interface ITotalDescriptor {
     // (undocumented)
@@ -750,9 +771,11 @@ export interface IUserWorkspaceSettings extends IUserSettings, IWorkspaceSetting
 }
 
 // @alpha
-export type IWidget = IWidgetDefinition & {
+export interface IWidget extends IWidgetDefinition {
+    readonly identifier: string;
     readonly ref: ObjRef;
-};
+    readonly uri: string;
+}
 
 // @alpha
 export type IWidgetAlert = IWidgetAlertDefinition & {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -132,6 +132,8 @@ export {
     IDashboardDateFilter,
     IFilterContextDefinition,
     RelativeType,
+    ITempFilterContext,
+    ITempFilterContextDefinition,
 } from "./workspace/dashboards/filterContext";
 export {
     Layout,
@@ -147,7 +149,7 @@ export {
     SectionHeader,
     Widget,
 } from "./workspace/dashboards/layout";
-export { IWidget, IWidgetDefinition, WidgetType } from "./workspace/dashboards/widget";
+export { IWidget, IWidgetDefinition, WidgetType, isWidget } from "./workspace/dashboards/widget";
 export { IWidgetAlert, IWidgetAlertDefinition } from "./workspace/dashboards/alert";
 export {
     AbsoluteDateFilterOption,

--- a/libs/sdk-backend-spi/src/workspace/dashboards/dashboard.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/dashboard.ts
@@ -1,8 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
 import { Layout } from "./layout";
-import { IWidget } from "./widget";
-import { IFilterContext } from "./filterContext";
+import { IFilterContext, ITempFilterContext } from "./filterContext";
 import {
     GUID,
     DateFilterConfigMode,
@@ -74,9 +73,9 @@ export interface IDashboardDefinition {
     readonly updated: string;
 
     /**
-     * Dashboard layout
+     * The layout of the dashboard determines the dashboard widgets {@link IWidget} and where they are rendered
      */
-    readonly layout: Layout;
+    readonly layout?: Layout;
 
     /**
      * Dashboard scheduled emails
@@ -84,14 +83,10 @@ export interface IDashboardDefinition {
     readonly scheduledMails: IScheduledMail[];
 
     /**
-     * Dashboard widgets
+     * Dashboard filter context, or temporary filter context
+     * (temporary filter context is used to override original filter context during the export)
      */
-    readonly widgets: IWidget[];
-
-    /**
-     * Dashboard filter context
-     */
-    readonly filterContext: IFilterContext[];
+    readonly filterContext: IFilterContext | ITempFilterContext;
 
     /**
      * Dashboard extended date filter config
@@ -146,7 +141,7 @@ export interface IListedDashboard {
  * See {@link IDashboardDefinition}
  * @alpha
  */
-export type IDashboard = IDashboardDefinition & {
+export interface IDashboard extends IDashboardDefinition {
     /**
      * Dashboard object ref
      */
@@ -161,4 +156,4 @@ export type IDashboard = IDashboardDefinition & {
      * Dashboard identifier
      */
     readonly identifier: string;
-};
+}

--- a/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
@@ -114,6 +114,38 @@ export interface IFilterContextDefinition {
  * See {@link IFilterContextDefinition}
  * @alpha
  */
-export type IFilterContext = IFilterContextDefinition & {
+export interface IFilterContext extends IFilterContextDefinition {
     readonly ref: ObjRef;
-};
+
+    readonly uri: string;
+
+    readonly identifier: string;
+}
+
+/**
+ * Temporary filter context serves to override original dashboard filter context during the dashboard export
+ *
+ * @alpha
+ */
+export interface ITempFilterContextDefinition {
+    /**
+     * Filter context created time
+     * YYYY-MM-DD HH:mm:ss
+     */
+    readonly created: string;
+
+    /**
+     * Attribute or date filters
+     */
+    readonly filters: FilterContextItem[];
+}
+
+/**
+ * See {@link ITempFilterContextDefinition}
+ * @alpha
+ */
+export interface ITempFilterContext extends ITempFilterContextDefinition {
+    readonly ref: ObjRef;
+
+    readonly uri: string;
+}

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -18,7 +18,9 @@ export interface IWorkspaceDashboards {
     getDashboards(): Promise<IListedDashboard[]>;
 
     /**
-     * Load dashboard by it's reference
+     * Load dashboard by it's reference,
+     * and optionally override filter context with the custom filter context
+     * (custom filter context is used mainly for exporting)
      *
      * @param ref - dashboard ref
      * @param filterContextRef - Override dashboard filter context with the custom filter context

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout.ts
@@ -1,5 +1,5 @@
 // (C) 2019-2020 GoodData Corporation
-import { ObjRef } from "@gooddata/sdk-model";
+import { IWidget } from "./widget";
 
 /**
  * Dashboard layout
@@ -27,7 +27,7 @@ export interface ILayoutWidget {
     /**
      * Widget object reference
      */
-    widget: ObjRef;
+    widget: IWidget;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/dashboards/tests/typeGuards.test.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/tests/typeGuards.test.ts
@@ -1,0 +1,30 @@
+// (C) 2019-2020 GoodData Corporation
+
+import { uriRef } from "@gooddata/sdk-model";
+import { InvalidInputTestCases } from "../../../../__mocks__/typeGuards";
+import { IWidget, isWidget } from "../widget";
+
+const testWidget: IWidget = {
+    ref: uriRef("/widget"),
+    insight: uriRef("/insight"),
+    type: "insight",
+    title: "",
+    uri: "",
+    identifier: "",
+    description: "",
+    alerts: [],
+    drills: [],
+};
+
+describe("dashboard type guards", () => {
+    describe("isWidget", () => {
+        const Scenarios: Array<[boolean, string, IWidget | any]> = [
+            ...InvalidInputTestCases,
+            [true, "widget", testWidget],
+        ];
+
+        it.each(Scenarios)("should return %s when input is %s", (expectedResult, _desc, input) => {
+            expect(isWidget(input)).toBe(expectedResult);
+        });
+    });
+});

--- a/libs/sdk-backend-spi/src/workspace/dashboards/widget.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/widget.ts
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
-
 import { ObjRef } from "@gooddata/sdk-model";
+import isEmpty from "lodash/isEmpty";
 import { IWidgetAlert } from "./alert";
 
 /**
@@ -180,9 +180,27 @@ export interface IWidgetDefinition {
  * See {@link IWidgetDefinition}]
  * @alpha
  */
-export type IWidget = IWidgetDefinition & {
+export interface IWidget extends IWidgetDefinition {
     /**
      * Visualization widget or kpi object ref
      */
     readonly ref: ObjRef;
-};
+
+    /**
+     * Visualization widget or kpi uri
+     */
+    readonly uri: string;
+
+    /**
+     * Visualization widget or kpi identifier
+     */
+    readonly identifier: string;
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IWidget}.
+ * @alpha
+ */
+export function isWidget(obj: any): obj is IWidget {
+    return !isEmpty(obj) && ((obj as IWidget).type === "kpi" || (obj as IWidget).type === "insight");
+}


### PR DESCRIPTION
- Added support for loading single dashboard in sdk-backend-bear
- Drilling and alerts are not yet needed/supported (there are another tasks for this)

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
