### PR TITLE
RELATED: RAIL-2579 - Fix ag-grid data source to correctly recognize effective sorts

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -86,6 +86,12 @@ export type AttributeInBucket = {
 export function attributeLocalId(attributeOrId: IAttribute | Identifier): string;
 
 // @public
+export function attributeLocatorElement(locator: IAttributeLocatorItem): Identifier;
+
+// @public
+export function attributeLocatorIdentifier(locator: IAttributeLocatorItem): Identifier;
+
+// @public
 export class AttributeMetadataObjectBuilder<T extends IAttributeMetadataObject = IAttributeMetadataObject> extends MetadataObjectBuilder<T> {
     // (undocumented)
     displayForms(displayForms: IAttributeDisplayFormMetadataObject[]): this;
@@ -1326,6 +1332,9 @@ export function measureItem(measure: IMeasure): ObjRef | undefined;
 export function measureLocalId(measureOrLocalId: MeasureOrLocalId): string;
 
 // @public
+export function measureLocatorIdentifier(locator: IMeasureLocatorItem): Identifier;
+
+// @public
 export function measureMasterIdentifier(measure: IMeasure<IPoPMeasureDefinition | IPreviousPeriodMeasureDefinition>): string;
 
 // @public
@@ -1588,6 +1597,9 @@ export type SortEntityIds = {
 
 // @public
 export function sortEntityIds(sort: ISortItem): SortEntityIds;
+
+// @public
+export function sortMeasureLocators(sort: IMeasureSortItem): ILocatorItem[];
 
 // @public
 export function totalIsNative(total: ITotal): boolean;

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -206,6 +206,51 @@ export function sortEntityIds(sort: ISortItem): SortEntityIds {
 }
 
 /**
+ * Given a measure sort item, return the locators which identify the measure (possibly scoped for particular
+ * attribute element).
+ *
+ * @param sort - measure sort items
+ * @returns measure sort locators
+ * @public
+ */
+export function sortMeasureLocators(sort: IMeasureSortItem): ILocatorItem[] {
+    return sort.measureSortItem.locators;
+}
+
+/**
+ * Given attribute locator, return the localId of attribute that it references.
+ *
+ * @param locator - attribute locator
+ * @returns attribute localId
+ * @public
+ */
+export function attributeLocatorIdentifier(locator: IAttributeLocatorItem): Identifier {
+    return locator.attributeLocatorItem.attributeIdentifier;
+}
+
+/**
+ * Given attribute locator, return the element that it references.
+ *
+ * @param locator - attribute locator
+ * @returns attribute element
+ * @public
+ */
+export function attributeLocatorElement(locator: IAttributeLocatorItem): Identifier {
+    return locator.attributeLocatorItem.element;
+}
+
+/**
+ * Given measure locator, return the localId of measure that it references.
+ *
+ * @param locator - measure locator
+ * @returns measure localId
+ * @public
+ */
+export function measureLocatorIdentifier(locator: IMeasureLocatorItem): Identifier {
+    return locator.measureLocatorItem.measureIdentifier;
+}
+
+/**
  * Creates a new attribute sort - sorting the result by values of the provided attribute's elements. The attribute
  * can be either specified by value or by reference using its local identifier.
  *

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -85,6 +85,10 @@ export {
     newAttributeLocator,
     SortEntityIds,
     sortEntityIds,
+    sortMeasureLocators,
+    attributeLocatorElement,
+    attributeLocatorIdentifier,
+    measureLocatorIdentifier,
 } from "./execution/base/sort";
 
 export {

--- a/libs/sdk-ui/src/base/results/internal/test/__snapshots__/resultMetaMethods.test.ts.snap
+++ b/libs/sdk-ui/src/base/results/internal/test/__snapshots__/resultMetaMethods.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`resultMetaMethods effective sort items are empty if there are no sorts 1`] = `Array []`;
+
+exports[`resultMetaMethods effective sort items strips invalid measure sort when attribute element not present 1`] = `Array []`;
+
+exports[`resultMetaMethods effective sort items strips invalid measure sort when attribute not present 1`] = `Array []`;
+
+exports[`resultMetaMethods effective sort items strips invalid measure sort when measure not present 1`] = `Array []`;
+
+exports[`resultMetaMethods effective sort items strips invalid measure sort when no measures in result 1`] = `Array []`;

--- a/libs/sdk-ui/src/base/results/internal/test/resultMetaMethods.test.ts
+++ b/libs/sdk-ui/src/base/results/internal/test/resultMetaMethods.test.ts
@@ -1,0 +1,69 @@
+// (C) 2020 GoodData Corporation
+
+import { ISortItem, newAttributeLocator, newMeasureSort } from "@gooddata/sdk-model";
+import { ReferenceRecordings, ReferenceLdm, ReferenceData } from "@gooddata/reference-workspace";
+import { DataViewFirstPage, recordedDataView, ScenarioRecording } from "@gooddata/sdk-backend-mockingbird";
+import cloneDeep from "lodash/cloneDeep";
+import { DataViewFacade } from "../../facade";
+
+function dataViewWithModifiedSorts(
+    scenario: ScenarioRecording,
+    dataViewId: string,
+    sortItems: ISortItem[],
+): DataViewFacade {
+    const scenarioCopy = cloneDeep(scenario);
+    const dataView = recordedDataView(scenarioCopy, dataViewId);
+
+    (dataView.definition as any).sortBy = sortItems;
+
+    return DataViewFacade.for(dataView);
+}
+
+describe("resultMetaMethods", () => {
+    const Scenarios: Array<[string, ScenarioRecording, string, ISortItem[]]> = [
+        [
+            "are empty if there are no sorts",
+            ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
+            DataViewFirstPage,
+            [],
+        ],
+        [
+            "strips invalid measure sort when no measures in result",
+            ReferenceRecordings.Scenarios.PivotTable.SingleAttribute,
+            DataViewFirstPage,
+            [newMeasureSort(ReferenceLdm.Amount)],
+        ],
+        [
+            "strips invalid measure sort when attribute not present",
+            ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
+            DataViewFirstPage,
+            [
+                newMeasureSort(ReferenceLdm.Amount, "desc", [
+                    newAttributeLocator(ReferenceLdm.Product.Name, ReferenceData.ProductName.CompuSci.uri),
+                ]),
+            ],
+        ],
+        [
+            "strips invalid measure sort when attribute element not present",
+            ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
+            DataViewFirstPage,
+            [
+                newMeasureSort(ReferenceLdm.Amount, "desc", [
+                    newAttributeLocator(ReferenceLdm.Region, "invalid"),
+                ]),
+            ],
+        ],
+        [
+            "strips invalid measure sort when measure not present",
+            ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
+            DataViewFirstPage,
+            [newMeasureSort(ReferenceLdm.Won)],
+        ],
+    ];
+
+    it.each(Scenarios)("effective sort items %s", (_desc, scenario, dataViewId, sortItems) => {
+        const dv = dataViewWithModifiedSorts(scenario, dataViewId, sortItems);
+
+        expect(dv.meta().effectiveSortItems()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
-  Measure sorts with attribute locators may end-up ineffective if
   the table is filtered to not show the attribute element which is
   used in the attribute locator
-  No problem for the backend & the rest of pivot table impl
-  However datasource checks (during reload) whether current sorts match the
   sorts on the backend;
-  This is problematic, because table knows that it is not sorted by the
   missing column, yet the data source looks at the definition sorts that
   contain the sort items - it determines that result transformation and
   redrive of execution is needed.
-  This is both unnecessary & leads to problems with resizing which is
   prone to racy behavior
-  Note: tried quick fix to trigger resizing after onModelUpdated - but this
   does not solve the problem 100%. some tables get good, but others do
   not. a lot of it is timing related it seems; showing up especially in
   dashboards with multiple tables on a dash.

JIRA: RAIL-2579

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
