### PR TITLE
RELATED: RAIL-1815 - Add support for cache resets into caching backend

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -107,11 +107,19 @@ export class AuthProviderCallGuard implements IAuthProviderCallGuard {
 }
 
 // @beta
+export type CacheControl = {
+    resetExecutions: () => void;
+    resetCatalogs: () => void;
+    resetAll: () => void;
+};
+
+// @beta
 export type CachingConfiguration = {
     maxExecutions: number | undefined;
     maxResultWindows: number | undefined;
     maxCatalogs: number | undefined;
     maxCatalogOptions: number | undefined;
+    onCacheReady?: (cacheControl: CacheControl) => void;
 };
 
 // @beta

--- a/libs/sdk-backend-base/src/cachingBackend/tests/withCaching.test.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/tests/withCaching.test.ts
@@ -1,17 +1,24 @@
 // (C) 2007-2020 GoodData Corporation
 
 import { IAnalyticalBackend, IExecutionResult } from "@gooddata/sdk-backend-spi";
-import { withCaching } from "../index";
+import { CacheControl, withCaching } from "../index";
 import { dummyBackend, dummyBackendEmptyData } from "../../dummyBackend";
 import { ReferenceLdm } from "@gooddata/reference-workspace";
-import { IAttributeOrMeasure, IBucket, newInsightDefinition, newBucket } from "@gooddata/sdk-model";
+import { IAttributeOrMeasure, IBucket, newBucket, newInsightDefinition } from "@gooddata/sdk-model";
+import { withEventing } from "../../eventingBackend";
 
-function createBackend(realBackend: IAnalyticalBackend = dummyBackendEmptyData()): IAnalyticalBackend {
+const defaultBackend = dummyBackendEmptyData();
+
+function withCachingForTests(
+    realBackend: IAnalyticalBackend = defaultBackend,
+    onCacheReady?: (cacheControl: CacheControl) => void,
+): IAnalyticalBackend {
     return withCaching(realBackend, {
         maxCatalogs: 1,
         maxCatalogOptions: 1,
         maxExecutions: 1,
         maxResultWindows: 1,
+        onCacheReady,
     });
 }
 
@@ -26,7 +33,7 @@ function doInsightExecution(backend: IAnalyticalBackend, buckets: IBucket[]): Pr
 
 describe("withCaching", () => {
     it("caches executions calls", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const first = await doExecution(backend, [ReferenceLdm.Won]);
         const second = await doExecution(backend, [ReferenceLdm.Won]);
@@ -35,7 +42,7 @@ describe("withCaching", () => {
     });
 
     it("caches insight executions calls with different buckets with the same measures and sanitizes the definition", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const firstBuckets = [newBucket("measures", ReferenceLdm.Won, ReferenceLdm.WinRate)];
 
@@ -64,7 +71,7 @@ describe("withCaching", () => {
     });
 
     it("caches insight executions calls with same buckets with the same measures and returns the same object", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const buckets = [newBucket("measures", ReferenceLdm.Won, ReferenceLdm.WinRate)];
         const result = await doInsightExecution(backend, buckets);
@@ -76,7 +83,7 @@ describe("withCaching", () => {
     });
 
     it("keeps the cached data views' methods intact", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const firstBuckets = [newBucket("measures", ReferenceLdm.Won, ReferenceLdm.WinRate)];
 
@@ -97,7 +104,7 @@ describe("withCaching", () => {
     });
 
     it("evicts when execution cache limit hit", () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const first = doExecution(backend, [ReferenceLdm.Won]);
         doExecution(backend, [ReferenceLdm.Amount]);
@@ -107,7 +114,7 @@ describe("withCaching", () => {
     });
 
     it("caches readWindow calls", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const result = await doExecution(backend, [ReferenceLdm.Won]);
         const first = await result.readWindow([0, 0], [1, 1]);
@@ -117,7 +124,7 @@ describe("withCaching", () => {
     });
 
     it("evicts when readWindow limit hit", async () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const result = await doExecution(backend, [ReferenceLdm.Won]);
         const first = result.readWindow([0, 0], [1, 1]);
@@ -128,7 +135,7 @@ describe("withCaching", () => {
     });
 
     it("deletes from cache if error occurs", async () => {
-        const backend = createBackend(dummyBackend());
+        const backend = withCachingForTests(dummyBackend());
 
         const result = await doExecution(backend, [ReferenceLdm.Won]);
 
@@ -149,7 +156,7 @@ describe("withCaching", () => {
     });
 
     it("caches workspace catalogs", () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const first = backend.workspace("test").catalog().load();
         const second = backend.workspace("test").catalog().load();
@@ -158,7 +165,7 @@ describe("withCaching", () => {
     });
 
     it("evicts workspace catalogs", () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         const first = backend.workspace("test").catalog().load();
         backend.workspace("someOtherWorkspace").catalog().load();
@@ -168,7 +175,7 @@ describe("withCaching", () => {
     });
 
     it("evicts workspace catalogs options", () => {
-        const backend = createBackend();
+        const backend = withCachingForTests();
 
         // first call caches result when getting catalog with default options
         const first = backend.workspace("test").catalog().load();
@@ -177,6 +184,43 @@ describe("withCaching", () => {
         backend.workspace("test").catalog().forTypes(["attribute"]).load();
 
         // now back to default options, will be new promise
+        const second = backend.workspace("test").catalog().load();
+
+        expect(second).not.toBe(first);
+    });
+
+    it("calls onCacheReady during construction", () => {
+        let cacheControl: CacheControl | undefined;
+
+        withCachingForTests(defaultBackend, (cc) => (cacheControl = cc));
+
+        expect(cacheControl).toBeDefined();
+    });
+
+    it("resets execution cache", async () => {
+        /*
+         * Execution caching is fully transparent. To verify effective executions, this test uses backend
+         * decorated with eventing in order to figure out how many executions fell through the caching.
+         */
+
+        let cacheControl: CacheControl | undefined;
+        let effectiveExecutions: number = 0;
+        const realBackend = withEventing(defaultBackend, { successfulExecute: () => effectiveExecutions++ });
+        const cachingBackend = withCachingForTests(realBackend, (cc) => (cacheControl = cc));
+
+        await doExecution(cachingBackend, [ReferenceLdm.Won]);
+        cacheControl?.resetExecutions();
+        await doExecution(cachingBackend, [ReferenceLdm.Won]);
+
+        expect(effectiveExecutions).toEqual(2);
+    });
+
+    it("resets catalog cache", async () => {
+        let cacheControl: CacheControl | undefined;
+
+        const backend = withCachingForTests(defaultBackend, (cc) => (cacheControl = cc));
+        const first = backend.workspace("test").catalog().load();
+        cacheControl?.resetCatalogs();
         const second = backend.workspace("test").catalog().load();
 
         expect(second).not.toBe(first);

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -18,7 +18,12 @@ export {
 } from "./decoratedBackend/catalog";
 
 export { withEventing, AnalyticalBackendCallbacks } from "./eventingBackend";
-export { withCaching, CachingConfiguration, DefaultCachingConfiguration } from "./cachingBackend";
+export {
+    withCaching,
+    CachingConfiguration,
+    DefaultCachingConfiguration,
+    CacheControl,
+} from "./cachingBackend";
 export { withNormalization, NormalizationConfig } from "./normalizingBackend";
 export { Normalizer, Denormalizer, NormalizationState } from "./normalizingBackend/normalizer";
 


### PR DESCRIPTION
-  onCacheReady callback added to caching backend config
-  this receives a CacheControl object which the client can use to reset the
   different top-level caches

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
