### PR TITLE
RELATED: BB-2304 upgrade GoodStrap, style fixes

### DIFF
--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
@@ -61,6 +61,8 @@ export class CustomFormatDialog extends React.PureComponent<
         return (
             <Overlay
                 closeOnParentScroll={true}
+                closeOnMouseDrag={true}
+                closeOnOutsideClick={true}
                 alignTo={anchorEl}
                 alignPoints={positioningToAlignPoints(positioning!)} // positioning is declared in defaultProps so it is always defined
                 onClose={onCancel}
@@ -69,13 +71,6 @@ export class CustomFormatDialog extends React.PureComponent<
                     <div className="gd-measure-custom-format-dialog-body s-custom-format-dialog-body">
                         <div className="gd-measure-custom-format-dialog-header">
                             <span>{intl.formatMessage({ id: "measureNumberCustomFormatDialog.title" })}</span>
-                            <div className="gd-dialog-close">
-                                <Button
-                                    className="gd-button-link gd-button-icon-only icon-cross s-dialog-close-button"
-                                    value=""
-                                    onClick={onCancel}
-                                />
-                            </div>
                         </div>
                         <div className="gd-measure-custom-format-dialog-content">
                             <FormatInput

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/DropdownItem.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/DropdownItem.tsx
@@ -57,7 +57,7 @@ export default class DropdownItem extends React.Component<
                         className={`gd-measure-format-template-preview-bubble bubble-light s-measure-format-template-help-bubble-${stringUtils.simplifyText(
                             template.name,
                         )}`}
-                        alignPoints={[{ align: "cr cl" }]}
+                        alignPoints={[{ align: "cr cl" }, { align: "cr bl" }, { align: "cr tl" }]}
                     >
                         <h3 className={"gd-measure-format-template-preview-bubble-title"}>{template.name}</h3>
                         <div

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
@@ -37,7 +37,7 @@ export class FormatTemplatesDropdown extends React.Component<
                         closeOnOutsideClick={true}
                         closeOnParentScroll={true}
                         alignTo=".gd-measure-custom-format-dialog-section-title"
-                        alignPoints={[{ align: "br tr" }]}
+                        alignPoints={[{ align: "br tr" }, { align: "cr cl", offset: { x: 10 } }]}
                         onClose={this.closeDropdown}
                     >
                         <div className="gd-dropdown overlay">

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/Preview.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/Preview.tsx
@@ -46,17 +46,12 @@ export class Preview extends React.PureComponent<ICustomFormatPreviewProps, ICus
                         onChange={this.onPreviewChange}
                         separators={separators}
                     />
-                    <div
-                        className={
-                            "s-custom-format-dialog-preview-formatted gd-measure-custom-format-dialog-preview-string"
-                        }
-                    >
-                        <FormattedPreview
-                            previewNumber={this.state.preview}
-                            format={format}
-                            separators={separators}
-                        />
-                    </div>
+                    <FormattedPreview
+                        previewNumber={this.state.preview}
+                        format={format}
+                        separators={separators}
+                        className="s-custom-format-dialog-preview-formatted gd-measure-custom-format-dialog-preview-string"
+                    />
                 </div>
                 <ExtendedPreview format={format} separators={separators} />
             </div>

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/FormattedPreview.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/FormattedPreview.tsx
@@ -6,6 +6,16 @@ import { ISeparators } from "@gooddata/sdk-ui";
 
 const { stripColors, numberFormat, colors2Object }: any = numberJS;
 
+export const Label: React.FC<{ value?: string; style?: React.CSSProperties; className?: string }> = ({
+    value,
+    style,
+    className,
+}) => (
+    <div className={cx("gd-measure-format-preview-formatted", className)}>
+        <span style={style}>{value}</span>
+    </div>
+);
+
 export interface IFormattedPreviewProps {
     previewNumber: number | null;
     format: string;
@@ -21,17 +31,15 @@ export const FormattedPreview: React.FC<IFormattedPreviewProps> = ({
     separators,
     className: customClassName,
 }) => {
-    const className = cx("gd-measure-format-preview-formatted", customClassName);
-
     if (format === "") {
-        return <span className={className} />;
+        return <Label />;
     }
 
     const preview = previewNumber !== null ? previewNumber : "";
 
     if (!colors) {
         const label = numberFormat(preview, stripColors(format), undefined, separators);
-        return <span className={className}>{label}</span>;
+        return <Label value={label} className={customClassName} />;
     }
 
     const { label, color = "", backgroundColor = "" } = colors2Object(
@@ -40,9 +48,5 @@ export const FormattedPreview: React.FC<IFormattedPreviewProps> = ({
 
     const style = { color, backgroundColor };
 
-    return (
-        <span className={className} style={style}>
-            {label}
-        </span>
-    );
+    return <Label value={label} className={customClassName} style={style} />;
 };

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/PreviewRows.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/PreviewRows.tsx
@@ -15,9 +15,12 @@ const PreviewNumberRow: React.FC<IPreviewNumberRowProps> = ({ previewNumber, for
         <div className="gd-measure-format-extended-preview-number">
             <span>{previewNumber}</span>
         </div>
-        <div className="s-number-format-preview-formatted gd-measure-format-extended-preview-formatted">
-            <FormattedPreview previewNumber={previewNumber} format={format} separators={separators} />
-        </div>
+        <FormattedPreview
+            previewNumber={previewNumber}
+            format={format}
+            separators={separators}
+            className="s-number-format-preview-formatted gd-measure-format-extended-preview-formatted"
+        />
     </div>
 );
 

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/tests/FormattedPreview.test.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/shared/tests/FormattedPreview.test.tsx
@@ -1,7 +1,7 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import { shallow } from "enzyme";
-import { FormattedPreview, IFormattedPreviewProps } from "../FormattedPreview";
+import { FormattedPreview, IFormattedPreviewProps, Label } from "../FormattedPreview";
 
 describe("FormattedPreview", () => {
     function renderComponent(props: Partial<IFormattedPreviewProps> = {}) {
@@ -24,17 +24,17 @@ describe("FormattedPreview", () => {
 
     it("should render empty span when no format is provided", () => {
         const wrapper = renderComponent({ format: "" });
-        expect(wrapper.text()).toEqual("");
+        expect(wrapper.find(Label).render().text()).toEqual("");
     });
 
     it("should render formatted number with colors when coloring is enabled", () => {
         const wrapper = renderComponent({ format: "[>1][green]#,##" });
-        expect(wrapper.props().style).toMatchObject({ color: "#00AA00" });
+        expect(wrapper.find(Label).props().style).toMatchObject({ color: "#00AA00" });
     });
 
     it("should render formatted number without colors when coloring is disabled", () => {
         const wrapper = renderComponent({ format: "[>1][GREEN]#,##", colors: false });
-        expect(wrapper.props().style).toEqual(undefined);
+        expect(wrapper.find(Label).props().style).toEqual(undefined);
     });
 
     it("should format null value properly if no value is provided", () => {
@@ -43,6 +43,6 @@ describe("FormattedPreview", () => {
             format: "[=NULL]value is null",
             colors: false,
         });
-        expect(wrapper.text()).toEqual("value is null");
+        expect(wrapper.find(Label).render().text()).toEqual("value is null");
     });
 });

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
@@ -37,6 +37,7 @@ export class PresetsDropdown extends React.PureComponent<IMeasureNumberFormatDro
             <Overlay
                 closeOnOutsideClick={true}
                 closeOnParentScroll={true}
+                closeOnMouseDrag={true}
                 alignTo={anchorEl}
                 alignPoints={positioningToAlignPoints(positioning!)} // positioning is declared in defaultProps so it is always defined
                 onClose={onClose}

--- a/libs/sdk-ui-kit/styles/scss/measureNumberFormat.scss
+++ b/libs/sdk-ui-kit/styles/scss/measureNumberFormat.scss
@@ -38,21 +38,10 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
         border-bottom: 1px solid $border-color;
 
         & > span {
-            flex: 1 0 auto;
-            line-height: 23px;
             color: $gd-color-state-blank;
             text-transform: uppercase;
             font-size: 11px;
             font-weight: bold;
-        }
-
-        .gd-dialog-close {
-            flex: 0 0 auto;
-
-            > button {
-                width: 21px;
-                height: 21px;
-            }
         }
     }
 
@@ -93,8 +82,6 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
                 flex: 0 0 58%;
                 padding-left: 8px;
                 font-weight: bold;
-                overflow: hidden;
-                text-overflow: ellipsis;
             }
         }
 
@@ -162,16 +149,6 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
 .gd-measure-format-extended-preview-row {
     display: flex;
     line-height: 20px;
-
-    span {
-        white-space: nowrap;
-    }
-}
-
-.gd-measure-format-extended-preview-number,
-.gd-measure-format-extended-preview-formatted {
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .gd-measure-format-extended-preview-number {
@@ -182,9 +159,7 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
     box-sizing: border-box;
     flex: 0 0 58%;
     padding-left: 8px;
-    overflow: hidden;
     font-weight: bold;
-    text-overflow: ellipsis;
 }
 
 .gd-measure-format-template-preview-bubble {
@@ -221,5 +196,14 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
         .gd-format-template-help {
             display: block;
         }
+    }
+}
+
+.gd-measure-format-preview-formatted {
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    > span {
+        white-space: nowrap;
     }
 }


### PR DESCRIPTION
- no cross icon for closing the dialog - it is closed on outside click
- fixed alignment of templates dropdown and information bubbles

Co-authored-by: Jan Strouhal <strouhaljan@users.noreply.github.com>

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
