### PR TITLE
RELATED: RAIL-1815 - Refine relative date attribute type

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -9,6 +9,7 @@ import {
     IAttributeElements,
     IAttribute,
     IMeasureFilter,
+    DateAttributeGranularity,
 } from "@gooddata/sdk-model";
 import compact from "lodash/compact";
 import isEmpty from "lodash/isEmpty";
@@ -85,6 +86,7 @@ const convertMeasureFilter = (filter: GdcVisualizationObject.Filter): IMeasureFi
         return {
             relativeDateFilter: {
                 ...filter.relativeDateFilter,
+                granularity: filter.relativeDateFilter.granularity as DateAttributeGranularity,
                 from: filter.relativeDateFilter.from!,
                 to: filter.relativeDateFilter.to!,
             },

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
@@ -11,7 +11,7 @@ import {
 import { Execution, AttributeGranularityResourceAttribute } from "@gooddata/api-client-tiger";
 import isResultAttributeHeader = Execution.isResultAttributeHeader;
 import isResultMeasureHeader = Execution.isResultMeasureHeader;
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { toSdkGranularity } from "../dateGranularityConversions";
 import { DateFormatter } from "../dateFormatting/types";
 import { createDateValueFormatter } from "../dateFormatting/dateValueFormatter";
@@ -32,7 +32,7 @@ const supportedSuffixes: string[] = Object.keys(AttributeGranularityResourceAttr
             AttributeGranularityResourceAttribute[key as keyof typeof AttributeGranularityResourceAttribute],
     );
 
-function getGranularity(header: IDimensionItemDescriptor): CatalogDateAttributeGranularity | undefined {
+function getGranularity(header: IDimensionItemDescriptor): DateAttributeGranularity | undefined {
     if (!isAttributeDescriptor(header)) {
         return undefined;
     }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueFormatter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueFormatter.ts
@@ -1,5 +1,5 @@
 // (C) 2020 GoodData Corporation
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { parseDateValue } from "./dateValueParser";
 import { DateFormatter } from "./types";
 
@@ -9,7 +9,7 @@ import { DateFormatter } from "./types";
  * @public
  */
 export function createDateValueFormatter(dateFormatter: DateFormatter) {
-    return (value: string, granularity: CatalogDateAttributeGranularity) => {
+    return (value: string, granularity: DateAttributeGranularity) => {
         const parsed = parseDateValue(value, granularity);
         return dateFormatter(parsed, granularity);
     };

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueParser.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueParser.ts
@@ -1,13 +1,13 @@
 // (C) 2020 GoodData Corporation
 import parse from "date-fns/parse";
 import identity from "lodash/identity";
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 
 type ValueTransform = (value: string) => string;
 
 const granularityParseValueTransformations: {
-    [granularity in CatalogDateAttributeGranularity]?: ValueTransform;
+    [granularity in DateAttributeGranularity]?: ValueTransform;
 } = {
     "GDC.time.day_in_week": (value) => {
         // server returns 0 = Sunday, 6 = Saturday
@@ -16,7 +16,7 @@ const granularityParseValueTransformations: {
     },
 };
 
-const granularityParsePatterns: { [granularity in CatalogDateAttributeGranularity]?: string } = {
+const granularityParsePatterns: { [granularity in DateAttributeGranularity]?: string } = {
     "GDC.time.date": "yyyy-MM-dd", // 2020-01-31
     "GDC.time.day_in_month": "d", // 1-31
     "GDC.time.day_in_week": "i", // 1-7
@@ -36,7 +36,7 @@ const granularityParsePatterns: { [granularity in CatalogDateAttributeGranularit
  * @param granularity - granularity to assume when parsing the value.
  * @internal
  */
-export const parseDateValue = (value: string, granularity: CatalogDateAttributeGranularity): Date => {
+export const parseDateValue = (value: string, granularity: DateAttributeGranularity): Date => {
     const parsePattern = granularityParsePatterns[granularity];
     if (!parsePattern) {
         throw new UnexpectedError(`No date parser for the "${granularity}" granularity available.`);

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/defaultDateFormatter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/defaultDateFormatter.ts
@@ -1,12 +1,12 @@
 // (C) 2020 GoodData Corporation
 import format from "date-fns/format";
 import { enUS, de, es, fr, ja, nl, pt, ptBR, zhCN } from "date-fns/locale";
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 import { DateFormatter } from "./types";
 
 const granularityFormatPatterns: {
-    [granularity in CatalogDateAttributeGranularity]?: string;
+    [granularity in DateAttributeGranularity]?: string;
 } = {
     "GDC.time.date": "P", // 01/31/2020
     "GDC.time.day_in_month": "dd", // 01-31

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/tests/dateValueFormatter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/tests/dateValueFormatter.test.ts
@@ -1,12 +1,12 @@
 // (C) 2020 GoodData Corporation
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { createDateValueFormatter } from "../dateValueFormatter";
 import { createDefaultDateFormatter } from "../defaultDateFormatter";
 
 describe("createDateValueFormatter", () => {
     const defaultDateValueFormatter = createDateValueFormatter(createDefaultDateFormatter());
 
-    type Scenario = [string, CatalogDateAttributeGranularity, string];
+    type Scenario = [string, DateAttributeGranularity, string];
     const scenarios: Scenario[] = [
         ["2020-01-31", "GDC.time.date", "01/31/2020"],
         ["1", "GDC.time.day_in_month", "01"],

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/types.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/types.ts
@@ -1,4 +1,4 @@
 // (C) 2020 GoodData Corporation
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 
-export type DateFormatter = (value: Date, granularity: CatalogDateAttributeGranularity) => string;
+export type DateFormatter = (value: Date, granularity: DateAttributeGranularity) => string;

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
@@ -1,14 +1,14 @@
 // (C) 2019-2020 GoodData Corporation
 import { AttributeGranularityResourceAttribute } from "@gooddata/api-client-tiger";
-import { CatalogDateAttributeGranularity } from "@gooddata/sdk-model";
+import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { NotSupported } from "@gooddata/sdk-backend-spi";
 
 type TigerToSdk = {
-    [key in AttributeGranularityResourceAttribute]: CatalogDateAttributeGranularity;
+    [key in AttributeGranularityResourceAttribute]: DateAttributeGranularity;
 };
 
 type SdkToTiger = {
-    [key in CatalogDateAttributeGranularity]: AttributeGranularityResourceAttribute | undefined;
+    [key in DateAttributeGranularity]: AttributeGranularityResourceAttribute | undefined;
 };
 
 /*
@@ -48,7 +48,7 @@ const TigerToSdkGranularityMap: TigerToSdk = {
  */
 export function toSdkGranularity(
     granularity: AttributeGranularityResourceAttribute,
-): CatalogDateAttributeGranularity {
+): DateAttributeGranularity {
     return TigerToSdkGranularityMap[granularity];
 }
 
@@ -83,7 +83,7 @@ const SdkToTigerGranularityMap: SdkToTiger = {
  * @throws NotSupport if the input granularity is not supported by tiger
  */
 export function toTigerGranularity(
-    granularity: CatalogDateAttributeGranularity,
+    granularity: DateAttributeGranularity,
 ): AttributeGranularityResourceAttribute {
     const tigerGranularity = SdkToTigerGranularityMap[granularity];
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -215,11 +215,8 @@ export class CatalogDateAttributeBuilder<T extends ICatalogDateAttribute = ICata
     // (undocumented)
     defaultDisplayForm(displayFormOrRef: IAttributeDisplayFormMetadataObject | ObjRef, modifications?: BuilderModifications<AttributeDisplayFormMetadataObjectBuilder>): this;
     // (undocumented)
-    granularity(granularity: CatalogDateAttributeGranularity): this;
+    granularity(granularity: DateAttributeGranularity): this;
 }
-
-// @public
-export type CatalogDateAttributeGranularity = "GDC.time.year" | "GDC.time.week_us" | "GDC.time.week_in_year" | "GDC.time.week_in_quarter" | "GDC.time.week" | "GDC.time.euweek_in_year" | "GDC.time.euweek_in_quarter" | "GDC.time.quarter" | "GDC.time.quarter_in_year" | "GDC.time.month" | "GDC.time.month_in_quarter" | "GDC.time.month_in_year" | "GDC.time.day_in_year" | "GDC.time.day_in_quarter" | "GDC.time.day_in_month" | "GDC.time.day_in_week" | "GDC.time.day_in_euweek" | "GDC.time.date";
 
 // @public
 export class CatalogDateDatasetBuilder<T extends ICatalogDateDataset = ICatalogDateDataset> extends Builder<T> {
@@ -289,12 +286,11 @@ export class DataSetMetadataObjectBuilder<T extends IDataSetMetadataObject = IDa
 }
 
 // @public
+export type DateAttributeGranularity = "GDC.time.year" | "GDC.time.week_us" | "GDC.time.week_in_year" | "GDC.time.week_in_quarter" | "GDC.time.week" | "GDC.time.euweek_in_year" | "GDC.time.euweek_in_quarter" | "GDC.time.quarter" | "GDC.time.quarter_in_year" | "GDC.time.month" | "GDC.time.month_in_quarter" | "GDC.time.month_in_year" | "GDC.time.day_in_year" | "GDC.time.day_in_quarter" | "GDC.time.day_in_month" | "GDC.time.day_in_week" | "GDC.time.day_in_euweek" | "GDC.time.date";
+
+// @public
 export const DateGranularity: {
-    date: string;
-    week: string;
-    month: string;
-    quarter: string;
-    year: string;
+    [short: string]: DateAttributeGranularity;
 };
 
 // @public
@@ -512,7 +508,7 @@ export interface ICatalogAttribute extends IGroupableCatalogItemBase {
 export interface ICatalogDateAttribute {
     attribute: IAttributeMetadataObject;
     defaultDisplayForm: IAttributeDisplayFormMetadataObject;
-    granularity: CatalogDateAttributeGranularity;
+    granularity: DateAttributeGranularity;
 }
 
 // @public
@@ -1009,7 +1005,7 @@ export interface IRelativeDateFilter {
     // (undocumented)
     relativeDateFilter: {
         dataSet: ObjRef;
-        granularity: string;
+        granularity: DateAttributeGranularity;
         from: number;
         to: number;
     };
@@ -1515,7 +1511,7 @@ export function newPositiveAttributeFilter(attributeOrRef: IAttribute | ObjRef |
 export function newPreviousPeriodMeasure(measureIdOrLocalId: MeasureOrLocalId, dateDataSets: IPreviousPeriodDateDataSetSimple[], modifications?: MeasureModifications<PreviousPeriodMeasureBuilder>): IMeasure<IPreviousPeriodMeasureDefinition>;
 
 // @public
-export function newRelativeDateFilter(dateDataSet: ObjRef | Identifier, granularity: string, from: number, to: number): IRelativeDateFilter;
+export function newRelativeDateFilter(dateDataSet: ObjRef | Identifier, granularity: DateAttributeGranularity, from: number, to: number): IRelativeDateFilter;
 
 // @public
 export function newTotal(type: TotalType, measureOrId: IMeasure | Identifier, attributeOrId: IAttribute | Identifier, alias?: string): ITotal;

--- a/libs/sdk-model/src/base/dateGranularities.ts
+++ b/libs/sdk-model/src/base/dateGranularities.ts
@@ -1,10 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
 
 /**
- * Date dataset attribute granularities.
+ * All possible date dataset attribute granularities.
  *
- * NOTE: This type enumerates all potentially supported granularities - implementations of analytical backend
- * MAY support only a subset of the granularities.
+ * NOTE: Implementations of analytical backend MAY support only a subset of these granularities.
+ *
+ * See {@link DateGranularity} for a more convenient way to access commonly used granularities.
  *
  * @public
  */
@@ -27,3 +28,16 @@ export type DateAttributeGranularity =
     | "GDC.time.day_in_week"
     | "GDC.time.day_in_euweek"
     | "GDC.time.date";
+
+/**
+ * Defines shortcuts for commonly used date dataset attribute granularities.
+ *
+ * @public
+ */
+export const DateGranularity: { [short: string]: DateAttributeGranularity } = {
+    date: "GDC.time.date",
+    week: "GDC.time.week_us",
+    month: "GDC.time.month",
+    quarter: "GDC.time.quarter",
+    year: "GDC.time.year",
+};

--- a/libs/sdk-model/src/base/dateGranularities.ts
+++ b/libs/sdk-model/src/base/dateGranularities.ts
@@ -1,0 +1,29 @@
+// (C) 2019-2020 GoodData Corporation
+
+/**
+ * Date dataset attribute granularities.
+ *
+ * NOTE: This type enumerates all potentially supported granularities - implementations of analytical backend
+ * MAY support only a subset of the granularities.
+ *
+ * @public
+ */
+export type DateAttributeGranularity =
+    | "GDC.time.year"
+    | "GDC.time.week_us"
+    | "GDC.time.week_in_year"
+    | "GDC.time.week_in_quarter"
+    | "GDC.time.week"
+    | "GDC.time.euweek_in_year"
+    | "GDC.time.euweek_in_quarter"
+    | "GDC.time.quarter"
+    | "GDC.time.quarter_in_year"
+    | "GDC.time.month"
+    | "GDC.time.month_in_quarter"
+    | "GDC.time.month_in_year"
+    | "GDC.time.day_in_year"
+    | "GDC.time.day_in_quarter"
+    | "GDC.time.day_in_month"
+    | "GDC.time.day_in_week"
+    | "GDC.time.day_in_euweek"
+    | "GDC.time.date";

--- a/libs/sdk-model/src/execution/filter/factory.ts
+++ b/libs/sdk-model/src/execution/filter/factory.ts
@@ -2,19 +2,20 @@
 import invariant from "ts-invariant";
 import isNil from "lodash/isNil";
 import {
-    IAttributeElements,
     ComparisonConditionOperator,
     IAbsoluteDateFilter,
+    IAttributeElements,
     IMeasureValueFilter,
     INegativeAttributeFilter,
     IPositiveAttributeFilter,
     IRelativeDateFilter,
     RangeConditionOperator,
 } from "./index";
-import { IAttribute, attributeDisplayFormRef } from "../attribute";
-import { ObjRef, isObjRef, Identifier, UriRef, LocalIdRef } from "../../objRef";
+import { attributeDisplayFormRef, IAttribute } from "../attribute";
+import { Identifier, isObjRef, LocalIdRef, ObjRef, UriRef } from "../../objRef";
 import { IMeasure, isMeasure, measureLocalId } from "../measure";
 import { idRef, localIdRef } from "../../objRef/factory";
+import { DateAttributeGranularity } from "../../base/dateGranularities";
 
 /**
  * Creates a new positive attribute filter.
@@ -104,11 +105,13 @@ export function newAbsoluteDateFilter(
  * @param granularity - granularity of the filters (month, year, etc.)
  * @param from - start of the interval – negative numbers mean the past, zero means today, positive numbers mean the future
  * @param to - end of the interval – negative numbers mean the past, zero means today, positive numbers mean the future
+ *
+ * See also {@link DateAttributeGranularity} and {@link DateGranularity}
  * @public
  */
 export function newRelativeDateFilter(
     dateDataSet: ObjRef | Identifier,
-    granularity: string,
+    granularity: DateAttributeGranularity,
     from: number,
     to: number,
 ): IRelativeDateFilter {

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -1,7 +1,8 @@
 // (C) 2019-2020 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import invariant from "ts-invariant";
-import { ObjRef, ObjRefInScope, UriRef, LocalIdRef } from "../../objRef";
+import { LocalIdRef, ObjRef, ObjRefInScope, UriRef } from "../../objRef";
+import { DateAttributeGranularity } from "../../base/dateGranularities";
 
 /**
  * Attribute elements specified by their URI.
@@ -105,30 +106,17 @@ export interface IAbsoluteDateFilter {
  * Filters results to a relative date range. The relative filtering is always done on some granularity - this specifies
  * the units in the 'from' and 'to' fields.
  *
- * {@link DateGranularity}
+ * See {@link DateAttributeGranularity} and {@link DateGranularity} for further detail.
  * @public
  */
 export interface IRelativeDateFilter {
     relativeDateFilter: {
         dataSet: ObjRef;
-        granularity: string;
+        granularity: DateAttributeGranularity;
         from: number;
         to: number;
     };
 }
-
-/**
- * Defines date data set granularities that can be used in relative date filter.
- *
- * @public
- */
-export const DateGranularity = {
-    date: "GDC.time.date",
-    week: "GDC.time.week_us",
-    month: "GDC.time.month",
-    quarter: "GDC.time.quarter",
-    year: "GDC.time.year",
-};
 
 /**
  * Attribute filters limit results of execution to data pertaining to attributes that are or are not specified

--- a/libs/sdk-model/src/execution/filter/tests/__snapshots__/factory.test.ts.snap
+++ b/libs/sdk-model/src/execution/filter/tests/__snapshots__/factory.test.ts.snap
@@ -283,7 +283,7 @@ Object {
       "identifier": "foo",
     },
     "from": 1,
-    "granularity": "quarter",
+    "granularity": "GDC.time.month",
     "to": 3,
   },
 }

--- a/libs/sdk-model/src/execution/filter/tests/factory.test.ts
+++ b/libs/sdk-model/src/execution/filter/tests/factory.test.ts
@@ -51,7 +51,7 @@ describe("filter factory", () => {
 
     describe("newRelativeDateFilter", () => {
         it("should generate correct filter", () => {
-            expect(newRelativeDateFilter("foo", "quarter", 1, 3)).toMatchSnapshot();
+            expect(newRelativeDateFilter("foo", "GDC.time.month", 1, 3)).toMatchSnapshot();
         });
     });
 

--- a/libs/sdk-model/src/execution/filter/tests/typeGuards.test.ts
+++ b/libs/sdk-model/src/execution/filter/tests/typeGuards.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2020 GoodData Corporation
 
 import { Account, Activity, Won } from "../../../../__mocks__/model";
 import { InvalidInputTestCases } from "../../../../__mocks__/typeGuards";
@@ -10,7 +10,6 @@ import {
     newRelativeDateFilter,
 } from "../factory";
 import {
-    DateGranularity,
     isAbsoluteDateFilter,
     isAttributeElementsByRef,
     isAttributeElementsByValue,
@@ -23,6 +22,7 @@ import {
     isComparisonConditionOperator,
     isRangeConditionOperator,
 } from "../index";
+import { DateGranularity } from "../../../base/dateGranularities";
 
 describe("filter type guards", () => {
     describe("isPositiveAttributeFilter", () => {

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -8,6 +8,8 @@ export {
     builderFactory,
 } from "./base/builder";
 
+export { DateAttributeGranularity } from "./base/dateGranularities";
+
 export { IDrillingActivationPostMessageData } from "./embedding/postMessage";
 
 export {
@@ -313,7 +315,6 @@ export { insightSanitize } from "./insight/sanitization";
 export {
     CatalogItemType,
     CatalogItem,
-    CatalogDateAttributeGranularity,
     ICatalogGroup,
     ICatalogAttribute,
     ICatalogFact,

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -8,7 +8,7 @@ export {
     builderFactory,
 } from "./base/builder";
 
-export { DateAttributeGranularity } from "./base/dateGranularities";
+export { DateAttributeGranularity, DateGranularity } from "./base/dateGranularities";
 
 export { IDrillingActivationPostMessageData } from "./embedding/postMessage";
 
@@ -101,7 +101,6 @@ export {
     IMeasureFilter,
     IDateFilter,
     IAttributeFilter,
-    DateGranularity,
     isAbsoluteDateFilter,
     isRelativeDateFilter,
     isPositiveAttributeFilter,

--- a/libs/sdk-model/src/ldm/catalog/dateDataset/factory.ts
+++ b/libs/sdk-model/src/ldm/catalog/dateDataset/factory.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import identity from "lodash/identity";
 import { Builder, builderFactory, BuilderModifications } from "../../../base/builder";
-import { CatalogDateAttributeGranularity, ICatalogDateAttribute, ICatalogDateDataset } from ".";
+import { ICatalogDateAttribute, ICatalogDateDataset } from ".";
 import { IAttributeMetadataObject, isAttributeMetadataObject } from "../../metadata/attribute";
 import {
     IAttributeDisplayFormMetadataObject,
@@ -19,6 +19,7 @@ import {
     newDataSetMetadataObject,
 } from "../../metadata";
 import { isDataSetMetadataObject } from "../../metadata/dataSet";
+import { DateAttributeGranularity } from "../../../base/dateGranularities";
 
 /**
  * Catalog date attribute builder
@@ -29,7 +30,7 @@ import { isDataSetMetadataObject } from "../../metadata/dataSet";
 export class CatalogDateAttributeBuilder<
     T extends ICatalogDateAttribute = ICatalogDateAttribute
 > extends Builder<T> {
-    public granularity(granularity: CatalogDateAttributeGranularity): this {
+    public granularity(granularity: DateAttributeGranularity): this {
         this.item.granularity = granularity;
         return this;
     }

--- a/libs/sdk-model/src/ldm/catalog/dateDataset/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/dateDataset/index.ts
@@ -4,31 +4,7 @@ import { ICatalogItemBase } from "../types";
 import { IAttributeMetadataObject } from "../../metadata/attribute";
 import { IAttributeDisplayFormMetadataObject } from "../../metadata/attributeDisplayForm";
 import { IDataSetMetadataObject } from "../../metadata/dataSet";
-
-/**
- * Type representing catalog date attribute granularity
- *
- * @public
- */
-export type CatalogDateAttributeGranularity =
-    | "GDC.time.year"
-    | "GDC.time.week_us"
-    | "GDC.time.week_in_year"
-    | "GDC.time.week_in_quarter"
-    | "GDC.time.week"
-    | "GDC.time.euweek_in_year"
-    | "GDC.time.euweek_in_quarter"
-    | "GDC.time.quarter"
-    | "GDC.time.quarter_in_year"
-    | "GDC.time.month"
-    | "GDC.time.month_in_quarter"
-    | "GDC.time.month_in_year"
-    | "GDC.time.day_in_year"
-    | "GDC.time.day_in_quarter"
-    | "GDC.time.day_in_month"
-    | "GDC.time.day_in_week"
-    | "GDC.time.day_in_euweek"
-    | "GDC.time.date";
+import { DateAttributeGranularity } from "../../../base/dateGranularities";
 
 /**
  * Type representing catalog dateDataset date attribute
@@ -39,7 +15,7 @@ export interface ICatalogDateAttribute {
     /**
      * Date attribute granularity
      */
-    granularity: CatalogDateAttributeGranularity;
+    granularity: DateAttributeGranularity;
 
     /**
      * Date attribute metadata object

--- a/libs/sdk-model/src/ldm/catalog/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/index.ts
@@ -57,12 +57,7 @@ export { CatalogMeasureBuilder, newCatalogMeasure } from "./measure/factory";
 export { ICatalogFact, isCatalogFact } from "./fact";
 export { CatalogFactBuilder, newCatalogFact } from "./fact/factory";
 
-export {
-    ICatalogDateDataset,
-    ICatalogDateAttribute,
-    CatalogDateAttributeGranularity,
-    isCatalogDateDataset,
-} from "./dateDataset";
+export { ICatalogDateDataset, ICatalogDateAttribute, isCatalogDateDataset } from "./dateDataset";
 export {
     CatalogDateDatasetBuilder,
     CatalogDateAttributeBuilder,


### PR DESCRIPTION
Establish DateAttributeGranularity type with all possible granularities. Use this in relative attribute filter.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
