### PR TITLE
RELATED: RAIL-2341 keep partial relativeDateFilters

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -72,15 +72,21 @@ const convertMeasureFilter = (filter: GdcVisualizationObject.Filter): IMeasureFi
         }
 
         // check for all-time filters with missing bounds (even one missing bound suggests an all time filter)
+        // we cannot remove them, as they do make sense in some rare legacy contexts
         if (isNil(filter.relativeDateFilter.from) || isNil(filter.relativeDateFilter.to)) {
-            return null;
+            // tslint:disable-next-line: no-console
+            console.warn(
+                "RelativeDateFilter without 'from' or 'to' field encountered." +
+                    "This can make sense in some legacy contexts (e.g. PoP measures with All time global filter), but generally, this indicates an error." +
+                    "Please check the visualization object data to make sure the relativeDateFilter data is what you expected.",
+            );
         }
 
         return {
             relativeDateFilter: {
                 ...filter.relativeDateFilter,
-                from: filter.relativeDateFilter.from,
-                to: filter.relativeDateFilter.to,
+                from: filter.relativeDateFilter.from!,
+                to: filter.relativeDateFilter.to!,
             },
         };
     }


### PR DESCRIPTION
They are needed by legacy insights with All time PoP measures.
Without the filters, the derived measures are discarded there.
However, we do not explicitly support them as they do not make sense in "normal" use.

JIRA: RAIL-2341

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
