### PR TITLE
RELATED: RAIL-2407 prevent updates after unmount in InsightView

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -121,6 +121,7 @@ class RenderInsightView extends React.Component<IInsightViewProps, IInsightViewS
     private insight: IInsight | undefined;
     private colorPalette: IColorPalette | undefined;
     private settings: IWorkspaceSettings | undefined;
+    private containerRef = React.createRef<HTMLDivElement>();
 
     public static defaultProps: Partial<IInsightViewProps> = {
         ErrorComponent,
@@ -165,7 +166,8 @@ class RenderInsightView extends React.Component<IInsightViewProps, IInsightViewS
     };
 
     private updateVisualization = () => {
-        if (!this.visualization) {
+        // if the container no longer exists, update was called after unmount -> do nothing
+        if (!this.visualization || !this.containerRef.current) {
             return;
         }
 
@@ -351,7 +353,7 @@ class RenderInsightView extends React.Component<IInsightViewProps, IInsightViewS
             <>
                 {this.state.isLoading && <LoadingComponent />}
                 {this.state.error && <ErrorComponent message={this.state.error.message} />}
-                <div className="visualization-uri-root" id={this.elementId} />
+                <div className="visualization-uri-root" id={this.elementId} ref={this.containerRef} />
             </>
         );
     }


### PR DESCRIPTION
It can happen so the call to updateVisualization happens after unmount
because it waits on async operations. Thus we need to check
that the target DOM node still exists when calling update.
This is done by keeping a ref to the div that is cleared on unmount automatically.

JIRA: RAIL-2407

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
