### PR TITLE
RELATED: RAIL-2234 fix dataset identifier type in tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/fromAfm/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/fromAfm/ObjRefConverter.ts
@@ -6,7 +6,7 @@ import { ExecuteAFM } from "@gooddata/gd-tiger-client";
 import ObjQualifier = ExecuteAFM.ObjQualifier;
 import { TigerAfmType } from "../types";
 
-const allValidTigerAfmTypes: TigerAfmType[] = ["metric", "label", "fact", "dataSet", "attribute"];
+const allValidTigerAfmTypes: TigerAfmType[] = ["metric", "label", "fact", "dataset", "attribute"];
 
 const objRefTypeByTigerType: {
     [objectType in TigerAfmType]: ObjectType;
@@ -14,7 +14,7 @@ const objRefTypeByTigerType: {
     attribute: "attribute",
     metric: "measure",
     label: "displayForm",
-    dataSet: "dataSet",
+    dataset: "dataSet",
     fact: "fact",
     variable: "variable",
 };

--- a/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/toAfm/ObjRefConverter.ts
@@ -17,7 +17,7 @@ const tigerAfmTypeByObjectAfmType: {
     attribute: "attribute",
     measure: "metric",
     displayForm: "label",
-    dataSet: "dataSet",
+    dataSet: "dataset",
     fact: "fact",
     variable: "variable",
 };
@@ -75,7 +75,7 @@ export function toDisplayFormQualifier(ref: ObjRef): ObjQualifier {
  * @internal
  */
 export function toDateDataSetQualifier(ref: ObjRef): ObjQualifier {
-    return toObjQualifier(ref, "dataSet");
+    return toObjQualifier(ref, "dataset");
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": "2019-08-06",
@@ -25,7 +25,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": -11,
@@ -41,7 +41,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": 5,
@@ -59,7 +59,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": -3,
@@ -75,7 +75,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": 25,
@@ -91,7 +91,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": 50,
@@ -107,7 +107,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": 2,
@@ -123,7 +123,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": "2019-08-06",
@@ -203,7 +203,7 @@ Object {
     "dataset": Object {
       "identifier": Object {
         "id": "closed",
-        "type": "dataSet",
+        "type": "dataset",
       },
     },
     "from": 20,

--- a/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/toAfm/tests/__snapshots__/MeasureConverter.test.ts.snap
@@ -69,7 +69,7 @@ Object {
           "dataset": Object {
             "identifier": Object {
               "id": "bar",
-              "type": "dataSet",
+              "type": "dataset",
             },
           },
           "periodsAgo": 3,
@@ -268,7 +268,7 @@ Object {
             "dataset": Object {
               "identifier": Object {
                 "id": "closed",
-                "type": "dataSet",
+                "type": "dataset",
               },
             },
             "from": "2019-08-06",
@@ -280,7 +280,7 @@ Object {
             "dataset": Object {
               "identifier": Object {
                 "id": "closed",
-                "type": "dataSet",
+                "type": "dataset",
               },
             },
             "from": 5,

--- a/libs/sdk-backend-tiger/src/types/index.ts
+++ b/libs/sdk-backend-tiger/src/types/index.ts
@@ -7,7 +7,7 @@ import { AuthenticatedCallGuard } from "@gooddata/sdk-backend-base";
  *
  * @public
  */
-export type TigerAfmType = "label" | "metric" | "dataSet" | "fact" | "attribute" | "variable";
+export type TigerAfmType = "label" | "metric" | "dataset" | "fact" | "attribute" | "variable";
 
 /**
  * Tiger authenticated call guard


### PR DESCRIPTION
It used to be "dataSet" but is now "dataset".

JIRA: RAIL-2234

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
