### PR TITLE
RELATED: RAIL-2610 make applyColumnSizes robust, improve typings

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -181,20 +181,20 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private unmounted: boolean = false;
 
-    private gridApi: GridApi = null;
-    private columnApi: ColumnApi = null;
-    private gridOptions: ICustomGridOptions = null;
-    private tableHeaders: TableHeaders = null;
-    private agGridDataSource: AgGridDatasource = null;
+    private gridApi: GridApi | null = null;
+    private columnApi: ColumnApi | null = null;
+    private gridOptions: ICustomGridOptions | null = null;
+    private tableHeaders: TableHeaders | null = null;
+    private agGridDataSource: AgGridDatasource | null = null;
 
-    private currentResult: IExecutionResult = null;
-    private visibleData: DataViewFacade = null;
-    private currentFingerprint: string = null;
+    private currentResult: IExecutionResult | null = null;
+    private visibleData: DataViewFacade | null = null;
+    private currentFingerprint: string | null = null;
 
     /**
      * Fingerprint of the last execution definition the initialize was called with.
      */
-    private lastInitRequestFingerprint: string = null;
+    private lastInitRequestFingerprint: string | null = null;
 
     private lastScrollPosition: IScrollPosition = {
         top: 0,
@@ -529,7 +529,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     }
 
     private applyColumnSizes(columnWidths: ColumnWidthItem[]) {
-        if (!this.columnApi) {
+        if (!this.columnApi || !this.visibleData) {
             return;
         }
 


### PR DESCRIPTION
Makes sure applyColumnSizes does not crash when called with no visible data.
Also, the typings in CorePivotTable were made more precise
to indicate fields that can be null explicitly.

JIRA: RAIL-2610

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
