### PR TITLE
RELATED: RAIL-2485 Update types for newMeasureValueFilter

### DIFF
--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterStackedToHundredPercentExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterStackedToHundredPercentExample.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import React, { Component } from "react";
 import { BarChart } from "@gooddata/sdk-ui-charts";
-import { newMeasureValueFilter, IMeasureValueFilter, measureIdentifier, idRef } from "@gooddata/sdk-model";
+import { newMeasureValueFilter, IMeasureValueFilter } from "@gooddata/sdk-model";
 import { LdmExt } from "../../../ldm";
 import { IMeasureValueFilterState } from "./MeasureValueFilterExample";
 
@@ -9,11 +9,7 @@ const measures = [LdmExt.TotalSales2, LdmExt.numberOfChecks];
 
 const attributes = [LdmExt.LocationName];
 
-const greaterThanFilter = newMeasureValueFilter(
-    idRef(measureIdentifier(LdmExt.TotalSales2)!),
-    "GREATER_THAN",
-    7000000,
-);
+const greaterThanFilter = newMeasureValueFilter(LdmExt.TotalSales2, "GREATER_THAN", 7000000);
 
 export class MeasureValueFilterExample extends Component<{}, IMeasureValueFilterState> {
     constructor(props: any) {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
@@ -94,7 +94,7 @@ export function toMeasureValueFilterMeasureQualifier(ref: ObjRefInScope) {
     if (isLocalIdRef(ref)) {
         return toLocalIdentifier(ref.localIdentifier);
     } else if (isObjRef(ref)) {
-        return toObjQualifier(ref, "metric");
+        return toObjQualifier(ref);
     } else {
         throw new UnexpectedError(
             `The measure property of measure value filter must be either object reference or local identifier`,

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -788,7 +788,7 @@ export interface IMeasureTitle {
 export interface IMeasureValueFilter {
     // (undocumented)
     measureValueFilter: {
-        measure: ObjRefInScope;
+        measure: UriRef | LocalIdRef;
         condition?: MeasureValueFilterCondition;
     };
 }
@@ -1463,10 +1463,10 @@ export const newMeasureMetadataObject: (ref: ObjRef, modifications?: BuilderModi
 export function newMeasureSort(measureOrId: IMeasure | string, sortDirection?: SortDirection, attributeLocators?: IAttributeLocatorItem[]): IMeasureSortItem;
 
 // @public
-export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;
+export function newMeasureValueFilter(measureOrRef: IMeasure | UriRef | LocalIdRef | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;
 
 // @public
-export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | string, operator: RangeConditionOperator, from: number, to: number, treatNullValuesAs?: number): IMeasureValueFilter;
+export function newMeasureValueFilter(measureOrRef: IMeasure | UriRef | LocalIdRef | string, operator: RangeConditionOperator, from: number, to: number, treatNullValuesAs?: number): IMeasureValueFilter;
 
 // @public
 export function newNegativeAttributeFilter(attributeOrRef: IAttribute | ObjRef | Identifier, notInValues: IAttributeElements | string[]): INegativeAttributeFilter;

--- a/libs/sdk-model/src/execution/filter/factory.ts
+++ b/libs/sdk-model/src/execution/filter/factory.ts
@@ -12,7 +12,7 @@ import {
     RangeConditionOperator,
 } from "./index";
 import { IAttribute, attributeDisplayFormRef } from "../attribute";
-import { ObjRefInScope, ObjRef, isObjRef, Identifier } from "../../objRef";
+import { ObjRef, isObjRef, Identifier, UriRef, LocalIdRef } from "../../objRef";
 import { IMeasure, isMeasure, measureLocalId } from "../measure";
 import { idRef, localIdRef } from "../../objRef/factory";
 
@@ -135,7 +135,7 @@ export function newRelativeDateFilter(
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | ObjRefInScope | string,
+    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
     operator: ComparisonConditionOperator,
     value: number,
     treatNullValuesAs?: number,
@@ -154,7 +154,7 @@ export function newMeasureValueFilter(
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | ObjRefInScope | string,
+    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
     operator: RangeConditionOperator,
     from: number,
     to: number,
@@ -174,13 +174,13 @@ export function newMeasureValueFilter(
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | ObjRefInScope | string,
+    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
     operator: ComparisonConditionOperator | RangeConditionOperator,
     val1: number,
     val2OrTreatNullValuesAsInComparison?: number,
     treatNullValuesAsInRange?: number,
 ): IMeasureValueFilter {
-    const ref: ObjRefInScope = isMeasure(measureOrRef)
+    const ref: UriRef | LocalIdRef = isMeasure(measureOrRef)
         ? { localIdentifier: measureLocalId(measureOrRef) }
         : typeof measureOrRef === "string"
         ? localIdRef(measureOrRef)

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import isEmpty = require("lodash/isEmpty");
 import invariant from "ts-invariant";
-import { ObjRef, ObjRefInScope } from "../../objRef";
+import { ObjRef, ObjRefInScope, UriRef, LocalIdRef } from "../../objRef";
 
 /**
  * Attribute elements specified by their URI.
@@ -194,7 +194,7 @@ export type MeasureValueFilterCondition = IComparisonCondition | IRangeCondition
  */
 export interface IMeasureValueFilter {
     measureValueFilter: {
-        measure: ObjRefInScope;
+        measure: UriRef | LocalIdRef; // keeping UriRef for the sake of legacy code
         condition?: MeasureValueFilterCondition;
     };
 }

--- a/libs/sdk-model/src/execution/filter/tests/__snapshots__/factory.test.ts.snap
+++ b/libs/sdk-model/src/execution/filter/tests/__snapshots__/factory.test.ts.snap
@@ -22,7 +22,7 @@ Object {
       },
     },
     "measure": Object {
-      "identifier": "measureObjIdentifier",
+      "localIdentifier": "measureObjLocalId",
     },
   },
 }
@@ -123,7 +123,7 @@ Object {
       },
     },
     "measure": Object {
-      "identifier": "measureObjIdentifier",
+      "localIdentifier": "measureObjLocalId",
     },
   },
 }

--- a/libs/sdk-model/src/execution/filter/tests/factory.test.ts
+++ b/libs/sdk-model/src/execution/filter/tests/factory.test.ts
@@ -7,6 +7,7 @@ import {
     newPositiveAttributeFilter,
     newRelativeDateFilter,
 } from "../factory";
+import { localIdRef } from "../../../objRef/factory";
 
 describe("filter factory", () => {
     describe("newPositiveAttributeFilter", () => {
@@ -59,12 +60,10 @@ describe("filter factory", () => {
             expect(newMeasureValueFilter(Won, "EQUAL_TO", 11)).toMatchSnapshot();
         });
         it("should generate comparison filter for measure identifier", () => {
-            expect(
-                newMeasureValueFilter({ identifier: "measureObjIdentifier" }, "EQUAL_TO", 11),
-            ).toMatchSnapshot();
+            expect(newMeasureValueFilter(localIdRef("measureObjLocalId"), "EQUAL_TO", 11)).toMatchSnapshot();
         });
         it("should generate comparison filter for measure local identifier", () => {
-            expect(newMeasureValueFilter("measureObjLocalId", "EQUAL_TO", 11)).toMatchSnapshot();
+            expect(newMeasureValueFilter(localIdRef("measureObjLocalId"), "EQUAL_TO", 11)).toMatchSnapshot();
         });
         it("should generate comparison filter for measure object with treatNullValuesAs", () => {
             expect(newMeasureValueFilter(Won, "EQUAL_TO", 11, 42)).toMatchSnapshot();
@@ -74,7 +73,7 @@ describe("filter factory", () => {
         });
         it("should generate ranger filter for measure identifier", () => {
             expect(
-                newMeasureValueFilter({ identifier: "measureObjIdentifier" }, "BETWEEN", 0, 100),
+                newMeasureValueFilter(localIdRef("measureObjLocalId"), "BETWEEN", 0, 100),
             ).toMatchSnapshot();
         });
         it("should generate ranger filter for measure local identifier", () => {

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilter.test.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilter.test.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { mount } from "enzyme";
 import noop = require("lodash/noop");
 import { withIntl } from "@gooddata/sdk-ui";
-import { IMeasureValueFilter, newMeasureValueFilter } from "@gooddata/sdk-model";
+import { IMeasureValueFilter, newMeasureValueFilter, localIdRef } from "@gooddata/sdk-model";
 
 import { MeasureValueFilter, IMeasureValueFilterProps } from "../MeasureValueFilter";
 import { MeasureValueFilterDropdown } from "../MeasureValueFilterDropdown";
@@ -12,9 +12,7 @@ import MVFDropdownFragment from "./fragments/MeasureValueFilterDropdown";
 // we cannot use factory here, it does not allow creating empty filters
 const emptyFilter: IMeasureValueFilter = {
     measureValueFilter: {
-        measure: {
-            identifier: "myMeasure",
-        },
+        measure: localIdRef("myMeasure"),
     },
 };
 
@@ -64,8 +62,8 @@ describe("Measure value filter", () => {
 
     it("should call onApply when Apply button clicked", () => {
         const onApply = jest.fn();
-        const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 100);
-        const expectedFilter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 123);
+        const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 100);
+        const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 123);
 
         const component = renderComponent({ onApply, filter });
 

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilterDropdown.test.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilterDropdown.test.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { mount } from "enzyme";
 import noop = require("lodash/noop");
-import { newMeasureValueFilter, IMeasureValueFilter } from "@gooddata/sdk-model";
+import { newMeasureValueFilter, IMeasureValueFilter, localIdRef } from "@gooddata/sdk-model";
 
 import MVFDropdownFragment from "./fragments/MeasureValueFilterDropdown";
 import { MeasureValueFilterDropdown, IMeasureValueFilterDropdownProps } from "../MeasureValueFilterDropdown";
@@ -11,9 +11,7 @@ import { withIntl } from "@gooddata/sdk-ui";
 // we cannot use factory here, it does not allow creating empty filters
 const emptyFilter: IMeasureValueFilter = {
     measureValueFilter: {
-        measure: {
-            identifier: "myMeasure",
-        },
+        measure: localIdRef("myMeasure"),
     },
 };
 
@@ -59,7 +57,7 @@ describe("Measure value filter dropdown", () => {
     });
 
     it("should have given operator preselected and values filled if filter is provided", () => {
-        const filter = newMeasureValueFilter({ identifier: "myMeasure" }, "LESS_THAN", 100);
+        const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 100);
         const component = renderComponent({ filter });
 
         expect(component.getSelectedOperatorTitle()).toEqual("Less than");
@@ -67,7 +65,7 @@ describe("Measure value filter dropdown", () => {
     });
 
     it("should have selected operator highlighted in operator dropdown", () => {
-        const filter = newMeasureValueFilter({ identifier: "myMeasure" }, "LESS_THAN", 100);
+        const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 100);
         const component = renderComponent({ filter });
 
         expect(component.openOperatorDropdown().getOperator("LESS_THAN").hasClass("is-selected")).toEqual(
@@ -132,11 +130,7 @@ describe("Measure value filter dropdown", () => {
             const onApply = jest.fn();
             const component = renderComponent({ onApply });
 
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "GREATER_THAN",
-                100,
-            );
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100);
 
             component
                 .openOperatorDropdown()
@@ -151,12 +145,7 @@ describe("Measure value filter dropdown", () => {
             const onApply = jest.fn();
             const component = renderComponent({ onApply });
 
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "BETWEEN",
-                100,
-                200,
-            );
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 100, 200);
 
             component
                 .openOperatorDropdown()
@@ -170,7 +159,7 @@ describe("Measure value filter dropdown", () => {
 
         it("should be called with null value when All operator is applied", () => {
             const onApply = jest.fn();
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 100);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 100);
             const component = renderComponent({ filter, onApply });
 
             component.openOperatorDropdown().selectOperator("ALL").clickApply();
@@ -182,7 +171,7 @@ describe("Measure value filter dropdown", () => {
             const onApply = jest.fn();
             const component = renderComponent({ onApply, usePercentage: true });
 
-            const expectedFilter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "GREATER_THAN", 1);
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 1);
 
             component
                 .openOperatorDropdown()
@@ -197,7 +186,7 @@ describe("Measure value filter dropdown", () => {
             const onApply = jest.fn();
             const component = renderComponent({ onApply, usePercentage: true });
 
-            const expectedFilter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 1, 2);
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 1, 2);
 
             component
                 .openOperatorDropdown()
@@ -211,7 +200,7 @@ describe("Measure value filter dropdown", () => {
 
         it("should be called with null value when All operator is applied when the measure is displayed as percentage", () => {
             const onApply = jest.fn();
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 100);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 100);
             const component = renderComponent({ filter, onApply, usePercentage: true });
 
             component.openOperatorDropdown().selectOperator("ALL").clickApply();
@@ -229,11 +218,7 @@ describe("Measure value filter dropdown", () => {
                 .setComparisonValue("42.1")
                 .clickApply();
 
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "GREATER_THAN",
-                0.421,
-            );
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 0.421);
             expect(onApply).toBeCalledWith(expectedFilter);
         });
 
@@ -248,17 +233,12 @@ describe("Measure value filter dropdown", () => {
                 .setRangeTo("1151.545")
                 .clickApply();
 
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "BETWEEN",
-                0.421,
-                11.51545,
-            );
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 0.421, 11.51545);
             expect(onApply).toBeCalledWith(expectedFilter);
         });
 
         it("should compensate for JavaScript multiplication result precision problem for comparison filter", () => {
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 46.001);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 46.001);
 
             const component = renderComponent({ filter, usePercentage: true });
 
@@ -266,7 +246,7 @@ describe("Measure value filter dropdown", () => {
         });
 
         it("should compensate for JavaScript multiplication result precision problem for range filter", () => {
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "NOT_BETWEEN", 1.11, 4.44);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "NOT_BETWEEN", 1.11, 4.44);
             const component = renderComponent({ filter, usePercentage: true });
 
             expect(component.getRangeFromInput().props().value).toEqual("111");
@@ -275,7 +255,7 @@ describe("Measure value filter dropdown", () => {
 
         describe("apply button", () => {
             it("should enable apply button when operator is changed to all from comparison operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "EQUAL_TO", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "EQUAL_TO", 10);
                 const component = renderComponent({ filter });
 
                 component.openOperatorDropdown().selectOperator("ALL");
@@ -284,7 +264,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should enable apply button when value changes with comparison operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "EQUAL_TO", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "EQUAL_TO", 10);
                 const component = renderComponent({ filter });
 
                 component.setComparisonValue("1000");
@@ -293,7 +273,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should disable apply button when value is empty with comparison operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "EQUAL_TO", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "EQUAL_TO", 10);
                 const component = renderComponent({ filter });
 
                 component.setComparisonValue("");
@@ -302,7 +282,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should disable apply button when value is equal to prop value with comparison operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "EQUAL_TO", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "EQUAL_TO", 10);
                 const component = renderComponent({ filter });
 
                 component.setComparisonValue("100").setComparisonValue("10");
@@ -311,7 +291,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it('should enable apply button when "from" value changes', () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.setRangeFrom("100");
@@ -320,7 +300,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it('should enable apply button when "to" value changes', () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.setRangeTo("100");
@@ -329,7 +309,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it('should disable apply button when "to" value is empty', () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.setRangeTo("");
@@ -338,7 +318,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it('should disable apply button when "from" value is empty', () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.setRangeFrom("");
@@ -347,7 +327,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should disable apply button when value is equal to prop value with range operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.setRangeTo("100").setRangeTo("10");
@@ -356,7 +336,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should enable apply button when operator is changed but value is same with comparison operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 10);
                 const component = renderComponent({ filter });
 
                 component.openOperatorDropdown().selectOperator("GREATER_THAN");
@@ -365,7 +345,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should enable apply button when operator is changed but value is same with range operator", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "BETWEEN", 10, 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 10, 10);
                 const component = renderComponent({ filter });
 
                 component.openOperatorDropdown().selectOperator("NOT_BETWEEN");
@@ -374,7 +354,7 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should enable apply button when operator and value is unchanged, but treat-null-values-as checkbox has been toggled", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "GREATER_THAN", 10);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 10);
 
                 const component = renderComponent({ filter, displayTreatNullAsZeroOption: true });
 
@@ -390,7 +370,7 @@ describe("Measure value filter dropdown", () => {
                 const component = renderComponent({ usePercentage: true, onApply });
 
                 const expectedComparisonFilter = newMeasureValueFilter(
-                    { localIdentifier: "myMeasure" },
+                    localIdRef("myMeasure"),
                     "GREATER_THAN",
                     1,
                 );
@@ -403,12 +383,7 @@ describe("Measure value filter dropdown", () => {
 
                 expect(onApply).toBeCalledWith(expectedComparisonFilter);
 
-                const expectedRangeFilter = newMeasureValueFilter(
-                    { localIdentifier: "myMeasure" },
-                    "BETWEEN",
-                    2,
-                    5,
-                );
+                const expectedRangeFilter = newMeasureValueFilter(localIdRef("myMeasure"), "BETWEEN", 2, 5);
 
                 component
                     .openOperatorDropdown()
@@ -424,7 +399,7 @@ describe("Measure value filter dropdown", () => {
 
     describe("press enter", () => {
         it("should be able to press enter to apply when apply button is enabled", () => {
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 10);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 10);
             const onApply = jest.fn();
             const component = renderComponent({ filter, onApply });
 
@@ -434,7 +409,7 @@ describe("Measure value filter dropdown", () => {
         });
 
         it("should not be able to press enter to apply when apply button is disabled", () => {
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "LESS_THAN", 10);
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "LESS_THAN", 10);
             const onApply = jest.fn();
             const component = renderComponent({ filter, onApply });
 
@@ -458,13 +433,8 @@ describe("Measure value filter dropdown", () => {
     describe("filter with treat-null-values-as", () => {
         it("should contain 'treatNullValuesAs' property if checked", () => {
             const onApply = jest.fn();
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "GREATER_THAN", 100);
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "GREATER_THAN",
-                100,
-                0,
-            );
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100);
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100, 0);
 
             const component = renderComponent({
                 filter,
@@ -479,13 +449,8 @@ describe("Measure value filter dropdown", () => {
 
         it("should contain 'treatNullValuesAs' equal to 0 if checked, but no 'treatNullAsZeroDefaultValue' was provided", () => {
             const onApply = jest.fn();
-            const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "GREATER_THAN", 100);
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "GREATER_THAN",
-                100,
-                0,
-            );
+            const filter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100);
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100, 0);
 
             const component = renderComponent({
                 filter,
@@ -502,16 +467,12 @@ describe("Measure value filter dropdown", () => {
             const onApply = jest.fn();
 
             const filterWithTreatNullValuesAsZero = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
+                localIdRef("myMeasure"),
                 "GREATER_THAN",
                 100,
                 0,
             );
-            const expectedFilter = newMeasureValueFilter(
-                { localIdentifier: "myMeasure" },
-                "GREATER_THAN",
-                100,
-            );
+            const expectedFilter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100);
 
             const component = renderComponent({
                 filter: filterWithTreatNullValuesAsZero,
@@ -574,19 +535,14 @@ describe("Measure value filter dropdown", () => {
             });
 
             it("should be checked when passed filter has a condition with 'treatNullValuesAsZero' property set to true", () => {
-                const filter = newMeasureValueFilter(
-                    { localIdentifier: "myMeasure" },
-                    "GREATER_THAN",
-                    100,
-                    0,
-                );
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100, 0);
                 const component = renderComponentWithTreatNullAsZeroOption({ filter });
 
                 expect(component.getTreatNullAsCheckbox().props().checked).toEqual(true);
             });
 
             it("should not be checked when passed filter has a condition without 'treatNullValuesAsZero' property even if 'treatNullAsZeroDefaultValue' property is truthy", () => {
-                const filter = newMeasureValueFilter({ localIdentifier: "myMeasure" }, "GREATER_THAN", 100);
+                const filter = newMeasureValueFilter(localIdRef("myMeasure"), "GREATER_THAN", 100);
                 const component = renderComponentWithTreatNullAsZeroOption({ filter });
 
                 expect(component.getTreatNullAsCheckbox().props().checked).toEqual(false);

--- a/libs/sdk-ui-pivot/src/impl/tests/AggregationsMenu.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/tests/AggregationsMenu.test.tsx
@@ -13,6 +13,7 @@ import {
     measureLocalId,
     newPositiveAttributeFilter,
     idRef,
+    localIdRef,
     newMeasureValueFilter,
 } from "@gooddata/sdk-model";
 import { DataViewFirstPage } from "@gooddata/sdk-backend-mockingbird";
@@ -146,7 +147,7 @@ describe("AggregationsMenu", () => {
 
     it("should disable native totals when there is at least one measure value filter set", () => {
         const defWithMeasureValueFilter = defWithFilters(emptyDef("testWorkspace"), [
-            newMeasureValueFilter(idRef("some-identifier"), "GREATER_THAN", 10),
+            newMeasureValueFilter(localIdRef("some-localIdentifier"), "GREATER_THAN", 10),
         ]);
 
         const wrapper = render({


### PR DESCRIPTION
JIRA: RAIL-2485

Changes were made to types for newMeasureValueFilter due to tiger backend not supporting identifier as a parameter for newMeasureValueFilter.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
