### PR TITLE
RELATED: RAIL-2107 - Fix up sdk-embedding

### DIFF
--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -8,9 +8,6 @@ import { GdcExecuteAFM } from '@gooddata/api-model-bear';
 import { GdcExport } from '@gooddata/api-model-bear';
 import { GdcVisualizationObject } from '@gooddata/api-model-bear';
 
-// @internal (undocumented)
-export function addListener(listener: GdcMessageEventListener, target?: Window & typeof globalThis): void;
-
 // @public
 export type CommandFailed<Product> = IGdcMessageEvent<Product, GdcEventType.AppCommandFailed, ICommandFailedBody>;
 
@@ -168,9 +165,23 @@ export namespace EmbeddedGdc {
         filters: FilterItem[];
     }
     // (undocumented)
-    export type INegativeAttributeFilter = GdcExecuteAFM.INegativeAttributeFilter;
+    export interface INegativeAttributeFilter {
+        // (undocumented)
+        negativeAttributeFilter: {
+            displayForm: ObjQualifier;
+            notIn: string[];
+            textFilter?: boolean;
+        };
+    }
     // (undocumented)
-    export type IPositiveAttributeFilter = GdcExecuteAFM.IPositiveAttributeFilter;
+    export interface IPositiveAttributeFilter {
+        // (undocumented)
+        positiveAttributeFilter: {
+            displayForm: ObjQualifier;
+            in: string[];
+            textFilter?: boolean;
+        };
+    }
     // (undocumented)
     export interface IRelativeDateFilter {
         // (undocumented)
@@ -198,15 +209,15 @@ export namespace EmbeddedGdc {
     // (undocumented)
     export function isAbsoluteDateFilter(filter: CompatibilityFilter): filter is IAbsoluteDateFilter;
     // (undocumented)
+    export function isAttributeFilter(filter: CompatibilityFilter): filter is AttributeFilterItem;
+    // (undocumented)
     export function isDateFilter(filter: CompatibilityFilter): filter is DateFilterItem;
     // (undocumented)
+    export function isNegativeAttributeFilter(filter: CompatibilityFilter): filter is INegativeAttributeFilter;
+    // (undocumented)
+    export function isPositiveAttributeFilter(filter: CompatibilityFilter): filter is IPositiveAttributeFilter;
+    // (undocumented)
     export function isRelativeDateFilter(filter: CompatibilityFilter): filter is IRelativeDateFilter;
-    const // (undocumented)
-    isAttributeFilter: typeof GdcExecuteAFM.isAttributeFilter;
-    const // (undocumented)
-    isPositiveAttributeFilter: typeof GdcExecuteAFM.isPositiveAttributeFilter;
-    const // (undocumented)
-    isNegativeAttributeFilter: typeof GdcExecuteAFM.isNegativeAttributeFilter;
     const // (undocumented)
     isObjIdentifierQualifier: typeof GdcExecuteAFM.isObjIdentifierQualifier;
     const // (undocumented)
@@ -500,14 +511,6 @@ export interface IGdcMessageEventListenerConfig {
     validReceivedPostEvents: string[];
 }
 
-// @internal (undocumented)
-export interface IHost {
-    // (undocumented)
-    parent?: IHost;
-    // (undocumented)
-    postMessage?: Window["postMessage"];
-}
-
 // @public
 export interface IObjectMeta {
     identifier: string;
@@ -531,18 +534,6 @@ export interface ISimpleDrillableItemsCommandBody {
     identifiers?: string[];
     uris?: string[];
 }
-
-// @internal (undocumented)
-export function postEvent(product: string, name: string, data: object, contextId?: string): void;
-
-// @internal (undocumented)
-export function removeListener(listener: GdcMessageEventListener, target?: Window & typeof globalThis): void;
-
-// @internal (undocumented)
-export function setConfig(product: string, validReceivedPostEvents: string[]): void;
-
-// @internal
-export const setHost: (h: IHost) => void;
 
 
 // (No @packageDocumentation comment for this package)

--- a/libs/sdk-embedding/src/iframe/common.ts
+++ b/libs/sdk-embedding/src/iframe/common.ts
@@ -254,9 +254,27 @@ export interface IDrillableItemsCommandBody extends ISimpleDrillableItemsCommand
  * @public
  */
 export namespace EmbeddedGdc {
-    // re-export from AFM namespace
-    export type IPositiveAttributeFilter = GdcExecuteAFM.IPositiveAttributeFilter;
-    export type INegativeAttributeFilter = GdcExecuteAFM.INegativeAttributeFilter;
+    /*
+     * Attribute filters were exposed in the 'old' format that did not match backend and used the
+     * textFilter boolean indicator. We have to honor this for the public API.
+     */
+
+    export interface IPositiveAttributeFilter {
+        positiveAttributeFilter: {
+            displayForm: ObjQualifier;
+            in: string[];
+            textFilter?: boolean;
+        };
+    }
+
+    export interface INegativeAttributeFilter {
+        negativeAttributeFilter: {
+            displayForm: ObjQualifier;
+            notIn: string[];
+            textFilter?: boolean;
+        };
+    }
+
     export interface IAbsoluteDateFilter {
         absoluteDateFilter: {
             // dataSet is required in AD only
@@ -265,6 +283,7 @@ export namespace EmbeddedGdc {
             to: string;
         };
     }
+
     export interface IRelativeDateFilter {
         relativeDateFilter: {
             // dataSet is required in AD only
@@ -298,9 +317,21 @@ export namespace EmbeddedGdc {
     export function isAbsoluteDateFilter(filter: CompatibilityFilter): filter is IAbsoluteDateFilter {
         return !isEmpty(filter) && (filter as IAbsoluteDateFilter).absoluteDateFilter !== undefined;
     }
-    export const isAttributeFilter = GdcExecuteAFM.isAttributeFilter;
-    export const isPositiveAttributeFilter = GdcExecuteAFM.isPositiveAttributeFilter;
-    export const isNegativeAttributeFilter = GdcExecuteAFM.isNegativeAttributeFilter;
+    export function isAttributeFilter(filter: CompatibilityFilter): filter is AttributeFilterItem {
+        return !isEmpty(filter) && (isPositiveAttributeFilter(filter) || isNegativeAttributeFilter(filter));
+    }
+
+    export function isPositiveAttributeFilter(
+        filter: CompatibilityFilter,
+    ): filter is IPositiveAttributeFilter {
+        return !isEmpty(filter) && (filter as IPositiveAttributeFilter).positiveAttributeFilter !== undefined;
+    }
+
+    export function isNegativeAttributeFilter(
+        filter: CompatibilityFilter,
+    ): filter is INegativeAttributeFilter {
+        return !isEmpty(filter) && (filter as INegativeAttributeFilter).negativeAttributeFilter !== undefined;
+    }
     export const isObjIdentifierQualifier = GdcExecuteAFM.isObjIdentifierQualifier;
     export const isObjectUriQualifier = GdcExecuteAFM.isObjectUriQualifier;
 

--- a/libs/sdk-embedding/src/index.ts
+++ b/libs/sdk-embedding/src/index.ts
@@ -24,8 +24,3 @@ export {
 export { EmbeddedAnalyticalDesigner } from "./iframe/ad";
 
 export { EmbeddedKpiDashboard } from "./iframe/kd";
-
-import * as filterConvertors from "./internal/filterConvertors";
-import * as messagingUtils from "./internal/messagingUtils";
-
-export { filterConvertors, messagingUtils };

--- a/libs/sdk-embedding/src/index.ts
+++ b/libs/sdk-embedding/src/index.ts
@@ -25,4 +25,7 @@ export { EmbeddedAnalyticalDesigner } from "./iframe/ad";
 
 export { EmbeddedKpiDashboard } from "./iframe/kd";
 
-export { IHost, setConfig, setHost, addListener, postEvent, removeListener } from "./iframe/messagingUtils";
+import * as filterConvertors from "./internal/filterConvertors";
+import * as messagingUtils from "./internal/messagingUtils";
+
+export { filterConvertors, messagingUtils };

--- a/libs/sdk-embedding/src/internal.ts
+++ b/libs/sdk-embedding/src/internal.ts
@@ -1,0 +1,5 @@
+// (C) 2020 GoodData Corporation
+import * as filterConvertors from "./internal/filterConvertors";
+import * as messagingUtils from "./internal/messagingUtils";
+
+export { filterConvertors, messagingUtils };

--- a/libs/sdk-embedding/src/internal/filterConvertors.ts
+++ b/libs/sdk-embedding/src/internal/filterConvertors.ts
@@ -1,0 +1,252 @@
+// (C) 2020 GoodData Corporation
+import { isEmpty, isString, isNumber } from "lodash";
+import { EmbeddedGdc } from "../iframe/common";
+
+export const EXTERNAL_DATE_FILTER_FORMAT = "YYYY-MM-DD";
+
+export interface IExternalFiltersObject {
+    attributeFilters: ITransformedAttributeFilterItem[];
+    dateFilters: ITransformedDateFilterItem[];
+}
+
+export interface ITransformedDateFilterItem {
+    granularity?: string;
+    from: string | number;
+    to: string | number;
+    datasetUri?: string;
+    datasetIdentifier?: string;
+}
+
+export interface ITransformedAttributeFilterItem {
+    negativeSelection: boolean;
+    attributeElements: string[];
+    dfIdentifier?: string;
+    dfUri?: string;
+}
+
+const DATE_FORMAT_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+export const ALL_TIME_GRANULARITY = "ALL_TIME_GRANULARITY";
+
+export type ITransformedFilterItem = ITransformedDateFilterItem | ITransformedAttributeFilterItem;
+
+function validateDataSet(dataSet: EmbeddedGdc.ObjQualifier | undefined): boolean {
+    if (!dataSet) {
+        return false;
+    }
+
+    const { uri, identifier } = getObjectUriIdentifier(dataSet);
+    return isString(uri) || isString(identifier);
+}
+
+export function isValidDateFilterFormat(
+    filterItem: EmbeddedGdc.DateFilterItem,
+    shouldValidateDataSet: boolean = true,
+): boolean {
+    if (EmbeddedGdc.isAbsoluteDateFilter(filterItem)) {
+        const {
+            absoluteDateFilter: { from, to, dataSet },
+        } = filterItem;
+
+        const isValidDataSet = shouldValidateDataSet ? validateDataSet(dataSet) : true;
+        return (
+            isValidDataSet &&
+            isString(from) &&
+            isString(to) &&
+            DATE_FORMAT_REGEX.test(from) &&
+            DATE_FORMAT_REGEX.test(to)
+        );
+    } else {
+        const {
+            relativeDateFilter: { from, to, dataSet },
+        } = filterItem;
+
+        const isValidDataSet = shouldValidateDataSet ? validateDataSet(dataSet) : true;
+        return isValidDataSet && isNumber(from) && isNumber(to);
+    }
+}
+
+function isValidAttributeFilterFormat(filterItem: EmbeddedGdc.AttributeFilterItem): boolean {
+    if (!EmbeddedGdc.isAttributeFilter(filterItem)) {
+        return false;
+    }
+
+    if (EmbeddedGdc.isPositiveAttributeFilter(filterItem)) {
+        const {
+            positiveAttributeFilter: { displayForm, in: attributeElements },
+        } = filterItem;
+        const { uri, identifier } = getObjectUriIdentifier(displayForm);
+        return (
+            (isString(uri) || isString(identifier)) &&
+            Array.isArray(attributeElements) &&
+            attributeElements.length !== 0
+        );
+    } else {
+        const {
+            negativeAttributeFilter: { displayForm, notIn: attributeElements },
+        } = filterItem;
+        const { uri, identifier } = getObjectUriIdentifier(displayForm);
+        // attributeElements could be empty in case of setting All Value
+        return (isString(uri) || isString(identifier)) && Array.isArray(attributeElements);
+    }
+}
+
+// `dataSet` is required in AD only.
+// In AD, we call this function with `shouldValidateDataSet = true`
+// In KD, we call this function with `shouldValidateDataSet = false`
+export function isValidFilterItemFormat(filterItem: any, shouldValidateDataSet: boolean = true): boolean {
+    if (EmbeddedGdc.isDateFilter(filterItem)) {
+        return isValidDateFilterFormat(filterItem, shouldValidateDataSet);
+    } else {
+        return isValidAttributeFilterFormat(filterItem);
+    }
+}
+
+export function isValidRemoveFilterItemFormat(filterItem: any): boolean {
+    if (EmbeddedGdc.isRemoveDateFilter(filterItem)) {
+        const { dataSet } = filterItem;
+        const { uri, identifier } = getObjectUriIdentifier(dataSet);
+        return isString(uri) || isString(identifier);
+    } else if (EmbeddedGdc.isRemoveAttributeFilter(filterItem)) {
+        const { displayForm } = filterItem;
+        const { uri, identifier } = getObjectUriIdentifier(displayForm);
+        return isString(uri) || isString(identifier);
+    }
+
+    return false;
+}
+
+export function isValidRemoveFiltersFormat(filters: any[]): boolean {
+    return !isEmpty(filters) && filters.every(isValidRemoveFilterItemFormat);
+}
+
+export function isValidFiltersFormat(filters: any[], shouldValidateDataSet: boolean = true): boolean {
+    return (
+        !isEmpty(filters) &&
+        filters.every((filter: any) => isValidFilterItemFormat(filter, shouldValidateDataSet))
+    );
+}
+
+export function getObjectUriIdentifier(
+    obj: EmbeddedGdc.ObjQualifier | undefined,
+): { uri?: string; identifier?: string } {
+    if (!obj) {
+        return {};
+    }
+
+    return {
+        uri: EmbeddedGdc.isObjectUriQualifier(obj) ? obj.uri : undefined,
+        identifier: EmbeddedGdc.isObjIdentifierQualifier(obj) ? obj.identifier : undefined,
+    };
+}
+
+function transformDateFilterItem(dateFilterItem: EmbeddedGdc.DateFilterItem): ITransformedDateFilterItem {
+    if (EmbeddedGdc.isAbsoluteDateFilter(dateFilterItem)) {
+        const {
+            absoluteDateFilter: { dataSet, from, to },
+        } = dateFilterItem;
+        const { uri: datasetUri, identifier: datasetIdentifier } = getObjectUriIdentifier(dataSet);
+        return {
+            to,
+            from,
+            datasetUri,
+            datasetIdentifier,
+        };
+    } else {
+        const {
+            relativeDateFilter: { granularity, dataSet, from, to },
+        } = dateFilterItem;
+        const { uri: datasetUri, identifier: datasetIdentifier } = getObjectUriIdentifier(dataSet);
+        return {
+            to,
+            from,
+            granularity,
+            datasetUri,
+            datasetIdentifier,
+        };
+    }
+}
+
+function transformAttributeFilterItem(
+    attributeFilterItem: EmbeddedGdc.AttributeFilterItem,
+): ITransformedAttributeFilterItem {
+    if (EmbeddedGdc.isPositiveAttributeFilter(attributeFilterItem)) {
+        const {
+            positiveAttributeFilter: { in: attributeElements, displayForm },
+        } = attributeFilterItem;
+        const { uri: dfUri, identifier: dfIdentifier } = getObjectUriIdentifier(displayForm);
+        return {
+            negativeSelection: false,
+            attributeElements,
+            dfIdentifier,
+            dfUri,
+        };
+    } else {
+        const {
+            negativeAttributeFilter: { notIn: attributeElements, displayForm },
+        } = attributeFilterItem;
+        const { uri: dfUri, identifier: dfIdentifier } = getObjectUriIdentifier(displayForm);
+        return {
+            negativeSelection: true,
+            attributeElements,
+            dfIdentifier,
+            dfUri,
+        };
+    }
+}
+
+export function transformFilterContext(filters: EmbeddedGdc.FilterItem[]): IExternalFiltersObject {
+    const defaultFiltersObject: IExternalFiltersObject = {
+        attributeFilters: [],
+        dateFilters: [],
+    };
+    if (isEmpty(filters)) {
+        return defaultFiltersObject;
+    }
+
+    return filters.reduce(
+        (
+            externalFilters: IExternalFiltersObject,
+            filterItem: EmbeddedGdc.FilterItem,
+        ): IExternalFiltersObject => {
+            if (EmbeddedGdc.isDateFilter(filterItem)) {
+                const dateFilter = transformDateFilterItem(filterItem);
+                externalFilters.dateFilters.push(dateFilter);
+            } else {
+                const attributeFilter = transformAttributeFilterItem(filterItem);
+                externalFilters.attributeFilters.push(attributeFilter);
+            }
+
+            return externalFilters;
+        },
+        defaultFiltersObject,
+    );
+}
+
+export function isTransformedDateFilterItem(
+    filterItem: ITransformedFilterItem,
+): filterItem is ITransformedDateFilterItem {
+    const { from, to } = filterItem as ITransformedDateFilterItem;
+    return !isEmpty(filterItem) && from !== undefined && to !== undefined;
+}
+
+export function isTransformedAttributeFilterItem(
+    filterItem: ITransformedFilterItem,
+): filterItem is ITransformedAttributeFilterItem {
+    const { attributeElements } = filterItem as ITransformedAttributeFilterItem;
+    return !isEmpty(filterItem) && attributeElements !== undefined;
+}
+
+export function isAllTimeDateFilterItem(filterItem: ITransformedFilterItem): boolean {
+    return (
+        !isEmpty(filterItem) &&
+        (filterItem as ITransformedDateFilterItem).granularity === ALL_TIME_GRANULARITY
+    );
+}
+
+export function isAllValueAttributeFilterItem(filterItem: ITransformedFilterItem): boolean {
+    return (
+        !isEmpty(filterItem) &&
+        isTransformedAttributeFilterItem(filterItem) &&
+        !filterItem.attributeElements.length
+    );
+}

--- a/libs/sdk-embedding/src/internal/messagingUtils.ts
+++ b/libs/sdk-embedding/src/internal/messagingUtils.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2020 GoodData Corporation
 import get from "lodash/get";
-import { GdcMessageEventListener, IGdcMessageEventListenerConfig, IGdcMessageEvent } from "./common";
+import { GdcMessageEventListener, IGdcMessageEventListenerConfig, IGdcMessageEvent } from "../iframe/common";
 
 /**
  * @internal

--- a/libs/sdk-embedding/src/internal/tests/filterUtils.test.ts
+++ b/libs/sdk-embedding/src/internal/tests/filterUtils.test.ts
@@ -1,0 +1,189 @@
+// (C) 2020 GoodData Corporation
+
+import {
+    transformFilterContext,
+    isValidFiltersFormat,
+    isAllValueAttributeFilterItem,
+    ALL_TIME_GRANULARITY,
+    isAllTimeDateFilterItem,
+} from "../filterConvertors";
+import { EmbeddedGdc } from "../../iframe/common";
+
+describe("filter utils", () => {
+    const absoluteDateFilter: EmbeddedGdc.IAbsoluteDateFilter = {
+        absoluteDateFilter: {
+            from: "2020-01-01",
+            to: "2020-02-01",
+            dataSet: {
+                uri: "uri",
+            },
+        },
+    };
+    const relativeDateFilter: EmbeddedGdc.IRelativeDateFilter = {
+        relativeDateFilter: {
+            granularity: "gdc.time.month",
+            from: -1,
+            to: 1,
+            dataSet: {
+                uri: "uri",
+            },
+        },
+    };
+    const absoluteDateFilterWithoutDataSet = {
+        absoluteDateFilter: {
+            from: "2020-01-01",
+            to: "2020-02-01",
+        },
+    };
+    const absoluteDateFilterWithoutUriAndIdentifier = {
+        absoluteDateFilter: {
+            from: "2020-01-01",
+            to: "2020-02-01",
+            dataSet: {},
+        },
+    };
+    const negativeAttributeFilter: EmbeddedGdc.INegativeAttributeFilter = {
+        negativeAttributeFilter: {
+            notIn: ["uri1"],
+            displayForm: {
+                uri: "dfuri",
+            },
+        },
+    };
+    const positiveAttributeFilter: EmbeddedGdc.IPositiveAttributeFilter = {
+        positiveAttributeFilter: {
+            in: ["uri1"],
+            displayForm: {
+                uri: "dfuri",
+            },
+        },
+    };
+    const positiveAttributeFilterWithoutDisplayForm = {
+        positiveAttributeFilter: {
+            in: ["uri1"],
+            displayForm: {},
+        },
+    };
+    const positiveAttributeFilterWithoutValue: EmbeddedGdc.IPositiveAttributeFilter = {
+        positiveAttributeFilter: {
+            in: [],
+            displayForm: {
+                uri: "dfUri",
+            },
+        },
+    };
+
+    it("should return false if have any item is not the filter item", () => {
+        expect(isValidFiltersFormat([absoluteDateFilter, {}])).toBe(false);
+        expect(isValidFiltersFormat([])).toBe(false);
+        expect(isValidFiltersFormat([null])).toBe(false);
+        expect(isValidFiltersFormat([undefined])).toBe(false);
+        expect(
+            isValidFiltersFormat([
+                {
+                    absoluteDateFilter: {
+                        from: -1,
+                        to: 1,
+                        dataSet: {
+                            uri: "uri",
+                        },
+                    },
+                },
+            ]),
+        ).toBe(false);
+        expect(
+            isValidFiltersFormat([
+                {
+                    relativeDateFilter: {
+                        from: "2020-01-01",
+                        to: "2020-02-01",
+                        dataSet: {
+                            uri: "uri",
+                        },
+                    },
+                },
+            ]),
+        ).toBe(false);
+    });
+
+    it("should check the date filter item format", () => {
+        expect(isValidFiltersFormat([absoluteDateFilter, relativeDateFilter])).toBe(true);
+    });
+
+    it("should return false when date filter is missing dataSet", () => {
+        expect(isValidFiltersFormat([absoluteDateFilterWithoutDataSet])).toBe(false);
+    });
+
+    it("should return false when date filter is missing uri and identifier", () => {
+        expect(isValidFiltersFormat([absoluteDateFilterWithoutUriAndIdentifier])).toBe(false);
+    });
+
+    it("should return true when date filter is missing uri and identifier and shouldValidateDataSet is false", () => {
+        expect(isValidFiltersFormat([absoluteDateFilterWithoutUriAndIdentifier], false)).toBe(true);
+    });
+
+    it("should check the attribute filter item format", () => {
+        expect(isValidFiltersFormat([negativeAttributeFilter, positiveAttributeFilter])).toBe(true);
+    });
+
+    it("should return false when attribute filter item is missing uri and identifier", () => {
+        expect(isValidFiltersFormat([positiveAttributeFilterWithoutDisplayForm])).toBe(false);
+    });
+
+    it("should return false when positive attribute filter item without filter values", () => {
+        expect(isValidFiltersFormat([positiveAttributeFilterWithoutValue])).toBe(false);
+    });
+
+    it("should transform filter context", () => {
+        const filters: EmbeddedGdc.FilterItem[] = [
+            absoluteDateFilter,
+            relativeDateFilter,
+            negativeAttributeFilter,
+            positiveAttributeFilter,
+        ];
+        expect(transformFilterContext(filters)).toEqual({
+            attributeFilters: [
+                {
+                    attributeElements: ["uri1"],
+                    dfIdentifier: undefined,
+                    dfUri: "dfuri",
+                    negativeSelection: true,
+                },
+                {
+                    attributeElements: ["uri1"],
+                    dfIdentifier: undefined,
+                    dfUri: "dfuri",
+                    negativeSelection: false,
+                },
+            ],
+            dateFilters: [
+                {
+                    datasetIdentifier: undefined,
+                    datasetUri: "uri",
+                    from: "2020-01-01",
+                    to: "2020-02-01",
+                },
+                {
+                    datasetIdentifier: undefined,
+                    datasetUri: "uri",
+                    from: -1,
+                    granularity: "gdc.time.month",
+                    to: 1,
+                },
+            ],
+        });
+    });
+
+    it("should check all time date filter item", () => {
+        expect(isAllTimeDateFilterItem({ from: 0, to: 0, granularity: ALL_TIME_GRANULARITY })).toBe(true);
+        expect(isAllTimeDateFilterItem({ from: 0, to: 0, granularity: "gdc.time.month" })).toBe(false);
+        expect(isAllTimeDateFilterItem({ from: "2020-01-01", to: "2020-01-01" })).toBe(false);
+    });
+
+    it("should check all value attribute filter item", () => {
+        expect(isAllValueAttributeFilterItem({ negativeSelection: true, attributeElements: [] })).toBe(true);
+        expect(isAllValueAttributeFilterItem({ negativeSelection: true, attributeElements: ["uri1"] })).toBe(
+            false,
+        );
+    });
+});

--- a/libs/sdk-embedding/src/internal/tests/messagingUtils.test.ts
+++ b/libs/sdk-embedding/src/internal/tests/messagingUtils.test.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2020 GoodData Corporation
 import { setHost, postEvent, setConfig, addListener, removeListener } from "../messagingUtils";
-import { IGdcMessageEvent } from "../common";
+import { IGdcMessageEvent } from "../../iframe/common";
 
 describe("Post events", () => {
     const event = {

--- a/libs/sdk-embedding/tsconfig.build.json
+++ b/libs/sdk-embedding/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/internal.ts"],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null

--- a/libs/sdk-embedding/tsconfig.dev.json
+++ b/libs/sdk-embedding/tsconfig.dev.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/internal.ts"],
     "compilerOptions": {
         "noUnusedLocals": false,
         "noUnusedParameters": false,


### PR DESCRIPTION
Filter definitions were wrong
Also need to move filter conversion logic from js-utils to here

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
