### PR TITLE
RELATED: RAIL-2093 enable calls to catalog with unspecified production flag

### DIFF
--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -299,7 +299,6 @@ class DummyWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 

--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -49,7 +49,6 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
         private readonly mappings: IUriMappings,
     ) {}

--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
@@ -96,6 +96,10 @@ const getProductionFlag = ({
     production,
     dataset,
 }: IWorkspaceCatalogFactoryOptions): GdcCatalog.ILoadCatalogItemsParams["production"] => {
+    // if production is undefined, leave it as is - it has meaning
+    if (production === undefined) {
+        return production;
+    }
     // if a dataset is specified, production must be false
     const sanitizedProduction = !dataset && production;
     return sanitizedProduction ? 1 : 0;
@@ -117,7 +121,6 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/catalog.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/catalog.ts
@@ -38,7 +38,6 @@ export class RecordedCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 
@@ -133,7 +132,6 @@ class RecordedAvailableCatalogFactory implements IWorkspaceCatalogAvailableItems
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -877,7 +877,7 @@ export interface IWorkspaceCatalogFactoryOptions {
     dataset?: ObjRef;
     excludeTags: ObjRef[];
     includeTags: ObjRef[];
-    production: boolean;
+    production?: boolean;
     types: CatalogItemType[];
 }
 

--- a/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
@@ -42,10 +42,12 @@ export interface IWorkspaceCatalogFactoryOptions {
     excludeTags: ObjRef[];
 
     /**
-     * Get only production ready catalog items.
-     * Default: true
+     * When true, get only production ready catalog items.
+     * When false, get only non-production ready catalog items.
+     * Otherwise, return both.
+     * Default: undefined
      */
-    production: boolean;
+    production?: boolean;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -65,7 +65,6 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -25,7 +25,6 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
             types: ["attribute", "measure", "fact", "dateDataset"],
             excludeTags: [],
             includeTags: [],
-            production: true,
         },
     ) {}
 


### PR DESCRIPTION
We need to be able to state that we do not care about the production status
of the catalog items when loading catalog.

JIRA: RAIL-2093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
