### PR TITLE
RELATED: RAIL-2093 fix unlisted metric handling in bear catalog

### DIFF
--- a/libs/sdk-backend-bear/tests/wiremock/start_wiremock.sh
+++ b/libs/sdk-backend-bear/tests/wiremock/start_wiremock.sh
@@ -21,8 +21,12 @@ CONTAINER_ID_FILE="${WIREMOCK_DIR}/.wiremock_containerid"
 
 mode=${1:-interactive}
 
+# macOS has no timeout available by default
+# https://stackoverflow.com/a/35512328/2546338
+function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+
 wait-for-url() {
-    timeout -s TERM 15 bash -c \
+    timeout 15 bash -c \
     'while [[ "$(curl -s -o /dev/null -L -w ''%{http_code}'' --insecure ${0})" != "200" ]];\
     do echo "Waiting for ${0}" && sleep 2;\
     done' ${1}

--- a/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
@@ -87,7 +87,8 @@ export interface IWorkspaceCatalogFactory
     readonly options: IWorkspaceCatalogFactoryOptions;
 
     /**
-     * Get catalog items for the current configuration
+     * Get catalog items for the current configuration.
+     * Returns items that are either not "unlisted" or that are created by the current user.
      *
      * @returns promise of catalog with loaded items
      */


### PR DESCRIPTION
The extra bear metrics call data is now only used to update the unlisted flag on existing catalog items.
The catalog documentation was updated to be more explicit about which items it returns.

Also, the wiremock script was made to work on macOS as well.

JIRA: RAIL-2093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
