### PR TITLE
RELATED: RAIL-2310 add support for loading facts in insightReferences

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
@@ -171,7 +171,7 @@ export class BearWorkspaceInsights implements IWorkspaceInsights {
 
     public getReferencedObjects = async (
         insight: IInsight,
-        types: SupportedInsightReferenceTypes[] = ["dataSet", "measure"],
+        types: SupportedInsightReferenceTypes[] = ["dataSet", "measure", "fact"],
     ): Promise<IInsightReferences> => {
         return new InsightReferencesQuery(this.authCall, this.workspace, insight, types).run();
     };

--- a/libs/sdk-backend-bear/src/backend/workspace/insights/insightReferences.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/insightReferences.ts
@@ -13,7 +13,7 @@ import keyBy from "lodash/keyBy";
 import flatMap from "lodash/fp/flatMap";
 import uniqBy from "lodash/fp/uniqBy";
 
-import { convertMetric } from "../../../toSdkModel/CatalogConverter";
+import { convertMetric, convertWrappedFact } from "../../../toSdkModel/CatalogConverter";
 
 const objectTypeToObjectCategory = (type: InsightReferenceTypes): GdcMetadata.ObjectCategory => {
     switch (type) {
@@ -199,16 +199,17 @@ export class InsightReferencesQuery {
             const fullObject = objectsByUri[obj.uri];
 
             switch (obj.type) {
-                case "fact":
                 case "attribute":
                 case "displayForm":
                 case "variable":
                     /*
                      * TODO: implement conversions in order to support these additional types;
-                     *  fact -> catalogItem
                      *  attribute&Df -> catalog item
                      *  variable -> ?? not catalog item, probably something else..
                      */
+                    break;
+                case "fact":
+                    catalogItems.push(convertWrappedFact({ fact: fullObject as GdcMetadata.IFact }));
                     break;
                 case "measure":
                     catalogItems.push(convertMetric({ metric: fullObject as GdcMetadata.IMetric }));

--- a/libs/sdk-backend-bear/src/toSdkModel/CatalogConverter.ts
+++ b/libs/sdk-backend-bear/src/toSdkModel/CatalogConverter.ts
@@ -155,6 +155,23 @@ export const convertDateDataset = (dateDataset: GdcDateDataSets.IDateDataSet): I
     );
 };
 
+export const convertWrappedFact = (fact: GdcMetadata.IWrappedFact): ICatalogFact => {
+    const { meta } = fact.fact;
+    const factRef = uriRef(meta.uri);
+
+    return newCatalogFact(catalogFact =>
+        catalogFact.fact(factRef, f =>
+            f
+                .id(meta.identifier)
+                .uri(meta.uri)
+                .title(meta.title)
+                .description(meta.summary)
+                .production(meta.isProduction === 1)
+                .unlisted(meta.unlisted === 1),
+        ),
+    );
+};
+
 export const convertMetric = (metric: GdcMetadata.IWrappedMetric): ICatalogMeasure => {
     const { content, meta } = metric.metric;
     const measureRef = uriRef(meta.uri);

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1228,7 +1228,7 @@ export enum SettingCatalog {
 }
 
 // @public
-export type SupportedInsightReferenceTypes = Exclude<InsightReferenceTypes, "attribute" | "fact" | "displayForm" | "variable">;
+export type SupportedInsightReferenceTypes = Exclude<InsightReferenceTypes, "attribute" | "displayForm" | "variable">;
 
 // @public
 export class UnexpectedError extends AnalyticalBackendError {

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -97,7 +97,7 @@ export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
  */
 export type SupportedInsightReferenceTypes = Exclude<
     InsightReferenceTypes,
-    "attribute" | "fact" | "displayForm" | "variable"
+    "attribute" | "displayForm" | "variable"
 >;
 
 /**


### PR DESCRIPTION
JIRA: RAIL-2301

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
