### PR TITLE
RELATED: RAIL-1815 fix sdk-ui-tests version policy

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -380,6 +380,7 @@
             "packageName": "@gooddata/sdk-ui-tests",
             "projectFolder": "libs/sdk-ui-tests",
             "reviewCategory": "production",
+            "versionPolicyName": "sdk",
             "shouldPublish": true
         },
         {


### PR DESCRIPTION
This makes sure the versions of sdk-ui-tests are in line with the other packages.

JIRA: RAIL-1815

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

TBD

-   [ ]

# Related Jira tasks

<!-- Optional

Example:
- FET-236: https://jira.intgdc.com/browse/FET-236

 -->
