### PR TITLE
RELATED: RAIL-2405 use JSON API compliant identifiers in tiger insights

### DIFF
--- a/libs/gd-tiger-client/api/gd-tiger-client.api.md
+++ b/libs/gd-tiger-client/api/gd-tiger-client.api.md
@@ -8268,6 +8268,8 @@ export namespace ExecuteAFM {
     export type SortItem = IAttributeSortItem | IMeasureSortItem;
     // (undocumented)
     export type TotalType = "sum" | "avg" | "max" | "min" | "nat" | "med";
+    const // (undocumented)
+    isObjIdentifierQualifier: (value: any) => value is IObjIdentifierQualifier;
 }
 
 // @public (undocumented)
@@ -9332,6 +9334,38 @@ export interface TagResourcesResponseSchemaAllOf {
 
 // @public
 export const tigerClientFactory: (axios: AxiosInstance) => ITigerClient;
+
+// @public (undocumented)
+export namespace VisualizationObject {
+    // (undocumented)
+    export type IAttributeOrMeasure = ExecuteAFM.IMeasure | ExecuteAFM.IAttribute;
+    // (undocumented)
+    export interface IBucket {
+        // (undocumented)
+        items: IAttributeOrMeasure[];
+        // (undocumented)
+        localIdentifier?: string;
+        // (undocumented)
+        totals?: ExecuteAFM.ITotalItem[];
+    }
+    // (undocumented)
+    export interface IVisualizationObject {
+        // (undocumented)
+        visualizationObject: {
+            title: string;
+            visualizationUrl: string;
+            buckets: IBucket[];
+            filters: ExecuteAFM.FilterItem[];
+            sorts: ExecuteAFM.SortItem[];
+            properties: VisualizationProperties;
+        };
+    }
+    // (undocumented)
+    export type VisualizationProperties = {
+        [key: string]: any;
+    };
+    {};
+}
 
 // @public
 export interface VisualizationObjectPatchResource {

--- a/libs/gd-tiger-client/src/gd-tiger-model/ExecuteAFM.ts
+++ b/libs/gd-tiger-client/src/gd-tiger-model/ExecuteAFM.ts
@@ -197,4 +197,11 @@ export namespace ExecuteAFM {
             measureIdentifier: ILocalIdentifierQualifier;
         };
     }
+
+    export const isObjIdentifierQualifier = (value: any): value is IObjIdentifierQualifier => {
+        return !!(
+            (value as Partial<IObjIdentifierQualifier>)?.identifier?.id &&
+            (value as Partial<IObjIdentifierQualifier>)?.identifier?.type
+        );
+    };
 }

--- a/libs/gd-tiger-client/src/gd-tiger-model/VisualizationObject.ts
+++ b/libs/gd-tiger-client/src/gd-tiger-model/VisualizationObject.ts
@@ -1,0 +1,27 @@
+// (C) 2019-2020 GoodData Corporation
+import { ExecuteAFM } from "./ExecuteAFM";
+
+export namespace VisualizationObject {
+    export interface IVisualizationObject {
+        visualizationObject: {
+            title: string;
+            visualizationUrl: string;
+            buckets: IBucket[];
+            filters: ExecuteAFM.FilterItem[]; // TODO make sure this includes Measure value filters when they land in tiger
+            sorts: ExecuteAFM.SortItem[];
+            properties: VisualizationProperties;
+        };
+    }
+
+    interface IBucket {
+        localIdentifier?: string;
+        items: IAttributeOrMeasure[];
+        totals?: ExecuteAFM.ITotalItem[];
+    }
+
+    type IAttributeOrMeasure = ExecuteAFM.IMeasure | ExecuteAFM.IAttribute;
+
+    type VisualizationProperties = {
+        [key: string]: any;
+    };
+}

