### PR TITLE
BUGFIX: RAIL-2346 - Import essential goodstrap styles into pivot table menu

### DIFF
--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -22,6 +22,7 @@
         "build": "bash scripts/build.sh && npm run api-extractor",
         "build-dev": "bash scripts/build.sh --dev",
         "dev": "bash scripts/build.sh --dev-watch",
+        "styles": "bash scripts/build.sh --styles",
         "test": "jest --watch",
         "test-once": "jest",
         "test-ci": "JEST_JUNIT_OUTPUT=./ci/results/test-results.xml jest --ci --config jest.ci.js",

--- a/libs/sdk-ui-pivot/scripts/build.sh
+++ b/libs/sdk-ui-pivot/scripts/build.sh
@@ -36,6 +36,8 @@ if [ "$FLAG" = "--dev" ]; then
     build-dev
 elif [ "$FLAG" = "--dev-watch" ]; then
     build-dev-watch
+elif [ "$FLAG" = "--styles" ]; then
+    _build_styles
 else
     build
 fi

--- a/libs/sdk-ui-pivot/styles/scss/menu.scss
+++ b/libs/sdk-ui-pivot/styles/scss/menu.scss
@@ -1,4 +1,10 @@
 // (C) 2007-2019 GoodData Corporation
+$gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
+
+@import "~@gooddata/sdk-ui/styles/scss/settings";
+@import "~@gooddata/goodstrap/lib/List/styles/List";
+@import "~@gooddata/goodstrap/lib/core/styles/IndigoFont";
+
 .gd-menuOpenner {
     position: relative;
     z-index: 1;


### PR DESCRIPTION
-  goodstrap list & list-item are needed (dropdown is list & items)
-  indigo font (for arrows that lead to submenu)
-  this was not needed before when everything was together - someone else typically
   dragged in these essential styles. now when pivot can be used standalone, it can show
   ugly

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
