### PR TITLE
RELATED: RAIL-2631 - Fix normalization bug where localIds are not assigned correctly

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1418,7 +1418,10 @@ export function modifyAttribute(attribute: IAttribute, modifications?: Attribute
 export function modifyMeasure<T extends IMeasureDefinitionType>(measure: IMeasure<T>, modifications?: MeasureModifications<MeasureBuilderBase<IMeasureDefinitionType>>): IMeasure<T>;
 
 // @public
-export function modifyPopMeasure(measure: IMeasure<IPoPMeasureDefinition>, modifications: MeasureModifications<PoPMeasureBuilder>): IMeasure<IPoPMeasureDefinition>;
+export function modifyPopMeasure(measure: IMeasure<IPoPMeasureDefinition>, modifications?: MeasureModifications<PoPMeasureBuilder>): IMeasure<IPoPMeasureDefinition>;
+
+// @public
+export function modifyPreviousPeriodMeasure(measure: IMeasure<IPreviousPeriodMeasureDefinition>, modifications?: MeasureModifications<PreviousPeriodMeasureBuilder>): IMeasure<IPreviousPeriodMeasureDefinition>;
 
 // @public
 export function modifySimpleMeasure(measure: IMeasure<IMeasureDefinition>, modifications?: MeasureModifications<MeasureBuilder>): IMeasure<IMeasureDefinition>;

--- a/libs/sdk-model/src/execution/measure/factory.ts
+++ b/libs/sdk-model/src/execution/measure/factory.ts
@@ -738,11 +738,36 @@ export function modifySimpleMeasure(
  */
 export function modifyPopMeasure(
     measure: IMeasure<IPoPMeasureDefinition>,
-    modifications: MeasureModifications<PoPMeasureBuilder>,
+    modifications: MeasureModifications<PoPMeasureBuilder> = identity,
 ): IMeasure<IPoPMeasureDefinition> {
     invariant(measure, "measure must be specified");
 
     const builder = new PoPMeasureBuilder(measure);
+
+    return modifications(builder).build();
+}
+
+/**
+ * Creates a new Previous Period measure by applying modifications on top of an existing measure.
+ *
+ * This operation is immutable and will not alter the input measure.
+ *
+ * The returned measure will have the same localIdentifier as the original measure. If you would like to assign
+ * new/different local identifier to the measure, you can do that using the modifications where you can provide
+ * either new custom localId or indicate that the measure should fall back to the auto-generated localId.
+ *
+ * @param measure - measure to use as template for the new measure
+ * @param modifications - modifications to apply
+ * @returns new instance
+ * @public
+ */
+export function modifyPreviousPeriodMeasure(
+    measure: IMeasure<IPreviousPeriodMeasureDefinition>,
+    modifications: MeasureModifications<PreviousPeriodMeasureBuilder> = identity,
+): IMeasure<IPreviousPeriodMeasureDefinition> {
+    invariant(measure, "measure must be specified");
+
+    const builder = new PreviousPeriodMeasureBuilder(measure);
 
     return modifications(builder).build();
 }

--- a/libs/sdk-model/src/execution/measure/tests/__snapshots__/factory.test.ts.snap
+++ b/libs/sdk-model/src/execution/measure/tests/__snapshots__/factory.test.ts.snap
@@ -15,6 +15,44 @@ Object {
 }
 `;
 
+exports[`measure factories modifyPopMeasure should change master measure and pop attribute 1`] = `
+Object {
+  "measure": Object {
+    "definition": Object {
+      "popMeasureDefinition": Object {
+        "measureIdentifier": "otherMaster",
+        "popAttribute": Object {
+          "identifier": "attrId2",
+          "type": "attribute",
+        },
+      },
+    },
+    "localIdentifier": "measure1",
+  },
+}
+`;
+
+exports[`measure factories modifyPreviousPeriodMeasure should change master measure and pop attribute 1`] = `
+Object {
+  "measure": Object {
+    "definition": Object {
+      "previousPeriodMeasure": Object {
+        "dateDataSets": Array [
+          Object {
+            "dataSet": Object {
+              "identifier": "dataset2",
+            },
+            "periodsAgo": -1,
+          },
+        ],
+        "measureIdentifier": "otherMaster",
+      },
+    },
+    "localIdentifier": "measure1",
+  },
+}
+`;
+
 exports[`measure factories modifySimpleMeasure should create new measure with cleaned up customizations and same localId 1`] = `
 Object {
   "measure": Object {

--- a/libs/sdk-model/src/execution/measure/tests/factory.test.ts
+++ b/libs/sdk-model/src/execution/measure/tests/factory.test.ts
@@ -3,6 +3,8 @@ import { Velocity, Won } from "../../../../__mocks__/model";
 import { newPositiveAttributeFilter } from "../../filter/factory";
 import {
     modifyMeasure,
+    modifyPopMeasure,
+    modifyPreviousPeriodMeasure,
     modifySimpleMeasure,
     newArithmeticMeasure,
     newMeasure,
@@ -111,6 +113,30 @@ describe("measure factories", () => {
         });
     });
 
+    describe("modifyPopMeasure", () => {
+        const ExistingMeasure = newPopMeasure("masterMeasure1", "attrId1", (m) => m.localId("measure1"));
+
+        it("should not modify input measure", () => {
+            modifyPopMeasure(ExistingMeasure, (m) => m.localId("measure2"));
+
+            expect(measureLocalId(ExistingMeasure)).toEqual("measure1");
+        });
+
+        it("should keep local id from the existing measure if new localid not provided", () => {
+            const newMeasure = modifyPopMeasure(ExistingMeasure);
+
+            expect(measureLocalId(ExistingMeasure)).toEqual(measureLocalId(newMeasure));
+        });
+
+        it("should change master measure and pop attribute", () => {
+            expect(
+                modifyPopMeasure(ExistingMeasure, (m) =>
+                    m.masterMeasure("otherMaster").popAttribute("attrId2"),
+                ),
+            ).toMatchSnapshot();
+        });
+    });
+
     describe("newPreviousPeriodMeasure", () => {
         it("should return a simple PP measure when supplied with strings", () => {
             expect(newPreviousPeriodMeasure("foo", [{ dataSet: "bar", periodsAgo: 3 }])).toMatchSnapshot();
@@ -118,6 +144,34 @@ describe("measure factories", () => {
 
         it("should return a simple PP measure when supplied with objects", () => {
             expect(newPreviousPeriodMeasure(Won, [{ dataSet: "bar", periodsAgo: 3 }])).toMatchSnapshot();
+        });
+    });
+
+    describe("modifyPreviousPeriodMeasure", () => {
+        const ExistingMeasure = newPreviousPeriodMeasure(
+            "masterMeasure1",
+            [{ dataSet: "dataset", periodsAgo: 1 }],
+            (m) => m.localId("measure1"),
+        );
+
+        it("should not modify input measure", () => {
+            modifyPreviousPeriodMeasure(ExistingMeasure, (m) => m.localId("measure2"));
+
+            expect(measureLocalId(ExistingMeasure)).toEqual("measure1");
+        });
+
+        it("should keep local id from the existing measure if new localid not provided", () => {
+            const newMeasure = modifyPreviousPeriodMeasure(ExistingMeasure);
+
+            expect(measureLocalId(ExistingMeasure)).toEqual(measureLocalId(newMeasure));
+        });
+
+        it("should change master measure and pop attribute", () => {
+            expect(
+                modifyPreviousPeriodMeasure(ExistingMeasure, (m) =>
+                    m.masterMeasure("otherMaster").dateDataSets([{ dataSet: "dataset2", periodsAgo: -1 }]),
+                ),
+            ).toMatchSnapshot();
         });
     });
 });

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -196,6 +196,7 @@ export {
     modifyMeasure,
     modifySimpleMeasure,
     modifyPopMeasure,
+    modifyPreviousPeriodMeasure,
     newArithmeticMeasure,
     newPopMeasure,
     newPreviousPeriodMeasure,


### PR DESCRIPTION
The PR fixes the bug and adds extra modifyPreviousPeriodMeasure function to sdk-model + additional tests to sdk-model.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
