### PR TITLE
RELATED: RAIL-2424 add drilling support to geo chart

### DIFF
--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -43,6 +43,7 @@
         "@gooddata/sdk-ui": "^8.0.0-alpha.104",
         "@gooddata/sdk-ui-vis-commons": "^8.0.0-alpha.104",
         "classnames": "^2.2.6",
+        "custom-event": "^1.0.1",
         "lodash": "^4.17.15",
         "mapbox-gl": "^1.6.1",
         "prop-types": "^15.6.0",

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
@@ -453,6 +453,7 @@ export default class GeoChartRenderer extends React.Component<IGeoChartRendererP
             geoData,
             properties,
             coordinates,
+            originalEvent.target,
         );
     };
 

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/drilling.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/drilling.ts
@@ -14,6 +14,7 @@ import { AttributeInfo, findGeoAttributesInDimension, parseGeoProperties } from 
 import { IAttributeDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
 import without = require("lodash/without");
 import omit = require("lodash/omit");
+import * as CustomEvent from "custom-event";
 
 function getDrillIntersectionForGeoChart(
     drillableItems: IHeaderPredicate[],
@@ -93,7 +94,6 @@ function getAttributeHeader(
     };
 }
 
-// (C) 2019-2020 GoodData Corporation
 export function handleGeoPushpinDrillEvent(
     drillableItems: IHeaderPredicate[],
     drillConfig: IDrillConfig,
@@ -101,6 +101,7 @@ export function handleGeoPushpinDrillEvent(
     geoData: IGeoData,
     pinProperties: GeoJSON.GeoJsonProperties,
     pinCoordinates: number[],
+    target: EventTarget,
 ): void {
     const { locationIndex } = pinProperties || {};
     const drillIntersection: IDrillEventIntersectionElement[] | undefined = getDrillIntersectionForGeoChart(
@@ -139,6 +140,14 @@ export function handleGeoPushpinDrillEvent(
     };
 
     if (onDrill) {
-        onDrill(drillEventExtended);
+        const shouldFireEvent = onDrill(drillEventExtended);
+        // if user-specified onDrill fn returns false, do not fire default DOM event
+        if (shouldFireEvent !== false) {
+            const event = new CustomEvent("drill", {
+                detail: drillEventExtended,
+                bubbles: true,
+            });
+            target.dispatchEvent(event);
+        }
     }
 }

--- a/libs/sdk-ui-geo/src/typings.d.ts
+++ b/libs/sdk-ui-geo/src/typings.d.ts
@@ -1,0 +1,4 @@
+// (C) 2020 GoodData Corporation
+declare module "custom-event" {
+    export = CustomEvent;
+}

--- a/libs/sdk-ui-geo/tsconfig.build.json
+++ b/libs/sdk-ui-geo/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "noImplicitAny": true,
         "baseUrl": null,

--- a/libs/sdk-ui-geo/tsconfig.dev.json
+++ b/libs/sdk-ui-geo/tsconfig.dev.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "noUnusedLocals": false,
         "noUnusedParameters": false,


### PR DESCRIPTION
The approach is heavily inspired in SDK7 version of this.

JIRA: RAIL-2424

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
