### PR TITLE
RELATED: RAIL-2414 ignore irrelevant filters in measure fingerprints

### DIFF
--- a/libs/sdk-model/src/execution/filter/tests/fingerprint.test.ts
+++ b/libs/sdk-model/src/execution/filter/tests/fingerprint.test.ts
@@ -2,7 +2,22 @@
 
 import { Account, Won } from "../../../../__mocks__/model";
 import { newMeasureValueFilter, newNegativeAttributeFilter } from "../factory";
-import { filterFingerprint } from "../fingerprint";
+import { filterFingerprint, isFilterRelevantForFingerprinting } from "../fingerprint";
+
+describe("isFilterRelevantForFingerprinting", () => {
+    it("should return false for noop measure value filter", () => {
+        const EmptyMvf = newMeasureValueFilter(Won, "EQUAL_TO", 0);
+        delete EmptyMvf.measureValueFilter.condition;
+
+        expect(isFilterRelevantForFingerprinting(EmptyMvf)).toEqual(false);
+    });
+
+    it("should return false for noop negative attribute filter", () => {
+        expect(isFilterRelevantForFingerprinting(newNegativeAttributeFilter(Account.Name, []))).toEqual(
+            false,
+        );
+    });
+});
 
 describe("filterFingerprint", () => {
     it("should return nothing for noop measure value filter", () => {

--- a/libs/sdk-model/src/execution/measure/fingerprint.ts
+++ b/libs/sdk-model/src/execution/measure/fingerprint.ts
@@ -4,6 +4,7 @@ import stringify from "json-stable-stringify";
 import { IMeasureFilter } from "../filter";
 import { IMeasure, IMeasureDefinition, isSimpleMeasure } from "./index";
 import merge = require("lodash/merge");
+import { isFilterRelevantForFingerprinting } from "../filter/fingerprint";
 
 type MeasureDefinitionPropsToDefault = Pick<
     IMeasureDefinition["measureDefinition"],
@@ -11,6 +12,13 @@ type MeasureDefinitionPropsToDefault = Pick<
 >;
 
 function simpleMeasureFingerprint(measure: IMeasure<IMeasureDefinition>): string {
+    const { measureDefinition } = measure.measure.definition;
+
+    const measureDefinitionWithSanitizedFilters = {
+        ...measureDefinition,
+        filters: measureDefinition.filters?.filter(isFilterRelevantForFingerprinting),
+    };
+
     const measureDefinitionDefaults: MeasureDefinitionPropsToDefault = {
         filters: [] as IMeasureFilter[],
         computeRatio: false,
@@ -18,7 +26,7 @@ function simpleMeasureFingerprint(measure: IMeasure<IMeasureDefinition>): string
 
     const measureDefinitionWithDefaults = merge(
         measureDefinitionDefaults,
-        measure.measure.definition.measureDefinition,
+        measureDefinitionWithSanitizedFilters,
     );
 
     return stringify({


### PR DESCRIPTION
This makes the logic the same for measure filters as for the "global" filters.

JIRA: RAIL-2414

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
