### PR TITLE
RELATED: RAIL-2107 fix PluggableBarChart sorting

### DIFF
--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -87,7 +87,7 @@ function getDefaultBarChartSort(
         return [newAttributeAreaSort(viewBy[0], SORT_DIR_DESC)];
     }
 
-    return !isEmpty(measures) ? [newMeasureSort(measures[0], SORT_DIR_DESC)] : [];
+    return isEmpty(stackBy) && !isEmpty(measures) ? [newMeasureSort(measures[0], SORT_DIR_DESC)] : [];
 }
 
 export function getDefaultTreemapSortFromBuckets(

--- a/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
@@ -156,21 +156,8 @@ describe("createSorts", () => {
                 expect(createSorts("bar", insightWithTwoMeasuresAndTwoViewBy, true)).toEqual(expectedSort);
             });
 
-            it("should return area sort for stacked bar chart", () => {
-                const expectedSort: ISortItem[] = [
-                    {
-                        measureSortItem: {
-                            direction: "desc",
-                            locators: [
-                                {
-                                    measureLocatorItem: {
-                                        measureIdentifier: "m1",
-                                    },
-                                },
-                            ],
-                        },
-                    },
-                ];
+            it("should return no sort for stacked bar chart with only measure", () => {
+                const expectedSort: ISortItem[] = [];
                 expect(createSorts("bar", insightWithSingleMeasureAndStack)).toEqual(expectedSort);
             });
         });


### PR DESCRIPTION
PluggableBarChart should not be sorted if viewBy is empty and stackBy is not.
This was tested implicitly in one of AD e2e tests.

JIRA: RAIL-2107

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
