### PR TITLE
RELATED: RAIL-2611 enable strict nulls in sdk-ui-pivot and fix errors

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -221,7 +221,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.state = {
             tableReady: false,
             columnTotals: cloneDeep(defTotals(execution.definition, 0)),
-            desiredHeight: config.maxHeight,
+            desiredHeight: config!.maxHeight,
             resized: false,
         };
 
@@ -271,7 +271,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                 tableReady: false,
                 columnTotals: cloneDeep(defTotals(execution.definition, 0)),
                 error: undefined,
-                desiredHeight: this.props.config.maxHeight,
+                desiredHeight: this.props.config!.maxHeight,
                 resized: false,
             },
             () => {
@@ -368,12 +368,12 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.agGridDataSource = createAgGridDatasource(
             {
                 headers: this.tableHeaders,
-                getGroupRows: () => this.props.groupRows,
+                getGroupRows: () => this.props.groupRows!,
                 getColumnTotals: this.getColumnTotals,
                 onPageLoaded: this.onPageLoaded,
             },
             this.visibleData,
-            this.getGridApi,
+            this.getGridApi as () => GridApi,
             this.props.intl,
         );
 
@@ -387,7 +387,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             .execute()
             .then((result) => {
                 result
-                    .readWindow([0, 0], [this.props.pageSize, COLS_PER_PAGE])
+                    .readWindow([0, 0], [this.props.pageSize!, COLS_PER_PAGE])
                     .then((dataView) => {
                         if (this.unmounted) {
                             /*
@@ -413,13 +413,13 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                         this.initializeNonReactState(result, dataView);
 
                         this.onLoadingChanged({ isLoading: false });
-                        this.props.onExportReady(
-                            createExportFunction(this.currentResult, this.props.exportTitle),
+                        this.props.onExportReady!(
+                            createExportFunction(this.currentResult!, this.props.exportTitle),
                         );
                         this.setState({ tableReady: true });
 
-                        const availableDrillTargets = this.getAvailableDrillTargets(this.visibleData);
-                        this.props.pushData({ dataView, availableDrillTargets });
+                        const availableDrillTargets = this.getAvailableDrillTargets(this.visibleData!);
+                        this.props.pushData!({ dataView, availableDrillTargets });
                     })
                     .catch((error) => {
                         if (this.unmounted) {
@@ -436,7 +436,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                                 result,
                             );
 
-                            this.props.pushData({ availableDrillTargets });
+                            this.props.pushData!({ availableDrillTargets });
                         }
 
                         /*
@@ -448,7 +448,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                                 DataViewFacade.for(error.dataView),
                             );
 
-                            this.props.pushData({ availableDrillTargets });
+                            this.props.pushData!({ availableDrillTargets });
                             this.onLoadingChanged({ isLoading: false });
                         }
 
@@ -501,11 +501,11 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
              */
 
             if (this.isAgGridRerenderNeeded(this.props, prevProps)) {
-                this.gridApi.refreshHeader();
+                this.gridApi?.refreshHeader();
             }
 
             if (this.isGrowToFitEnabled() && !this.isGrowToFitEnabled(prevProps)) {
-                this.growToFit(this.columnApi);
+                this.growToFit(this.columnApi!);
             }
 
             const prevColumnWidths = this.getColumnWidths(prevProps);
@@ -517,7 +517,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         }
     }
 
-    private applyColumnSizes(columnWidths: ColumnWidthItem[]) {
+    private applyColumnSizes(columnWidths: ColumnWidthItem[] | undefined) {
         if (!this.columnApi || !this.visibleData) {
             return;
         }
@@ -642,9 +642,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         if (this.props.execution.fingerprint() === execution.fingerprint()) {
             this.setState({ error: error.getMessage() });
 
-            if (onExportReady) {
-                onExportReady(createExportErrorFunction(error));
-            }
+            onExportReady!(createExportErrorFunction(error));
 
             this.props.onError?.(error);
         }
@@ -710,7 +708,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     };
 
     private getColumnWidths = (props: ICorePivotTableProps): ColumnWidthItem[] | undefined => {
-        return props.config?.columnSizing?.columnWidths;
+        return props.config!.columnSizing?.columnWidths;
     };
 
     private hasColumnWidths = () => {
@@ -800,7 +798,9 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private isPivotTableReady = (api: GridApi) => {
         const noRowHeadersOrRows = () => {
-            return this.visibleData.rawData().isEmpty() && this.visibleData.meta().hasNoHeadersInDim(0);
+            return Boolean(
+                this.visibleData?.rawData().isEmpty() && this.visibleData.meta().hasNoHeadersInDim(0),
+            );
         };
         const dataRendered = () => {
             return noRowHeadersOrRows() || api.getRenderedNodes().length > 0;
@@ -833,8 +833,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             if (this.isGrowToFitEnabled()) {
                 this.growToFit(event.columnApi);
             } else if (this.shouldPerformAutoresize() && this.isColumnAutoresizeEnabled()) {
-                const columns = this.columnApi.getAllColumns();
-                this.resetColumnsWidthToDefault(this.columnApi, columns);
+                const columns = this.columnApi!.getAllColumns();
+                this.resetColumnsWidthToDefault(this.columnApi!, columns);
             }
             this.resizing = false;
             this.setState({
@@ -889,7 +889,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         if (sumOfWidths < clientWidth) {
             const columnIds = this.getColumnIds(columns);
             setColumnMaxWidth(columnApi, columnIds, undefined);
-            this.gridApi.sizeColumnsToFit();
+            this.gridApi?.sizeColumnsToFit();
             setColumnMaxWidthIf(
                 columnApi,
                 columnIds,
@@ -929,8 +929,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private onPageLoaded = (dv: DataViewFacade): void => {
         const currentResult = dv.result();
-        if (!this.currentResult.equals(currentResult)) {
-            this.props.onExportReady(currentResult.export.bind(currentResult));
+        if (!this.currentResult?.equals(currentResult)) {
+            this.props.onExportReady!(currentResult.export.bind(currentResult));
         }
         this.currentResult = currentResult;
         this.visibleData = dv;
@@ -942,7 +942,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private onMenuAggregationClick = (menuAggregationClickConfig: IMenuAggregationClickConfig) => {
         const newColumnTotals = getUpdatedColumnTotals(this.getColumnTotals(), menuAggregationClickConfig);
 
-        this.props.pushData({
+        this.props.pushData!({
             properties: {
                 totals: newColumnTotals,
             },
@@ -951,7 +951,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.setState({ columnTotals: newColumnTotals }, () => {
             // make ag-grid refresh data
             // see: https://www.ag-grid.com/javascript-grid-infinite-scrolling/#changing-the-datasource
-            this.setGridDataSource(this.agGridDataSource);
+            this.setGridDataSource(this.agGridDataSource!);
         });
     };
 
@@ -959,17 +959,19 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         const missingContainerRef = !this.containerRef; // table having no data will be unmounted, it causes ref null
         const isTableRendered = this.shouldAutoResizeColumns()
             ? this.state.resized
-            : this.isPivotTableReady(this.gridApi);
+            : this.isPivotTableReady(this.gridApi!);
         if (missingContainerRef || isTableRendered) {
             this.stopWatchingTableRendered();
         }
     };
 
     private stopWatchingTableRendered = () => {
-        clearInterval(this.watchingIntervalId);
-        this.watchingIntervalId = null;
+        if (this.watchingIntervalId) {
+            clearInterval(this.watchingIntervalId);
+            this.watchingIntervalId = null;
+        }
 
-        this.props.afterRender();
+        this.props.afterRender!();
     };
 
     //
@@ -979,7 +981,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private onGridReady = (event: GridReadyEvent) => {
         this.gridApi = event.api;
         this.columnApi = event.columnApi;
-        this.setGridDataSource(this.agGridDataSource);
+        this.setGridDataSource(this.agGridDataSource!);
         this.updateDesiredHeight(this.visibleData);
 
         if (this.props.groupRows) {
@@ -1039,17 +1041,15 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.updateStickyRow();
     };
 
-    private getAttributeHeader(colId: string, columnDefs: IGridHeader[]): IAttributeDescriptor {
-        const matchingColDef: IGridHeader = columnDefs.find(
-            (columnDef: IGridHeader) => columnDef.field === colId,
-        );
+    private getAttributeHeader(colId: string, columnDefs: IGridHeader[]): IAttributeDescriptor | undefined {
+        const matchingColDef = columnDefs.find((columnDef: IGridHeader) => columnDef.field === colId);
         if (matchingColDef && matchingColDef.drillItems.length === 1) {
             const drillItemHeader = matchingColDef.drillItems[0];
             if (isAttributeDescriptor(drillItemHeader)) {
                 return drillItemHeader;
             }
         }
-        return null;
+        return undefined;
     }
 
     private getItemAndAttributeHeaders = (
@@ -1093,7 +1093,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     };
 
     private getRowDrillItem = (cellEvent: IGridCellEvent) =>
-        get(cellEvent, ["data", "headerItemMap", cellEvent.colDef.field]);
+        get(cellEvent, ["data", "headerItemMap", cellEvent.colDef.field!]);
 
     private getDrillItems = (cellEvent: IGridCellEvent): IMappingHeader[] => {
         const { colDef } = cellEvent;
@@ -1115,8 +1115,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private cellClicked = (cellEvent: IGridCellEvent) => {
         const { onDrill } = this.props;
-        const tableHeaders = this.tableHeaders;
-        const dv = this.visibleData;
+        const tableHeaders = this.tableHeaders!;
+        const dv = this.visibleData!;
         const drillablePredicates = this.getDrillablePredicates();
         const { colDef, rowIndex } = cellEvent;
         const rowType = get(cellEvent, ["data", "type"], "");
@@ -1151,14 +1151,14 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             drillContext,
         };
 
-        if (onDrill(drillEvent)) {
+        if (onDrill!(drillEvent)) {
             // This is needed for /analyze/embedded/ drilling with post message
             // More info: https://github.com/gooddata/gdc-analytical-designer/blob/develop/test/drillEventing/drillEventing_page.html
             const event = new CustomEvent("drill", {
                 detail: drillEvent,
                 bubbles: true,
             });
-            cellEvent.event.target.dispatchEvent(event);
+            cellEvent.event?.target?.dispatchEvent(event);
             return true;
         }
 
@@ -1183,12 +1183,12 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         column.getColDef().suppressSizeToFit = false;
 
         if (this.isColumnAutoResized(id)) {
-            this.columnApi.setColumnWidth(column, this.autoResizedColumns[id].width);
+            this.columnApi?.setColumnWidth(column, this.autoResizedColumns[id].width);
             return;
         }
 
-        this.autoresizeColumnsByColumnId(this.columnApi, this.getColumnIds([column]));
-        if (isColumnDisplayed(this.columnApi.getAllDisplayedVirtualColumns(), column)) {
+        this.autoresizeColumnsByColumnId(this.columnApi!, this.getColumnIds([column]));
+        if (isColumnDisplayed(this.columnApi!.getAllDisplayedVirtualColumns(), column)) {
             // skip columns out of viewport because these can not be autoresized
             this.resizedColumnsStore.addToManuallyResizedColumn(column, true);
         }
@@ -1207,16 +1207,16 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
             if (this.numberOfColumnResizedCalls === UIClick.DOUBLE_CLICK) {
                 this.numberOfColumnResizedCalls = 0;
-                await this.onColumnsManualReset(columnEvent.columns);
+                await this.onColumnsManualReset(columnEvent.columns!);
             } else if (this.numberOfColumnResizedCalls === UIClick.CLICK) {
                 this.numberOfColumnResizedCalls = 0;
-                this.onColumnsManualResized(columnEvent.columns);
+                this.onColumnsManualResized(columnEvent.columns!);
             }
         }
     };
 
     private getAllMeasureColumns() {
-        return this.columnApi.getAllColumns().filter((col) => isMeasureColumn(col));
+        return this.columnApi!.getAllColumns().filter((col) => isMeasureColumn(col));
     }
 
     private onColumnsManualReset = async (columns: Column[]) => {
@@ -1252,9 +1252,9 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
     private onColumnsManualResized = (columns: Column[]) => {
         if (this.isAllMeasureResizeOperation(columns)) {
-            resizeAllMeasuresColumns(this.columnApi, this.resizedColumnsStore, columns[0]);
+            resizeAllMeasuresColumns(this.columnApi!, this.resizedColumnsStore, columns[0]);
         } else if (this.isWeakMeasureResizeOperation(columns)) {
-            resizeWeakMeasureColumns(this.columnApi, this.resizedColumnsStore, columns[0]);
+            resizeWeakMeasureColumns(this.columnApi!, this.resizedColumnsStore, columns[0]);
         } else {
             columns.forEach((column) => {
                 this.resizedColumnsStore.addToManuallyResizedColumn(column);
@@ -1265,9 +1265,9 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     };
 
     private afterOnResizeColumns() {
-        this.growToFit(this.columnApi);
-        const columnWidths = this.resizedColumnsStore.getColumnWidthsFromMap(this.visibleData);
-        this.props.onColumnResized(columnWidths);
+        this.growToFit(this.columnApi!);
+        const columnWidths = this.resizedColumnsStore.getColumnWidthsFromMap(this.visibleData!);
+        this.props.onColumnResized!(columnWidths);
     }
 
     private sortChanged = (event: SortChangedEvent): void => {
@@ -1281,13 +1281,13 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             .getAllColumns()
             .filter((col) => col.getSort() !== undefined && col.getSort() !== null)
             .map((col) => ({
-                colId: col.getColDef().field,
+                colId: col.getColDef().field!,
                 sort: col.getSort() as SortDirection,
             }));
 
         const sortItems = getSortsFromModel(sortModel, this.currentResult);
 
-        this.props.pushData({
+        this.props.pushData!({
             properties: {
                 sortItems,
             },
@@ -1317,7 +1317,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private createGridOptions = (): ICustomGridOptions => {
         const tableHeaders = this.tableHeaders;
         const { pageSize } = this.props;
-        const totalRowCount = this.visibleData.rawData().firstDimSize();
+        const totalRowCount = this.visibleData!.rawData().firstDimSize();
         const separators = get(this.props, ["config", "separators"], undefined);
 
         /*
@@ -1334,7 +1334,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
          * and shrinking, it will not be so big.
          */
         const extraTotalsBuffer = this.props.config && this.props.config.menu ? 10 : 0;
-        const effectivePageSize = Math.min(pageSize, totalRowCount + extraTotalsBuffer);
+        const effectivePageSize = Math.min(pageSize!, totalRowCount + extraTotalsBuffer);
 
         const commonHeaderComponentParams = {
             onMenuAggregationClick: this.onMenuAggregationClick,
@@ -1346,10 +1346,10 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
         return {
             // Initial data
-            columnDefs: tableHeaders.allHeaders,
+            columnDefs: tableHeaders!.allHeaders,
             rowData: [],
             defaultColDef: {
-                cellClass: this.getCellClass(null),
+                cellClass: this.getCellClass(),
                 headerComponentFramework: ColumnHeader as any,
                 headerComponentParams: {
                     menu: this.getMenuConfig,
@@ -1361,7 +1361,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                 resizable: true,
             },
             defaultColGroupDef: {
-                headerClass: this.getHeaderClass(null),
+                headerClass: this.getHeaderClass(),
                 children: [],
                 headerGroupComponentFramework: ColumnGroupHeader as any,
                 headerGroupComponentParams: {
@@ -1431,16 +1431,16 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                     ),
                     // wrong params type from ag-grid, we need any
                     valueFormatter: (params: any) => {
-                        return params.value !== undefined
+                        return params.value !== undefined && this.currentResult
                             ? getMeasureCellFormattedValue(
                                   params.value,
                                   getMeasureFormat(params.colDef, this.currentResult),
                                   separators,
                               )
-                            : null;
+                            : (null as any);
                     },
                     cellStyle: (params) => {
-                        return params.value !== undefined
+                        return params.value !== undefined && this.currentResult
                             ? getMeasureCellStyle(
                                   params.value,
                                   getMeasureFormat(params.colDef, this.currentResult),
@@ -1469,9 +1469,9 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     /**
      * getCellClass returns class for drillable cells. (maybe format in the future as well)
      */
-    private getCellClass = (classList: string) => (cellClassParams: CellClassParams): string => {
+    private getCellClass = (classList?: string) => (cellClassParams: CellClassParams): string => {
         const { rowIndex } = cellClassParams;
-        const dv = this.visibleData;
+        const dv = this.visibleData!;
         const colDef = cellClassParams.colDef as IGridHeader;
         const drillablePredicates = this.getDrillablePredicates();
         // return none if no drillableItems are specified
@@ -1483,7 +1483,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         const isRowSubtotal = rowType === ROW_SUBTOTAL;
 
         if (drillablePredicates.length !== 0 && !isRowTotal && !isRowSubtotal) {
-            const rowDrillItem = get(cellClassParams, ["data", "headerItemMap", colDef.field]);
+            const rowDrillItem = get(cellClassParams, ["data", "headerItemMap", colDef.field!]);
             const headers: IMappingHeader[] = rowDrillItem
                 ? [...colDef.drillItems, rowDrillItem]
                 : colDef.drillItems;
@@ -1493,7 +1493,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             );
         }
 
-        const attributeId = colDef.field;
+        const attributeId = colDef.field!;
         const isPinnedRow = cellClassParams.node.isRowPinned();
         const hiddenCell = !isPinnedRow && this.getGroupingProvider().isRepeatedValue(attributeId, rowIndex);
         const rowSeparator = !hiddenCell && this.getGroupingProvider().isGroupBoundary(rowIndex);
@@ -1501,7 +1501,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
 
         return cx(
             classList,
-            getCellClassNames(rowIndex, colDef.index, hasDrillableHeader),
+            getCellClassNames(rowIndex, colDef.index!, hasDrillableHeader),
             colDef.index !== undefined ? `gd-column-index-${colDef.index}` : null,
             colDef.measureIndex !== undefined ? `gd-column-measure-${colDef.measureIndex}` : null,
             isRowTotal ? "gd-row-total" : null,
@@ -1511,13 +1511,13 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         );
     };
 
-    private getHeaderClass = (classList: string) => (headerClassParams: any): string => {
+    private getHeaderClass = (classList?: string) => (headerClassParams: any): string => {
         const colDef: IGridHeader = headerClassParams.colDef;
         const { field, measureIndex, index } = colDef;
         const treeIndexes = colDef
             ? indexOfTreeNode(
                   colDef,
-                  this.tableHeaders.allHeaders,
+                  this.tableHeaders!.allHeaders,
                   (nodeA, nodeB) => nodeA.field !== undefined && nodeA.field === nodeB.field,
               )
             : null;
@@ -1542,16 +1542,16 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     // misc :)
     //
     private getGroupingProvider(): IGroupingProvider {
-        return this.agGridDataSource.getGroupingProvider();
+        return this.agGridDataSource!.getGroupingProvider();
     }
 
     private getDrillablePredicates(): IHeaderPredicate[] {
-        return convertDrillableItemsToPredicates(this.props.drillableItems);
+        return convertDrillableItemsToPredicates(this.props.drillableItems!);
     }
 
     private isStickyRowAvailable(): boolean {
         const gridApi = this.getGridApi();
-        return this.props.groupRows && gridApi && stickyRowExists(gridApi);
+        return Boolean(this.props.groupRows && gridApi && stickyRowExists(gridApi));
     }
 
     private updateStickyRow(): void {
@@ -1587,7 +1587,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         const aggregationCount = sumBy(dv.rawData().totals(), (total) => total.length);
         const rowCount = dv.rawData().firstDimSize();
 
-        const headerHeight = ApiWrapper.getHeaderHeight(this.gridApi);
+        const headerHeight = ApiWrapper.getHeaderHeight(this.gridApi!);
 
         // add small room for error to avoid scrollbars that scroll one, two pixels
         // increased in order to resolve issue BB-1509
@@ -1619,8 +1619,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         return this.scrollBarExists() ? getScrollbarWidth() : 0;
     }
 
-    private calculateDesiredHeight(dv: DataViewFacade): number {
-        const { maxHeight } = this.props.config;
+    private calculateDesiredHeight(dv: DataViewFacade): number | undefined {
+        const { maxHeight } = this.props.config!;
         if (!maxHeight) {
             return;
         }

--- a/libs/sdk-ui-pivot/src/PivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/PivotTable.tsx
@@ -24,6 +24,7 @@ import {
     IntlWrapper,
 } from "@gooddata/sdk-ui";
 import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { InvariantError } from "ts-invariant";
 
 /**
  * Prepares new execution matching pivot table props.
@@ -33,7 +34,19 @@ import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
  * @internal
  */
 export function prepareExecution(props: IPivotTableProps): IPreparedExecution {
-    const { backend, workspace, filters, sortBy } = props;
+    const { backend, workspace, filters, sortBy = [] } = props;
+
+    if (!backend) {
+        throw new InvariantError(
+            "Backend was not provided in prepareExecution. Either pass it as a prop or use BackendContext.",
+        );
+    }
+
+    if (!workspace) {
+        throw new InvariantError(
+            "Workspace was not provided in prepareExecution. Either pass it as a prop or use WorkspaceContext.",
+        );
+    }
 
     return backend
         .workspace(workspace)

--- a/libs/sdk-ui-pivot/src/impl/AggregationsMenu.tsx
+++ b/libs/sdk-ui-pivot/src/impl/AggregationsMenu.tsx
@@ -41,7 +41,7 @@ export interface IAggregationsMenuProps {
     colId: string;
     getExecutionDefinition: () => IExecutionDefinition;
     getDataView: () => DataViewFacade;
-    getTotals: () => ITotal[];
+    getTotals?: () => ITotal[];
     onAggregationSelect: (clickConfig: IMenuAggregationClickConfig) => void;
     onMenuOpenedChange: ({ opened, source }: IOnOpenedChangeParams) => void;
 }
@@ -109,7 +109,7 @@ export default class AggregationsMenu extends React.Component<IAggregationsMenuP
     }
 
     private getColumnTotals(measureLocalIdentifiers: string[], isAttributeHeader: boolean): IColumnTotal[] {
-        const columnTotals = this.props.getTotals() || [];
+        const columnTotals = this.props.getTotals?.() ?? [];
 
         if (isAttributeHeader) {
             return menuHelper.getTotalsForAttributeHeader(columnTotals, measureLocalIdentifiers);

--- a/libs/sdk-ui-pivot/src/impl/ColumnGroupHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/ColumnGroupHeader.tsx
@@ -30,7 +30,7 @@ export default class ColumnGroupHeader extends React.Component<IProps> {
                 enableSorting={false}
                 menuPosition={ALIGN_LEFT}
                 textAlign={ALIGN_LEFT}
-                menu={showMenu ? menu() : null}
+                menu={showMenu ? menu?.() : undefined}
                 onMenuAggregationClick={this.props.onMenuAggregationClick}
                 colId={columnGroupDef.field}
                 getExecutionDefinition={this.props.getExecutionDefinition}

--- a/libs/sdk-ui-pivot/src/impl/ColumnHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/ColumnHeader.tsx
@@ -21,7 +21,7 @@ export const DESC: SortDirection = "desc";
 
 class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHeaderState> {
     public state: IColumnHeaderState = {
-        sorting: null,
+        sorting: undefined,
     };
 
     public UNSAFE_componentWillMount(): void {
@@ -66,7 +66,7 @@ class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHeaderStat
                 defaultSortDirection={this.getDefaultSortDirection()}
                 onSortClick={this.onSortRequested}
                 onMenuAggregationClick={this.props.onMenuAggregationClick}
-                menu={menu()}
+                menu={menu?.()}
                 colId={column.getColDef().field}
                 getExecutionDefinition={this.props.getExecutionDefinition}
                 getColumnTotals={this.props.getColumnTotals}
@@ -78,7 +78,7 @@ class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHeaderStat
 
     private getFieldType() {
         const colId = this.props.column.getColDef().field;
-        const fields = getParsedFields(colId);
+        const fields = getParsedFields(colId!);
         const [lastFieldType] = fields[fields.length - 1];
 
         return lastFieldType;

--- a/libs/sdk-ui-pivot/src/impl/GroupingProvider.ts
+++ b/libs/sdk-ui-pivot/src/impl/GroupingProvider.ts
@@ -40,7 +40,7 @@ class DefaultGroupingProvider implements IGroupingProvider {
 class AttributeGroupingProvider implements IGroupingProvider {
     private itemUris: IAttributesRowItemUris;
     private itemRepetitions: IAttributesRowItemRepetitions;
-    private repetitionsCounts: number[];
+    private repetitionsCounts: number[] | null;
     private maxRepetitions: number;
 
     constructor() {
@@ -94,7 +94,7 @@ class AttributeGroupingProvider implements IGroupingProvider {
     private update() {
         this.repetitionsCounts = null;
         this.maxRepetitions = 0;
-        let previousColumnId: string = null;
+        let previousColumnId: string | null = null;
 
         Object.keys(this.itemUris).forEach((columnId) => {
             const rowCount = this.itemUris[columnId].length;
@@ -112,15 +112,15 @@ class AttributeGroupingProvider implements IGroupingProvider {
             previousColumnId = columnId;
         });
 
-        this.maxRepetitions = max(this.repetitionsCounts);
+        this.maxRepetitions = max(this.repetitionsCounts) ?? 0;
     }
 
     private updateAttributeColumn(
         itemUris: string[],
         itemRepetitions: boolean[],
-        previousAttributeItemRepetitions: boolean[],
+        previousAttributeItemRepetitions: boolean[] | null,
     ) {
-        let previousItemUri: string = null;
+        let previousItemUri: string | null = null;
         itemUris.forEach((itemUri, rowIndex) => {
             let repeatedItem = previousItemUri === itemUri;
             if (previousAttributeItemRepetitions !== null) {
@@ -129,7 +129,7 @@ class AttributeGroupingProvider implements IGroupingProvider {
 
             if (repeatedItem) {
                 itemRepetitions[rowIndex] = true;
-                this.repetitionsCounts[rowIndex] += 1;
+                this.repetitionsCounts![rowIndex] += 1;
             }
 
             previousItemUri = itemUri;

--- a/libs/sdk-ui-pivot/src/impl/HeaderCell.tsx
+++ b/libs/sdk-ui-pivot/src/impl/HeaderCell.tsx
@@ -28,16 +28,16 @@ export interface IHeaderCellProps extends ICommonHeaderParams {
     defaultSortDirection?: SortDirection;
     menuPosition?: AlignPositions;
     textAlign?: AlignPositions;
-    sortDirection?: SortDirection;
+    sortDirection?: SortDirection | null;
     onSortClick?: (direction: SortDirection) => void;
-    menu?: IMenu;
+    menu?: IMenu | null;
     colId?: string;
 }
 
 export interface IHeaderCellState {
     isMenuOpen: boolean;
     isMenuButtonVisible: boolean;
-    currentSortDirection: SortDirection;
+    currentSortDirection: SortDirection | null;
 }
 
 export default class HeaderCell extends React.Component<IHeaderCellProps, IHeaderCellState> {
@@ -60,14 +60,14 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
 
     public componentDidMount(): void {
         this.setState({
-            currentSortDirection: this.props.sortDirection,
+            currentSortDirection: this.props.sortDirection!,
         });
     }
 
     public UNSAFE_componentWillReceiveProps(nextProps: IHeaderCellProps): void {
         if (nextProps.sortDirection !== this.props.sortDirection) {
             this.setState({
-                currentSortDirection: this.props.sortDirection,
+                currentSortDirection: this.props.sortDirection!,
             });
         }
     }
@@ -104,13 +104,13 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
 
         return (
             <AggregationsMenu
-                intl={intl}
-                colId={colId}
+                intl={intl!}
+                colId={colId!}
                 isMenuOpened={isMenuOpen}
                 isMenuButtonVisible={isMenuButtonVisible}
-                showSubmenu={menu.aggregationsSubMenu}
-                getExecutionDefinition={getExecutionDefinition}
-                getDataView={getDataView}
+                showSubmenu={menu.aggregationsSubMenu!}
+                getExecutionDefinition={getExecutionDefinition!}
+                getDataView={getDataView!}
                 getTotals={getColumnTotals}
                 onMenuOpenedChange={this.handleMenuOpenedChange}
                 onAggregationSelect={this.menuItemClick}
@@ -172,7 +172,7 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
             const { sortDirection } = this.props;
             if (sortDirection === null) {
                 return this.setState({
-                    currentSortDirection: this.props.defaultSortDirection,
+                    currentSortDirection: this.props.defaultSortDirection!,
                 });
             } else if (sortDirection === "asc") {
                 return this.setState({
@@ -192,7 +192,7 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
 
     private onMouseLeaveHeaderCellText = () => {
         this.setState({
-            currentSortDirection: this.props.sortDirection,
+            currentSortDirection: this.props.sortDirection!,
         });
     };
 
@@ -203,11 +203,11 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
             return;
         }
         if (sortDirection === null) {
-            const nextSortDirection = defaultSortDirection;
+            const nextSortDirection = defaultSortDirection!;
             this.setState({
-                currentSortDirection: nextSortDirection,
+                currentSortDirection: nextSortDirection!,
             });
-            onSortClick(nextSortDirection);
+            onSortClick!(nextSortDirection);
             return;
         }
 
@@ -215,7 +215,7 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
         this.setState({
             currentSortDirection: nextSort,
         });
-        onSortClick(nextSort);
+        onSortClick!(nextSort);
     };
 
     private showMenuButton = () => {

--- a/libs/sdk-ui-pivot/src/impl/agGridApiWrapper.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridApiWrapper.ts
@@ -47,17 +47,23 @@ function getPinnedTopRowElement(gridApi: GridApi): HTMLElement | null {
 
 function addPinnedTopRowClass(gridApi: GridApi, className: string): void {
     const rowElement = getPinnedTopRowElement(gridApi);
-    rowElement.classList.add(className);
+    if (rowElement) {
+        rowElement.classList.add(className);
+    }
 }
 
 function removePinnedTopRowClass(gridApi: GridApi, className: string): void {
     const rowElement = getPinnedTopRowElement(gridApi);
-    rowElement.classList.remove(className);
+    if (rowElement) {
+        rowElement.classList.remove(className);
+    }
 }
 
 function setPinnedTopRowStyle(gridApi: GridApi, propertyName: string, propertyValue: string): void {
     const rowElement = getPinnedTopRowElement(gridApi);
-    rowElement.style[propertyName] = propertyValue;
+    if (rowElement) {
+        rowElement.style[propertyName] = propertyValue;
+    }
 }
 
 function getPinnedTopRowCellElementWrapper(gridApi: GridApi, attributeId: string): HTMLElement | null {
@@ -70,7 +76,9 @@ function getPinnedTopRowCellElementWrapper(gridApi: GridApi, attributeId: string
         return index.slice(0, attributeId.length) === attributeId && pinnedTopRow.cellComps[index] !== null;
     });
 
-    return pinnedTopRow.cellComps[columnIndex] ? pinnedTopRow.cellComps[columnIndex].eGui : null;
+    return columnIndex !== undefined && pinnedTopRow.cellComps[columnIndex]
+        ? pinnedTopRow.cellComps[columnIndex].eGui
+        : null;
 }
 
 function getPinnedTopRowCellElement(gridApi: GridApi, attributeId: string): HTMLElement | null {

--- a/libs/sdk-ui-pivot/src/impl/agGridDataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridDataSource.ts
@@ -57,7 +57,7 @@ export class AgGridDatasource implements IDatasource {
 
     private processData = (dv: DataViewFacade, params: IGetRowsParams): void => {
         if (!dv) {
-            return null;
+            return;
         }
 
         const { successCallback } = params;
@@ -71,7 +71,7 @@ export class AgGridDatasource implements IDatasource {
 
         const rowAttributeIds = columnDefs
             .filter((columnDef) => columnDef.type === ROW_ATTRIBUTE_COLUMN)
-            .map((columnDef) => columnDef.field);
+            .map((columnDef) => columnDef.field!);
 
         this.grouping.processPage(rowData, offset[0], rowAttributeIds);
 
@@ -83,7 +83,7 @@ export class AgGridDatasource implements IDatasource {
 
         // set totals
         if (areTotalsChanged(this.gridApiProvider(), rowTotals)) {
-            this.gridApiProvider().setPinnedBottomRowData(rowTotals);
+            this.gridApiProvider()?.setPinnedBottomRowData(rowTotals);
         }
     };
 
@@ -119,7 +119,8 @@ export class AgGridDatasource implements IDatasource {
                 this.currentResult = newResult;
 
                 newResult
-                    .readWindow([startRow, 0], [endRow - startRow, undefined])
+                    // the as any cast is fishy but I did not want to change if as it could have unforeseen consequences
+                    .readWindow([startRow, 0], [endRow - startRow, undefined as any])
                     .then((data) => {
                         const dv = DataViewFacade.for(data);
                         this.gridApiProvider()?.setInfiniteRowCount(data.totalCount[0]);

--- a/libs/sdk-ui-pivot/src/impl/agGridDataSourceUtils.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridDataSourceUtils.ts
@@ -13,7 +13,7 @@ export const areTotalsChanged = (gridApi: GridApi | undefined, newTotals: IGridT
     }
 
     for (let i = 0; i < currentTotalsCount; i++) {
-        if (!isEqual(gridApi.getPinnedBottomRow(i).data, newTotals[i])) {
+        if (!isEqual(gridApi?.getPinnedBottomRow(i).data, newTotals[i])) {
             return true;
         }
     }

--- a/libs/sdk-ui-pivot/src/impl/agGridDrilling.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridDrilling.ts
@@ -32,7 +32,7 @@ export const getDrillRowData = (leafColumnDefs: ColDef[], rowData: { [key: strin
                     ...drillRow,
                     {
                         // Unlike fields, drilling data should not be sanitized, because it is not used in HTML properties
-                        id: getIdsFromUri(drillItemUri, false)[1],
+                        id: getIdsFromUri(drillItemUri!, false)[1],
                         name: rowData[colDef.field],
                     },
                 ];
@@ -45,7 +45,7 @@ export const getDrillRowData = (leafColumnDefs: ColDef[], rowData: { [key: strin
 export const getMeasureDrillItem = (
     responseHeaders: IDimensionItemDescriptor[],
     header: IResultMeasureHeader,
-): IMeasureDescriptor => {
+): IMeasureDescriptor | null => {
     const measureGroupHeader = responseHeaders.find(isMeasureGroupDescriptor);
 
     return get(measureGroupHeader, ["measureGroupHeader", "items", header.measureHeaderItem.order], null);
@@ -72,7 +72,10 @@ export const assignDrillItemsAndType = (
     } else if (isResultMeasureHeader(currentHeader)) {
         // measure uri and identifier
         header.type = MEASURE_COLUMN;
-        drillItems.push(getMeasureDrillItem(responseHeaders, currentHeader));
+        const drillItem = getMeasureDrillItem(responseHeaders, currentHeader);
+        if (drillItem) {
+            drillItems.push(drillItem);
+        }
         header.drillItems = drillItems;
         header.measureIndex = currentHeader.measureHeaderItem.order;
     }

--- a/libs/sdk-ui-pivot/src/impl/agGridSorting.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridSorting.ts
@@ -20,7 +20,7 @@ import {
     SortDirection,
 } from "@gooddata/sdk-model";
 import { IExecutionResult } from "@gooddata/sdk-backend-spi";
-import invariant from "ts-invariant";
+import invariant, { InvariantError } from "ts-invariant";
 
 /*
  * All code related to sorting the ag-grid backed Pivot Table is concentrated here
@@ -61,7 +61,7 @@ export const getSortItemByColId = (
                     : newAttributeSort(attributeLocalId, direction);
             }
         }
-        invariant(false, `could not find attribute header matching ${colId}`);
+        throw new InvariantError(`could not find attribute header matching ${colId}`);
     } else if (lastFieldType === FIELD_TYPE_MEASURE) {
         const headerItem = measureDescriptors[parseInt(lastFieldId, 10)];
         const attributeLocators = getAttributeLocators(fields, attributeDescriptors);
@@ -80,7 +80,7 @@ export const getSortItemByColId = (
             },
         };
     }
-    invariant(false, `could not find header matching ${colId}`);
+    throw new InvariantError(`could not find header matching ${colId}`);
 };
 
 export function getSortsFromModel(sortModel: ISortModelItem[], result: IExecutionResult): ISortItem[] {

--- a/libs/sdk-ui-pivot/src/impl/agGridUtils.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridUtils.ts
@@ -39,7 +39,7 @@ export const sanitizeField = (field: string): string =>
 // returns [attributeId, attributeValueId]
 // attributeValueId can be null if supplied with attribute uri instead of attribute value uri
 export const getIdsFromUri = (uri: string, sanitize = true): (string | null)[] => {
-    const [, attributeId, , attributeValueId = null] = uri.match(/obj\/([^/]*)(\/elements\?id=)?(.*)?$/);
+    const [, attributeId, , attributeValueId = null] = uri.match(/obj\/([^/]*)(\/elements\?id=)?(.*)?$/)!;
     return [attributeId, attributeValueId].map((id: string | null) =>
         id && sanitize ? sanitizeField(id) : id,
     );
@@ -65,7 +65,7 @@ export const getRowNodeId = (item: IGridRow["headerItemMap"]): string => {
             }
 
             const uri = getMappingHeaderUri(mappingHeader);
-            const ids = getIdsFromUri(uri);
+            const ids = getIdsFromUri(uri!);
             return `${key}${ID_SEPARATOR}${ids[1]}`;
         })
         .join(FIELD_SEPARATOR);
@@ -86,7 +86,7 @@ export const cellRenderer = (params: ICellRendererParams): string => {
         params.data &&
         params.data.rowTotalActiveMeasures &&
         params.data.rowTotalActiveMeasures.some((measureColId: string) =>
-            params.colDef.field.endsWith(measureColId),
+            params.colDef.field!.endsWith(measureColId),
         );
 
     const formattedValue =
@@ -101,14 +101,14 @@ export const getTreeLeaves = (
     tree: IGridHeader[] | IGridHeader,
     getChildren = (node: any) => node && node.children,
 ): IGridHeader[] => {
-    const leaves = [];
+    const leaves: IGridHeader[] = [];
     const nodes = Array.isArray(tree) ? [...tree] : [tree];
     let node;
     let children;
     while (
         ((node = nodes.shift()),
         (children = getChildren(node)),
-        (children && children.length) || (leaves.push(node) && nodes.length))
+        (children && children.length) || (leaves.push(node!) && nodes.length))
     ) {
         if (children) {
             nodes.push(...children);
@@ -123,7 +123,7 @@ export const indexOfTreeNode = (
     matchNode = (nodeA: any, nodeB: any) => nodeA === nodeB,
     getChildren = (node: any) => (node && node.children) || [],
     indexes: number[] = [],
-): number[] => {
+): number[] | null => {
     const nodes = Array.isArray(tree) ? [...tree] : [tree];
     for (let nodeIndex = 0; nodeIndex < nodes.length; nodeIndex++) {
         const currentNode = nodes[nodeIndex];
@@ -151,20 +151,19 @@ export function getMeasureFormat(gridHeader: IGridHeader, result: IExecutionResu
         throw new Error(`Cannot get measure format from header ${Object.keys(header)}`);
     }
 
-    const measureIndex = gridHeader.measureIndex;
+    const measureIndex = gridHeader.measureIndex!;
     return header.measureGroupHeader.items[measureIndex].measureHeaderItem.format;
 }
 
-export function getSubtotalStyles(dimension: IDimension): string[] {
+export function getSubtotalStyles(dimension: IDimension | undefined): (string | null)[] {
     if (!dimension || !dimension.totals) {
         return [];
     }
 
     let even = false;
     const subtotalStyles = dimension.itemIdentifiers.slice(1).map((attributeIdentifier) => {
-        const hasSubtotal = dimension.totals.some(
-            (total) => total.attributeIdentifier === attributeIdentifier,
-        );
+        const hasSubtotal =
+            dimension.totals?.some((total) => total.attributeIdentifier === attributeIdentifier) ?? false;
 
         if (hasSubtotal) {
             even = !even;
@@ -204,8 +203,8 @@ export function getAttributeLocators(
         );
         return {
             attributeLocatorItem: {
-                attributeIdentifier: attributeHeaderMatch.attributeHeader.localIdentifier,
-                element: `${attributeHeaderMatch.attributeHeader.formOf.uri}/elements?id=${fieldValueId}`,
+                attributeIdentifier: attributeHeaderMatch!.attributeHeader.localIdentifier,
+                element: `${attributeHeaderMatch!.attributeHeader.formOf.uri}/elements?id=${fieldValueId}`,
             },
         };
     });
@@ -213,7 +212,7 @@ export function getAttributeLocators(
 
 export const getColumnIdentifierFromDef = (colDef: IGridHeader | ColDef): string => {
     // field should be always present, fallback to colId could happen for empty columns
-    return colDef.field || colDef.colId;
+    return colDef.field || colDef.colId!;
 };
 
 export const getColumnIdentifier = (item: Column | IGridHeader | ColDef): string => {

--- a/libs/sdk-ui-pivot/src/impl/aggregationsMenuHelper.ts
+++ b/libs/sdk-ui-pivot/src/impl/aggregationsMenuHelper.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 import { ITotal, TotalType } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
+import invariant, { InvariantError } from "ts-invariant";
 import { IMenuAggregationClickConfig } from "../types";
 
 import { AVAILABLE_TOTALS, FIELD_TYPE_ATTRIBUTE, FIELD_TYPE_MEASURE } from "./agGridConst";
@@ -91,8 +91,8 @@ function getHeaderMeasureLocalIdentifiers(
     } else if (lastFieldType === FIELD_TYPE_ATTRIBUTE) {
         return measureGroupHeaderItems.map((item) => item.measureHeaderItem.localIdentifier);
     }
-    invariant(
-        false,
+
+    throw new InvariantError(
         `Unknown field type '${lastFieldType}' provided (valid types: ${[
             FIELD_TYPE_MEASURE,
             FIELD_TYPE_ATTRIBUTE,

--- a/libs/sdk-ui-pivot/src/impl/stickyRowHandler.ts
+++ b/libs/sdk-ui-pivot/src/impl/stickyRowHandler.ts
@@ -14,7 +14,11 @@ export const initializeStickyRow = (gridApi: GridApi): void => {
     gridApi.setPinnedTopRowData([{}]);
 };
 
-export const updateStickyRowPosition = (gridApi: GridApi, apiWrapper: any = ApiWrapper): void => {
+export const updateStickyRowPosition = (gridApi: GridApi | null, apiWrapper: any = ApiWrapper): void => {
+    if (!gridApi) {
+        return;
+    }
+
     const headerHeight = apiWrapper.getHeaderHeight(gridApi);
     apiWrapper.setPinnedTopRowStyle(gridApi, "top", `${headerHeight}px`);
     apiWrapper.setPinnedTopRowStyle(gridApi, "padding-right", `${getScrollbarWidth()}px`);
@@ -49,11 +53,11 @@ export const updateStickyRowContentClasses = (
     currentScrollPosition: IScrollPosition,
     lastScrollPosition: IScrollPosition,
     rowHeight: number,
-    gridApi: GridApi,
+    gridApi: GridApi | null,
     groupingProvider: IGroupingProvider,
     apiWrapper: typeof ApiWrapper,
 ): void => {
-    if (!shouldUpdate(currentScrollPosition, lastScrollPosition, rowHeight)) {
+    if (!gridApi || !shouldUpdate(currentScrollPosition, lastScrollPosition, rowHeight)) {
         return;
     }
 

--- a/libs/sdk-ui-pivot/src/impl/tableCell.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableCell.ts
@@ -13,7 +13,11 @@ import {
 } from "../types";
 import { isMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 
-function getFormattedNumber(cellContent: MeasureCell, format: string, separators: ISeparators): string {
+function getFormattedNumber(
+    cellContent: MeasureCell,
+    format: string,
+    separators: ISeparators | undefined,
+): string {
     const parsedNumber: string | number =
         cellContent === null ? "" : typeof cellContent === "string" ? parseFloat(cellContent) : cellContent;
 
@@ -34,7 +38,7 @@ export function getCellClassNames(rowIndex: number, columnIndex: number, isDrill
 export function getMeasureCellFormattedValue(
     cellContent: MeasureCell,
     format: string,
-    separators: ISeparators,
+    separators: ISeparators | undefined,
 ): string {
     const formattedNumber = getFormattedNumber(cellContent, format, separators);
     const { label } = colors2Object(formattedNumber);
@@ -45,7 +49,7 @@ export function getMeasureCellFormattedValue(
 export function getMeasureCellStyle(
     cellContent: MeasureCell,
     format: string,
-    separators: ISeparators,
+    separators: ISeparators | undefined,
     applyColor: boolean,
 ): ITableCellStyle {
     const formattedNumber = getFormattedNumber(cellContent, format, separators);

--- a/libs/sdk-ui-pivot/src/impl/tests/__snapshots__/agGridData.test.ts.snap
+++ b/libs/sdk-ui-pivot/src/impl/tests/__snapshots__/agGridData.test.ts.snap
@@ -42,7 +42,7 @@ Object {
       },
     },
   },
-  "subtotalStyle": null,
+  "subtotalStyle": undefined,
   "type": "rowSubtotal",
 }
 `;

--- a/libs/sdk-ui-pivot/src/impl/tests/agColumnWrapper.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/tests/agColumnWrapper.test.ts
@@ -26,8 +26,8 @@ describe("agColumnWrapper", () => {
     describe("setColumnMaxWidth", () => {
         it("should set internal property maxWidth of column and column.getColDef().maxWidth", async () => {
             const maxWidth = 500;
-            const columnDef1 = { maxWidth: undefined as number };
-            const columnDef2 = { maxWidth: undefined as number };
+            const columnDef1 = { maxWidth: (undefined as unknown) as number };
+            const columnDef2 = { maxWidth: (undefined as unknown) as number };
 
             const columnsMaps = {
                 colId1: getFakeColumn(columnDef1),
@@ -47,8 +47,8 @@ describe("agColumnWrapper", () => {
     describe("setColumnMaxWidthIf", () => {
         it("should set internal property maxWidth of column and column.getColDef().maxWidth when condition is true", async () => {
             const maxWidth = 500;
-            const columnDef1 = { maxWidth: undefined as number };
-            const columnDef2 = { maxWidth: undefined as number };
+            const columnDef1 = { maxWidth: (undefined as unknown) as number };
+            const columnDef2 = { maxWidth: (undefined as unknown) as number };
 
             const columnsMaps = {
                 colId1: getFakeColumn(columnDef1),
@@ -66,8 +66,8 @@ describe("agColumnWrapper", () => {
 
         it("should not set internal property maxWidth of column and column.getColDef().maxWidth when condition is false", async () => {
             const maxWidth = 500;
-            const columnDef1 = { maxWidth: undefined as number };
-            const columnDef2 = { maxWidth: undefined as number };
+            const columnDef1 = { maxWidth: (undefined as unknown) as number };
+            const columnDef2 = { maxWidth: (undefined as unknown) as number };
 
             const columnsMaps = {
                 colId1: getFakeColumn(columnDef1),

--- a/libs/sdk-ui-pivot/src/impl/tests/agGridApiWrapper.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/tests/agGridApiWrapper.test.tsx
@@ -128,7 +128,7 @@ describe("agGridApiWrapper", () => {
                 const cellElement = ApiWrapper.getCellElement(api, firstAttributeColumnId, 0);
 
                 expect(cellElement instanceof HTMLElement).toBe(true);
-                expect(cellElement.classList.contains("ag-cell")).toBe(true);
+                expect(cellElement!.classList.contains("ag-cell")).toBe(true);
             });
         });
 
@@ -140,7 +140,9 @@ describe("agGridApiWrapper", () => {
                 ApiWrapper.addCellClass(api, firstAttributeColumnId, 0, newClassName);
 
                 const cellElement = ApiWrapper.getCellElement(api, firstAttributeColumnId, 0);
-                expect(cellElement.classList.contains(newClassName)).toBe(true);
+
+                expect(cellElement).toBeDefined();
+                expect(cellElement!.classList.contains(newClassName)).toBe(true);
             });
         });
 
@@ -153,7 +155,9 @@ describe("agGridApiWrapper", () => {
                 ApiWrapper.removeCellClass(api, firstAttributeColumnId, 0, newClassName);
 
                 const cellElement = ApiWrapper.getCellElement(api, firstAttributeColumnId, 0);
-                expect(cellElement.classList.contains(newClassName)).toBe(false);
+
+                expect(cellElement).toBeDefined();
+                expect(cellElement!.classList.contains(newClassName)).toBe(false);
             });
         });
     });
@@ -165,8 +169,8 @@ describe("agGridApiWrapper", () => {
 
                 const element = ApiWrapper.getPinnedTopRowElement(api);
 
-                expect(element.classList.contains("ag-floating-top")).toBe(true);
                 expect(element instanceof HTMLElement).toBe(true);
+                expect(element!.classList.contains("ag-floating-top")).toBe(true);
             });
         });
 
@@ -178,7 +182,9 @@ describe("agGridApiWrapper", () => {
                 ApiWrapper.addPinnedTopRowClass(api, newPinnedRowClassName);
 
                 const pinnedTopRowElement = ApiWrapper.getPinnedTopRowElement(api);
-                expect(pinnedTopRowElement.classList.contains(newPinnedRowClassName)).toBe(true);
+
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.classList.contains(newPinnedRowClassName)).toBe(true);
             });
         });
 
@@ -191,7 +197,9 @@ describe("agGridApiWrapper", () => {
                 ApiWrapper.removePinnedTopRowClass(api, newPinnedRowClassName);
 
                 const pinnedTopRowElement = ApiWrapper.getPinnedTopRowElement(api);
-                expect(pinnedTopRowElement.classList.contains(newPinnedRowClassName)).toBe(false);
+
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.classList.contains(newPinnedRowClassName)).toBe(false);
             });
         });
 
@@ -202,7 +210,9 @@ describe("agGridApiWrapper", () => {
                 ApiWrapper.setPinnedTopRowStyle(api, "max-width", "123px");
 
                 const pinnedTopRowElement = ApiWrapper.getPinnedTopRowElement(api);
-                expect(pinnedTopRowElement.style["max-width"]).toEqual("123px");
+
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.style["max-width"]).toEqual("123px");
             });
         });
     });
@@ -215,8 +225,8 @@ describe("agGridApiWrapper", () => {
                 const cellElement = ApiWrapper.getPinnedTopRowCellElementWrapper(api, firstAttributeColumnId);
 
                 expect(cellElement instanceof HTMLElement).toBe(true);
-                expect(!!cellElement.querySelector("span")).toEqual(true);
-                expect(cellElement.classList.contains("ag-cell")).toBe(true);
+                expect(!!cellElement!.querySelector("span")).toEqual(true);
+                expect(cellElement!.classList.contains("ag-cell")).toBe(true);
             });
         });
 
@@ -226,7 +236,8 @@ describe("agGridApiWrapper", () => {
 
                 const cellElement = ApiWrapper.getPinnedTopRowCellElement(api, firstAttributeColumnId);
 
-                expect(cellElement.innerHTML).toEqual(firstAttributePinnedTopValue);
+                expect(cellElement).toBeDefined();
+                expect(cellElement!.innerHTML).toEqual(firstAttributePinnedTopValue);
             });
         });
 
@@ -241,7 +252,9 @@ describe("agGridApiWrapper", () => {
                     api,
                     firstAttributeColumnId,
                 );
-                expect(pinnedTopRowElement.classList.contains(newPinnedRowCellClassName)).toBe(true);
+
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.classList.contains(newPinnedRowCellClassName)).toBe(true);
             });
         });
 
@@ -261,7 +274,9 @@ describe("agGridApiWrapper", () => {
                     api,
                     firstAttributeColumnId,
                 );
-                expect(pinnedTopRowElement.classList.contains(newPinnedRowCellClassName)).toBe(false);
+
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.classList.contains(newPinnedRowCellClassName)).toBe(false);
             });
         });
 
@@ -276,7 +291,8 @@ describe("agGridApiWrapper", () => {
                     firstAttributeColumnId,
                 );
 
-                expect(pinnedTopRowElement.innerText).toEqual("new_text");
+                expect(pinnedTopRowElement).toBeDefined();
+                expect(pinnedTopRowElement!.innerText).toEqual("new_text");
             });
         });
     });

--- a/libs/sdk-ui-pivot/src/impl/tests/agGridDataSourceUtils.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/tests/agGridDataSourceUtils.test.ts
@@ -54,7 +54,7 @@ describe("getGridDataSourceUtils", () => {
             },
         };
         const emptyTotalRows: IGridTotalsRow[] = [];
-        const noTotalRows: IGridTotalsRow[] = null;
+        const noTotalRows: IGridTotalsRow[] | null = null;
         const oneTotalRows: IGridTotalsRow[] = [totalSum];
 
         it.each([

--- a/libs/sdk-ui-pivot/src/impl/tests/agGridDrilling.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/tests/agGridDrilling.test.ts
@@ -90,7 +90,7 @@ describe("getDrillIntersection", () => {
 
     it("should return intersection of row attribute and row attribute value for row header cell", async () => {
         const rowColDef = columnDefs[0]; // row header
-        const drillItems = [rowData[0].headerItemMap[rowColDef.field], ...rowColDef.drillItems];
+        const drillItems = [rowData[0].headerItemMap[rowColDef.field!], ...rowColDef.drillItems];
         const intersection = getDrillIntersection(drillItems);
         expect(intersection).toMatchSnapshot();
     });

--- a/libs/sdk-ui-pivot/src/impl/utils.ts
+++ b/libs/sdk-ui-pivot/src/impl/utils.ts
@@ -19,7 +19,7 @@ const getScrollbarWidthBody = (): number => {
     const widthWithScroll = inner.offsetWidth;
 
     // remove divs
-    outer.parentNode.removeChild(outer);
+    outer.parentNode?.removeChild(outer);
 
     return widthNoScroll - widthWithScroll;
 };

--- a/libs/sdk-ui-pivot/src/menu/ControlledMenu.tsx
+++ b/libs/sdk-ui-pivot/src/menu/ControlledMenu.tsx
@@ -7,7 +7,7 @@ export interface IControlledMenuProps extends Partial<IMenuPositionConfig> {
     opened: boolean;
     openAction?: OpenAction;
     closeOnScroll: boolean;
-    portalTarget: Element;
+    portalTarget: Element | undefined;
     onOpenedChange: OnOpenedChange;
     toggler: React.ReactNode;
     togglerWrapperClassName?: string;

--- a/libs/sdk-ui-pivot/src/menu/Menu.tsx
+++ b/libs/sdk-ui-pivot/src/menu/Menu.tsx
@@ -31,7 +31,7 @@ const Menu: React.SFC<IMenuProps> = (props: IMenuProps) => (
                 toggler={props.toggler}
                 togglerWrapperClassName={props.togglerWrapperClassName}
                 portalTarget={props.portalTarget}
-                closeOnScroll={props.closeOnScroll}
+                closeOnScroll={props.closeOnScroll!}
             >
                 {isFunction(props.children)
                     ? props.children({

--- a/libs/sdk-ui-pivot/src/menu/MenuState.tsx
+++ b/libs/sdk-ui-pivot/src/menu/MenuState.tsx
@@ -13,7 +13,7 @@ export interface IMenuStateProps extends IMenuStateConfig {
 }
 
 export interface IMenuStateState {
-    opened: boolean;
+    opened?: boolean;
 }
 
 export default class MenuState extends React.Component<IMenuStateProps, IMenuStateState> {
@@ -25,13 +25,13 @@ export default class MenuState extends React.Component<IMenuStateProps, IMenuSta
         super(props);
 
         this.state = {
-            opened: this.isControlled() ? this.props.opened : this.props.defaultOpened,
+            opened: this.isControlled() ? this.props.opened : this.props.defaultOpened!,
         };
     }
 
     public render(): React.ReactNode {
         return this.props.children({
-            opened: this.isControlled() ? this.props.opened : this.state.opened,
+            opened: (this.isControlled() ? this.props.opened : this.state.opened) ?? false,
             onOpenedChange: this.onOpenedChange,
         });
     }

--- a/libs/sdk-ui-pivot/src/menu/menuOpener/MenuOpenedByHover.tsx
+++ b/libs/sdk-ui-pivot/src/menu/menuOpener/MenuOpenedByHover.tsx
@@ -6,7 +6,7 @@ import MenuPosition from "../positioning/MenuPosition";
 export default class MenuOpenedByHover extends React.Component<IMenuOpenedBySharedProps> {
     private static openCloseDelayMs = 200;
 
-    private timerCloseDelay: number = null;
+    private timerCloseDelay: number | null = null;
 
     public componentWillUnmount(): void {
         this.clearCloseDelayTimer();
@@ -36,7 +36,9 @@ export default class MenuOpenedByHover extends React.Component<IMenuOpenedByShar
     }
 
     private clearCloseDelayTimer = (): void => {
-        window.clearTimeout(this.timerCloseDelay);
+        if (this.timerCloseDelay) {
+            window.clearTimeout(this.timerCloseDelay);
+        }
     };
 
     private hoverStart = (): void => {

--- a/libs/sdk-ui-pivot/src/menu/menuOpener/MenuOpener.tsx
+++ b/libs/sdk-ui-pivot/src/menu/menuOpener/MenuOpener.tsx
@@ -9,7 +9,7 @@ export interface IMenuOpenerProps extends Partial<IMenuPositionConfig> {
     opened: boolean;
     onOpenedChange: OnOpenedChange;
     openAction?: OpenAction;
-    portalTarget?: Element;
+    portalTarget?: Element | null;
     toggler: React.ReactNode;
     togglerWrapperClassName?: string;
     children: React.ReactNode;
@@ -27,7 +27,7 @@ export default class MenuOpener extends React.Component<IMenuOpenerProps> {
     };
 
     public render(): React.ReactNode {
-        const Component = this.getComponentByOpenAction();
+        const Component = this.getComponentByOpenAction() as React.ElementType;
 
         return (
             <Component

--- a/libs/sdk-ui-pivot/src/menu/positioning/MenuPosition.tsx
+++ b/libs/sdk-ui-pivot/src/menu/positioning/MenuPosition.tsx
@@ -47,7 +47,7 @@ export default class MenuPosition extends React.Component<IMenuPositionProps, IM
         togglerElInitialized: false,
     };
 
-    private togglerEl: HTMLElement = null;
+    private togglerEl: HTMLElement | null = null;
 
     // React Measure is not used because it cannot detect the left/top coordinate
     // changes of absolute positioned blocks. This caused problems where left/top
@@ -71,7 +71,7 @@ export default class MenuPosition extends React.Component<IMenuPositionProps, IM
         // any element specified in targetElement prop). Any submenus are rendered
         // inside of previous menu, so they do not need any portals.
 
-        const ContentWrapper = contentWrapper;
+        const ContentWrapper = contentWrapper as React.ComponentType;
 
         const MaybeWrapper = topLevelMenu ? React.Fragment : Wrapper;
 
@@ -100,7 +100,7 @@ export default class MenuPosition extends React.Component<IMenuPositionProps, IM
         );
     }
 
-    private setTogglerEl = (el: HTMLElement) => {
+    private setTogglerEl = (el: HTMLElement | null) => {
         this.togglerEl = el;
         this.setState({
             togglerElInitialized: true,

--- a/libs/sdk-ui-pivot/src/menu/positioning/PositionedMenuContent.tsx
+++ b/libs/sdk-ui-pivot/src/menu/positioning/PositionedMenuContent.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import React from "react";
+import React, { createRef } from "react";
 import {
     getViewportDimensionsAndCoords,
     getElementDimensions,
@@ -10,7 +10,7 @@ import { IMenuPositionConfig } from "../MenuSharedTypes";
 
 export interface IPositionedMenuContentProps extends IMenuPositionConfig {
     topLevelMenu: boolean;
-    togglerEl: HTMLElement;
+    togglerEl: HTMLElement | null;
     children: React.ReactNode;
 }
 
@@ -28,7 +28,7 @@ export default class PositionedMenuContent extends React.Component<
         top: 0,
     };
 
-    private menuEl: HTMLElement = null;
+    private menuElRef = createRef<HTMLDivElement>();
 
     public componentDidUpdate(prevProps: IPositionedMenuContentProps): void {
         if (
@@ -60,7 +60,7 @@ export default class PositionedMenuContent extends React.Component<
                     left: this.state.left,
                     top: this.state.top,
                 }}
-                ref={this.setElMenu}
+                ref={this.menuElRef}
             >
                 {this.props.children}
             </div>
@@ -77,18 +77,14 @@ export default class PositionedMenuContent extends React.Component<
         window.removeEventListener("scroll", this.positionMenu, true);
     }
 
-    private setElMenu = (el: HTMLElement) => {
-        this.menuEl = el;
-    };
-
     private positionMenu = () => {
-        if (!this.props.togglerEl || !this.menuEl) {
+        if (!this.props.togglerEl || !this.menuElRef.current) {
             return;
         }
 
         const { left, top } = calculateMenuPosition({
             toggler: getElementDimensionsAndCoords(this.props.togglerEl),
-            menu: getElementDimensions(this.menuEl),
+            menu: getElementDimensions(this.menuElRef.current),
             viewport: getViewportDimensionsAndCoords(),
             alignment: this.props.alignment,
             spacing: this.props.spacing,

--- a/libs/sdk-ui-pivot/src/menu/positioning/positioningCalculations.ts
+++ b/libs/sdk-ui-pivot/src/menu/positioning/positioningCalculations.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { MenuAlignment } from "../MenuSharedTypes";
 
 export interface IDimensions {
@@ -116,11 +116,11 @@ export function calculateMenuPosition({
         left:
             typeof coordinates.left === "number"
                 ? coordinates.left
-                : toggler.width - menu.width - coordinates.right,
+                : toggler.width - menu.width - coordinates.right!,
         top:
             typeof coordinates.top === "number"
                 ? coordinates.top
-                : toggler.height - menu.height - coordinates.bottom,
+                : toggler.height - menu.height - coordinates.bottom!,
     };
 
     // Returned coordinates are relative to toggler.

--- a/libs/sdk-ui-pivot/src/menu/tests/MenuState.test.tsx
+++ b/libs/sdk-ui-pivot/src/menu/tests/MenuState.test.tsx
@@ -41,6 +41,7 @@ describe("Menu state", () => {
             onOpenedChange: expect.any(Function),
         });
 
+        // @ts-expect-error the value is assigned at this point
         fnOnOpenedChange({ opened: true, source: "TOGGLER_BUTTON_CLICK" });
 
         expect(fnMenuStateChildren).toHaveBeenCalledTimes(2);
@@ -51,6 +52,7 @@ describe("Menu state", () => {
         expect(fnOnOpenedChangeProp).toHaveBeenCalledTimes(1);
         expect(fnOnOpenedChangeProp).toHaveBeenCalledWith({ opened: true, source: "TOGGLER_BUTTON_CLICK" });
 
+        // @ts-expect-error the value is assigned at this point
         fnOnOpenedChange({ opened: false, source: "TOGGLER_BUTTON_CLICK" });
 
         expect(fnMenuStateChildren).toHaveBeenCalledTimes(3);
@@ -94,6 +96,7 @@ describe("Menu state", () => {
         });
         expect(fnOnOpenedChangeProp).toHaveBeenCalledTimes(0);
 
+        // @ts-expect-error the value is assigned at this point
         fnOnOpenedChange(false);
 
         expect(fnOnOpenedChangeProp).toHaveBeenCalledTimes(1);

--- a/libs/sdk-ui-pivot/src/menu/utils/OutsideClickHandler.tsx
+++ b/libs/sdk-ui-pivot/src/menu/utils/OutsideClickHandler.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import React from "react";
+import React, { createRef } from "react";
 
 export interface IOutsideClickHandlerProps {
     onOutsideClick: (e: MouseEvent) => void;
@@ -13,7 +13,7 @@ export default class OutsideClickHandler extends React.Component<IOutsideClickHa
         useCapture: true,
     };
 
-    private wrapperEl: HTMLElement = null;
+    private wrapperElRef = createRef<HTMLDivElement>();
 
     public componentDidUpdate(prevProps: IOutsideClickHandlerProps): void {
         if (
@@ -34,20 +34,16 @@ export default class OutsideClickHandler extends React.Component<IOutsideClickHa
     }
 
     public render(): React.ReactNode {
-        return <div ref={this.setWrapperEl}>{this.props.children}</div>;
+        return <div ref={this.wrapperElRef}>{this.props.children}</div>;
     }
 
-    private setWrapperEl = (el: HTMLElement) => {
-        this.wrapperEl = el;
-    };
-
     private handleClick = (e: MouseEvent) => {
-        if (!this.wrapperEl) {
+        if (!this.wrapperElRef.current) {
             // In IE11 the wrapperEl is not initialized for some reason.
             return;
         }
 
-        if (this.wrapperEl.contains(e.target as HTMLElement)) {
+        if (this.wrapperElRef.current.contains(e.target as HTMLElement)) {
             return;
         }
 

--- a/libs/sdk-ui-pivot/src/types.ts
+++ b/libs/sdk-ui-pivot/src/types.ts
@@ -114,7 +114,7 @@ export interface ITableCellStyleAndFormattedValue {
 }
 
 export function isAttributeCell(cell: TableCell): cell is IAttributeCell {
-    return cell && (cell as IAttributeCell).uri !== undefined;
+    return (cell as IAttributeCell)?.uri !== undefined;
 }
 
 /**

--- a/libs/sdk-ui-pivot/tsconfig.json
+++ b/libs/sdk-ui-pivot/tsconfig.json
@@ -13,6 +13,7 @@
         "noImplicitAny": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
+        "strictNullChecks": true,
         "outDir": "dist",
         "sourceMap": true,
         "suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
The errors were fixed like this:
* items from props with defaultProps values were suffixed by !
* field and colId are considered always defined (in spite of AG grid typings) so there are ! as well
* some types were extended by null and/or undefined to reflect reality
* in CorePivotTable some instance properties were suffixed by ! because we are quite sure they are there at those points

JIRA: RAIL-2611

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
