### PR TITLE
RELATED: RAIL-2234 - Load tiger date datasets

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -1,0 +1,143 @@
+// (C) 2019-2020 GoodData Corporation
+
+import {
+    AttributeResourceSchema,
+    AttributeResourcesResponseSchema,
+    DatasetResourceSchema,
+    ITigerClient,
+    LabelResourceReference,
+    LabelResourceSchema,
+    SuccessIncluded,
+} from "@gooddata/gd-tiger-client";
+import { CatalogItem, ICatalogAttribute, ICatalogDateDataset } from "@gooddata/sdk-model";
+import {
+    convertAttribute,
+    convertDateAttribute,
+    convertDateDataset,
+} from "../../../toSdkModel/CatalogConverter";
+
+export type LoaderResult = {
+    nonDateAttributes: ICatalogAttribute[];
+    dateDatasets: ICatalogDateDataset[];
+};
+
+function lookupRelatedObject(included: SuccessIncluded[] | undefined, id: string, type: string) {
+    if (!included) {
+        return;
+    }
+
+    return included?.find(item => item.type === type && item.id === id);
+}
+
+function getAttributeLabels(
+    attribute: AttributeResourceSchema,
+    included: SuccessIncluded[] | undefined,
+): LabelResourceSchema[] {
+    const labelsRefs = (attribute.relationships as any).labels.data as LabelResourceReference[];
+    const allLabels: LabelResourceSchema[] = labelsRefs
+        .map(ref => {
+            const obj = lookupRelatedObject(included, ref.id, ref.type);
+
+            if (!obj) {
+                return;
+            }
+
+            return obj as LabelResourceSchema;
+        })
+        .filter((obj): obj is LabelResourceSchema => obj !== undefined);
+
+    return allLabels;
+}
+
+function createNonDateAttributes(attributes: AttributeResourcesResponseSchema): ICatalogAttribute[] {
+    const nonDateAttributes = attributes.data.filter(attr => attr.attributes.granularity === undefined);
+
+    return nonDateAttributes.map(attribute => {
+        const allLabels = getAttributeLabels(attribute, attributes.included);
+        const defaultLabel = allLabels[0];
+
+        /*
+         * TODO: this is temporary way to identify labels with geo pushpin; normally this should be done
+         *  using some indicator on the metadata object. for sakes of speed & after agreement with tiger team
+         *  falling back to use of id convention.
+         */
+        const geoLabels = allLabels.filter(label => label.id.search(/^.*\.geo__/) > -1);
+
+        return convertAttribute(attribute, defaultLabel, geoLabels);
+    });
+}
+
+type DatasetWithAttributes = {
+    dataset: DatasetResourceSchema;
+    attributes: AttributeResourceSchema[];
+};
+
+function identifyDateDatasets(
+    dateAttributes: AttributeResourceSchema[],
+    included: SuccessIncluded[] | undefined,
+) {
+    const datasets: { [id: string]: DatasetWithAttributes } = {};
+
+    dateAttributes.forEach(attribute => {
+        const ref = (attribute.relationships as any)?.dataset?.data;
+
+        if (!ref) {
+            return;
+        }
+
+        const dataset = lookupRelatedObject(included, ref.id, ref.type) as DatasetResourceSchema;
+
+        if (!dataset) {
+            return;
+        }
+
+        const entry = datasets[ref.id];
+
+        if (!entry) {
+            datasets[ref.id] = {
+                dataset,
+                attributes: [attribute],
+            };
+        } else {
+            entry.attributes.push(attribute);
+        }
+    });
+
+    return Object.values(datasets);
+}
+
+function createDateDatasets(attributes: AttributeResourcesResponseSchema): ICatalogDateDataset[] {
+    const dateAttributes = attributes.data.filter(attr => attr.attributes.granularity !== undefined);
+    const dateDatasets = identifyDateDatasets(dateAttributes, attributes.included);
+
+    return dateDatasets.map(dd => {
+        const catalogDateAttributes = dd.attributes.map(attribute => {
+            const labels = getAttributeLabels(attribute, attributes.included);
+            const defaultLabel = labels[0];
+
+            return convertDateAttribute(attribute, defaultLabel);
+        });
+
+        return convertDateDataset(dd.dataset, catalogDateAttributes);
+    });
+}
+
+export async function loadAttributesAndDateDatasets(
+    client: ITigerClient,
+    includeTags: string[],
+): Promise<CatalogItem[]> {
+    const attributes = await client.metadata.attributesGet(
+        {
+            contentType: "application/json",
+            include: "tags,labels,dataset",
+        },
+        {
+            "filter[tags.id]": includeTags,
+        },
+    );
+
+    const nonDateAttributes: CatalogItem[] = createNonDateAttributes(attributes.data);
+    const dateDatasets: CatalogItem[] = createDateDatasets(attributes.data);
+
+    return nonDateAttributes.concat(dateDatasets);
+}

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -1,21 +1,16 @@
 // (C) 2019-2020 GoodData Corporation
 import {
+    IWorkspaceCatalog,
     IWorkspaceCatalogFactory,
     IWorkspaceCatalogFactoryOptions,
-    IWorkspaceCatalog,
 } from "@gooddata/sdk-backend-spi";
