### PR TITLE
RELATED: RAIL-2501 sanitize from/to in measure value filter in tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
@@ -124,13 +124,15 @@ export function convertMeasureValueFilter(filter: IMeasureValueFilter): ExecuteA
     }
 
     if (isRangeCondition(condition)) {
-        const { operator, from, to, treatNullValuesAs } = condition.range;
+        const { operator, from: originalFrom, to: originalTo, treatNullValuesAs } = condition.range;
         return {
             rangeMeasureValueFilter: {
                 measure: toMeasureValueFilterMeasureQualifier(measureValueFilter.measure),
                 operator,
-                from,
-                to,
+                // make sure the boundaries are always from <= to, because tiger backend cannot handle from > to in a user friendly way
+                // this is effectively the same behavior as in bear
+                from: Math.min(originalFrom, originalTo),
+                to: Math.max(originalFrom, originalTo),
                 treatNullValuesAs,
             },
         };

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
@@ -75,11 +75,20 @@ describe("tiger filter converter from model to AFM", () => {
                 "relative date filter",
                 newRelativeDateFilter(ReferenceLdmExt.ClosedDataDatasetRef, DateGranularity.date, 20, 30),
             ],
+            ["comparison measure value filter", newMeasureValueFilter(ReferenceLdm.Won, "GREATER_THAN", 128)],
             [
-                "comparison measure value filter",
-                newMeasureValueFilter(ReferenceLdm.Won, "GREATER_THAN", 124, 0),
+                "comparison measure value filter with treatNullValueAs",
+                newMeasureValueFilter(ReferenceLdm.Won, "GREATER_THAN", 128, 0),
             ],
             ["range measure value filter", newMeasureValueFilter(ReferenceLdm.Won, "BETWEEN", 64, 128)],
+            [
+                "range measure value filter with treatNullValueAs",
+                newMeasureValueFilter(ReferenceLdm.Won, "BETWEEN", 64, 128, 0),
+            ],
+            [
+                "range measure value filter with crossed boundaries",
+                newMeasureValueFilter(ReferenceLdm.Won, "BETWEEN", 128, 64),
+            ],
         ];
         it.each(Scenarios)("should return %s", (_desc, input) => {
             expect(convertVisualizationObjectFilter(input)).toMatchSnapshot();

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -139,8 +139,21 @@ Object {
       "localIdentifier": "m_acugFHNJgsBy",
     },
     "operator": "GREATER_THAN",
+    "treatNullValuesAs": undefined,
+    "value": 128,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert visualization object filter should return comparison measure value filter with treatNullValueAs 1`] = `
+Object {
+  "comparisonMeasureValueFilter": Object {
+    "measure": Object {
+      "localIdentifier": "m_acugFHNJgsBy",
+    },
+    "operator": "GREATER_THAN",
     "treatNullValuesAs": 0,
-    "value": 124,
+    "value": 128,
   },
 }
 `;
@@ -193,6 +206,34 @@ Object {
     "operator": "BETWEEN",
     "to": 128,
     "treatNullValuesAs": undefined,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert visualization object filter should return range measure value filter with crossed boundaries 1`] = `
+Object {
+  "rangeMeasureValueFilter": Object {
+    "from": 64,
+    "measure": Object {
+      "localIdentifier": "m_acugFHNJgsBy",
+    },
+    "operator": "BETWEEN",
+    "to": 128,
+    "treatNullValuesAs": undefined,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert visualization object filter should return range measure value filter with treatNullValueAs 1`] = `
+Object {
+  "rangeMeasureValueFilter": Object {
+    "from": 64,
+    "measure": Object {
+      "localIdentifier": "m_acugFHNJgsBy",
+    },
+    "operator": "BETWEEN",
+    "to": 128,
+    "treatNullValuesAs": 0,
   },
 }
 `;


### PR DESCRIPTION
Tiger cannot handle "crossed" from and to (i.e. from > to)
so we sanitize this when converting to AFM.

JIRA: RAIL-2501

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
