### PR TITLE
RELATED: RAIL-2093 use deepEquality in drillingIsSame in PivotTable

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -371,7 +371,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
      * @param prevProps
      */
     private isReinitNeeded(prevProps: ICorePivotTableProps): boolean {
-        const drillingIsSame = prevProps.drillableItems === this.props.drillableItems;
+        const drillingIsSame = isEqual(prevProps.drillableItems, this.props.drillableItems);
 
         if (!drillingIsSame) {
             return true;


### PR DESCRIPTION
This makes sure that when the drillableItems are samantically the same,
an expensive reinit is avoided.

Typical example of this is an inlined array constant,
which referentially changes on every render of the parent.

JIRA: RAIL-2093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
