### PR TITLE
RELATED: RAIL-2460 - Cleanup CI scripts

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -23,7 +23,6 @@ start_wiremocks () {
   _WIREMOCK_START="${WIREMOCK_DIR}/start_wiremock.sh"
   _WIREMOCK_STOP="${WIREMOCK_DIR}/stop_wiremock.sh"
 
-  docker network prune -f
   docker network create ${WIREMOCK_NET} || { echo "Network creation failed" && exit 1 ; }
 
   $_WIREMOCK_START detached

--- a/libs/sdk-ui-tests/backstop/run-backstop.sh
+++ b/libs/sdk-ui-tests/backstop/run-backstop.sh
@@ -15,7 +15,6 @@ GID=$(id -g)
 
 echo "Creating docker network for the storybook & backstop to share: ${BACKSTOP_NET}"
 
-docker network prune -f
 docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && exit 1 ; }
 
 {


### PR DESCRIPTION
Removed docker network pruning from scripts. While this command should be normal cleanup stuff, I'm removing it in light of the recent problems on CI. The command was not there for long and was added "for good measure" as part of fix for other errors related to docker network.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
