### PR TITLE
RELATED: RAIL-2625, RAIL-2625 small fixes in XIRR and withEntireDataView

### DIFF
--- a/libs/sdk-ui-charts/src/charts/xirr/internal/utils/XirrTransformationUtils.ts
+++ b/libs/sdk-ui-charts/src/charts/xirr/internal/utils/XirrTransformationUtils.ts
@@ -37,7 +37,7 @@ const computeXirr = (executionData: IXirrExecutionData[]): number => {
 
     const transactions = executionData
         .map((datum) => ({
-            amount: Number.parseFloat(datum.value.toString()),
+            amount: datum.value != null ? Number.parseFloat(datum.value.toString()) : 0,
             date: datum.date,
         }))
         .filter((datum) => datum.amount !== 0) // zero values are irrelevant to XIRR computation, filter them out here to avoid useless Date parsing later

--- a/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
+++ b/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
@@ -171,19 +171,17 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
             this.setState(state);
         }
 
-        private onError(error: GoodDataSdkError, execution = this.props.execution) {
+        private onError(error: GoodDataSdkError) {
             const { onExportReady } = this.props;
 
-            if (this.props.execution.fingerprint() === execution.fingerprint()) {
-                this.setState({ error: error.getMessage(), dataView: null });
-                this.onLoadingChanged({ isLoading: false });
+            this.setState({ error: error.getMessage(), dataView: null });
+            this.onLoadingChanged({ isLoading: false });
 
-                if (onExportReady) {
-                    onExportReady(createExportErrorFunction(error));
-                }
-
-                this.props.onError?.(error);
+            if (onExportReady) {
+                onExportReady(createExportErrorFunction(error));
             }
+
+            this.props.onError?.(error);
         }
 
         private onDataTooLarge() {


### PR DESCRIPTION
RAIL-2626: prevents null reference in XIRR computation
RAIL-2625: removes unnecessary if in withEntireDataView.onError

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