--- a/libs/gd-tiger-client/src/index.ts
+++ b/libs/gd-tiger-client/src/index.ts
@@ -8,6 +8,7 @@ import { axios as defaultAxios, newAxios } from "./axios";
 
 export { ExecuteAFM } from "./gd-tiger-model/ExecuteAFM";
 export { Execution } from "./gd-tiger-model/Execution";
+export { VisualizationObject } from "./gd-tiger-model/VisualizationObject";
 
 export { newAxios };
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -16,10 +16,13 @@ import {
     insightTitle,
     insightId,
 } from "@gooddata/sdk-model";
+import { VisualizationObject } from "@gooddata/gd-tiger-client";
 import uuid4 from "uuid/v4";
 
 import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToUri, objRefToIdentifier } from "../../../fromObjRef";
+import { convertVisualizationObject } from "../../../toSdkModel/VisualizationObjectConverter";
+import { convertInsight } from "../../../fromSdkModel/InsightConverter";
 
 import { visualizationClasses as visualizationClassesMocks } from "./mocks/visualizationClasses";
 
@@ -115,7 +118,9 @@ export class TigerWorkspaceInsights implements IWorkspaceInsights {
         );
 
         const insight = insightFromInsightDefinition(
-            response.data.data.attributes.content! as IInsightDefinition,
+            convertVisualizationObject(
+                response.data.data.attributes.content! as VisualizationObject.IVisualizationObject,
+            ),
             response.data.data.id,
             (response.data.data.links as any)?.self,
         );
@@ -136,7 +141,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsights {
                         id: uuid4(),
                         type: "visualizationObject", // should be VisualizationObjectPostResourceTypeEnum.VisualizationObject,
                         attributes: {
-                            content: insight,
+                            content: convertInsight(insight),
                             title: insightTitle(insight),
                         },
                     },
@@ -161,7 +166,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsights {
                         id: insightId(insight),
                         type: "visualizationObject", // should be VisualizationObjectPostResourceTypeEnum.VisualizationObject,
                         attributes: {
-                            content: insight,
+                            content: convertInsight(insight),
                             title: insightTitle(insight),
                         },
                     },

--- a/libs/sdk-backend-tiger/src/fromAfm/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/fromAfm/ObjRefConverter.ts
@@ -1,0 +1,44 @@
+// (C) 2007-2020 GoodData Corporation
+import isEmpty = require("lodash/isEmpty");
+import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
+import { isUriRef, ObjRef, ObjectType } from "@gooddata/sdk-model";
+import { ExecuteAFM } from "@gooddata/gd-tiger-client";
+import ObjQualifier = ExecuteAFM.ObjQualifier;
+import { TigerAfmType } from "../types";
+
+const allValidTigerAfmTypes: TigerAfmType[] = ["metric", "label", "fact", "dataSet", "attribute"];
+
+const objRefTypeByTigerType: {
+    [objectType in TigerAfmType]: ObjectType;
+} = {
+    attribute: "attribute",
+    metric: "measure",
+    label: "displayForm",
+    dataSet: "dataSet",
+    fact: "fact",
+    variable: "variable",
+};
+
+const isValidTigerAfmType = (obj: any): obj is TigerAfmType => {
+    return !isEmpty(obj) && allValidTigerAfmTypes.some(afmType => afmType === obj);
+};
+
+function toObjectType(value: TigerAfmType): ObjectType {
+    if (!isValidTigerAfmType(value)) {
+        throw new UnexpectedError(`Cannot convert ${value} to ObjRef, ${value} is not valid TigerAfmType`);
+    }
+
+    const type = objRefTypeByTigerType[value];
+    return type;
+}
+
+export function toObjRef(qualifier: ObjQualifier): ObjRef {
+    if (isUriRef(qualifier)) {
+        throw new NotSupported(`Tiger backend does not allow referencing objects by URI.`);
+    }
+
+    return {
+        identifier: qualifier.identifier.id,
+        type: toObjectType(qualifier.identifier.type as TigerAfmType),
+    };
+}

