### PR TITLE
RELATED: RAIL-2234 - Fix over-time comparison measures and date filter conversions

### DIFF
--- a/libs/gd-tiger-client/api/gd-tiger-client.api.md
+++ b/libs/gd-tiger-client/api/gd-tiger-client.api.md
@@ -8174,16 +8174,23 @@ export namespace ExecuteAFM {
         };
     }
     // (undocumented)
-    export interface IPopMeasure {
+    export interface IOverPeriodMeasure {
+        // (undocumented)
+        dateAttributes: IPopDateAttribute[];
         // (undocumented)
         measureIdentifier: ILocalIdentifierQualifier;
-        // (undocumented)
-        popAttribute: ObjQualifier;
     }
     // (undocumented)
-    export interface IPopMeasureDefinition {
+    export interface IOverPeriodMeasureDefinition {
         // (undocumented)
-        popMeasure: IPopMeasure;
+        overPeriodMeasure: IOverPeriodMeasure;
+    }
+    // (undocumented)
+    export interface IPopDateAttribute {
+        // (undocumented)
+        attribute: ObjQualifier;
+        // (undocumented)
+        periodsAgo: number;
     }
     // (undocumented)
     export interface IPositiveAttributeFilter {
@@ -8257,7 +8264,7 @@ export namespace ExecuteAFM {
     // (undocumented)
     export type LocatorItem = IAttributeLocatorItem | IMeasureLocatorItem;
     // (undocumented)
-    export type MeasureDefinition = ISimpleMeasureDefinition | IArithmeticMeasureDefinition | IPopMeasureDefinition | IPreviousPeriodMeasureDefinition;
+    export type MeasureDefinition = ISimpleMeasureDefinition | IArithmeticMeasureDefinition | IOverPeriodMeasureDefinition | IPreviousPeriodMeasureDefinition;
     // (undocumented)
     export type ObjQualifier = IObjIdentifierQualifier;
     // (undocumented)

--- a/libs/gd-tiger-client/src/gd-tiger-model/ExecuteAFM.ts
+++ b/libs/gd-tiger-client/src/gd-tiger-model/ExecuteAFM.ts
@@ -36,7 +36,7 @@ export namespace ExecuteAFM {
     export type MeasureDefinition =
         | ISimpleMeasureDefinition
         | IArithmeticMeasureDefinition
-        | IPopMeasureDefinition
+        | IOverPeriodMeasureDefinition
         | IPreviousPeriodMeasureDefinition;
 
     export interface ISimpleMeasureDefinition {
@@ -47,8 +47,8 @@ export namespace ExecuteAFM {
         arithmeticMeasure: IArithmeticMeasure;
     }
 
-    export interface IPopMeasureDefinition {
-        popMeasure: IPopMeasure;
+    export interface IOverPeriodMeasureDefinition {
+        overPeriodMeasure: IOverPeriodMeasure;
     }
 
     export interface IPreviousPeriodMeasureDefinition {
@@ -71,9 +71,14 @@ export namespace ExecuteAFM {
         operator: ArithmeticMeasureOperator;
     }
 
-    export interface IPopMeasure {
+    export interface IPopDateAttribute {
+        attribute: ObjQualifier;
+        periodsAgo: number;
+    }
+
+    export interface IOverPeriodMeasure {
         measureIdentifier: ILocalIdentifierQualifier;
-        popAttribute: ObjQualifier;
+        dateAttributes: IPopDateAttribute[];
     }
 
     export interface IPreviousPeriodMeasure {

--- a/libs/sdk-backend-tiger/src/toAfm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/FilterConverter.ts
@@ -16,6 +16,7 @@ import {
 } from "@gooddata/sdk-model";
 import { ExecuteAFM } from "@gooddata/gd-tiger-client";
 import { toDateDataSetQualifier, toDisplayFormQualifier } from "./ObjRefConverter";
+import { toTigerGranularity } from "../toSdkModel/dateGranularityConversions";
 
 function convertPositiveFilter(filter: IPositiveAttributeFilter): ExecuteAFM.IPositiveAttributeFilter {
     const displayFormRef = filter.positiveAttributeFilter.displayForm;
@@ -91,7 +92,7 @@ export function convertRelativeDateFilter(filter: IRelativeDateFilter): ExecuteA
     return {
         relativeDateFilter: {
             dataset: toDateDataSetQualifier(datasetRef),
-            granularity: relativeDateFilter.granularity,
+            granularity: toTigerGranularity(relativeDateFilter.granularity as any),
             from: Number(relativeDateFilter.from),
             to: Number(relativeDateFilter.to),
         },

--- a/libs/sdk-backend-tiger/src/toAfm/MeasureConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/MeasureConverter.ts
@@ -112,14 +112,21 @@ function convertSimpleMeasureDefinition(definition: IMeasureDefinition): Execute
     };
 }
 
-function convertPopMeasureDefinition(definition: IPoPMeasureDefinition): ExecuteAFM.IPopMeasureDefinition {
+function convertPopMeasureDefinition(
+    definition: IPoPMeasureDefinition,
+): ExecuteAFM.IOverPeriodMeasureDefinition {
     const { popMeasureDefinition } = definition;
     const attributeRef = popMeasureDefinition.popAttribute;
 
     return {
-        popMeasure: {
+        overPeriodMeasure: {
             measureIdentifier: toLocalIdentifier(popMeasureDefinition.measureIdentifier),
-            popAttribute: toDisplayFormQualifier(attributeRef),
+            dateAttributes: [
+                {
+                    attribute: toDisplayFormQualifier(attributeRef),
+                    periodsAgo: 1,
+                },
+            ],
         },
     };
 }

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -29,7 +29,7 @@ Object {
       },
     },
     "from": -11,
-    "granularity": "GDC.time.date",
+    "granularity": "day",
     "to": 0,
   },
 }
@@ -45,7 +45,7 @@ Object {
       },
     },
     "from": 5,
-    "granularity": "GDC.time.date",
+    "granularity": "day",
     "to": NaN,
   },
 }
@@ -63,7 +63,7 @@ Object {
       },
     },
     "from": -3,
-    "granularity": "GDC.time.month",
+    "granularity": "month",
     "to": 9,
   },
 }
@@ -79,7 +79,7 @@ Object {
       },
     },
     "from": 25,
-    "granularity": "GDC.time.quarter",
+    "granularity": "quarter",
     "to": -2,
   },
 }
