### PR TITLE
RELATED: RAIL-2625 unmount PluggableHeadline on error

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -121,6 +121,8 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
         const measureBucket = insightBucket(insight, BucketNames.MEASURES);
 
         if (!measureBucket || bucketIsEmpty(measureBucket)) {
+            // unmount on error because currently AD cannot recover in certain cases (RAIL-2625)
+            this.unmount();
             throw new GoodDataSdkError(PluggableVisualizationErrorCodes.INVALID_BUCKETS);
         }
 


### PR DESCRIPTION
This is because AD cannot recover it in certain cases.

JIRA: RAIL-2625

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
