### PR TITLE
RELATED: RAIL-2523 rationalize Insight models

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/InsightConverter.ts
@@ -18,6 +18,8 @@ import {
     insightUri,
     insightIsLocked,
     IInsight,
+    insightCreated,
+    insightUpdated,
 } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
 import omitBy from "lodash/omitBy";
@@ -84,6 +86,7 @@ export const convertInsightDefinition = (
         content: convertInsightContent(insight),
         meta: {
             title: insightTitle(insight),
+            category: "visualizationObject",
         },
         // tslint:disable-next-line no-object-literal-type-assertion
     } as GdcVisualizationObject.IVisualizationObject;
@@ -102,6 +105,8 @@ export const convertInsight = (insight: IInsight): GdcVisualizationObject.IVisua
             ...convertedDefinition.meta,
             identifier: insightId(insight),
             uri: insightUri(insight),
+            created: insightCreated(insight),
+            updated: insightUpdated(insight),
             ...(locked && { locked }),
         },
     };

--- a/libs/sdk-model/__mocks__/insights.ts
+++ b/libs/sdk-model/__mocks__/insights.ts
@@ -70,6 +70,12 @@ export class InsightBuilder {
         return this;
     };
 
+    public created = (created: string): InsightBuilder => {
+        this.insight.created = created;
+
+        return this;
+    };
+
     public updated = (updated: string): InsightBuilder => {
         this.insight.updated = updated;
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -697,6 +697,9 @@ export type IInsight = IInsightDefinition & {
     insight: {
         identifier: string;
         uri: string;
+        created?: string;
+        updated?: string;
+        isLocked?: boolean;
     };
 };
 
@@ -709,8 +712,6 @@ export type IInsightDefinition = {
         filters: IFilter[];
         sorts: ISortItem[];
         properties: VisualizationProperties;
-        updated?: string;
-        isLocked?: boolean;
     };
 };
 
@@ -835,6 +836,9 @@ export function insightBucket(insight: IInsightDefinition, idOrFun?: string | Bu
 // @public
 export function insightBuckets(insight: IInsightDefinition, ...ids: string[]): IBucket[];
 
+// @public
+export function insightCreated(insight: IInsight): string | undefined;
+
 // Warning: (ae-internal-missing-underscore) The name "InsightDefinitionBuilder" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
@@ -870,7 +874,7 @@ export function insightHasMeasures(insight: IInsightDefinition): boolean;
 export function insightId(insight: IInsight): string;
 
 // @public
-export function insightIsLocked(insight: IInsightDefinition): boolean;
+export function insightIsLocked(insight: IInsight): boolean;
 
 // @public
 export function insightItems(insight: IInsightDefinition): IAttributeOrMeasure[];
@@ -905,7 +909,7 @@ export function insightTitle(insight: IInsightDefinition): string;
 export function insightTotals(insight: IInsightDefinition): ITotal[];
 
 // @public
-export function insightUpdated(insight: IInsightDefinition): string | undefined;
+export function insightUpdated(insight: IInsight): string | undefined;
 
 // @public
 export function insightUri(insight: IInsight): string;

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -285,6 +285,7 @@ export {
     insightTitle,
     insightUri,
     insightIsLocked,
+    insightCreated,
     insightUpdated,
     insightTotals,
     insightFilters,

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -38,6 +38,24 @@ export type IInsight = IInsightDefinition & {
          * Link to the insight.
          */
         uri: string;
+
+        /**
+         * Last update date - YYYY-MM-DD HH:mm:ss
+         *
+         */
+        created?: string;
+
+        /**
+         * Last update date - YYYY-MM-DD HH:mm:ss
+         *
+         */
+        updated?: string;
+
+        /**
+         * Insight is locked for editing & deleting
+         *
+         */
+        isLocked?: boolean;
     };
 };
 
@@ -90,20 +108,6 @@ export type IInsightDefinition = {
          * any way.
          */
         properties: VisualizationProperties;
-
-        /**
-         * Last update date - YYYY-MM-DD HH:mm:ss
-         *
-         * TODO: move to insight
-         */
-        updated?: string;
-
-        /**
-         * Insight is locked for editing & deleting
-         *
-         * TODO: move to insight
-         */
-        isLocked?: boolean;
     };
 };
 
@@ -447,13 +451,26 @@ export function insightUri(insight: IInsight): string {
 }
 
 /**
+ * Gets the date when the insight was created
+ *
+ * @param insight - insight
+ * @returns string - YYYY-MM-DD HH:mm:ss
+ * @public
+ */
+export function insightCreated(insight: IInsight): string | undefined {
+    invariant(insight, "insight must be specified");
+
+    return insight.insight.created;
+}
+
+/**
  * Gets the date of the last insight update
  *
  * @param insight - insight
  * @returns string - YYYY-MM-DD HH:mm:ss
  * @public
  */
-export function insightUpdated(insight: IInsightDefinition): string | undefined {
+export function insightUpdated(insight: IInsight): string | undefined {
     invariant(insight, "insight must be specified");
 
     return insight.insight.updated;
@@ -466,7 +483,7 @@ export function insightUpdated(insight: IInsightDefinition): string | undefined 
  * @returns boolean
  * @public
  */
-export function insightIsLocked(insight: IInsightDefinition): boolean {
+export function insightIsLocked(insight: IInsight): boolean {
     invariant(insight, "insight must be specified");
 
     return insight.insight.isLocked || false;

--- a/libs/sdk-model/src/insight/tests/insight.test.ts
+++ b/libs/sdk-model/src/insight/tests/insight.test.ts
@@ -27,6 +27,7 @@ import {
     insightId,
     insightUri,
     insightIsLocked,
+    insightCreated,
     insightUpdated,
     insightFilters,
     insightProperties,
@@ -345,6 +346,24 @@ describe("insightIsLocked", () => {
 
     it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
         expect(() => insightIsLocked(input)).toThrow();
+    });
+});
+
+describe("insightCreated", () => {
+    const insightCreatedDate = "2020-01-31 13:24:07";
+    const SavedInsight = newInsight(VisClassId, (m) => m.created(insightCreatedDate));
+
+    const Scenarios: Array<[string | undefined, string, any]> = [
+        [undefined, "insight that has not been saved", EmptyInsight],
+        [insightCreatedDate, "saved insight", SavedInsight],
+    ];
+
+    it.each(Scenarios)("should return %s for %s", (expectedResult, _desc, insightArg) => {
+        expect(insightCreated(insightArg)).toBe(expectedResult);
+    });
+
+    it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
+        expect(() => insightCreated(input)).toThrow();
     });
 });
 


### PR DESCRIPTION
* Move some properties from IInsightDefinition to IInsight
as they only make sense for saved insights.
* Add insightCreated utility function to obtain the created date
* Expand bear convertInsight with the created/updated data

JIRA: RAIL-2523

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
