### PR TITLE
RELATED: RAIL-2107,RAIL-2577 include refs in IObjectExpressionToken, fix bear tokenizer

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/metadata/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/metadata/index.ts
@@ -176,6 +176,7 @@ export class BearWorkspaceMetadata implements IWorkspaceMetadata {
                     return {
                         type: meta.type,
                         value: meta.title,
+                        ref: meta.ref,
                     };
                 }
 

--- a/libs/sdk-backend-bear/src/backend/workspace/metadata/measureExpressionTokens.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/metadata/measureExpressionTokens.ts
@@ -15,7 +15,7 @@ const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
     ["text", /^[^{}[\]]+/],
     ["quoted_text", /^"(?:[^"\\]|\\\\.)*"/],
-    ["identifier", /^\{.*\}/],
+    ["identifier", /^\{[^}]+\}/],
     ["element_uri", /^\[[a-zA-Z0-9\\/]+elements\?id=\d+]/],
     ["uri", /^\[[a-zA-Z0-9\\/]+]/],
 ];

--- a/libs/sdk-backend-bear/src/backend/workspace/metadata/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/metadata/test/measureExpressionTokens.test.ts
@@ -1,0 +1,26 @@
+// (C) 2020 GoodData Corporation
+import { tokenizeExpression } from "../measureExpressionTokens";
+
+describe("tokenizeExpression", () => {
+    it("splits MAQL with more than one identifier to tokens (RAIL-2577)", () => {
+        const expression =
+            "select avg({fact.opportunitysnapshot.amount}) where {attr.account.id} in ([/gdc/md/projectId/obj/969/elements?id=123]) and {snapshot.year} > 2011";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "select avg(" },
+            { type: "identifier", value: "fact.opportunitysnapshot.amount" },
+            { type: "text", value: ") where " },
+            { type: "identifier", value: "attr.account.id" },
+            { type: "text", value: " in (" },
+            {
+                type: "element_uri",
+                value: "/gdc/md/projectId/obj/969/elements?id=123",
+            },
+            { type: "text", value: ") and " },
+            { type: "identifier", value: "snapshot.year" },
+            { type: "text", value: " > 2011" },
+        ]);
+    });
+});

--- a/libs/sdk-backend-tiger/src/backend/workspace/metadata/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/metadata/index.ts
@@ -72,7 +72,12 @@ export class TigerWorkspaceMetadata implements IWorkspaceMetadata {
         }
         const [type, id] = regexToken.value.split("/");
         if (type === "metric" || type === "fact" || type === "attribute" || type === "label") {
-            return this.resolveObjectToken(id, type, metricMetadata.data.included || []);
+            return this.resolveObjectToken(
+                id,
+                type,
+                metricMetadata.data.included || [],
+                metricMetadata.data.data.id,
+            );
         }
         throw new Error(`Cannot resolve title of object type ${type}`);
     }
@@ -81,6 +86,7 @@ export class TigerWorkspaceMetadata implements IWorkspaceMetadata {
         objectId: string,
         objectType: "metric" | "fact" | "attribute" | "label",
         includedObjects: ReadonlyArray<SuccessIncluded>,
+        identifier: string,
     ): IMeasureExpressionToken {
         const includedObject = includedObjects.find((includedObject) => {
             return includedObject.id === objectId && includedObject.type === objectType;
@@ -100,6 +106,7 @@ export class TigerWorkspaceMetadata implements IWorkspaceMetadata {
         return {
             type: typeMapping[objectType],
             value,
+            ref: idRef(identifier),
         };
     }
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -935,6 +935,7 @@ export function insightVisualizationUrl(insight: IInsightDefinition): string;
 
 // @public
 export interface IObjectExpressionToken {
+    ref: ObjRef;
     type: ObjectType;
     value: string;
 }

--- a/libs/sdk-model/src/ldm/measure.ts
+++ b/libs/sdk-model/src/ldm/measure.ts
@@ -1,5 +1,5 @@
 // (C) 2019-2020 GoodData Corporation
-import { ObjectType } from "../objRef";
+import { ObjectType, ObjRef } from "../objRef";
 
 /**
  * Token representing part of parsed MAQL measure expression
@@ -54,6 +54,11 @@ export interface IObjectExpressionToken {
      * Title of the object
      */
     value: string;
+
+    /**
+     * Ref of the object
+     */
+    ref: ObjRef;
 }
 
 /**


### PR DESCRIPTION
* RAIL-2107: Include refs in IObjectExpressionToken This allows the users to refer to the token objects from their apps.
* RAIL-2577: Fix too greedy identifier RegExp in bear MAQL tokenizer

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
