### PR TITLE
BUGFIX: SD-1045 Metric name is shown as localIdentifier in KD if insight has local date filter

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -842,7 +842,7 @@ export interface INegativeAttributeFilter {
 }
 
 // @public
-export function insightAttributes(insight: IInsightDefinition): IAttribute[];
+export function insightAttributes(insight: IInsightDefinition, attributePredicate?: AttributePredicate): IAttribute[];
 
 // @public
 export function insightBucket(insight: IInsightDefinition, idOrFun?: string | BucketPredicate): IBucket | undefined;
@@ -892,7 +892,7 @@ export function insightIsLocked(insight: IInsight): boolean;
 export function insightItems(insight: IInsightDefinition): IAttributeOrMeasure[];
 
 // @public
-export function insightMeasures(insight: IInsightDefinition): IMeasure[];
+export function insightMeasures(insight: IInsightDefinition, measurePredicate?: MeasurePredicate): IMeasure[];
 
 // @internal (undocumented)
 export type InsightModifications = (builder: InsightDefinitionBuilder) => InsightDefinitionBuilder;

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -10,8 +10,8 @@ import {
     BucketItemModifications,
 } from "../execution/buckets";
 import { IFilter } from "../execution/filter";
-import { IMeasure, measureLocalId } from "../execution/measure";
-import { attributeLocalId, IAttribute } from "../execution/attribute";
+import { IMeasure, measureLocalId, MeasurePredicate, anyMeasure } from "../execution/measure";
+import { attributeLocalId, IAttribute, AttributePredicate, anyAttribute } from "../execution/attribute";
 import { ITotal } from "../execution/base/totals";
 import {
     bucketsAttributes,
@@ -271,13 +271,17 @@ export function insightItems(insight: IInsightDefinition): IAttributeOrMeasure[]
  * Gets all measures used in the provided insight.
  *
  * @param insight - insight to work with
+ * @param measurePredicate - predicate to select measures satisfying some conditions
  * @returns empty if none
  * @public
  */
-export function insightMeasures(insight: IInsightDefinition): IMeasure[] {
+export function insightMeasures(
+    insight: IInsightDefinition,
+    measurePredicate: MeasurePredicate = anyMeasure,
+): IMeasure[] {
     invariant(insight, "insight must be specified");
 
-    return bucketsMeasures(insight.insight.buckets);
+    return bucketsMeasures(insight.insight.buckets, measurePredicate);
 }
 
 /**
@@ -297,13 +301,17 @@ export function insightHasMeasures(insight: IInsightDefinition): boolean {
  * Gets all attributes used in the provided insight
  *
  * @param insight - insight to work with
+ * @param attributePredicate - predicate to select attributes satisfying some conditions
  * @returns empty if none
  * @public
  */
-export function insightAttributes(insight: IInsightDefinition): IAttribute[] {
+export function insightAttributes(
+    insight: IInsightDefinition,
+    attributePredicate: AttributePredicate = anyAttribute,
+): IAttribute[] {
     invariant(insight, "insight must be specified");
 
-    return bucketsAttributes(insight.insight.buckets);
+    return bucketsAttributes(insight.insight.buckets, attributePredicate);
 }
 
 /**

--- a/libs/sdk-model/src/insight/tests/insight.test.ts
+++ b/libs/sdk-model/src/insight/tests/insight.test.ts
@@ -13,9 +13,9 @@ import {
 } from "../..";
 import { newInsight } from "../../../__mocks__/insights";
 import { Account, Activity, Velocity, Won } from "../../../__mocks__/model";
-import { IAttribute } from "../../execution/attribute";
+import { IAttribute, AttributePredicate } from "../../execution/attribute";
 import { IBucket, newBucket, BucketItemModifications } from "../../execution/buckets";
-import { IMeasure, isMeasure } from "../../execution/measure";
+import { IMeasure, isMeasure, MeasurePredicate } from "../../execution/measure";
 import {
     insightAttributes,
     insightBucket,
@@ -127,6 +127,7 @@ describe("insightMeasures", () => {
             [Velocity.Sum, Velocity.Min, Won],
         ],
     ];
+    const measurePredicate: MeasurePredicate = (measure: IMeasure): boolean => measure === Velocity.Min;
 
     it.each(Scenarios)("should return %s", (_desc, insightArg, expectedResult) => {
         expect(insightMeasures(insightArg)).toEqual(expectedResult);
@@ -134,6 +135,10 @@ describe("insightMeasures", () => {
 
     it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
         expect(() => insightMeasures(input)).toThrow();
+    });
+
+    it("should return an array containing only one measure Velocity.Min", () => {
+        expect(insightMeasures(InsightWithThreeBuckets, measurePredicate)).toEqual([Velocity.Min]);
     });
 });
 
@@ -164,6 +169,8 @@ describe("insightAttributes", () => {
             [Activity.Subject, Account.Name],
         ],
     ];
+    const attributePredicate: AttributePredicate = (attribute: IAttribute): boolean =>
+        attribute === Account.Name;
 
     it.each(Scenarios)("should return %s", (_desc, insightArg, expectedResult) => {
         expect(insightAttributes(insightArg)).toEqual(expectedResult);
@@ -171,6 +178,10 @@ describe("insightAttributes", () => {
 
     it.each(InvalidScenarios)("should throw when %s", (_desc, input) => {
         expect(() => insightAttributes(input)).toThrow();
+    });
+
+    it("should return an array containing only one attribute Account.Name", () => {
+        expect(insightAttributes(InsightWithThreeBuckets, attributePredicate)).toEqual([Account.Name]);
     });
 });
 

--- a/libs/sdk-ui/src/base/measureTitles/ignoreTitlesForSimpleMeasures.ts
+++ b/libs/sdk-ui/src/base/measureTitles/ignoreTitlesForSimpleMeasures.ts
@@ -7,6 +7,9 @@ import {
     isAdhocMeasure,
     modifyMeasure,
     insightModifyItems,
+    isDateFilter,
+    insightMeasures,
+    measureFilters,
 } from "@gooddata/sdk-model";
 
 /**
@@ -22,6 +25,15 @@ import {
  * @internal
  */
 export function ignoreTitlesForSimpleMeasures<T extends IInsightDefinition>(insight: T): T {
+    const measuresWithDateFilter = insightMeasures(
+        insight,
+        (measure: IMeasure): boolean => measureFilters(measure)?.some(isDateFilter) ?? false,
+    );
+    if (measuresWithDateFilter.length > 0) {
+        // If the insight contains a measure with a date filter, all other measures are considered adhoc measures
+        // and their titles should be left intact.
+        return insight;
+    }
     return insightModifyItems(
         insight,
         (bucketItem: IAttributeOrMeasure): IAttributeOrMeasure => {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
