### PR TITLE
RELATED:  RAIL-2410 change semantics of execution.equals

### DIFF
--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -22,6 +22,7 @@ import {
     IDataView,
     NotImplemented,
 } from "@gooddata/sdk-backend-spi";
+import isEqual from "lodash/isEqual";
 import {
     CustomBackendConfig,
     CustomBackendState,
@@ -88,7 +89,7 @@ class CustomPreparedExecution implements IPreparedExecution {
     };
 
     public equals = (other: IPreparedExecution): boolean => {
-        return this._fingerprint === other.fingerprint();
+        return isEqual(this.definition, other.definition);
     };
 
     public fingerprint = (): string => {

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -42,6 +42,7 @@ import {
     ObjRef,
     ISortItem,
 } from "@gooddata/sdk-model";
+import isEqual from "lodash/isEqual";
 import { AbstractExecutionFactory } from "../toolkit/execution";
 
 /**
@@ -295,7 +296,7 @@ function dummyPreparedExecution(
             return fp;
         },
         equals(other: IPreparedExecution): boolean {
-            return fp === other.fingerprint();
+            return isEqual(this.definition, other.definition);
         },
     };
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecution.ts
@@ -10,6 +10,7 @@ import {
     IExecutionDefinition,
     ISortItem,
 } from "@gooddata/sdk-model";
+import isEqual from "lodash/isEqual";
 import { BearAuthenticatedCallGuard } from "../../../types/auth";
 import { convertExecutionApiError } from "../../../utils/errorHandling";
 import { BearExecutionResult } from "./executionResult";
@@ -62,7 +63,7 @@ export class BearPreparedExecution implements IPreparedExecution {
     }
 
     public equals(other: IPreparedExecution): boolean {
-        return this.fingerprint() === other.fingerprint();
+        return isEqual(this.definition, other.definition);
     }
 }
 

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -40,6 +40,7 @@ import {
     ISortItem,
 } from "@gooddata/sdk-model";
 import { AbstractExecutionFactory } from "@gooddata/sdk-backend-base";
+import isEqual = require("lodash/isEqual");
 
 const defaultConfig = { hostname: "test" };
 
@@ -296,7 +297,7 @@ function recordedPreparedExecution(
             return fp;
         },
         equals(other: IPreparedExecution): boolean {
-            return fp === other.fingerprint();
+            return isEqual(this.definition, other.definition);
         },
     };
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -27,6 +27,7 @@ import invariant from "ts-invariant";
 import { ExecutionRecording, RecordingIndex, ScenarioRecording } from "./types";
 import { Denormalizer, NormalizationState, AbstractExecutionFactory } from "@gooddata/sdk-backend-base";
 import flatMap = require("lodash/flatMap");
+import isEqual = require("lodash/isEqual");
 
 //
 //
@@ -110,7 +111,7 @@ function recordedPreparedExecution(
             return fp;
         },
         equals(other: IPreparedExecution): boolean {
-            return fp === other.fingerprint();
+            return isEqual(this.definition, other.definition);
         },
     };
 }

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -145,14 +145,18 @@ export interface IPreparedExecution {
     execute(): Promise<IExecutionResult>;
 
     /**
-     * Tests whether this execution and the other execution are the same.
+     * Tests whether this execution and the other execution are the same. This effectively means that
+     * their definitions are deeply equal.
+     *
+     * If you are only concerned with the equality from the result calculation point of view,
+     * consider comparing fingerprints instead.
      *
      * @param other - another execution
      */
     equals(other: IPreparedExecution): boolean;
 
     /**
-     * Fingerprint of this prepared execution - this is effectivelly fingerprint of the execution
+     * Fingerprint of this prepared execution - this is effectively the fingerprint of the execution
      * definition underlying this instance of Prepared Execution.
      */
     fingerprint(): string;

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
@@ -10,6 +10,7 @@ import {
     IExecutionDefinition,
     ISortItem,
 } from "@gooddata/sdk-model";
+import isEqual = require("lodash/isEqual");
 import { TigerExecutionResult } from "./executionResult";
 import { toAfmExecution } from "../../../convertors/toBackend/afm/toAfmResultSpec";
 import { DateFormatter } from "../../../convertors/fromBackend/dateFormatting/types";
@@ -52,7 +53,7 @@ export class TigerPreparedExecution implements IPreparedExecution {
     }
 
     public equals(other: IPreparedExecution): boolean {
-        return this.fingerprint() === other.fingerprint();
+        return isEqual(this.definition, other.definition);
     }
 }
 

--- a/libs/sdk-model/src/execution/executionDefinition/index.ts
+++ b/libs/sdk-model/src/execution/executionDefinition/index.ts
@@ -159,7 +159,7 @@ export function defSetDimensions(
  * The contract and the approximate nature of the fingerprint can be described as follows:
  *
  * -  If two execution definitions have the same fingerprint, then they definitely are effectively the same
- *    and backend will perform the same computation for them.
+ *    from the result calculation point of view and the backend will perform the same computation for them.
  *
  * -  If two execution definition have different fingerprint, they MAY OR MAY NOT lead to different execution. Or
  *    more concrete: two executions with two different fingerprints MAY lead to the same execution and same results.

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoValidatorHOC.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoValidatorHOC.tsx
@@ -115,11 +115,11 @@ export function geoValidatorHOC<T>(InnerComponent: React.ComponentClass<T>): Rea
         private isSameData(execution?: IPreparedExecution, nextExecution?: IPreparedExecution): boolean {
             if (!execution || !nextExecution) {
                 // one of data views is undefined. just test if the other one is also undefined, otherwise
-                // data is definitelly different
+                // data is definitely different
                 return execution === nextExecution;
             }
 
-            return execution.equals(nextExecution);
+            return execution.fingerprint() === nextExecution.fingerprint();
         }
     }
 

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -377,7 +377,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             return true;
         }
 
-        const prepExecutionSame = this.props.execution.equals(prevProps.execution);
+        const prepExecutionSame = this.props.execution.fingerprint() === prevProps.execution.fingerprint();
         const fingerprintSame = this.currentFingerprint === this.props.execution.fingerprint();
 
         return !prepExecutionSame && !fingerprintSame;
@@ -386,7 +386,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private onError(error: GoodDataSdkError, execution = this.props.execution) {
         const { onExportReady } = this.props;
 
-        if (this.props.execution.equals(execution)) {
+        if (this.props.execution.fingerprint() === execution.fingerprint()) {
             this.setState({ error: error.getMessage() });
 
             if (onExportReady) {

--- a/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
+++ b/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
@@ -126,6 +126,7 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
         }
 
         public UNSAFE_componentWillReceiveProps(nextProps: Readonly<T & ILoadingInjectedProps>) {
+            //  we need strict equality here in case only the buckets changed (not measures or attributes)
             if (!this.props.execution.equals(nextProps.execution)) {
                 this.initDataLoading(nextProps.execution);
             }
@@ -156,7 +157,7 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
         private onError(error: GoodDataSdkError, execution = this.props.execution) {
             const { onExportReady } = this.props;
 
-            if (this.props.execution.equals(execution)) {
+            if (this.props.execution.fingerprint() === execution.fingerprint()) {
                 this.setState({ error: error.getMessage(), dataView: null });
                 this.onLoadingChanged({ isLoading: false });
 


### PR DESCRIPTION
The execution.equals now means deep equality, because the bucket differences
(ignored by the fingerprint) can be significant in some cases.

The current execution.equals uses were revised and if applicable
replaced with fingerprint comparisons.

JIRA: RAIL-2410

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
