### PR TITLE
RELATED: RAIL-2107 - Add support for geoPins in catalog for tiger backend

### DIFF
--- a/libs/sdk-backend-tiger/src/toSdkModel/CatalogConverter.ts
+++ b/libs/sdk-backend-tiger/src/toSdkModel/CatalogConverter.ts
@@ -12,6 +12,7 @@ import {
     newCatalogFact,
     IGroupableCatalogItemBase,
     IGroupableCatalogItemBuilder,
+    newAttributeDisplayFormMetadataObject,
 } from "@gooddata/sdk-model";
 import {
     AttributeResourceSchema,
@@ -55,17 +56,25 @@ const commonGroupableCatalogItemModifications = <
 
 export const convertAttribute = (
     attribute: AttributeResourceSchema,
-    defaultDisplayForm: LabelResourceSchema,
+    defaultLabel: LabelResourceSchema,
+    geoLabels: LabelResourceSchema[],
 ): ICatalogAttribute => {
+    const geoPinDisplayForms = geoLabels.map(label => {
+        return newAttributeDisplayFormMetadataObject(
+            idRef(label.id, "displayForm"),
+            commonMetadataObjectModifications(label),
+        );
+    });
+
     return newCatalogAttribute(catalogA =>
         catalogA
             .attribute(idRef(attribute.id, "attribute"), a =>
                 a.modify(commonMetadataObjectModifications(attribute)),
             )
-            .defaultDisplayForm(idRef(defaultDisplayForm.id, "displayForm"), df =>
-                df.modify(commonMetadataObjectModifications(defaultDisplayForm)),
+            .defaultDisplayForm(idRef(defaultLabel.id, "displayForm"), df =>
+                df.modify(commonMetadataObjectModifications(defaultLabel)),
             )
-            .geoPinDisplayForms([])
+            .geoPinDisplayForms(geoPinDisplayForms)
             .modify(commonGroupableCatalogItemModifications(attribute)),
     );
 };


### PR DESCRIPTION
-  geo pin labels are identified using id name convention
-  if label identifier matches convention (/^.*\.geo__/) then it is added
   under geoPinDisplayForms prop of attribute catalog items

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
