### PR TITLE
RELATED: RAIL-2446 do not remove noop filters from Insights in bear

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -31,7 +31,7 @@ const convertAttributeElements = (items: string[]): IAttributeElements => {
     return isUriLike(first) ? { uris: items } : { values: items };
 };
 
-const convertFilter = (filter: GdcVisualizationObject.ExtendedFilter): IFilter | null => {
+const convertFilter = (filter: GdcVisualizationObject.ExtendedFilter): IFilter => {
     if (GdcVisualizationObject.isMeasureValueFilter(filter)) {
         return {
             measureValueFilter: {
@@ -44,7 +44,7 @@ const convertFilter = (filter: GdcVisualizationObject.ExtendedFilter): IFilter |
     return convertMeasureFilter(filter);
 };
 
-const convertMeasureFilter = (filter: GdcVisualizationObject.Filter): IMeasureFilter | null => {
+const convertMeasureFilter = (filter: GdcVisualizationObject.Filter): IMeasureFilter => {
     if (GdcVisualizationObject.isAttributeFilter(filter)) {
         if (GdcVisualizationObject.isPositiveAttributeFilter(filter)) {
             return {

--- a/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
@@ -105,17 +105,3 @@ export const convertFilter = (filter: IMeasureFilter): GdcVisualizationObject.Fi
         return convertRelativeDateFilter(filter);
     }
 };
-
-const isSelectAllFilter = (filter: IFilter): boolean => {
-    if (isNegativeAttributeFilter(filter)) {
-        const elements = filterAttributeElements(filter);
-        const elementData = isAttributeElementsByRef(elements) ? elements.uris : elements.values;
-        return elementData.length === 0;
-    }
-
-    return false;
-};
-
-export const shouldFilterBeIncluded = (filter: IFilter): boolean => {
-    return !isSelectAllFilter(filter);
-};

--- a/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
@@ -23,7 +23,7 @@ import isEmpty from "lodash/isEmpty";
 import omitBy from "lodash/omitBy";
 import { convertUrisToReferences } from "../fromBackend/ReferenceConverter";
 import { serializeProperties } from "../fromBackend/PropertiesConverter";
-import { convertExtendedFilter, shouldFilterBeIncluded } from "./FilterConverter";
+import { convertExtendedFilter } from "./FilterConverter";
 import { convertMeasure } from "./MeasureConverter";
 
 const convertAttribute = (attribute: IAttribute): GdcVisualizationObject.IAttribute => {
@@ -61,7 +61,7 @@ const convertInsightContent = (
 
     const nonEmptyProperties = omitBy(properties, (value, key) => key !== "controls" && isEmpty(value));
 
-    const filters = insightFilters(insight).filter(shouldFilterBeIncluded).map(convertExtendedFilter);
+    const filters = insightFilters(insight).map(convertExtendedFilter);
 
     return {
         buckets: insightBuckets(insight).map(convertBucket),

--- a/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/MeasureConverter.ts
@@ -29,7 +29,7 @@ import {
 } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
 import { toBearRef } from "./ObjRefConverter";
-import { convertFilter, shouldFilterBeIncluded } from "./FilterConverter";
+import { convertFilter } from "./FilterConverter";
 
 const convertPreviousPeriodDataSet = (
     dataSet: IPreviousPeriodDateDataSet,
@@ -85,7 +85,7 @@ const convertSimpleMeasureDefinition = (
 
     const aggregation = measureAggregation(measure);
     const computeRatio = measureDoesComputeRatio(measure);
-    const filters = (measureFilters(measure) || []).filter(shouldFilterBeIncluded).map(convertFilter);
+    const filters = (measureFilters(measure) || []).map(convertFilter);
 
     return {
         measureDefinition: {


### PR DESCRIPTION
While this made sense, it was confusing to the users.

JIRA: RAIL-2446

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