-import { CatalogItemType, ObjRef, CatalogItem } from "@gooddata/sdk-model";
-import flatten = require("lodash/flatten");
+import { CatalogItem, CatalogItemType, ICatalogFact, ICatalogMeasure, ObjRef } from "@gooddata/sdk-model";
 import { TigerAuthenticatedCallGuard } from "../../../types";
-import {
-    convertAttribute,
-    convertMeasure,
-    convertFact,
-    convertGroup,
-} from "../../../toSdkModel/CatalogConverter";
+import { convertFact, convertGroup, convertMeasure } from "../../../toSdkModel/CatalogConverter";
 import { TigerWorkspaceCatalog } from "./catalog";
 import { objRefToIdentifier } from "../../../fromObjRef";
-import { LabelResourceReference, LabelResourceSchema } from "@gooddata/gd-tiger-client";
+import { loadAttributesAndDateDatasets } from "./datasetLoader";
+import flatten = require("lodash/flatten");
 
 export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     constructor(
@@ -61,70 +56,27 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     };
 
     public load = async (): Promise<IWorkspaceCatalog> => {
-        const { types } = this.options;
-        const loaderByType: { [type in CatalogItemType]: () => Promise<CatalogItem[]> } = {
-            attribute: this.loadAttributes,
-            measure: this.loadMeasures,
-            fact: this.loadFacts,
-            dateDataset: this.loadDateDatasets,
-        };
+        const loadersResults = await Promise.all([
+            this.loadMeasures(),
+            this.loadFacts(),
+            this.loadAttributesAndDates(),
+        ]);
 
-        const loadersPromises = types.map(type => loaderByType[type]());
-        const loadersResults = await Promise.all(loadersPromises);
-        const catalogItems = flatten(loadersResults);
+        const catalogItems: CatalogItem[] = flatten<CatalogItem>(loadersResults);
 
         const groups = await this.loadGroups();
 
         return new TigerWorkspaceCatalog(this.authCall, this.workspace, groups, catalogItems, this.options);
     };
 
