### PR TITLE
RELATED: RAIL-2537 delete removed items before saving dashboard in bear

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -159,12 +159,13 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboards {
             filterContext,
             layout,
         };
-        await this.updateBearDashboard(updatedDashboardWithSavedDependencies);
 
-        // Delete widgets after removing references to them in the dashboard
-        // or backend throws the error that we are removing the dashboard dependency
+        // Delete widgets after removing references to them in the dashboard before updating the dashboard
+        // otherwise backend will throw an error that we are removing the dashboard dependency in the update call
         const deletedWidgets = this.collectDeletedWidgets(originalDashboard.layout, updatedDashboard.layout);
         await this.deleteBearWidgets(deletedWidgets);
+
+        await this.updateBearDashboard(updatedDashboardWithSavedDependencies);
 
         return updatedDashboardWithSavedDependencies;
     };


### PR DESCRIPTION
The items removed from a dashboard need to be deleted
prior to calling the update itself, otherwise bear throws.

JIRA: RAIL-2537

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
