### PR TITLE
RELATED: RAIL-2569 add support indicating functions to IVisualizationCatalog

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/tests/VisualizationCatalog.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/tests/VisualizationCatalog.test.ts
@@ -12,10 +12,34 @@ describe("CatalogViaTypeToClassMap", () => {
         expect(factory).toBeDefined();
     });
 
+    it("indicates support for URI", () => {
+        const result = TestCatalog.hasFactoryForUri("local:someType");
+
+        expect(result).toBeTruthy();
+    });
+
+    it("indicates no support for unknown URI", () => {
+        const result = TestCatalog.hasFactoryForUri("local:unknownType");
+
+        expect(result).toBeFalsy();
+    });
+
     it("resolves insight", () => {
         const factory = TestCatalog.forInsight(newInsightDefinition("local:someType"));
 
         expect(factory).toBeDefined();
+    });
+
+    it("indicates support for insight", () => {
+        const result = TestCatalog.hasFactoryForInsight(newInsightDefinition("local:someType"));
+
+        expect(result).toBeTruthy();
+    });
+
+    it("indicates no support for insight with unknown visualization class", () => {
+        const result = TestCatalog.hasFactoryForInsight(newInsightDefinition("local:unknownType"));
+
+        expect(result).toBeFalsy();
     });
 
     it("throws when URI cannot be resolved", () => {


### PR DESCRIPTION
These functions return a boolean flag indicating
that a given visualiuzation class is supported.

JIRA: RAIL-2569

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
