### PR TITLE
BUGFIX: RAIL-2596 - Fix `this` binding in XirrTransformation

### DIFF
--- a/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
@@ -57,12 +57,12 @@ class XirrTransformation extends React.Component<IXirrTransformationProps & Wrap
     private getDisableDrillUnderlineFromConfig = (): boolean =>
         this.props.config ? this.props.config.disableDrillUnderline : false;
 
-    private handleFiredDrillEvent(item: IHeadlineFiredDrillEventItemContext, target: HTMLElement) {
+    private handleFiredDrillEvent = (item: IHeadlineFiredDrillEventItemContext, target: HTMLElement) => {
         const { onDrill, dataView } = this.props;
         const drillEventData = buildDrillEventData(item, dataView);
 
         fireDrillEvent(onDrill, drillEventData, target);
-    }
+    };
 }
 
 export default injectIntl(XirrTransformation);


### PR DESCRIPTION
https://jira.intgdc.com/browse/RAIL-2596

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
