### PR TITLE
RELATED: RAIL-2301, RAIL-2342 - Referenced objects for insight returns metrics in catalog format

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/insights/insightReferences.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/insightReferences.ts
@@ -1,0 +1,229 @@
+// (C) 2019-2020 GoodData Corporation
+
+import { BearAuthenticatedCallGuard } from "../../../types";
+import { CatalogItem, IInsight, IMetadataObject, insightUri } from "@gooddata/sdk-model";
+import { IInsightReferences, InsightReferenceTypes } from "@gooddata/sdk-backend-spi";
+import { GdcMetadata, GdcMetadataObject } from "@gooddata/gd-bear-model";
+import { getObjectIdFromUri } from "../../../utils/api";
+import union from "lodash/union";
+import { convertMetadataObject } from "../../../toSdkModel/MetaConverter";
+import flow from "lodash/flow";
+import isEmpty from "lodash/isEmpty";
+import keyBy from "lodash/keyBy";
+import flatMap from "lodash/fp/flatMap";
+import uniqBy from "lodash/fp/uniqBy";
+
+import { convertMetric } from "../../../toSdkModel/CatalogConverter";
+
+const objectTypeToObjectCategory = (type: InsightReferenceTypes): GdcMetadata.ObjectCategory => {
+    switch (type) {
+        case "displayForm":
+            return "attributeDisplayForm";
+        case "measure":
+            return "metric";
+        case "variable":
+            return "prompt";
+        default:
+            return type;
+    }
+};
+
+const objectTypesWithLinkToDataset: InsightReferenceTypes[] = ["fact", "attribute"];
+const objectCategoriesWithLinkToDataset: GdcMetadata.ObjectCategory[] = objectTypesWithLinkToDataset.map(
+    objectTypeToObjectCategory,
+);
+
+type BulkUsedByResponse = { useMany: { [idx: number]: { entries: GdcMetadata.IObjectXrefEntry[] } } };
+
+/**
+ * Given requested types, return types of objects that should be queried using 'using2' resource
+ *
+ * 1. When user wants data set info, then facts and attributes always must be queried
+ * 2. When user wants attribute or display form, then both must be queried because they are needed
+ *    for the CatalogItem
+ */
+function typesForXref(types: InsightReferenceTypes[]): InsightReferenceTypes[] {
+    let enrichedTypes = types.includes("dataSet")
+        ? union<InsightReferenceTypes>(types, objectTypesWithLinkToDataset)
+        : types;
+
+    if (types.includes("attribute") || types.includes("displayForm")) {
+        enrichedTypes = union(enrichedTypes, ["attribute", "displayForm"]);
+    }
+
+    return enrichedTypes;
+}
+
+/**
+ * Given requested types, return types of objects that should be loaded.
+ *
+ * When user wants attribute or display form, then both must be queried because they are needed for CatalogItem
+ */
+function typesForLoad(types: InsightReferenceTypes[]): InsightReferenceTypes[] {
+    if (types.includes("attribute") || types.includes("displayForm")) {
+        return union(types, ["attribute", "displayForm"]);
+    }
+
+    return types;
+}
+
+export class InsightReferencesQuery {
+    private readonly objectId: string;
+    private readonly typesForXref: InsightReferenceTypes[];
+    private readonly typesForLoad: InsightReferenceTypes[];
+
+    constructor(
+        private readonly authCall: BearAuthenticatedCallGuard,
+        private readonly workspace: string,
+        private readonly insight: IInsight,
+        private readonly requestedTypes: InsightReferenceTypes[],
+    ) {
+        const uri = insightUri(this.insight);
+        this.objectId = getObjectIdFromUri(uri);
+        this.typesForXref = typesForXref(this.requestedTypes);
+        this.typesForLoad = typesForLoad(this.requestedTypes);
+    }
+
+    public run = async (): Promise<IInsightReferences> => {
+        if (isEmpty(this.typesForXref)) {
+            return {};
+        }
+
+        const xrefs: GdcMetadata.IObjectXrefEntry[] = await this.findReferencedObjects();
+
+        /*
+         * If dataSet information is needed, do one more call to find out to which data sets do the
+         * different facts and attributes belong. Query resource cannot return dataSets because the relationship
+         * to dataSets is in the 'opposite direction'.
+         */
+        if (this.requestedTypes.includes("dataSet")) {
+            const datasets: GdcMetadata.IObjectXrefEntry[] = await this.findDatasets(xrefs);
+
+            xrefs.push(...datasets);
+        }
+
+        /*
+         * Xrefs do not contain all the necessary information. Load the referenced objects.
+         */
+        const objects = await this.loadObjects(xrefs);
+
+        return this.createResult(objects);
+    };
+
+    //
+    //
+    //
+
+    /**
+     * Uses the query resource to obtain all objects of the desired types which are used by the insight.
+     */
+    private findReferencedObjects = async (): Promise<GdcMetadata.IObjectXrefEntry[]> => {
+        const categories = this.typesForXref.map(objectTypeToObjectCategory);
+        const { entries: allDirectObjects } = await this.authCall(sdk =>
+            sdk.xhr.getParsed<{ entries: GdcMetadata.IObjectXrefEntry[] }>(
+                `/gdc/md/${this.workspace}/using2/${this.objectId}?types=${categories.join(",")}`,
+            ),
+        );
+
+        return allDirectObjects;
+    };
+
+    /**
+     * Given objects used by the insight, retrieve dataSets to which they belong. The usedBy2 is bulk mode
+     * is used for this.
+     */
+    private findDatasets = async (
+        objects: GdcMetadata.IObjectXrefEntry[],
+    ): Promise<GdcMetadata.IObjectXrefEntry[]> => {
+        // only some object types will have a reference to a dataSet, so no need to load other object types
+        const uris = objects
+            .filter(i => objectCategoriesWithLinkToDataset.includes(i.category as GdcMetadata.ObjectCategory))
+            .map(i => i.link);
+
+        const usedByPayload = {
+            inUseMany: {
+                uris,
+                types: ["dataSet"],
+                nearest: false,
+            },
+        };
+
+        const datasetResponses = await this.authCall(sdk => {
+            return sdk.xhr.postParsed<BulkUsedByResponse>(`/gdc/md/${this.workspace}/usedby2`, {
+                body: usedByPayload,
+            });
+        });
+
+        return flow(
+            flatMap((response: { entries: GdcMetadata.IObjectXrefEntry[] }) => response.entries),
+            uniqBy((dataSet: GdcMetadata.IObjectXrefEntry) => dataSet.identifier),
+        )(Object.values(datasetResponses.useMany));
+    };
+
+    /**
+     * Give the discovered references, bulk load data for objects of those types that the caller is interested in.
+     */
+    private loadObjects = async (
+        xrefs: GdcMetadata.IObjectXrefEntry[],
+    ): Promise<GdcMetadataObject.WrappedObject[]> => {
+        const categories = this.typesForLoad.map(objectTypeToObjectCategory);
+        const objectUrisToObtain = xrefs
+            .filter(i => categories.includes(i.category as GdcMetadata.ObjectCategory))
+            .map(meta => meta.link);
+
+        return this.authCall(sdk => sdk.md.getObjects(this.workspace, objectUrisToObtain));
+    };
+
+    //
+    //
+    //
+
+    private createResult(objects: GdcMetadataObject.WrappedObject[]): IInsightReferences {
+        const unwrappedObjects: GdcMetadataObject.IObject[] = objects.map(
+            GdcMetadataObject.unwrapMetadataObject,
+        );
+        const convertedObjects = unwrappedObjects.map(convertMetadataObject);
+        const wantDatasets = this.requestedTypes.includes("dataSet");
+
+        if (this.requestedTypes.length === 1 && wantDatasets) {
+            return {
+                dataSetMeta: convertedObjects,
+            };
+        }
+
+        const objectsByUri = keyBy(unwrappedObjects, obj => (obj as any).meta.uri);
+        const catalogItems: CatalogItem[] = [];
+        const dataSetMeta: IMetadataObject[] = [];
+
+        convertedObjects.forEach(obj => {
+            const fullObject = objectsByUri[obj.uri];
+
+            switch (obj.type) {
+                case "fact":
+                case "attribute":
+                case "displayForm":
+                case "variable":
+                    /*
+                     * TODO: implement conversions in order to support these additional types;
+                     *  fact -> catalogItem
+                     *  attribute&Df -> catalog item
+                     *  variable -> ?? not catalog item, probably something else..
+                     */
+                    break;
+                case "measure":
+                    catalogItems.push(convertMetric({ metric: fullObject as GdcMetadata.IMetric }));
+                    break;
+                case "dataSet":
+                    dataSetMeta.push(obj);
+                    break;
+            }
+        });
+
+        const datasetProp = wantDatasets ? { dataSetMeta } : {};
+
+        return {
+            ...datasetProp,
+            catalogItems,
+        };
+    }
+}

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/insights.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/insights.ts
@@ -3,9 +3,11 @@
 import {
     IInsightQueryOptions,
     IInsightQueryResult,
+    IInsightReferences,
     InsightOrdering,
-    UnexpectedResponseError,
     IWorkspaceInsights,
+    SupportedInsightReferenceTypes,
+    UnexpectedResponseError,
 } from "@gooddata/sdk-backend-spi";
 import {
     IInsight,
@@ -13,13 +15,11 @@ import {
     insightId,
     insightTitle,
     isIdentifierRef,
-    ObjRef,
-    IVisualizationClass,
     isUriRef,
+    IVisualizationClass,
+    ObjRef,
     visClassId,
     visClassUri,
-    ObjectType,
-    IMetadataObject,
 } from "@gooddata/sdk-model";
 import { InsightRecording, RecordingIndex } from "./types";
 import { identifierToRecording, RecordingPager } from "./utils";
@@ -129,10 +129,9 @@ export class RecordedInsights implements IWorkspaceInsights {
 
     public getReferencedObjects = async (
         _insight: IInsight,
-        _types?: Array<Exclude<ObjectType, "insight" | "tag">>,
-    ): Promise<IMetadataObject[]> => {
-        // return empty array for now
-        return [];
+        _types?: SupportedInsightReferenceTypes[],
+    ): Promise<IInsightReferences> => {
+        return {};
     };
 
     private async getVisualizationClassByUri(uri: string): Promise<IVisualizationClass> {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -590,6 +590,12 @@ export interface IInsightQueryOptions {
 export interface IInsightQueryResult extends IPagedResource<IInsight> {
 }
 
+// @public
+export interface IInsightReferences {
+    catalogItems?: CatalogItem[];
+    dataSetMeta?: IMetadataObject[];
+}
+
 // @alpha
 export interface ILayoutWidget {
     widget: IWidget;
@@ -666,6 +672,9 @@ export interface IMeasureGroupDescriptor {
 
 // @public
 export type InsightOrdering = "id" | "title" | "updated";
+
+// @public (undocumented)
+export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
 
 // @public
 export interface IPagedResource<TItem> {
@@ -1062,7 +1071,7 @@ export interface IWorkspaceInsights {
     deleteInsight(ref: ObjRef): Promise<void>;
     getInsight(ref: ObjRef): Promise<IInsight>;
     getInsights(options?: IInsightQueryOptions): Promise<IInsightQueryResult>;
-    getReferencedObjects(insight: IInsight, types?: Array<Exclude<ObjectType, "insight" | "tag">>): Promise<IMetadataObject[]>;
+    getReferencedObjects(insight: IInsight, types?: SupportedInsightReferenceTypes[]): Promise<IInsightReferences>;
     getVisualizationClass(ref: ObjRef): Promise<IVisualizationClass>;
     getVisualizationClasses(): Promise<IVisualizationClass[]>;
     updateInsight(insight: IInsight): Promise<IInsight>;
@@ -1214,6 +1223,9 @@ export enum SettingCatalog {
     disableKpiDashboardHeadlineUnderline = "disableKpiDashboardHeadlineUnderline",
     enableAxisNameConfiguration = "enableAxisNameConfiguration"
 }
+
+// @public
+export type SupportedInsightReferenceTypes = Exclude<InsightReferenceTypes, "attribute" | "fact" | "displayForm" | "variable">;
 
 // @public
 export class UnexpectedError extends AnalyticalBackendError {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -54,6 +54,9 @@ export {
     InsightOrdering,
     IInsightQueryOptions,
     IInsightQueryResult,
+    IInsightReferences,
+    InsightReferenceTypes,
+    SupportedInsightReferenceTypes,
 } from "./workspace/insights";
 
 export { IWorkspaceMetadata } from "./workspace/metadata";

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -7,6 +7,7 @@ import {
     ObjRef,
     IMetadataObject,
     ObjectType,
+    CatalogItem,
 } from "@gooddata/sdk-model";
 import { IPagedResource } from "../../common/paging";
 
@@ -76,12 +77,47 @@ export interface IWorkspaceInsights {
      * Get all metadata objects referenced by a given insight.
      *
      * @param insight - insight to get referenced objects for
-     * @param types - optional array of object types to include
+     * @param types - optional array of object types to include, when not specified, all supported references will
+     *  be retrieved
      */
     getReferencedObjects(
         insight: IInsight,
-        types?: Array<Exclude<ObjectType, "insight" | "tag">>,
-    ): Promise<IMetadataObject[]>;
+        types?: SupportedInsightReferenceTypes[],
+    ): Promise<IInsightReferences>;
+}
+
+/**
+ * @public
+ */
+export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
+
+/**
+ * List of currently supported types of references that can be retrieved using getReferencedObjects()
+ * @public
+ */
+export type SupportedInsightReferenceTypes = Exclude<
+    InsightReferenceTypes,
+    "attribute" | "fact" | "displayForm" | "variable"
+>;
+
+/**
+ * Contains information about objects that may be referenced by an insight. The contents of this object
+ * depend on the insight and the types requested at the time of call to getReferencedObjects.
+ *
+ * @public
+ */
+export interface IInsightReferences {
+    /**
+     * If requested, measures, attributes, display forms, facts and dateDataSets referenced by the insight will be
+     * returned here. If none of them were requested, the catalogItems will be undefined. If some were
+     * requested but insight is not referencing those types, then the array will be empty.
+     */
+    catalogItems?: CatalogItem[];
+
+    /**
+     * If requested, metadata about data sets from which this insight queries data will be returned here.
+     */
+    dataSetMeta?: IMetadataObject[];
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -2,22 +2,22 @@
 import {
     IInsightQueryOptions,
     IInsightQueryResult,
-    UnexpectedError,
+    IInsightReferences,
     IWorkspaceInsights,
+    SupportedInsightReferenceTypes,
+    UnexpectedError,
 } from "@gooddata/sdk-backend-spi";
 import {
-    IVisualizationClass,
     IInsight,
     IInsightDefinition,
+    IVisualizationClass,
     ObjRef,
     objRefToString,
-    ObjectType,
-    IMetadataObject,
 } from "@gooddata/sdk-model";
 import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToUri } from "../../../fromObjRef";
 
-import { insights as insightsMocks, appendIdAndUri } from "./mocks/insights";
+import { appendIdAndUri, insights as insightsMocks } from "./mocks/insights";
 import { visualizationClasses as visualizationClassesMocks } from "./mocks/visualizationClasses";
 
 export class TigerWorkspaceInsights implements IWorkspaceInsights {
@@ -82,18 +82,14 @@ export class TigerWorkspaceInsights implements IWorkspaceInsights {
         return this.authCall(async () => insight);
     };
 
-    public deleteInsight = async (
-        // @ts-ignore
-        ref: ObjRef,
-    ): Promise<void> => {
-        return this.authCall(async () => undefined);
+    public deleteInsight = async (_ref: ObjRef): Promise<void> => {
+        return Promise.resolve();
     };
 
     public getReferencedObjects = async (
         _insight: IInsight,
-        _types?: Array<Exclude<ObjectType, "insight" | "tag">>,
-    ): Promise<IMetadataObject[]> => {
-        // return empty array for now
-        return this.authCall(async () => []);
+        _types?: SupportedInsightReferenceTypes[],
+    ): Promise<IInsightReferences> => {
+        return Promise.resolve({});
     };
 }


### PR DESCRIPTION
-  Modified the return type (catalog items for metrics, metadata object for data sets)
-  Narrowed down the supported types that can be retrieved using the service
-  Impl for bear moved to separate file, refactored, optimized to use bulk usedBy and
   modified to return metrics as CatalogItems


---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
