### PR TITLE
RELATED: RAIL-2423 fix extended reference point handling with geoChart

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -54,6 +54,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         const allAttributes = getAllAttributeItemsWithPreference(buckets, [
             BucketNames.VIEW,
             BucketNames.TREND,
+            BucketNames.LOCATION,
             BucketNames.STACK,
             BucketNames.SEGMENT,
         ]);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -70,6 +70,7 @@ export class PluggableLineChart extends PluggableBaseChart {
         let stacks: IBucketItem[] = getStackItems(buckets);
         const dateItems = getDateItems(buckets);
         const allAttributes = getAllAttributeItemsWithPreference(buckets, [
+            BucketNames.LOCATION,
             BucketNames.TREND,
             BucketNames.VIEW,
             BucketNames.SEGMENT,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -92,7 +92,13 @@ export const getColumnAttributes = (buckets: IBucketOfFun[]): IBucketItem[] => {
 export const getRowAttributes = (buckets: IBucketOfFun[]): IBucketItem[] => {
     return getItemsFromBuckets(
         buckets,
-        [BucketNames.ATTRIBUTE, BucketNames.ATTRIBUTES, BucketNames.VIEW, BucketNames.TREND],
+        [
+            BucketNames.ATTRIBUTE,
+            BucketNames.ATTRIBUTES,
+            BucketNames.VIEW,
+            BucketNames.TREND,
+            BucketNames.LOCATION,
+        ],
         [ATTRIBUTE, DATE],
     );
 };

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -494,7 +494,11 @@ export function getStackItems(buckets: IBucketOfFun[], itemTypes: string[] = [AT
 }
 
 export function getAttributeItems(buckets: IBucketOfFun[]): IBucketItem[] {
-    return getAllAttributeItemsWithPreference(buckets, [BucketNames.VIEW, BucketNames.TREND]);
+    return getAllAttributeItemsWithPreference(buckets, [
+        BucketNames.LOCATION,
+        BucketNames.VIEW,
+        BucketNames.TREND,
+    ]);
 }
 
 export function getAttributeItemsWithoutStacks(buckets: IBucketOfFun[]): IBucketItem[] {


### PR DESCRIPTION
The LOCATION bucket was ignored in places it should not be ignored.

JIRA: RAIL-2423

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
