### PR TITLE
RELATED: RAIL-2357 fix workspaces.forCurrentUser in bear

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -283,8 +283,7 @@ export function dummyDataView(definition: IExecutionDefinition, result?: IExecut
 //
 // @internal
 export interface IAuthenticatedAsyncCallContext {
-    // (undocumented)
-    principal: AuthenticatedPrincipal;
+    getPrincipal(): Promise<AuthenticatedPrincipal>;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "IAuthProviderCallGuard" should be prefixed with an underscore because the declaration is marked as @internal

--- a/libs/sdk-backend-base/src/toolkit/auth.ts
+++ b/libs/sdk-backend-base/src/toolkit/auth.ts
@@ -13,7 +13,13 @@ import {
  * @internal
  */
 export interface IAuthenticatedAsyncCallContext {
-    principal: AuthenticatedPrincipal;
+    /**
+     * Returns the currently authenticated principal.
+     * Calling this function MAY trigger the authentication flow in case the current session
+     * is not yet authenticated and the principal is unknown.
+     * If the authentication flow fails, the NotAuthenticated error is thrown.
+     */
+    getPrincipal(): Promise<AuthenticatedPrincipal>;
 }
 
 /**

--- a/libs/sdk-backend-bear/src/backend/user/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/user/settings.ts
@@ -7,8 +7,8 @@ export class BearUserSettingsService implements IUserSettingsService {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
 
     public async query(): Promise<IUserSettings> {
-        return this.authCall(async (sdk, context) => {
-            const userLoginMd5 = userLoginMd5FromAuthenticatedPrincipal(context.principal);
+        return this.authCall(async (sdk, { getPrincipal }) => {
+            const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
 
             const flags = await sdk.user.getUserFeatureFlags(userLoginMd5);
 

--- a/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/settings/settings.ts
@@ -22,8 +22,8 @@ export class BearWorkspaceSettings implements IWorkspaceSettingsService {
     }
 
     public queryForCurrentUser(): Promise<IUserWorkspaceSettings> {
-        return this.authCall(async (sdk, context) => {
-            const userLoginMd5 = userLoginMd5FromAuthenticatedPrincipal(context.principal);
+        return this.authCall(async (sdk, { getPrincipal }) => {
+            const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
 
             const [workspaceFeatureFlags, userFeatureFlags] = await Promise.all([
                 sdk.project.getProjectFeatureFlags(this.workspace),

--- a/libs/sdk-backend-bear/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspaces/index.ts
@@ -2,6 +2,7 @@
 import { IWorkspaceQueryFactory, IWorkspaceQuery, IWorkspaceQueryResult } from "@gooddata/sdk-backend-spi";
 import { convertUserProject } from "../../fromSdkModel/WorkspaceConverter";
 import { BearAuthenticatedCallGuard } from "../../types";
+import { userLoginMd5FromAuthenticatedPrincipal } from "../../utils/api";
 
 export class BearWorkspaceQueryFactory implements IWorkspaceQueryFactory {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
@@ -48,8 +49,8 @@ class BearWorkspaceQuery implements IWorkspaceQuery {
     ): Promise<IWorkspaceQueryResult> {
         const {
             userProjects: { paging, items },
-        } = await this.authCall(async (sdk, { principal }) => {
-            const userId = this.userId || principal.userId;
+        } = await this.authCall(async (sdk, { getPrincipal }) => {
+            const userId = this.userId || (await userLoginMd5FromAuthenticatedPrincipal(getPrincipal));
             return sdk.project.getProjectsWithPaging(userId, offset, limit, search);
         });
 

--- a/libs/sdk-backend-bear/src/utils/api.ts
+++ b/libs/sdk-backend-bear/src/utils/api.ts
@@ -8,8 +8,11 @@ import last from "lodash/last";
  *
  * @internal
  */
-export const userLoginMd5FromAuthenticatedPrincipal = (principal: AuthenticatedPrincipal): string => {
-    const selfLink: string = principal.userMeta?.links?.self;
+export const userLoginMd5FromAuthenticatedPrincipal = async (
+    getPrincipal: () => Promise<AuthenticatedPrincipal>,
+): Promise<string> => {
+    const principal = await getPrincipal();
+    const selfLink: string = principal.userMeta?.links?.self ?? "";
     const userLoginMd5 = last(selfLink.split("/"));
 
     if (!userLoginMd5) {


### PR DESCRIPTION
This changes the API of the IAuthenticatedAsyncCallContext so that the principal
is obtained using a getter. This getter tries to return the existing principal
but in case there is none, it triggers an authentication flow to obtain it.
If the authentication fails, NotAuthorized is thrown.

JIRA: RAIL-2357

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
