### PR TITLE
RELATED:  RAIL-2382 use DecoratedDataView in DefinitionSanitizingExecutionResult

### DIFF
--- a/libs/sdk-backend-base/src/cachingBackend/tests/withCaching.test.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/tests/withCaching.test.ts
@@ -75,6 +75,27 @@ describe("withCaching", () => {
         expect(second).toBe(first);
     });
 
+    it("keeps the cached data views' methods intact", async () => {
+        const backend = createBackend();
+
+        const firstBuckets = [newBucket("measures", ReferenceLdm.Won, ReferenceLdm.WinRate)];
+
+        const secondBuckets = [
+            newBucket("measures", ReferenceLdm.Won),
+            newBucket("secondary_measures", ReferenceLdm.WinRate),
+        ];
+
+        const first = await doInsightExecution(backend, firstBuckets);
+        const second = await doInsightExecution(backend, secondBuckets);
+
+        const firstAll = await first.readAll();
+        // the secondAll object is from cache but has an altered definition, let's check the methods are still there and work
+        const secondAll = await second.readAll();
+
+        expect(secondAll.fingerprint).toBeDefined();
+        expect(secondAll.equals(firstAll)).toBe(true);
+    });
+
     it("evicts when execution cache limit hit", () => {
         const backend = createBackend();
 

--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -7,6 +7,8 @@ import {
     IExportConfig,
     IExportResult,
     IPreparedExecution,
+    IResultHeader,
+    DataValue,
 } from "@gooddata/sdk-backend-spi";
 import {
     IAttributeOrMeasure,
@@ -154,6 +156,43 @@ export abstract class DecoratedExecutionResult implements IExecutionResult {
     }
 
     public equals(other: IExecutionResult): boolean {
+        return this.decorated.equals(other);
+    }
+
+    public fingerprint(): string {
+        return this.decorated.fingerprint();
+    }
+}
+
+/**
+ * Abstract base class for data view decorators. Implements delegates to decorated data view. Concrete
+ * implementations can override just the functions they are interested in.
+ *
+ * @alpha
+ */
+export abstract class DecoratedDataView implements IDataView {
+    public offset: number[];
+    public count: number[];
+    public totalCount: number[];
+    public headerItems: IResultHeader[][][];
+    public data: DataValue[] | DataValue[][];
+    public totals?: DataValue[][][];
+    public definition: IExecutionDefinition;
+    public result: IExecutionResult;
+
+    constructor(private readonly decorated: IDataView, result?: IExecutionResult) {
+        this.result = result ?? decorated.result;
+
+        this.count = decorated.count;
+        this.data = decorated.data;
+        this.definition = decorated.definition;
+        this.headerItems = decorated.headerItems;
+        this.offset = decorated.offset;
+        this.totalCount = decorated.totalCount;
+        this.totals = decorated.totals;
+    }
+
+    public equals(other: IDataView): boolean {
         return this.decorated.equals(other);
     }
 


### PR DESCRIPTION
This is done so that we can keep the definition overriding more explicit.

JIRA: RAIL-2382

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
