### PR TITLE
RELATED: RAIL-2407 add support for tiger backends without auth to catalog-export

### DIFF
--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -70,7 +70,7 @@ async function run() {
             await exportMetadataToCatalog(projectMetadata, filePath);
         }
 
-        logSuccess("All data have been successfuly exported");
+        logSuccess("All data have been successfully exported");
         logBox(chalk`The result is located at {bold ${filePath}}`);
 
         process.exit(0);

--- a/tools/catalog-export/src/loaders/tiger/tigerClient.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerClient.ts
@@ -15,13 +15,15 @@ export const DefaultGetOptions = {
  * @param username - username for authentication
  * @param password - password for authentication
  */
-export function createTigerClient(hostname: string, username: string, password: string): ITigerClient {
+export function createTigerClient(hostname: string, username?: string, password?: string): ITigerClient {
     const axios = newAxios(hostname);
 
-    axios.defaults.auth = {
-        username,
-        password,
-    };
+    if (username && password) {
+        axios.defaults.auth = {
+            username,
+            password,
+        };
+    }
 
     return tigerClientFactory(axios);
 }


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
