### PR TITLE
RELATED: RAIL-2421 differentiate between EMTY_AFM and other errors

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -59,8 +59,18 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
     protected supportedPropertiesList: string[];
     protected propertiesMeta: any;
 
-    protected isError: boolean;
+    private hasError: boolean;
+    private hasEmptyAfm: boolean;
+
     protected isLoading: boolean;
+
+    protected setIsError = (value: boolean): void => {
+        this.hasError = value;
+    };
+
+    protected getIsError = (): boolean => {
+        return this.hasEmptyAfm || this.hasError;
+    };
 
     protected constructor(props: IVisConstruct) {
         this.callbacks = props.callbacks;
@@ -110,6 +120,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
         executionFactory: IExecutionFactory,
     ): void {
         this.updateInstanceProperties(options, insight);
+        this.hasEmptyAfm = !insightHasDataDefined(insight);
 
         let shouldRenderVisualization: boolean;
         try {
@@ -197,14 +208,19 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
     protected onError = (error: GoodDataSdkError) => {
         this.callbacks.onError?.(error);
 
-        this.isError = true;
+        // EMPTY_AFM is handled in update as it can change on any render contrary to other error types
+        // that have to be set manually or by loading
+        if (error.message !== PluggableVisualizationErrorCodes.EMPTY_AFM) {
+            this.hasError = true;
+        }
+
         this.renderConfigurationPanel(this.currentInsight);
     };
 
     protected onLoadingChanged = (loadingState: ILoadingState) => {
         this.callbacks.onLoadingChanged?.(loadingState);
 
-        this.isError = false;
+        this.hasError = false;
         this.isLoading = loadingState.isLoading;
         this.renderConfigurationPanel(this.currentInsight);
     };

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -129,7 +129,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
                     references={this.references}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -42,7 +42,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                     insight={insight}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                     axis={this.axis}

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -266,7 +266,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                     axis={this.axis}

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
@@ -132,7 +132,7 @@ export class PluggableBubbleChart extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -78,7 +78,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,
@@ -110,8 +110,10 @@ export class PluggableBulletChart extends PluggableBaseChart {
     }
 
     private setPrimaryMeasureIsMissingError(measureBuckets: IBucketOfFun[]): void {
-        this.isError =
+        const hasPrimaryMeasureIsMissingError =
             measureBuckets[0].items.length === 0 &&
             (measureBuckets[1].items.length > 0 || measureBuckets[2].items.length > 0);
+
+        this.setIsError(hasPrimaryMeasureIsMissingError);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -227,7 +227,7 @@ describe("PluggableBulletChart", () => {
                 referencePointMocks.secondaryAndTertiaryMeasuresWithTwoAttributesReferencePoint,
             );
 
-            expect((bulletChart as any).isError).toEqual(true);
+            expect((bulletChart as any).getIsError()).toEqual(true);
         });
 
         it("should set to false if primary measure is present", async () => {
@@ -235,7 +235,7 @@ describe("PluggableBulletChart", () => {
                 referencePointMocks.multipleMetricsNoCategoriesReferencePoint,
             );
 
-            expect((bulletChart as any).isError).toEqual(false);
+            expect((bulletChart as any).getIsError()).toEqual(false);
         });
     });
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -165,7 +165,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
                     insight={insight}
                     colors={this.colors}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -107,7 +107,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -139,7 +139,7 @@ export class PluggableLineChart extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                     axis={this.axis}

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -119,7 +119,7 @@ export class PluggablePieChart extends PluggableBaseChart {
                     pushData={this.handlePushData}
                     colors={this.colors}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                     references={this.references}

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/PluggableScatterPlot.tsx
@@ -66,7 +66,7 @@ export class PluggableScatterPlot extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -115,7 +115,7 @@ export class PluggableTreemap extends PluggableBaseChart {
                     colors={this.colors}
                     pushData={this.handlePushData}
                     type={this.type}
-                    isError={this.isError}
+                    isError={this.getIsError()}
                     isLoading={this.isLoading}
                     featureFlags={this.featureFlags}
                 />,


### PR DESCRIPTION
Since EMPTY_AFM can change on any update to the component,
we need to handle it separately.

JIRA: RAIL-2421

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
