### PR TITLE
RELATED: RAIL-2629 relax shouldComponentUpdate in GeoValidator

### DIFF
--- a/libs/sdk-ui-geo/src/core/geoChart/GeoValidatorHOC.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoValidatorHOC.tsx
@@ -119,7 +119,8 @@ export function geoValidatorHOC<T>(InnerComponent: React.ComponentClass<T>): Rea
                 return execution === nextExecution;
             }
 
-            return execution.fingerprint() === nextExecution.fingerprint();
+            // we need equals here (not just fingerprint) for cases where measure is moved from one bucket to another
+            return execution.equals(nextExecution);
         }
     }
 


### PR DESCRIPTION
We need to check for strict equality in isSameData in cases
there are the same measures but in different buckets.

JIRA: RAIL-2629

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
