### PR TITLE
RELATED: RAIL-2107 - Fix versioning policy of examples-workspace

### DIFF
--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -55,7 +55,7 @@
         "react-dom": "^16.5.2"
     },
     "devDependencies": {
-        "@gooddata/examples-workspace": "^8.0.1",
+        "@gooddata/examples-workspace": "^8.0.0-alpha.85",
         "@gooddata/sdk-backend-mockingbird": "^8.0.0-alpha.85",
         "@gooddata/tslint-config": "1.0.0",
         "@microsoft/api-extractor": "^7.3.8",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -48,7 +48,7 @@
         "@babel/runtime": "^7.7.2",
         "@gooddata/numberjs": "^3.2.4",
         "@gooddata/reference-workspace": "^8.0.0-alpha.85",
-        "@gooddata/examples-workspace": "^8.0.1",
+        "@gooddata/examples-workspace": "^8.0.0-alpha.85",
         "@gooddata/sdk-backend-base": "^8.0.0-alpha.85",
         "@gooddata/sdk-backend-mockingbird": "^8.0.0-alpha.85",
         "@gooddata/sdk-backend-spi": "^8.0.0-alpha.85",

--- a/rush.json
+++ b/rush.json
@@ -304,6 +304,7 @@
             "packageName": "@gooddata/examples-workspace",
             "projectFolder": "tools/examples-workspace",
             "reviewCategory": "tools",
+            "versionPolicyName": "sdk",
             "shouldPublish": true
         },
         {

--- a/tools/examples-workspace/package.json
+++ b/tools/examples-workspace/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@gooddata/examples-workspace",
-    "version": "8.0.1",
+    "version": "8.0.0-alpha.85",
     "author": "GoodData",
     "description": "GoodData SDK TypeScript skeleton",
     "repository": "https://github.com/gooddata/gooddata-ui-sdk/tree/master/libs/examples-workspace",


### PR DESCRIPTION
-  bad policy in rush.json, version 8.0.0 and 8.0.1 of examples workspace released
-  this is package with non-sensitive test data so no big deal
-  we will have to rename the package to live-examples-workspace :)

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
