### PR TITLE
RELATED: RAIL-2093 add insightSetFilters function

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -876,6 +876,9 @@ export type InsightModifications = (builder: InsightDefinitionBuilder) => Insigh
 export function insightProperties(insight: IInsightDefinition): VisualizationProperties;
 
 // @public
+export function insightSetFilters<T extends IInsightDefinition>(insight: T, filters?: IFilter[]): T;
+
+// @public
 export function insightSetProperties<T extends IInsightDefinition>(insight: T, properties?: VisualizationProperties): T;
 
 // @public

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -285,6 +285,7 @@ export {
     insightTotals,
     insightFilters,
     insightVisualizationUrl,
+    insightSetFilters,
     insightSetProperties,
     insightSetSorts,
     visClassUrl,

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -517,6 +517,27 @@ export function insightSetSorts<T extends IInsightDefinition>(insight: T, sorts:
     } as T;
 }
 
+/**
+ * Gets a new insight that 'inherits' all data from the provided insight but has different filters. New
+ * filters will be used in the new insight as-is, no merging with existing filters.
+ *
+ * @param insight - insight to work with
+ * @param filters - new filters to apply
+ * @returns always new instance
+ * @public
+ */
+export function insightSetFilters<T extends IInsightDefinition>(insight: T, filters: IFilter[] = []): T {
+    invariant(insight, "insight must be specified");
+
+    // tslint:disable-next-line: no-object-literal-type-assertion
+    return {
+        insight: {
+            ...insight.insight,
+            filters,
+        },
+    } as T;
+}
+
 //
 // Visualization class functions
 //

--- a/libs/sdk-model/src/insight/tests/insight.test.ts
+++ b/libs/sdk-model/src/insight/tests/insight.test.ts
@@ -2,12 +2,6 @@
 
 import {
     IFilter,
-    insightFilters,
-    insightProperties,
-    insightSetProperties,
-    insightSetSorts,
-    insightSorts,
-    insightTotals,
     ITotal,
     newAttributeLocator,
     newAttributeSort,
@@ -15,9 +9,7 @@ import {
     newPositiveAttributeFilter,
     newTotal,
     ISortItem,
-    VisualizationProperties,
     IAttributeOrMeasure,
-    insightItems,
 } from "../..";
 import { newInsight } from "../../../__mocks__/insights";
 import { Account, Activity, Velocity, Won } from "../../../__mocks__/model";
@@ -36,6 +28,15 @@ import {
     insightUri,
     insightIsLocked,
     insightUpdated,
+    insightFilters,
+    insightProperties,
+    insightSetFilters,
+    insightSetProperties,
+    insightSetSorts,
+    insightSorts,
+    insightTotals,
+    insightItems,
+    VisualizationProperties,
 } from "../index";
 
 const MixedBucket = newBucket("bucket1", Account.Name, Won);
@@ -362,6 +363,33 @@ describe("insightUpdated", () => {
 
     it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
         expect(() => insightUpdated(input)).toThrow();
+    });
+});
+
+describe("insightSetFilters", () => {
+    const AccountFilter = newPositiveAttributeFilter(Account.Name, { values: ["foo"] });
+    const ActivityFilter = newPositiveAttributeFilter(Activity.Subject, { values: ["bar"] });
+
+    it("should set new filters in insight without them", () => {
+        expect(insightSetFilters(EmptyInsight, [AccountFilter]).insight.filters).toEqual([AccountFilter]);
+    });
+
+    it("should overwrite filters in insight that has them", () => {
+        const InsightWithSomeFilters = insightSetFilters(EmptyInsight, [AccountFilter]);
+
+        expect(insightSetFilters(InsightWithSomeFilters, [ActivityFilter]).insight.filters).toEqual([
+            ActivityFilter,
+        ]);
+    });
+
+    it("should clear filters if called without parameter", () => {
+        const InsightWithSomeFilters = insightSetFilters(EmptyInsight, [AccountFilter]);
+
+        expect(insightSetFilters(InsightWithSomeFilters).insight.filters).toEqual([]);
+    });
+
+    it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
+        expect(() => insightSetFilters(input)).toThrow();
     });
 });
 


### PR DESCRIPTION
Also improved imports in insight.test.ts to avoid barrel file when possible.

JIRA: RAIL-2093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
