### PR TITLE
BUGFIX: RAIL-2605 - Fix column width sanitization

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -379,7 +379,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         const adaptedColumnWidths = adaptMdObjectWidthItemsToPivotTable(columnWidths, insight);
 
         if (!isEqual(columnWidths, adaptedColumnWidths)) {
-            this.visualizationProperties.properties.controls.columnWidths = adaptedColumnWidths;
+            this.visualizationProperties.controls.columnWidths = adaptedColumnWidths;
             this.pushData({
                 properties: {
                     controls: {


### PR DESCRIPTION
-  Code did not reflect a fix from some time back which removed the double-wrap of properties

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
