### PR TITLE
BUGFIX: RAIL-2083 - Ignore empty positive attribute filters

### DIFF
--- a/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/normalizer.ts
@@ -28,6 +28,7 @@ import {
     modifyAttribute,
     modifyMeasure,
     IMeasureDefinition,
+    isAttributeFilter,
 } from "@gooddata/sdk-model";
 import {
     IDimensionDescriptor,
@@ -228,7 +229,7 @@ export class Normalizer {
 
         // throw away noop filters
         const filters = copy.filters.filter(f => {
-            if (isNegativeAttributeFilter(f)) {
+            if (isAttributeFilter(f)) {
                 return !filterIsEmpty(f);
             } else if (isMeasureValueFilter(f)) {
                 return measureValueFilterCondition(f) !== undefined;

--- a/libs/sdk-backend-bear/src/toAfm/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/toAfm/FilterConverter.ts
@@ -19,11 +19,16 @@ import isNil from "lodash/isNil";
 import { toBearRef, toScopedBearRef } from "../fromObjRef/ObjRefConverter";
 
 function convertAttributeFilter(filter: IAttributeFilter): GdcExecuteAFM.FilterItem | null {
-    if (!isPositiveAttributeFilter(filter)) {
-        if (filterIsEmpty(filter)) {
-            return null;
-        }
+    /*
+     * When sending either positive or negative filter and the in/notIn is empty, backend will bomb
+     * with "Cannot parse MAQL expression(s): %s". Previously code was only throwing away empty negative
+     * filters.
+     */
+    if (filterIsEmpty(filter)) {
+        return null;
+    }
 
+    if (!isPositiveAttributeFilter(filter)) {
         return {
             negativeAttributeFilter: {
                 displayForm: toBearRef(filter.negativeAttributeFilter.displayForm),

--- a/libs/sdk-backend-bear/src/toAfm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-bear/src/toAfm/tests/FilterConverter.test.ts
@@ -132,6 +132,14 @@ describe("bear filter converter from model to AFM", () => {
         it.each(Scenarios)("returns AFM measure %s", (_desc, input) => {
             expect(convertFilter(input)).toMatchSnapshot();
         });
+
+        it("should filter out empty attribute filters and not cause RAIL-2083", () => {
+            const emptyPositiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, []);
+            const emptyNegativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, []);
+
+            expect(convertFilter(emptyPositiveFilter)).toBeNull();
+            expect(convertFilter(emptyNegativeFilter)).toBeNull();
+        });
     });
 
     describe("convert measure filter", () => {

--- a/libs/sdk-backend-bear/src/toAfm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
+++ b/libs/sdk-backend-bear/src/toAfm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
@@ -200,4 +200,33 @@ Object {
 }
 `;
 
+exports[`converts execution definition to AFM Execution should remove empty attribute filters and not cause RAIL-2083 1`] = `
+Array [
+  Object {
+    "positiveAttributeFilter": Object {
+      "displayForm": Object {
+        "identifier": "label.product.id.name",
+      },
+      "in": Object {
+        "values": Array [
+          "value 1",
+        ],
+      },
+    },
+  },
+  Object {
+    "negativeAttributeFilter": Object {
+      "displayForm": Object {
+        "identifier": "label.product.id.name",
+      },
+      "notIn": Object {
+        "values": Array [
+          "value 2",
+        ],
+      },
+    },
+  },
+]
+`;
+
 exports[`converts execution definition to AFM Execution throw error with dimensions with native totals but no attribute in bucket 1`] = `"Native total references attribute that is not in any dimension: a_label.account.id.name"`;

--- a/libs/sdk-backend-bear/src/toAfm/tests/toAfmResultSpec.test.ts
+++ b/libs/sdk-backend-bear/src/toAfm/tests/toAfmResultSpec.test.ts
@@ -17,6 +17,8 @@ import {
     newDefForBuckets,
     newBucket,
     attributeLocalId,
+    defWithFilters,
+    newNegativeAttributeFilter,
 } from "@gooddata/sdk-model";
 
 const workspace = "test workspace";
@@ -71,5 +73,22 @@ describe("converts execution definition to AFM Execution", () => {
                 ),
             ),
         ).toThrowErrorMatchingSnapshot();
+    });
+
+    it("should remove empty attribute filters and not cause RAIL-2083", () => {
+        const emptyPositiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, []);
+        const emptyNegativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, []);
+        const positiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, ["value 1"]);
+        const negativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, ["value 2"]);
+
+        const def = defWithFilters(emptyDef("test"), [
+            emptyPositiveFilter,
+            emptyNegativeFilter,
+            positiveFilter,
+            negativeFilter,
+        ]);
+        const result = toAfmExecution(def);
+
+        expect(result.execution.afm.filters).toMatchSnapshot();
     });
 });

--- a/libs/sdk-backend-tiger/src/toAfm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/FilterConverter.ts
@@ -34,10 +34,6 @@ function convertPositiveFilter(filter: IPositiveAttributeFilter): ExecuteAFM.IPo
 }
 
 function convertNegativeFilter(filter: INegativeAttributeFilter): ExecuteAFM.INegativeAttributeFilter | null {
-    if (filterIsEmpty(filter)) {
-        return null;
-    }
-
     const displayFormRef = filter.negativeAttributeFilter.displayForm;
     const attributeElements = filter.negativeAttributeFilter.notIn;
 
@@ -54,6 +50,10 @@ function convertNegativeFilter(filter: INegativeAttributeFilter): ExecuteAFM.INe
 }
 
 function convertAttributeFilter(filter: IAttributeFilter): ExecuteAFM.FilterItem | null {
+    if (filterIsEmpty(filter)) {
+        return null;
+    }
+
     if (isPositiveAttributeFilter(filter)) {
         return convertPositiveFilter(filter);
     }

--- a/libs/sdk-backend-tiger/src/toAfm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/FilterConverter.test.ts
@@ -96,5 +96,13 @@ describe("tiger filter converter from model to AFM", () => {
                 convertVisualizationObjectFilter(visualizationObjectFilter.measureValueFilter),
             ).toThrowErrorMatchingSnapshot();
         });
+
+        it("should filter out empty attribute filters and not cause RAIL-2083", () => {
+            const emptyPositiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, []);
+            const emptyNegativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, []);
+
+            expect(convertVisualizationObjectFilter(emptyPositiveFilter)).toBeNull();
+            expect(convertVisualizationObjectFilter(emptyNegativeFilter)).toBeNull();
+        });
     });
 });

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`converts execution definition to AFM Execution should remove empty attribute filters and not cause RAIL-2083 1`] = `
+Array [
+  Object {
+    "positiveAttributeFilter": Object {
+      "displayForm": Object {
+        "identifier": Object {
+          "id": "label.product.id.name",
+          "type": "label",
+        },
+      },
+      "in": Object {
+        "values": Array [
+          "value 1",
+        ],
+      },
+    },
+  },
+  Object {
+    "negativeAttributeFilter": Object {
+      "displayForm": Object {
+        "identifier": Object {
+          "id": "label.product.id.name",
+          "type": "label",
+        },
+      },
+      "notIn": Object {
+        "values": Array [
+          "value 2",
+        ],
+      },
+    },
+  },
+]
+`;
+
 exports[`converts execution definition to AFM Execution should return AFM Execution with definition that has filters 1`] = `
 Object {
   "execution": Object {

--- a/libs/sdk-backend-tiger/src/toAfm/tests/toAfmResultSpec.test.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/toAfmResultSpec.test.ts
@@ -13,6 +13,8 @@ import {
     newTotal,
     newTwoDimensional,
     MeasureGroupIdentifier,
+    newNegativeAttributeFilter,
+    defWithFilters,
 } from "@gooddata/sdk-model";
 
 const workspace = "test workspace";
@@ -53,5 +55,22 @@ describe("converts execution definition to AFM Execution", () => {
         expect(() =>
             toAfmExecution(defSetDimensions(emptyDef(workspace), Dimensions)),
         ).toThrowErrorMatchingSnapshot();
+    });
+
+    it("should remove empty attribute filters and not cause RAIL-2083", () => {
+        const emptyPositiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, []);
+        const emptyNegativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, []);
+        const positiveFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, ["value 1"]);
+        const negativeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, ["value 2"]);
+
+        const def = defWithFilters(emptyDef("test"), [
+            emptyPositiveFilter,
+            emptyNegativeFilter,
+            positiveFilter,
+            negativeFilter,
+        ]);
+        const result = toAfmExecution(def);
+
+        expect(result.execution.filters).toMatchSnapshot();
     });
 });

--- a/libs/sdk-model/src/execution/filter/factory.ts
+++ b/libs/sdk-model/src/execution/filter/factory.ts
@@ -21,7 +21,7 @@ import { idRef } from "../../objRef/factory";
  *
  * @param attributeOrRef - either instance of attribute to create filter for or ref or identifier of attribute's display form
  * @param inValues - values to filter for; these can be either specified as AttributeElements object or as an array
- *  of attribute element _values_
+ *  of attribute element _values_; if you specify empty array, then the filter will be noop and will be ignored
  * @public
  */
 export function newPositiveAttributeFilter(
@@ -49,7 +49,7 @@ export function newPositiveAttributeFilter(
  *
  * @param attributeOrRef - either instance of attribute to create filter for or ref or identifier of attribute's display form
  * @param notInValues - values to filter out; these can be either specified as AttributeElements object or as an array
- *  of attribute element _values_
+ *  of attribute element _values_; if you specify empty array, then the filter will be noop and will be ignored
  * @public
  */
 export function newNegativeAttributeFilter(

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -43,6 +43,7 @@ export type IAttributeElements = IAttributeElementsByRef | IAttributeElementsByV
  * MAY influence the results of the execution indirectly: if the execution definition specifies MAQL measures that
  * use the filtered attribute.
  *
+ * If the attribute elements in the `in` property are empty, then the filter is NOOP.
  * @public
  */
 export interface IPositiveAttributeFilter {
@@ -64,6 +65,8 @@ export interface IPositiveAttributeFilter {
  * The filter can be specified even for attributes that are not included in the execution - such a filter then
  * MAY influence the results of the execution indirectly: if the execution definition specifies MAQL measures that
  * use the filtered attribute.
+ *
+ * If the attribute elements in the `notIn` property are empty, then the filter is NOOP.
  *
  * @public
  */


### PR DESCRIPTION
-  Empty positive attr filters cause backend errors
-  We were previously stripping only empty negative filters
-  Now we also remove empty positive filters
-  Added tests
-  Updated API docs with this additional contractual information
-  Updated withNormalization

Note: apps do not allow creation of empty attribute filters ('apply' is not possible when selection is empty)

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