-    private loadAttributes = async () => {
+    private loadAttributesAndDates = async (): Promise<CatalogItem[]> => {
         const { includeTags = [] } = this.options;
         const tagsIdentifiers = await this.objRefsToIdentifiers(includeTags);
 
-        const attributes = await this.authCall(sdk =>
-            sdk.metadata.attributesGet(
-                {
-                    contentType: "application/json",
-                    include: "tags,labels",
-                },
-                {
-                    "filter[tags.id]": tagsIdentifiers,
-                },
-            ),
-        );
-
-        const getIncludedItem = (id: string, type: string) =>
-            attributes.data.included?.find(item => item.type === type && item.id === id);
-
-        return attributes.data.data.map(attribute => {
-            const labelsRefs = (attribute.relationships as any).labels.data as LabelResourceReference[];
-            const allLabels: LabelResourceSchema[] = labelsRefs
-                .map(ref => {
-                    const obj = getIncludedItem(ref.id, ref.type);
-
-                    if (!obj) {
-                        return;
-                    }
-
-                    return obj as LabelResourceSchema;
-                })
-                .filter((obj): obj is LabelResourceSchema => obj !== undefined);
-
-            const defaultLabel = allLabels[0];
-
-            /*
-             * TODO: this is temporary way to identify labels with geo pushpin; normally this should be done
-             *  using some indicator on the metadata object. for sakes of speed & after agreement with tiger team
-             *  falling back to use of id convention.
-             */
-            const geoLabels = allLabels.filter(label => label.id.search(/^.*\.geo__/) > -1);
-
-            return convertAttribute(attribute, defaultLabel, geoLabels);
-        });
+        return this.authCall(sdk => loadAttributesAndDateDatasets(sdk, tagsIdentifiers));
     };
 
-    private loadMeasures = async () => {
+    private loadMeasures = async (): Promise<ICatalogMeasure[]> => {
         const measures = await this.authCall(sdk =>
             sdk.metadata.metricsGet({
                 contentType: "application/json",
@@ -134,7 +86,7 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
         return measures.data.data.map(convertMeasure);
     };
 
-    private loadFacts = async () => {
+    private loadFacts = async (): Promise<ICatalogFact[]> => {
         const { includeTags = [] } = this.options;
         const tagsIdentifiers = await this.objRefsToIdentifiers(includeTags);
 
@@ -151,12 +103,6 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
         );
 
         return facts.data.data.map(convertFact);
-    };
-
-    private loadDateDatasets = async () => {
-        const dataSets = await this.authCall(async () => []);
-
-        return dataSets;
     };
 
     private loadGroups = async () => {

--- a/libs/sdk-backend-tiger/src/toSdkModel/dateGranularityConversions.ts
+++ b/libs/sdk-backend-tiger/src/toSdkModel/dateGranularityConversions.ts
@@ -1,0 +1,43 @@
+// (C) 2019-2020 GoodData Corporation
+import { AttributeGranularityResourceAttribute } from "@gooddata/gd-tiger-client";
+import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+
+type TigerToSdk = {
+    [key in AttributeGranularityResourceAttribute]: CatalogDateAttributeGranularity;
+};
+
+/*
+    Year = "year",
+    Day = "day",
+    Quarter = "quarter",
+    Month = "month",
+    Week = "week",
+    QuarterOfYear = "quarterOfYear",
+    MonthOfYear = "monthOfYear",
+    DayOfYear = "dayOfYear",
+    DayOfWeek = "dayOfWeek",
+    DayOfMonth = "dayOfMonth",
+    WeekOfYear = "weekOfYear",
+ */
+
+const TigerToSdkGranularityMap: TigerToSdk = {
+    [AttributeGranularityResourceAttribute.Year]: "GDC.time.year",
+    [AttributeGranularityResourceAttribute.Day]: "GDC.time.date",
+    [AttributeGranularityResourceAttribute.Quarter]: "GDC.time.quarter",
+    [AttributeGranularityResourceAttribute.Month]: "GDC.time.month",
+    [AttributeGranularityResourceAttribute.Week]: "GDC.time.week",
+
+    [AttributeGranularityResourceAttribute.QuarterOfYear]: "GDC.time.quarter_in_year",
+    [AttributeGranularityResourceAttribute.MonthOfYear]: "GDC.time.month_in_year",
+
+    [AttributeGranularityResourceAttribute.DayOfYear]: "GDC.time.day_in_year",
+    [AttributeGranularityResourceAttribute.DayOfWeek]: "GDC.time.day_in_week",
+    [AttributeGranularityResourceAttribute.DayOfMonth]: "GDC.time.day_in_month",
+    [AttributeGranularityResourceAttribute.WeekOfYear]: "GDC.time.week_in_year",
+};
+
+export function toSdkGranularity(
+    granularity: AttributeGranularityResourceAttribute,
+): CatalogDateAttributeGranularity {
+    return TigerToSdkGranularityMap[granularity];
+}


### PR DESCRIPTION
-  Refactored catalog factory:
   -  attributes, labels & datasets are loaded at once
   -  then non-date attributes are filtered out and catalog attributes are created
   -  then date attributes are grouped with their datasets and catalog date datasets area created

-  Date data sets now returned and can be shown in AD as usual on bear

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
