### PR TITLE
RELATED: ONE-4572 pivot table reports also drillable attributes 

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -39,7 +39,9 @@ import {
     ErrorComponent,
     getDrillIntersection,
     GoodDataSdkError,
-    IDrillableItemPushData,
+    IAvailableDrillTargets,
+    IAvailableDrillTargetMeasure,
+    IAvailableDrillTargetAttribute,
     IDrillEvent,
     IDrillEventContextTable,
     IDrillEventIntersectionElement,
@@ -273,18 +275,38 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         );
     };
 
-    private getSupportedDrillableItems = (dv: DataViewFacade): IDrillableItemPushData[] => {
+    private getAttributeItemsForDimension = (
+        dv: DataViewFacade,
+        dimension: number,
+    ): IAvailableDrillTargetAttribute[] => {
         return dv
+            .meta()
+            .attributeDescriptorsForDim(dimension)
+            .map((attribute: IAttributeDescriptor) => {
+                return {
+                    dimension,
+                    attribute,
+                };
+            });
+    };
+
+    private getAvailableDrillTargets = (dv: DataViewFacade): IAvailableDrillTargets => {
+        const measureDescriptors = dv
             .meta()
             .measureDescriptors()
             .map(
-                (measure: IMeasureDescriptor): IDrillableItemPushData => ({
-                    type: "measure",
-                    localIdentifier: measure.measureHeaderItem.localIdentifier,
-                    title: measure.measureHeaderItem.name,
+                (measure: IMeasureDescriptor): IAvailableDrillTargetMeasure => ({
+                    measure,
                     attributes: dv.meta().attributeDescriptors(),
                 }),
             );
+
+        const rowAttributeItems = this.getAttributeItemsForDimension(dv, 0);
+        const columnAttributeItems = this.getAttributeItemsForDimension(dv, 1);
+        return {
+            measures: measureDescriptors,
+            attributes: [...rowAttributeItems, ...columnAttributeItems],
+        };
     };
 
     private onLoadingChanged = (loadingState: ILoadingState): void => {
@@ -359,8 +381,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                         );
                         this.setState({ tableReady: true });
 
-                        const supportedDrillableItems = this.getSupportedDrillableItems(this.visibleData);
-                        this.props.pushData({ dataView, supportedDrillableItems });
+                        const availableDrillTargets = this.getAvailableDrillTargets(this.visibleData);
+                        this.props.pushData({ dataView, availableDrillTargets });
                     })
                     .catch((error) => {
                         if (this.unmounted) {
@@ -372,11 +394,11 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                          * metadata essential for setup of drilling. Look for that and if available push up.
                          */
                         if (isNoDataError(error) && error.dataView) {
-                            const supportedDrillableItems = this.getSupportedDrillableItems(
+                            const availableDrillTargets = this.getAvailableDrillTargets(
                                 DataViewFacade.for(error.dataView),
                             );
 
-                            this.props.pushData({ supportedDrillableItems });
+                            this.props.pushData({ availableDrillTargets });
                         }
 
                         this.onError(convertError(error));

--- a/libs/sdk-ui-pivot/src/tests/CorePivotTable.test.tsx
+++ b/libs/sdk-ui-pivot/src/tests/CorePivotTable.test.tsx
@@ -13,10 +13,11 @@ import * as stickyRowHandler from "../impl/stickyRowHandler";
 import agGridApiWrapper from "../impl/agGridApiWrapper";
 import { ICorePivotTableProps } from "../types";
 import { IPreparedExecution, prepareExecution } from "@gooddata/sdk-backend-spi";
-import { recordedBackend } from "@gooddata/sdk-backend-mockingbird";
+import { recordedBackend, DataViewFirstPage } from "@gooddata/sdk-backend-mockingbird";
 import { ReferenceLdm, ReferenceRecordings } from "@gooddata/reference-workspace";
 import { measureLocalId } from "@gooddata/sdk-model";
 import noop from "lodash/noop";
+import { recordedDataFacade } from "../../__mocks__/recordings";
 
 const intl = createIntlMock();
 
@@ -308,6 +309,19 @@ describe("CorePivotTable", () => {
 
             expect(updateStickyRow).toHaveBeenCalledTimes(1);
             expect(updateStickyRowPosition).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("getAvailableDrillTargets", () => {
+        it("should return attributes and measures for pivot table", () => {
+            const table = getTableInstance();
+            const fixture = recordedDataFacade(
+                ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
+                DataViewFirstPage,
+            );
+            const targets = table.getAvailableDrillTargets(fixture);
+            expect(targets.measures.length).toEqual(1);
+            expect(targets.attributes.length).toEqual(2);
         });
     });
 

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -94,9 +94,10 @@ export {
     ILoadingState,
     IExportFunction,
     IExtendedExportConfig,
-    IDrillableItemPushData,
+    IAvailableDrillTargets,
+    IAvailableDrillTargetMeasure,
+    IAvailableDrillTargetAttribute,
     IColorAssignment,
-    DrillableItemType,
     IColorsData,
 } from "./vis/Events";
 export {

--- a/libs/sdk-ui/src/base/vis/Events.ts
+++ b/libs/sdk-ui/src/base/vis/Events.ts
@@ -1,6 +1,12 @@
 // (C) 2007-2020 GoodData Corporation
-import { IDataView, IExportConfig, IExportResult, IAttributeDescriptor } from "@gooddata/sdk-backend-spi";
-import { IColor, IColorPalette, Identifier, ITotal, ISortItem } from "@gooddata/sdk-model";
+import {
+    IDataView,
+    IExportConfig,
+    IExportResult,
+    IAttributeDescriptor,
+    IMeasureDescriptor,
+} from "@gooddata/sdk-backend-spi";
+import { IColor, IColorPalette, ITotal, ISortItem } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "../errors/GoodDataSdkError";
 import { IMappingHeader } from "../headerMatching/MappingHeader";
 
@@ -34,13 +40,19 @@ export interface IColorsData {
     colorPalette: IColorPalette;
 }
 
-export type DrillableItemType = "measure";
+export interface IAvailableDrillTargets {
+    attributes?: IAvailableDrillTargetAttribute[];
+    measures?: IAvailableDrillTargetMeasure[];
+}
 
-export interface IDrillableItemPushData {
-    type: DrillableItemType;
-    localIdentifier: Identifier;
-    title: string;
+export interface IAvailableDrillTargetMeasure {
+    measure: IMeasureDescriptor;
     attributes: IAttributeDescriptor[];
+}
+
+export interface IAvailableDrillTargetAttribute {
+    dimension: number;
+    attribute: IAttributeDescriptor;
 }
 
 /**
@@ -56,5 +68,5 @@ export interface IPushData {
     propertiesMeta?: any;
     colors?: IColorsData;
     initialProperties?: any;
-    supportedDrillableItems?: IDrillableItemPushData[];
+    availableDrillTargets?: IAvailableDrillTargets;
 }


### PR DESCRIPTION
Originally, visualizations reported drillable measures in
`supportedDrillableItems` array. This is now restructured to
`activeDrillTargets` which contains measures and attributes.

```
export interface IAvailableDrillTargets {
    attributes?: IAvailableDrillTargetAttribute[];
    measures?: IAvailableDrillTargetMeasure[];
}
```

This is a breaking change and requires gooddata/gdc-dashboards#2999

JIRA: ONE-4572

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->