### PR TITLE
RELATED: RAIL-2234 make sure dateFormatter is defaulted for the whole tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -30,6 +30,7 @@ import {
     TelemetryData,
 } from "@gooddata/sdk-backend-base";
 import { DateFormatter } from "../dateFormatting/types";
+import { createDefaultDateFormatter } from "../dateFormatting/defaultDateFormatter";
 
 const CAPABILITIES: BackendCapabilities = {
     canCalculateTotals: false,
@@ -90,6 +91,7 @@ export class TigerBackend implements IAnalyticalBackend {
     private readonly implConfig: TigerBackendConfig;
     private readonly sdk: ITigerClient;
     private readonly authProvider: AuthProviderCallGuard | undefined;
+    private readonly dateFormatter: DateFormatter;
 
     constructor(
         config: AnalyticalBackendConfig = {},
@@ -101,6 +103,7 @@ export class TigerBackend implements IAnalyticalBackend {
         this.implConfig = implConfig;
         this.telemetry = telemetry;
         this.authProvider = authProvider;
+        this.dateFormatter = implConfig.dateFormatter ?? createDefaultDateFormatter();
 
         const axios = createAxios(this.config, this.implConfig, this.telemetry);
         this.sdk = tigerClientFactory(axios);
@@ -130,7 +133,7 @@ export class TigerBackend implements IAnalyticalBackend {
 
     public workspace(id: string): IAnalyticalWorkspace {
         invariant(isString(id), `Invalid workspaceId: ${id}`);
-        return new TigerWorkspace(this.authApiCall, id, this.implConfig.dateFormatter);
+        return new TigerWorkspace(this.authApiCall, id, this.dateFormatter);
     }
 
     public workspaces(): IWorkspaceQueryFactory {

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
@@ -10,7 +10,7 @@ export class TigerExecution extends AbstractExecutionFactory {
     constructor(
         private readonly authCall: AuthenticatedCallGuard,
         workspace: string,
-        private readonly dateFormatter?: DateFormatter,
+        private readonly dateFormatter: DateFormatter,
     ) {
         super(workspace);
     }

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -49,7 +49,7 @@ export class TigerExecutionResult implements IExecutionResult {
         private readonly authCall: TigerAuthenticatedCallGuard,
         public readonly definition: IExecutionDefinition,
         readonly execResponse: Execution.IExecutionResponse,
-        private readonly dateFormatter?: DateFormatter,
+        private readonly dateFormatter: DateFormatter,
     ) {
         this.dimensions = transformResultDimensions(execResponse.executionResponse.dimensions);
         this.resultId = execResponse.executionResponse.links.executionResult;
@@ -127,7 +127,7 @@ class TigerDataView implements IDataView {
     constructor(
         result: IExecutionResult,
         execResult: Execution.IExecutionResult,
-        dateFormatter?: DateFormatter,
+        dateFormatter: DateFormatter,
     ) {
         this.result = result;
         this.definition = result.definition;

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
@@ -22,7 +22,7 @@ export class TigerPreparedExecution implements IPreparedExecution {
         private readonly authCall: TigerAuthenticatedCallGuard,
         public readonly definition: IExecutionDefinition,
         private readonly executionFactory: IExecutionFactory,
-        private readonly dateFormatter?: DateFormatter,
+        private readonly dateFormatter: DateFormatter,
     ) {}
 
     public async execute(): Promise<IExecutionResult> {

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -32,7 +32,7 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
     constructor(
         private readonly authCall: TigerAuthenticatedCallGuard,
         public readonly workspace: string,
-        private readonly dateFormatter?: DateFormatter,
+        private readonly dateFormatter: DateFormatter,
     ) {}
 
     public elements(): IElementQueryFactory {

--- a/libs/sdk-backend-tiger/src/dateFormatting/dateValueFormatter.ts
+++ b/libs/sdk-backend-tiger/src/dateFormatting/dateValueFormatter.ts
@@ -2,14 +2,13 @@
 import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
 import { parseDateValue } from "./dateValueParser";
 import { DateFormatter } from "./types";
-import { createDefaultDateFormatter } from "./defaultDateFormatter";
 
 /**
  * Creates a function that takes a string date attribute value and a granularity and returns a formatted date string.
  * @param dateFormatter - function to use to format Date values to a string
  * @public
  */
-export function createDateValueFormatter(dateFormatter: DateFormatter = createDefaultDateFormatter()) {
+export function createDateValueFormatter(dateFormatter: DateFormatter) {
     return (value: string, granularity: CatalogDateAttributeGranularity) => {
         const parsed = parseDateValue(value, granularity);
         return dateFormatter(parsed, granularity);

--- a/libs/sdk-backend-tiger/src/dateFormatting/tests/dateValueFormatter.test.ts
+++ b/libs/sdk-backend-tiger/src/dateFormatting/tests/dateValueFormatter.test.ts
@@ -1,9 +1,10 @@
 // (C) 2020 GoodData Corporation
 import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
 import { createDateValueFormatter } from "../dateValueFormatter";
+import { createDefaultDateFormatter } from "../defaultDateFormatter";
 
 describe("createDateValueFormatter", () => {
-    const defaultDateValueFormatter = createDateValueFormatter();
+    const defaultDateValueFormatter = createDateValueFormatter(createDefaultDateFormatter());
 
     type Scenario = [string, CatalogDateAttributeGranularity, string];
     const scenarios: Scenario[] = [

--- a/libs/sdk-backend-tiger/src/fromAfm/result.ts
+++ b/libs/sdk-backend-tiger/src/fromAfm/result.ts
@@ -45,8 +45,8 @@ function getGranularity(header: IDimensionItemDescriptor): CatalogDateAttributeG
 
 function transformHeaderItems(
     dimensions: IDimensionDescriptor[],
+    dateFormatter: DateFormatter,
     dimensionHeaders?: Execution.IDimensionHeader[],
-    dateFormatter?: DateFormatter,
 ): IResultHeader[][][] {
     if (!dimensionHeaders) {
         return [[[]]];
@@ -94,11 +94,11 @@ function transformHeaderItems(
 export function transformExecutionResult(
     result: Execution.IExecutionResult,
     dimensions: IDimensionDescriptor[],
-    dateFormatter?: DateFormatter,
+    dateFormatter: DateFormatter,
 ): TransformerResult {
     return {
         data: result.data,
-        headerItems: transformHeaderItems(dimensions, result.dimensionHeaders, dateFormatter),
+        headerItems: transformHeaderItems(dimensions, dateFormatter, result.dimensionHeaders),
         offset: result.paging.offset,
         count: result.paging.count,
         total: result.paging.total,


### PR DESCRIPTION
This makes sure that all the submodules of tiger would use the same date formatter.

JIRA: RAIL-2234

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
