### PR TITLE
RELATED: RAIL-2407 expose AnonymousAuthProvider in base and tiger

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -66,6 +66,18 @@ export type AnalyticalBackendCallbacks = {
     failedResultReadWindow?: (offset: number[], size: number[], error: any) => void;
 };
 
+// @public
+export class AnonymousAuthProvider implements IAuthProviderCallGuard {
+    // (undocumented)
+    authenticate(_context: AuthenticationContext): Promise<AuthenticatedPrincipal>;
+    // (undocumented)
+    deauthenticate(_context: AuthenticationContext): Promise<void>;
+    // (undocumented)
+    getCurrentPrincipal(_context: AuthenticationContext): Promise<AuthenticatedPrincipal | null>;
+    // (undocumented)
+    reset(): void;
+}
+
 // @beta (undocumented)
 export type ApiClientProvider = (config: CustomBackendConfig) => any;
 
@@ -286,9 +298,7 @@ export interface IAuthenticatedAsyncCallContext {
     getPrincipal(): Promise<AuthenticatedPrincipal>;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "IAuthProviderCallGuard" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @public
 export interface IAuthProviderCallGuard extends IAuthenticationProvider {
     // (undocumented)
     reset(): void;

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -29,6 +29,7 @@ export {
     IAuthenticatedAsyncCallContext,
     IAuthProviderCallGuard,
     NoopAuthProvider,
+    AnonymousAuthProvider,
 } from "./toolkit/auth";
 
 export { TelemetryData } from "./toolkit/backend";

--- a/libs/sdk-backend-base/src/toolkit/auth.ts
+++ b/libs/sdk-backend-base/src/toolkit/auth.ts
@@ -44,7 +44,7 @@ export type AuthenticatedCallGuard<TSdk = any> = <TReturn>(
 
 /**
  * see AuthProviderCallGuard
- * @internal
+ * @public
  */
 export interface IAuthProviderCallGuard extends IAuthenticationProvider {
     reset(): void;
@@ -138,6 +138,7 @@ export const AnonymousUser: AuthenticatedPrincipal = {
 /**
  * This is a noop implementation of authentication provider - it does nothing and assumes anonymous user.
  *
+ * @public
  */
 export class AnonymousAuthProvider implements IAuthProviderCallGuard {
     public authenticate(_context: AuthenticationContext): Promise<AuthenticatedPrincipal> {

--- a/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
+++ b/libs/sdk-backend-tiger/api/sdk-backend-tiger.api.md
@@ -5,7 +5,10 @@
 ```ts
 
 import { AnalyticalBackendConfig } from '@gooddata/sdk-backend-spi';
+import { AnonymousAuthProvider } from '@gooddata/sdk-backend-base';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
+
+export { AnonymousAuthProvider }
 
 // @public
 function tigerFactory(config?: AnalyticalBackendConfig, implConfig?: any): IAnalyticalBackend;

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -16,3 +16,4 @@ function tigerFactory(config?: AnalyticalBackendConfig, implConfig?: any): IAnal
 }
 
 export default tigerFactory;
+export { AnonymousAuthProvider } from "@gooddata/sdk-backend-base";


### PR DESCRIPTION
Also uses the AnonymousAuthProvider as a default in tiger

JIRA: RAIL-2407

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
