### PR TITLE
RELATED: BB-2443 /gdc/app/account/bootstrap response extension

### DIFF
--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -1814,6 +1814,7 @@ export namespace GdcUser {
             current?: {
                 mapboxToken?: string;
                 project: IProject | null;
+                projectLcm?: IProjectLcm;
                 featureFlags?: IFeatureFlags;
                 projectPermissions: IProjectPermissions | null;
                 projectTemplates: ITemplateInfo[] | null;
@@ -1977,6 +1978,15 @@ export namespace GdcUser {
         icon: string;
         // (undocumented)
         integration: Uri;
+    }
+    // (undocumented)
+    export interface IProjectLcm {
+        // (undocumented)
+        clientId?: string;
+        // (undocumented)
+        dataProductId?: string;
+        // (undocumented)
+        segmentId?: string;
     }
     // (undocumented)
     export interface IProjectPermissions {

--- a/libs/api-model-bear/src/user/GdcUser.ts
+++ b/libs/api-model-bear/src/user/GdcUser.ts
@@ -340,6 +340,12 @@ export namespace GdcUser {
         currentOffsetMs: number;
     }
 
+    export interface IProjectLcm {
+        clientId?: string;
+        dataProductId?: string;
+        segmentId?: string;
+    }
+
     export interface IBootstrapResource {
         bootstrapResource: {
             accountSetting: IAccountSetting;
@@ -349,6 +355,7 @@ export namespace GdcUser {
             current?: {
                 mapboxToken?: string;
                 project: IProject | null;
+                projectLcm?: IProjectLcm;
                 featureFlags?: IFeatureFlags;
                 projectPermissions: IProjectPermissions | null;
                 projectTemplates: ITemplateInfo[] | null;


### PR DESCRIPTION
There are two new optional pieces of information in /gdc/app/account/bootstrap response: clientId and dataProductId.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
