### PR TITLE
RELATED: RAIL-2560 - Fix bug where tiger backend returns invalid measure descriptors and headers

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -671,11 +671,11 @@ export interface IListedDashboard {
 export interface IMeasureDescriptor {
     // (undocumented)
     measureHeaderItem: {
-        uri?: string;
-        identifier?: string;
         localIdentifier: string;
         name: string;
         format: string;
+        uri?: string;
+        identifier?: string;
     };
 }
 

--- a/libs/sdk-backend-spi/src/workspace/execution/results.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/results.ts
@@ -32,11 +32,28 @@ export interface IMeasureGroupDescriptor {
 export interface IMeasureDescriptor {
     // TODO: rename this to measureDescriptor ... the goal is to get rid of the overused 'header' nomenclature
     measureHeaderItem: {
+        localIdentifier: string;
+
+        /**
+         * Measure name. Backend must fill the name according to the following rules:
+         *
+         * -  If measure definition contained 'title', then name MUST equal to 'title',
+         * -  Else if measure definition contained 'alias', then name MUST equal to 'alias',
+         * -  Else if the backend has a name of the measure in its records, then it MUST include that name
+         * -  Otherwise the name must default to value of localIdentifier
+         */
+        name: string;
+
+        /**
+         * Measure format. Backend must fill the name according to the following rules:
+         *
+         * -  If measure definition contained 'format', then the format from the definition MUST be used
+         * -  Else if backend has a format for the measure in its records, then it MUST include that format
+         * -  Otherwise the format must be defaulted
+         */
+        format: string;
         uri?: string;
         identifier?: string;
-        localIdentifier: string;
-        name: string;
-        format: string;
     };
 }
 
@@ -137,7 +154,19 @@ export interface IResultAttributeHeader {
  */
 export interface IResultMeasureHeader {
     measureHeaderItem: {
+        /**
+         * Measure name - equals to the measure name contained in the respective measure descriptor, included here
+         * for convenience and easy access.
+         *
+         * Note: check out the contract for measure name as described in {@link IMeasureDescriptor} - it is
+         * somewhat more convoluted than one would expect.
+         */
         name: string;
+
+        /**
+         * Index of this measure's descriptor within the measure group description. The measure group descriptor
+         * is included in the execution result.
+         */
         order: number;
     };
 }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
@@ -9,16 +9,20 @@ import { Execution } from "@gooddata/api-client-tiger";
 
 import isAttributeHeader = Execution.isAttributeHeader;
 
+const DEFAULT_FORMAT = "#,#.##";
+
 function transformDimension(dim: Execution.IResultDimension): IDimensionDescriptor {
     return {
         headers: dim.headers.map((header, headerIdx) => {
             const h = header;
 
             if (isAttributeHeader(h)) {
-                // TODO: SDK8: make our mind about whether URIs should be optional in attribute headers
-                //  perhaps it makes sense. perhaps the URIs should be always present and should be coming from
-                //  new stack as well? anyway, making URIs optional in the domain model will mean waterfall of fun
-                //  changes across public interface of the SDK (drilling etc)
+                /*
+                 * Funny stuff #1: we have to set 'uri' to some made-up value resembling the URIs sent by bear. This
+                 *  is because pivot table relies on the format of URIs. Ideally we would refactor pivot table to
+                 *  not care about this however this aspect is like a couple of eggs that hold the pivot spaghetti
+                 *  together - cannot be easily untangled.
+                 */
                 const attrDescriptor: IAttributeDescriptor = {
                     attributeHeader: {
                         uri: `/obj/${headerIdx}`,
@@ -35,14 +39,21 @@ function transformDimension(dim: Execution.IResultDimension): IDimensionDescript
 
                 return attrDescriptor;
             } else {
+                /*
+                 * Funny stuff #2: tiger does not send name & format according to the contract (which is inspired
+                 *  by bear behavior). The code must reconciliate as follows:
+                 *
+                 *  -  if name does not come from tiger, then default the name to localIdentifier
+                 *  -  if format does not come from tiger, then default to a hardcoded format
+                 */
                 const measureDescriptor: IMeasureGroupDescriptor = {
                     measureGroupHeader: {
                         items: h.measureGroupHeader.items.map((m) => {
                             const newItem: IMeasureDescriptor = {
                                 measureHeaderItem: {
                                     localIdentifier: m.measureHeaderItem.localIdentifier,
-                                    name: m.measureHeaderItem.name,
-                                    format: m.measureHeaderItem.format,
+                                    name: m.measureHeaderItem.name ?? m.measureHeaderItem.localIdentifier,
+                                    format: m.measureHeaderItem.format ?? DEFAULT_FORMAT,
                                 },
                             };
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
@@ -78,6 +78,12 @@ function transformHeaderItems(
                         const primaryLabel =
                             header.attributeHeader.primaryLabelValue ?? header.attributeHeader.labelValue;
 
+                        /*
+                         * Funny stuff #1 - we have to set 'uri' to some made-up value resembling the URIs sent by bear. This
+                         * is because pivot table relies on the format of URIs. Ideally we would refactor pivot table to
+                         * not care about this however this aspect is like a couple of eggs that hold the pivot spaghetti
+                         * together - cannot be easily untangled.
+                         */
                         return {
                             attributeHeaderItem: {
                                 uri: `/obj/${headerGroupIndex}/elements?id=${primaryLabel}`,
@@ -90,8 +96,9 @@ function transformHeaderItems(
 
                     if (isResultMeasureHeader(header)) {
                         /*
-                         * Tiger sends just the measure index in the measure headers. This is the index of the
-                         * measure descriptor within the measure group.
+                         * Funny stuff #2 - Tiger sends just the measure index in the measure headers. This is the index of the
+                         * measure descriptor within the measure group. The code looks up the measure descriptor so that
+                         * it can then fill in the `name` to the one in the descriptor
                          */
                         const measureIndex = header.measureHeader.measureIndex;
 

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -14,6 +14,21 @@ import { withNormalization } from "@gooddata/sdk-backend-base";
  */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function tigerFactory(config?: AnalyticalBackendConfig, implConfig?: any): IAnalyticalBackend {
+    /*
+     * Execution normalization is applied by default for tiger. This is so that tiger does not have to support
+     * questionable mechanics of measure name and format assignment and attribute name assigment; tiger does not
+     * accept those parameters on input to AFM.
+     *
+     * Normalizing decorator takes care of this transparently - it will modify the execution definition under the
+     * covers, remove the nonsense and then send the execution to the real tiger impl. Once tiger impl returns data,
+     * the decorator will apply denormalization and reinstate the detail it stripped away.
+     *
+     * IMPORTANT: in order for the decorator to work without issues, it is important that the results provided by the
+     * tiger backend match the contracts for result dimension and data view header items. To this end, there are
+     * couple of alternations / enrichment of tiger's descriptors and header items. Those are done during
+     * conversion. See `src/convertors/fromBackend/dimensions.ts` and `result.ts` in the same dir.
+     */
+
     return withNormalization(new TigerBackend(config, implConfig));
 }
 


### PR DESCRIPTION
This then makes denormalizer not match header item with the actual measure name to use.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
