### PR TITLE
RELATED: RAIL-2579 - Fix PluggablePivotTable so that it filters out invalid sorts from ins…

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/sortItemsHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/sortItemsHelpers.ts
@@ -22,7 +22,7 @@ import { IAttributeFilter, IBucketFilter, IBucketItem } from "../../../interface
 import { BucketNames } from "@gooddata/sdk-ui";
 import { isAttributeFilter } from "../../../utils/bucketHelper";
 
-function adaptSortItemsToPivotTable(
+function filterInvalidSortItems(
     originalSortItems: ISortItem[],
     measureLocalIdentifiers: string[],
     rowAttributeLocalIdentifiers: string[],
@@ -97,7 +97,7 @@ export function adaptReferencePointSortItemsToPivotTable(
         (columnAttribute) => columnAttribute.localIdentifier,
     );
 
-    return adaptSortItemsToPivotTable(
+    return filterInvalidSortItems(
         originalSortItems,
         measureLocalIdentifiers,
         rowAttributeLocalIdentifiers,
@@ -105,10 +105,7 @@ export function adaptReferencePointSortItemsToPivotTable(
     );
 }
 
-export function adaptMdObjectSortItemsToPivotTable(
-    originalSortItems: ISortItem[],
-    buckets: IBucket[],
-): ISortItem[] {
+export function sanitizePivotTableSorts(originalSortItems: ISortItem[], buckets: IBucket[]): ISortItem[] {
     const measureLocalIdentifiers = bucketsMeasures(buckets).map(measureLocalId);
 
     const rowBucket = bucketsFind(buckets, BucketNames.ATTRIBUTE);
@@ -119,7 +116,7 @@ export function adaptMdObjectSortItemsToPivotTable(
         ? bucketAttributes(columnBucket).map(attributeLocalId)
         : [];
 
-    return adaptSortItemsToPivotTable(
+    return filterInvalidSortItems(
         originalSortItems,
         measureLocalIdentifiers,
         rowAttributeLocalIdentifiers,


### PR DESCRIPTION
Fix in this PR ensures that invalid sort items that MAY be saved in the insight are correctly removed before rendering the CorePivotTable (otherwise these invalid sorts & combination of resizing impl and timeouts and all lead to pivot table to not show up in the UI).

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
