### PR TITLE
RELATED: RAIL-2422 fix configuration panel in place mutation

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/DropdownControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/DropdownControl.tsx
@@ -7,6 +7,7 @@ import DisabledBubbleMessage from "../DisabledBubbleMessage";
 import { getTranslation } from "../../utils/translations";
 import { IVisualizationProperties } from "../../interfaces/Visualization";
 import { IDropdownItem } from "../../interfaces/Dropdown";
+import cloneDeep = require("lodash/cloneDeep");
 import set = require("lodash/set");
 
 export interface IDropdownControlProps {
@@ -78,7 +79,11 @@ class DropdownControl extends React.PureComponent<IDropdownControlProps & Wrappe
 
     private onSelect(selectedItem: IDropdownItem) {
         const { valuePath, properties, pushData } = this.props;
-        const newProperties = set(properties, `controls.${valuePath}`, selectedItem.value);
+
+        // we must not change the properties at any cost, so deep clone for now.
+        // ideally we should use st. like immer with copy on write to not clone everything all the time
+        const newProperties = cloneDeep(properties);
+        set(newProperties, `controls.${valuePath}`, selectedItem.value);
 
         pushData({ properties: newProperties });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -125,12 +125,12 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         const sizeMeasures: IBucketItem[] = (primaryMeasures.length > 0
             ? primaryMeasures
             : allMeasures.filter((measure: IBucketItem): boolean => !includes(secondaryMeasures, measure))
-        ).slice(0, this.getPreferedBucketItemLimit(BucketNames.SIZE));
+        ).slice(0, this.getPreferredBucketItemLimit(BucketNames.SIZE));
 
         const colorMeasures: IBucketItem[] = (secondaryMeasures.length > 0
             ? secondaryMeasures
             : allMeasures.filter((measure: IBucketItem): boolean => !includes(sizeMeasures, measure))
-        ).slice(0, this.getPreferedBucketItemLimit(BucketNames.COLOR));
+        ).slice(0, this.getPreferredBucketItemLimit(BucketNames.COLOR));
 
         set(newExtendedReferencePoint, BUCKETS, [
             {
@@ -327,7 +327,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
                 .filter((attribute: IBucketItem): boolean => !isDateBucketItem(attribute))
                 .slice(0, 1);
         }
-        return segments.slice(0, this.getPreferedBucketItemLimit(BucketNames.SEGMENT));
+        return segments.slice(0, this.getPreferredBucketItemLimit(BucketNames.SEGMENT));
     }
 
     private getLocationItems(buckets: IBucketOfFun[]): IBucketItem[] {
@@ -337,10 +337,10 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
             [ATTRIBUTE],
         ).filter((bucketItem: IBucketItem): boolean => Boolean(bucketItem.locationDisplayFormRef));
 
-        return locationItems.slice(0, this.getPreferedBucketItemLimit(BucketNames.LOCATION));
+        return locationItems.slice(0, this.getPreferredBucketItemLimit(BucketNames.LOCATION));
     }
 
-    private getPreferedBucketItemLimit(preferredBucket: string): number {
+    private getPreferredBucketItemLimit(preferredBucket: string): number {
         const { buckets: bucketsUiConfig } = this.getUiConfig();
         return bucketsUiConfig[preferredBucket].itemsLimit;
     }


### PR DESCRIPTION
This meant that props of many components were mutated in place which broke shouldComponentUpdate.
This manifested in GeoChart but was a problem everywhere.

Also a typo in PluggableGeoPushpinChart was fixed.

JIRA: RAIL-2422

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