@@ -95,7 +95,7 @@ Object {
       },
     },
     "from": 50,
-    "granularity": "GDC.time.week_us",
+    "granularity": "week",
     "to": 100,
   },
 }
@@ -111,7 +111,7 @@ Object {
       },
     },
     "from": 2,
-    "granularity": "GDC.time.year",
+    "granularity": "year",
     "to": 7,
   },
 }
@@ -180,7 +180,7 @@ Object {
       },
     },
     "from": 20,
-    "granularity": "GDC.time.date",
+    "granularity": "day",
     "to": 30,
   },
 }

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
@@ -39,15 +39,20 @@ Object {
 exports[`measure converter should return converted pop measure definition from model to AFM 1`] = `
 Object {
   "definition": Object {
-    "popMeasure": Object {
+    "overPeriodMeasure": Object {
+      "dateAttributes": Array [
+        Object {
+          "attribute": Object {
+            "identifier": Object {
+              "id": "attr",
+              "type": "attribute",
+            },
+          },
+          "periodsAgo": 1,
+        },
+      ],
       "measureIdentifier": Object {
         "localIdentifier": "m_acugFHNJgsBy",
-      },
-      "popAttribute": Object {
-        "identifier": Object {
-          "id": "attr",
-          "type": "attribute",
-        },
       },
     },
   },
@@ -279,7 +284,7 @@ Object {
               },
             },
             "from": 5,
-            "granularity": "GDC.time.date",
+            "granularity": "day",
             "to": 22,
           },
         },

--- a/libs/sdk-backend-tiger/src/toSdkModel/dateGranularityConversions.ts
+++ b/libs/sdk-backend-tiger/src/toSdkModel/dateGranularityConversions.ts
@@ -1,9 +1,14 @@
 // (C) 2019-2020 GoodData Corporation
 import { AttributeGranularityResourceAttribute } from "@gooddata/gd-tiger-client";
 import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { NotSupported } from "@gooddata/sdk-backend-spi";
 
 type TigerToSdk = {
     [key in AttributeGranularityResourceAttribute]: CatalogDateAttributeGranularity;
+};
+
+type SdkToTiger = {
+    [key in CatalogDateAttributeGranularity]: AttributeGranularityResourceAttribute | undefined;
 };
 
 /*
@@ -25,7 +30,7 @@ const TigerToSdkGranularityMap: TigerToSdk = {
     [AttributeGranularityResourceAttribute.Day]: "GDC.time.date",
     [AttributeGranularityResourceAttribute.Quarter]: "GDC.time.quarter",
     [AttributeGranularityResourceAttribute.Month]: "GDC.time.month",
-    [AttributeGranularityResourceAttribute.Week]: "GDC.time.week",
+    [AttributeGranularityResourceAttribute.Week]: "GDC.time.week_us",
 
     [AttributeGranularityResourceAttribute.QuarterOfYear]: "GDC.time.quarter_in_year",
     [AttributeGranularityResourceAttribute.MonthOfYear]: "GDC.time.month_in_year",
@@ -36,8 +41,55 @@ const TigerToSdkGranularityMap: TigerToSdk = {
     [AttributeGranularityResourceAttribute.WeekOfYear]: "GDC.time.week_in_year",
 };
 
+/**
+ * Converts supported tiger backend granularities to values recognized by the SDK.
+ *
+ * @param granularity - tiger granularity
+ */
 export function toSdkGranularity(
     granularity: AttributeGranularityResourceAttribute,
 ): CatalogDateAttributeGranularity {
     return TigerToSdkGranularityMap[granularity];
+}
+
+const SdkToTigerGranularityMap: SdkToTiger = {
+    "GDC.time.year": AttributeGranularityResourceAttribute.Year,
+    "GDC.time.date": AttributeGranularityResourceAttribute.Day,
+    "GDC.time.quarter": AttributeGranularityResourceAttribute.Quarter,
+    "GDC.time.month": AttributeGranularityResourceAttribute.Month,
+    "GDC.time.week_us": AttributeGranularityResourceAttribute.Week,
+    "GDC.time.week": AttributeGranularityResourceAttribute.Week,
+
+    "GDC.time.quarter_in_year": AttributeGranularityResourceAttribute.QuarterOfYear,
+    "GDC.time.month_in_year": AttributeGranularityResourceAttribute.MonthOfYear,
+
+    "GDC.time.day_in_year": AttributeGranularityResourceAttribute.DayOfYear,
+    "GDC.time.day_in_week": AttributeGranularityResourceAttribute.DayOfWeek,
+    "GDC.time.day_in_month": AttributeGranularityResourceAttribute.DayOfMonth,
+    "GDC.time.week_in_year": AttributeGranularityResourceAttribute.WeekOfYear,
+
+    "GDC.time.day_in_euweek": undefined,
+    "GDC.time.day_in_quarter": undefined,
+    "GDC.time.euweek_in_quarter": undefined,
+    "GDC.time.euweek_in_year": undefined,
+    "GDC.time.month_in_quarter": undefined,
+    "GDC.time.week_in_quarter": undefined,
+};
+
+/**
+ * Converts granularity values recognized by the SDK into granularities known by tiger. Note that
+ * SDK granularities are superset of those supported by tiger.
+ *
+ * @throws NotSupport if the input granularity is not supported by tiger
+ */
+export function toTigerGranularity(
+    granularity: CatalogDateAttributeGranularity,
+): AttributeGranularityResourceAttribute {
+    const tigerGranularity = SdkToTigerGranularityMap[granularity];
+
+    if (!tigerGranularity) {
+        throw new NotSupported(`The ${granularity} is not supported on tiger backend.`);
+    }
+
+    return tigerGranularity;
 }


### PR DESCRIPTION
-  tiger does not have popMeasure, it has overPeriodMeasure. supports list of
   attributes and periodsAgo. modified convertor to create single element array
   with the popAttribute and periodsAgo: 1

-  The relative date filter granularity must be translated when sending data
   to tiger. granularities are different. added convertor.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
