### PR TITLE
RELATED: RAIL-2562 stop pivot table initialize if data is no longer valid

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -184,6 +184,11 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private visibleData: DataViewFacade = null;
     private currentFingerprint: string = null;
 
+    /**
+     * Fingerprint of the last execution definition the initialize was called with.
+     */
+    private lastInitRequestFingerprint: string = null;
+
     private lastScrollPosition: IScrollPosition = {
         top: 0,
         left: 0,
@@ -238,6 +243,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.currentResult = null;
         this.visibleData = null;
         this.currentFingerprint = null;
+        this.lastInitRequestFingerprint = null;
         this.firstDataRendered = false;
         this.resizedColumnsStore = new ResizedColumnsStore();
         this.autoResizedColumns = {};
@@ -353,6 +359,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private initialize(execution: IPreparedExecution): void {
         this.onLoadingChanged({ isLoading: true });
+        this.lastInitRequestFingerprint = defFingerprint(execution.definition);
         execution
             .execute()
             .then((result) => {
@@ -363,6 +370,14 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                             /*
                              * Stop right now if the component gets unmounted while it is still being
                              * initialized.
+                             */
+                            return;
+                        }
+
+                        if (this.lastInitRequestFingerprint !== defFingerprint(dataView.definition)) {
+                            /*
+                             * Stop right now if the data are not relevant anymore because there was another
+                             * initialize request in the meantime.
                              */
                             return;
                         }


### PR DESCRIPTION
Make sure that the initialization continues with the received data
only if the data is still valid, i.e. for the same execution definition
the initialize was last called with.

JIRA: RAIL-2562

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
