### PR TITLE
TRIVIAL: fix PR template links, add rsync docs to sdk-dev

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ Supported PR commands:
 
 # PR Checklist
 
--   [ ] commit messages adhere to the [commit message guidelines](docs/contributing.md#what-should-the-commits-look-like)
+-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
 -   [ ] `check` passes
 -   [ ] `check-extended` passes
--   [ ] `rush change` [was run if applicable](docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
+-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)

--- a/docs/sdk-dev.md
+++ b/docs/sdk-dev.md
@@ -327,6 +327,8 @@ what data to obtain) please see:
 
 ### Debugging packages in your own app
 
+#### Using links
+
 There might be situations when you want to quickly test changes made in the SDK packages in your own app. Let's try `sdk-ui` as an example (this guide is applicable to other packages – `sdk-model`, `sdk-backend-spi`, etc. as well). Use the following steps (we assume your app uses `yarn` as a dependency manager, you should be able to replace `yarn` by `pnpm` or `npm` depending on your app's setup and achieve the same results):
 
 1.  Run `yarn link` in the `sdk-ui` folder.
@@ -336,3 +338,15 @@ You only have to do the linking once. After you linked the package, you can run 
 
 1.  Run `rushx dev` in the `sdk-ui` folder. This will start the compilation in watch mode and will rebuild `sdk-ui` on every change
 2.  Run your app (you can use watch mode if applicable). You will see the up-to-date version of `sdk-ui` in your app and it will refresh as long as `pnpm run dev` is running.
+
+#### Using `rsync`
+
+Alternatively, if you want to avoid the potential problems with links, you can use the [`rsync`](https://en.wikipedia.org/wiki/Rsync) utility to copy the dist files of your version of the SDK packages to your app's `node_modules`. For example:
+
+```bash
+cd gooddata-ui-sdk
+rush build
+rsync -rptgD --no-links --include="/*/dist/*" ./libs/ ~/your-app/node_modules/@gooddata/
+```
+
+This will make sure that the SDK8 files in your app are from your local SDK8 version. To revert the changes, run `yarn install --force` or equivalent in your app.


### PR DESCRIPTION
This provides an alternative to yarn link for local testing of the SDK.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
