### PR TITLE
RELATED: RAIL-2623 fix empty value handling in PivotTable

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -340,6 +340,13 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         }
     };
 
+    private fixEmptyHeaders = (dataView: IDataView): void => {
+        fixEmptyHeaderItems(
+            dataView,
+            `(${this.props.intl.formatMessage({ id: "visualization.emptyValue" })})`,
+        );
+    };
+
     private initializeNonReactState = (result: IExecutionResult, dataView: IDataView) => {
         this.currentResult = result;
         this.visibleData = DataViewFacade.for(dataView);
@@ -371,6 +378,10 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                 getGroupRows: () => this.props.groupRows!,
                 getColumnTotals: this.getColumnTotals,
                 onPageLoaded: this.onPageLoaded,
+                dataViewTransform: (dataView) => {
+                    this.fixEmptyHeaders(dataView);
+                    return dataView;
+                },
             },
             this.visibleData,
             this.getGridApi as () => GridApi,
@@ -405,10 +416,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                             return;
                         }
 
-                        fixEmptyHeaderItems(
-                            dataView,
-                            `(${this.props.intl.formatMessage({ id: "visualization.emptyValue" })})`,
-                        );
+                        this.fixEmptyHeaders(dataView);
 
                         this.initializeNonReactState(result, dataView);
 

--- a/libs/sdk-ui-pivot/src/impl/agGridDataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridDataSource.ts
@@ -137,8 +137,9 @@ export class AgGridDatasource implements IDatasource {
                     // the as any cast is fishy but I did not want to change if as it could have unforeseen consequences
                     .readWindow([startRow, 0], [endRow - startRow, undefined as any])
                     .then((data) => {
-                        const dv = DataViewFacade.for(data);
-                        this.gridApiProvider()?.setInfiniteRowCount(data.totalCount[0]);
+                        const dataView = this.config.dataViewTransform(data);
+                        const dv = DataViewFacade.for(dataView);
+                        this.gridApiProvider()?.setInfiniteRowCount(dataView.totalCount[0]);
                         this.currentSorts = dv.meta().effectiveSortItems();
                         this.processData(dv, params);
                     })

--- a/libs/sdk-ui-pivot/src/impl/agGridTypes.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridTypes.ts
@@ -2,6 +2,7 @@
 import { IMappingHeader, DataViewFacade } from "@gooddata/sdk-ui";
 import { CellEvent, ColDef, GridOptions } from "@ag-grid-community/all-modules";
 import { ITotal, SortDirection } from "@gooddata/sdk-model";
+import { IDataView } from "@gooddata/sdk-backend-spi";
 
 export interface IGridRow {
     headerItemMap: {
@@ -77,6 +78,7 @@ export type DatasourceConfig = {
     getGroupRows: () => boolean;
     getColumnTotals: () => ITotal[];
     onPageLoaded: OnPageLoaded;
+    dataViewTransform: (dv: IDataView) => IDataView;
 };
 
 export type OnPageLoaded = (dv: DataViewFacade) => void;


### PR DESCRIPTION
The fixEmptyHeaderItems was only called on init but not
on subsequent loads. The dataViewTransform hook was added
that allows transforming the dataView when it is loaded in datasource.

JIRA: RAIL-2623

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