--- a/libs/sdk-backend-tiger/src/fromSdkModel/InsightConverter.ts
+++ b/libs/sdk-backend-tiger/src/fromSdkModel/InsightConverter.ts
@@ -1,0 +1,26 @@
+// (C) 2019-2020 GoodData Corporation
+import cloneDeepWith from "lodash/cloneDeepWith";
+import { IInsightDefinition, isIdentifierRef } from "@gooddata/sdk-model";
+import { VisualizationObject } from "@gooddata/gd-tiger-client";
+
+import { toObjQualifier } from "../toAfm/ObjRefConverter";
+
+const cloneWithSanitizedIds = (item: any) =>
+    cloneDeepWith(item, value => {
+        if (isIdentifierRef(value)) {
+            return toObjQualifier(value);
+        }
+
+        return undefined;
+    });
+
+export const convertInsight = (insight: IInsightDefinition): VisualizationObject.IVisualizationObject => {
+    return {
+        visualizationObject: {
+            ...insight.insight,
+            buckets: cloneWithSanitizedIds(insight.insight.buckets),
+            filters: cloneWithSanitizedIds(insight.insight.filters),
+            sorts: cloneWithSanitizedIds(insight.insight.sorts),
+        },
+    };
+};

--- a/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
@@ -27,8 +27,12 @@ const isValidAfmType = (obj: any): obj is AfmObjectType => {
 };
 
 // TODO: get rid of the defaultValue, tiger should explode if ref is not provided correctly
-function toTigerAfmType(value: ObjectType | undefined, defaultValue: TigerAfmType): TigerAfmType {
+function toTigerAfmType(value: ObjectType | undefined, defaultValue?: TigerAfmType): TigerAfmType {
     if (!value) {
+        if (!defaultValue) {
+            throw new UnexpectedError("No value or default value was provided to toTigerAfmType ");
+        }
+
         return defaultValue;
     }
 
@@ -40,7 +44,7 @@ function toTigerAfmType(value: ObjectType | undefined, defaultValue: TigerAfmTyp
     return type;
 }
 
-function toObjQualifier(ref: ObjRef, defaultValue: TigerAfmType): ObjQualifier {
+export function toObjQualifier(ref: ObjRef, defaultValue?: TigerAfmType): ObjQualifier {
     if (isUriRef(ref)) {
         throw new NotSupported(`Tiger backend does not allow referencing objects by URI.`);
     }

--- a/libs/sdk-backend-tiger/src/toSdkModel/VisualizationObjectConverter.ts
+++ b/libs/sdk-backend-tiger/src/toSdkModel/VisualizationObjectConverter.ts
@@ -1,0 +1,28 @@
+// (C) 2019-2020 GoodData Corporation
+import cloneDeepWith from "lodash/cloneDeepWith";
+import { IInsightDefinition } from "@gooddata/sdk-model";
+import { ExecuteAFM, VisualizationObject } from "@gooddata/gd-tiger-client";
+
+import { toObjRef } from "../fromAfm/ObjRefConverter";
+
+const cloneWithSanitizedIds = (item: any) =>
+    cloneDeepWith(item, value => {
+        if (ExecuteAFM.isObjIdentifierQualifier(value)) {
+            return toObjRef(value);
+        }
+
+        return undefined;
+    });
+
+export const convertVisualizationObject = (
+    visualizationObject: VisualizationObject.IVisualizationObject,
+): IInsightDefinition => {
+    return {
+        insight: {
+            ...visualizationObject.visualizationObject,
+            buckets: cloneWithSanitizedIds(visualizationObject.visualizationObject.buckets),
+            filters: cloneWithSanitizedIds(visualizationObject.visualizationObject.filters),
+            sorts: cloneWithSanitizedIds(visualizationObject.visualizationObject.sorts),
+        },
+    };
+};


### PR DESCRIPTION
Converts identifiers of items in saved insights to JSON API compatible ones

JIRA: RAIL-2405

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
