### PR TITLE
RELATED: RAIL-1973 - Fix default data point formatter to strip color codes

### DIFF
--- a/libs/sdk-ui/src/base/results/dataAccessConfig.ts
+++ b/libs/sdk-ui/src/base/results/dataAccessConfig.ts
@@ -1,7 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
 import { DataValue } from "@gooddata/sdk-backend-spi";
-import { ISeparators, numberFormat } from "@gooddata/numberjs";
+import { ISeparators, numberFormat, colors2Object, INumberObject } from "@gooddata/numberjs";
 import isEmpty = require("lodash/isEmpty");
+import escape = require("lodash/escape");
+import unescape = require("lodash/unescape");
+
+const customEscape = (str: string) => str && escape(unescape(str));
 
 /**
  * @alpha
@@ -15,7 +19,8 @@ export type HeaderTranslator = (value: string) => string;
 
 /**
  * Creates value formatter that uses @gooddata/numberjs to format raw measure values according
- * to the format string.
+ * to the format string. By default, the format will strip away all the coloring information and
+ * just return the value as string.
  *
  * @param separators - number separators to use. if not specified then numberjs defaults will be used
  * @alpha
@@ -24,7 +29,10 @@ export function createNumberJsFormatter(separators?: ISeparators): ValueFormatte
     return (value: DataValue, format: string) => {
         const valueToFormat = value === null && !isEmpty(format) ? "" : parseFloat(value as string);
 
-        return numberFormat(valueToFormat, format, undefined, separators);
+        const formattedValue = numberFormat(valueToFormat, format, undefined, separators);
+        const formattedObject: INumberObject = colors2Object(formattedValue);
+
+        return customEscape(formattedObject.label);
     };
 }
 

--- a/libs/sdk-ui/src/base/results/facade.ts
+++ b/libs/sdk-ui/src/base/results/facade.ts
@@ -1,6 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import { IExecutionDefinition } from "@gooddata/sdk-model";
 import { IDataView, IExecutionResult } from "@gooddata/sdk-backend-spi";
+import { DataAccessConfig } from "./dataAccessConfig";
 import { IExecutionDefinitionMethods, newExecutionDefinitonMethods } from "./internal/definitionMethods";
 import { IResultMetaMethods, newResultMetaMethods } from "./internal/resultMetaMethods";
 import { IResultDataMethods, newResultDataMethods } from "./internal/resultDataMethods";
@@ -74,9 +75,9 @@ export class DataViewFacade {
      * @returns methods to access data in a curated fashion using data slices and data series iterators
      * @alpha
      */
-    public data(): IDataAccessMethods {
+    public data(config?: DataAccessConfig): IDataAccessMethods {
         if (!this.dataAccessMethods) {
-            this.dataAccessMethods = newDataAccessMethods(this.dataView);
+            this.dataAccessMethods = newDataAccessMethods(this.dataView, config);
         }
 
         return this.dataAccessMethods;

--- a/libs/sdk-ui/src/base/results/test/dataAccessConfig.test.ts
+++ b/libs/sdk-ui/src/base/results/test/dataAccessConfig.test.ts
@@ -1,0 +1,48 @@
+// (C) 2019-2020 GoodData Corporation
+
+import { createNumberJsFormatter } from "../dataAccessConfig";
+
+const typicalFormat = "$#,#.##";
+
+const fancyFormat =
+    "[>=9000000][color=2190c0]██████████;\n" +
+    "[>=8000000][color=2190c0]█████████░;\n" +
+    "[>=7000000][color=2190c0]████████░░;\n" +
+    "[>=6000000][color=2190c0]███████░░░;\n" +
+    "[>=5000000][color=2190c0]██████░░░░;\n" +
+    "[>=4000000][color=2190c0]█████░░░░░;\n" +
+    "[>=3000000][color=2190c0]████░░░░░░;\n" +
+    "[>=2000000][color=2190c0]███░░░░░░░;\n" +
+    "[>=1000000][color=2190c0]██░░░░░░░░;";
+
+const formatWithColoring = "[<0][red]$#,#.##;\n" + "[<100000][blue]$#,#.##;\n" + "[>=100000][green]$#,#.##";
+
+const formatWithXss = `<img src="#" onerror=alert('Owned')/>`;
+
+describe("default data point formatter", () => {
+    it("should return formatted number", () => {
+        const formatter = createNumberJsFormatter();
+
+        expect(formatter("123456", typicalFormat)).toEqual("$123,456");
+    });
+
+    it("should return just the formatted number, without color codes", () => {
+        const formatter = createNumberJsFormatter();
+
+        expect(formatter("123", formatWithColoring)).toEqual("$123");
+    });
+
+    it("should return fancy formatted number, without color codes", () => {
+        const formatter = createNumberJsFormatter();
+
+        expect(formatter("1000000", fancyFormat)).toEqual("██░░░░░░░░");
+    });
+
+    it("should escape to prevent xss", () => {
+        const formatter = createNumberJsFormatter();
+
+        expect(formatter("123", formatWithXss)).toEqual(
+            "&lt;img src=&quot;123&quot; onerror=alert(&#39;Owned&#39;)/&gt;",
+        );
+    });
+});


### PR DESCRIPTION
-   Before was just using format function, which retains color codes
-   Now also feeds this to colors2object function, which returns
    label + fg color + bg color; takes just the label and does the
    escaping. similar to our other code

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
