### PR TITLE
RELATED: RAIL-2521 unify dataset loading logic in bear

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -160,7 +160,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
     private loadAvailableDateDatasets = async (
         sanitizedVisualizationObject: GdcVisualizationObject.IVisualizationObject,
     ): Promise<ICatalogDateDataset[]> => {
-        const { types, includeTags, excludeTags, dataset } = this.options;
+        const { types, includeTags, excludeTags, dataset, production } = this.options;
 
         const includeDateDatasets = types.includes("dateDataset");
         if (!includeDateDatasets) {
@@ -173,6 +173,9 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
             dataset ? objRefToIdentifier(dataset, this.authCall) : Promise.resolve(""),
         ]);
 
+        // only return all the date datasets ignoring production or custom datasets if neither of those were specified by the user
+        const shouldReturnAllDateDataSets = !production && !dataSetIdentifier;
+
         const result = await this.authCall((sdk) =>
             sdk.catalogue.loadDateDataSets(this.workspace, {
                 bucketItems: sanitizedVisualizationObject.content,
@@ -181,6 +184,7 @@ export class BearWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCata
                 attributesMap: this.mappings.attributeByDisplayFormUri,
                 includeObjectsWithTags: includeTagsIds.length ? includeTagsIds : undefined,
                 excludeObjectsWithTags: excludeTagsIds.length ? excludeTagsIds : undefined,
+                returnAllDateDataSets: shouldReturnAllDateDataSets,
             }),
         );
         return result.dateDataSets.map(convertDateDataset);

--- a/libs/sdk-backend-bear/tests/integrated/catalog.test.ts
+++ b/libs/sdk-backend-bear/tests/integrated/catalog.test.ts
@@ -11,11 +11,7 @@ beforeAll(async () => {
 
 describe("bear catalog", () => {
     it("should read catalog for reference workspace", async () => {
-        const result = await backend
-            .workspace(testWorkspace())
-            .catalog()
-            .load();
-
+        const result = await backend.workspace(testWorkspace()).catalog().load();
         expect(result).toMatchSnapshot();
     });
 
@@ -28,12 +24,9 @@ describe("bear catalog", () => {
          * backend responding with 400 (because the API client generates invalid MAQL).
          */
 
-        const catalog = await backend
-            .workspace(testWorkspace())
-            .catalog()
-            .load();
+        const catalog = await backend.workspace(testWorkspace()).catalog().load();
 
-        const aritmeticMeasure = newArithmeticMeasure(
+        const arithmeticMeasure = newArithmeticMeasure(
             [ReferenceLdm.Amount, ReferenceLdm.Amount_1.Sum],
             "sum",
         );
@@ -41,9 +34,9 @@ describe("bear catalog", () => {
             .availableItems()
             .forItems([
                 ReferenceLdm.Amount_1.Sum,
-                newPopMeasure(ReferenceLdm.Amount_1.Sum, "closed.year", m => m.alias("PoP measure")),
-                aritmeticMeasure,
-                newPopMeasure(aritmeticMeasure, "closed.year", m => m.alias("PoP measure")),
+                newPopMeasure(ReferenceLdm.Amount_1.Sum, "closed.year", (m) => m.alias("PoP measure")),
+                arithmeticMeasure,
+                newPopMeasure(arithmeticMeasure, "closed.year", (m) => m.alias("PoP measure")),
             ])
             .load();
 

--- a/libs/sdk-backend-bear/tests/wiremock/recordings/mappings/gdc_internal_projects_l32xdyl4bjuzgf9kkqr2avl55gtuyjwf_loaddatedatasets-08d5a289-765f-4b51-9566-4916714f38db.json
+++ b/libs/sdk-backend-bear/tests/wiremock/recordings/mappings/gdc_internal_projects_l32xdyl4bjuzgf9kkqr2avl55gtuyjwf_loaddatedatasets-08d5a289-765f-4b51-9566-4916714f38db.json
@@ -15,7 +15,7 @@
         },
         "bodyPatterns": [
             {
-                "equalToJson": "{\"dateDataSetsRequest\":{\"includeUnavailableDateDataSetsCount\":true,\"includeAvailableDateAttributes\":true,\"bucketItems\":[\"SELECT SUM([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/1102])\",\"SELECT (SELECT SUM([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/1102])) FOR PREVIOUS ([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/497])\"],\"requiredDataSets\":{\"type\":\"PRODUCTION\"}}}",
+                "equalToJson": "{\"dateDataSetsRequest\":{\"includeUnavailableDateDataSetsCount\":true,\"includeAvailableDateAttributes\":true,\"bucketItems\":[\"SELECT SUM([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/1102])\",\"SELECT (SELECT SUM([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/1102])) FOR PREVIOUS ([/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/497])\"],\"requiredDataSets\":{\"type\":\"ALL\"}}}",
                 "ignoreArrayOrder": false,
                 "ignoreExtraElements": false
             }


### PR DESCRIPTION
This effectively uses the change from 591f8761ba21563867b686745eb6db9349fd36b9
in availableItemsFactory as well as in factory.
Therefore the configuration between "normal" and available items catalog is consistent.

JIRA: RAIL-2521

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
