### PR TITLE
RELATED: RAIL-2340 respect explicit production settings in loadDateDatasets

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
@@ -212,7 +212,7 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     };
 
     private loadDateDatasets = async (attributesMap: IAttributeByKey): Promise<ICatalogDateDataset[]> => {
-        const { types } = this.options;
+        const { types, production } = this.options;
 
         const includeDateDatasets = types.includes("dateDataset");
         if (!includeDateDatasets) {
@@ -221,9 +221,12 @@ export class BearWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
 
         const { includeTagsIds, excludeTagsIds, dataSetId } = await this.getTagsAndDatasetIds();
 
+        // only return all the date datasets ignoring production or custom datasets if neither of those were specified by the user
+        const shouldReturnAllDateDataSets = !production && !dataSetId;
+
         const result = await this.authCall((sdk) =>
             sdk.catalogue.loadDateDataSets(this.workspace, {
-                returnAllDateDataSets: true,
+                returnAllDateDataSets: shouldReturnAllDateDataSets,
                 dataSetIdentifier: dataSetId,
                 attributesMap,
                 excludeObjectsWithTags: excludeTagsIds.length ? excludeTagsIds : undefined,

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -976,7 +976,7 @@ export interface IWorkspaceCatalogFactoryMethods<TFactory, TOptions> {
     forDataset(dataset: ObjRef): TFactory;
     forTypes(types: CatalogItemType[]): TFactory;
     includeTags(tags: ObjRef[]): TFactory;
-    withOptions(options: TOptions): TFactory;
+    withOptions(options: Partial<TOptions>): TFactory;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/catalog.ts
@@ -231,7 +231,7 @@ export interface IWorkspaceCatalogFactoryMethods<TFactory, TOptions> {
      * @param options - catalog options
      * @returns catalog factory
      */
-    withOptions(options: TOptions): TFactory;
+    withOptions(options: Partial<TOptions>): TFactory;
 }
 
 /**


### PR DESCRIPTION
Previously, when production was set to true, all the date datasets
were returned anyway (including non-production ones).
This is wrong as production: true must discard date datasets
from non-production datasets.

Also, related withOptions interface was relaxed.

JIRA: RAIL-2340

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
