### PR TITLE
RELATED: RAIL-2484 propagate alias in geo attribute tooltips

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -48,6 +48,7 @@ import {
     newBucket,
     ObjRef,
     uriRef,
+    attributeAlias,
 } from "@gooddata/sdk-model";
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import { IGeoConfig, CoreGeoChart, getGeoChartDimensions } from "@gooddata/sdk-ui-geo";
@@ -245,19 +246,23 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
 
             const locationBucket = insightBucket(insight, BucketNames.LOCATION);
             let ref: ObjRef = idRef(tooltipText, "displayForm");
+            let alias = "";
 
             if (locationBucket) {
                 const attribute = bucketAttribute(locationBucket);
+                if (attribute) {
+                    alias = attributeAlias(attribute);
 
-                if (attribute && isUriRef(attributeDisplayFormRef(attribute))) {
-                    ref = uriRef(tooltipText);
+                    if (isUriRef(attributeDisplayFormRef(attribute))) {
+                        ref = uriRef(tooltipText);
+                    }
                 }
             }
 
             buckets.push(
                 newBucket(
                     BucketNames.TOOLTIP_TEXT,
-                    newAttribute(ref, (m) => m.localId("tooltipText_df")),
+                    newAttribute(ref, (m) => m.localId("tooltipText_df").alias(alias)),
                 ),
             );
         }


### PR DESCRIPTION
The alias must be copied over to the ad hoc tooltipText attribute
so that it is actually shown in the tooltips.

JIRA: RAIL-2484

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
