### PR TITLE
RELATED: RAIL-2093 add getWidget API

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -40,6 +40,7 @@ import {
     GdcFilterContext,
     GdcVisualizationClass,
     GdcMetadataObject,
+    GdcVisualizationWidget,
 } from "@gooddata/api-model-bear";
 import { BearAuthenticatedCallGuard } from "../../../types/auth";
 import * as fromSdkModel from "../../../convertors/toBackend/DashboardConverter";
@@ -52,6 +53,7 @@ import { objRefToUri, getObjectIdFromUri, userUriFromAuthenticatedPrincipal } fr
 import keyBy from "lodash/keyBy";
 import { WidgetReferencesQuery } from "./widgetReferences";
 import invariant from "ts-invariant";
+import { convertVisualizationWidget } from "../../../convertors/fromBackend/DashboardConverter";
 
 type DashboardDependencyCategory = Extract<
     GdcMetadata.ObjectCategory,
@@ -306,6 +308,16 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboards {
         );
 
         return new WidgetReferencesQuery(this.authCall, this.workspace, widget, types).run();
+    };
+
+    public getWidget = async (ref: ObjRef): Promise<IWidget> => {
+        const widgetUri = await objRefToUri(ref, this.workspace, this.authCall);
+        const [widget] = await this.authCall((sdk) =>
+            sdk.md.getObjects<GdcVisualizationWidget.IWrappedVisualizationWidget>(this.workspace, [
+                widgetUri,
+            ]),
+        );
+        return convertVisualizationWidget(widget);
     };
 
     // Alerts

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1101,6 +1101,7 @@ export interface IWorkspaceDashboards {
     getDashboard(ref: ObjRef, filterContextRef?: ObjRef): Promise<IDashboard>;
     getDashboards(): Promise<IListedDashboard[]>;
     getScheduledMailsCountForDashboard(ref: ObjRef): Promise<number>;
+    getWidget(ref: ObjRef): Promise<IWidget>;
     getWidgetAlertsCountForWidgets(refs: ObjRef[]): Promise<IWidgetAlertCount[]>;
     getWidgetReferencedObjects(widget: IWidget, types?: SupportedWidgetReferenceTypes[]): Promise<IWidgetReferences>;
     updateDashboard(dashboard: IDashboard, updatedDashboard: IDashboardDefinition): Promise<IDashboard>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -146,4 +146,11 @@ export interface IWorkspaceDashboards {
         widget: IWidget,
         types?: SupportedWidgetReferenceTypes[],
     ): Promise<IWidgetReferences>;
+
+    /**
+     * Get widget object
+     *
+     * @param ref - widget reference
+     */
+    getWidget(ref: ObjRef): Promise<IWidget>;
 }


### PR DESCRIPTION
This is needed in certain cases when we need the absolutely latest version of a widget.

JIRA: RAIL-2093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
