### PR TITLE
RELATED: ONE-4598 sdk-ui: charts report drillable attributes

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -48,7 +48,6 @@ import {
     GoodDataSdkError,
     IAvailableDrillTargets,
     IAvailableDrillTargetMeasure,
-    IAvailableDrillTargetAttribute,
     IDrillEvent,
     IDrillEventContextTable,
     IDrillEventIntersectionElement,
@@ -282,21 +281,6 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         );
     };
 
-    private getAttributeItemsForDimension = (
-        dv: DataViewFacade,
-        dimension: number,
-    ): IAvailableDrillTargetAttribute[] => {
-        return dv
-            .meta()
-            .attributeDescriptorsForDim(dimension)
-            .map((attribute: IAttributeDescriptor) => {
-                return {
-                    dimension,
-                    attribute,
-                };
-            });
-    };
-
     private getAvailableDrillTargets = (dv: DataViewFacade): IAvailableDrillTargets => {
         const measureDescriptors = dv
             .meta()
@@ -308,11 +292,16 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                 }),
             );
 
-        const rowAttributeItems = this.getAttributeItemsForDimension(dv, 0);
-        const columnAttributeItems = this.getAttributeItemsForDimension(dv, 1);
+        const rowAttributeItems = dv
+            .meta()
+            .attributeDescriptorsForDim(0)
+            .map((attribute: IAttributeDescriptor) => ({
+                attribute,
+            }));
+
         return {
             measures: measureDescriptors,
-            attributes: [...rowAttributeItems, ...columnAttributeItems],
+            attributes: rowAttributeItems,
         };
     };
 

--- a/libs/sdk-ui-pivot/src/tests/CorePivotTable.test.tsx
+++ b/libs/sdk-ui-pivot/src/tests/CorePivotTable.test.tsx
@@ -319,7 +319,7 @@ describe("CorePivotTable", () => {
     });
 
     describe("getAvailableDrillTargets", () => {
-        it("should return attributes and measures for pivot table", () => {
+        it("should return attributes (row only) and measures for pivot table", () => {
             const table = getTableInstance();
             const fixture = recordedDataFacade(
                 ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithRowAndColumnAttributes,
@@ -327,7 +327,7 @@ describe("CorePivotTable", () => {
             );
             const targets = table.getAvailableDrillTargets(fixture);
             expect(targets.measures.length).toEqual(1);
-            expect(targets.attributes.length).toEqual(2);
+            expect(targets.attributes.length).toEqual(1);
         });
     });
 

--- a/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
+++ b/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
@@ -209,14 +209,20 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
                             attributes,
                         }),
                     ),
+                attributes: dv
+                    .meta()
+                    .attributeDescriptors()
+                    .map((attribute) => ({ attribute })),
             };
         }
 
         private getAvailableDrillTargetsFromExecutionResult(
             executionResult: IExecutionResult,
         ): IAvailableDrillTargets {
+            const getDimensionHeaders = (dimensionDescriptor: IDimensionDescriptor) =>
+                dimensionDescriptor.headers;
             const attributeDescriptors: IAttributeDescriptor[] = flow(
-                flatMap((dimensionDescriptor: IDimensionDescriptor) => dimensionDescriptor.headers),
+                flatMap(getDimensionHeaders),
                 filter(isAttributeDescriptor),
                 uniqBy((attributeDescriptor) => attributeDescriptor.attributeHeader.formOf.identifier),
             )(executionResult.dimensions);
@@ -237,6 +243,7 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
                         attributes: attributeDescriptors,
                     }),
                 ),
+                attributes: attributeDescriptors.map((attribute) => ({ attribute })),
             };
         }
 

--- a/libs/sdk-ui/src/base/vis/Events.ts
+++ b/libs/sdk-ui/src/base/vis/Events.ts
@@ -51,7 +51,6 @@ export interface IAvailableDrillTargetMeasure {
 }
 
 export interface IAvailableDrillTargetAttribute {
-    dimension: number;
     attribute: IAttributeDescriptor;
 }
 


### PR DESCRIPTION
Similarly as with pivot table, charts report attributes in available drill targets.
Dimension is no longer provided with the attribute as it is already filtered on sdk side.

JIRA: ONE-4598

Related: https://github.com/gooddata/gdc-dashboards/pull/3138

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)