### PR TITLE
BUGFIX: SD-582 Child label is disappeared when change rotation Y-axis to 90° on Bar chart

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
@@ -113,8 +113,12 @@ export function formatOverlappingForParentAttribute(category: any): string {
         return formatOverlapping.call(this);
     }
 
-    const chartHeight = get(this, "axis.chart.chartHeight", 1);
     const categoriesCount = get(this, "axis.categoriesTree", []).length;
+    if (categoriesCount === 1) {
+        // Let the width be auto to make sure "this.value" is displayed on screen
+        return `<div style="overflow: hidden; text-overflow: ellipsis">${this.value}</div>`;
+    }
+    const chartHeight = get(this, "axis.chart.chartHeight", 1);
     const width = Math.floor(chartHeight / categoriesCount);
     const pixelOffset = 40; // parent attribute should have more space than its children
 
@@ -124,8 +128,12 @@ export function formatOverlappingForParentAttribute(category: any): string {
 }
 
 export function formatOverlapping(): string {
-    const chartHeight = get(this, "chart.chartHeight", 1);
     const categoriesCount = get(this, "axis.categories", []).length;
+    if (categoriesCount === 1) {
+        // Let the width be auto to make sure "this.value" is displayed on screen
+        return `<div align="center" style="overflow: hidden; text-overflow: ellipsis">${this.value}</div>`;
+    }
+    const chartHeight = get(this, "chart.chartHeight", 1);
     const width = Math.floor(chartHeight / categoriesCount);
     const pixelOffset = 20;
 


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
