### PR TITLE
Restrict Show in % when MVF on derived is present

### DIFF
--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -2113,7 +2113,11 @@ export const measureValueFilterReferencePoint: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
-            items: masterMeasureItems,
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "secondary_measures",
+            items: masterMeasureItems.slice(1),
         },
         {
             localIdentifier: "view",
@@ -2157,6 +2161,57 @@ export const measureValueFilterReferencePoint: IReferencePoint = {
                 filters: [
                     {
                         measureLocalIdentifier: masterMeasureItems[2].localIdentifier,
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+export const measureValueFilterByDerivedReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "secondary_measures",
+            items: masterMeasureItems.slice(1).concat(derivedMeasureItems),
+        },
+        {
+            localIdentifier: "view",
+            items: attributeItems,
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [
+            {
+                localIdentifier: "filter_by_derived_measure",
+                filters: [
+                    {
+                        measureLocalIdentifier: derivedMeasureItems[0].localIdentifier,
+                        condition: {
+                            comparison: {
+                                operator: "GREATER_THAN",
+                                value: 100,
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                localIdentifier: "fbv2",
+                filters: [
+                    {
+                        measureLocalIdentifier: masterMeasureItems[1].localIdentifier,
+                        condition: {
+                            range: {
+                                operator: "BETWEEN",
+                                from: 100,
+                                to: 200,
+                            },
+                        },
                     },
                 ],
             },

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
@@ -143,6 +143,7 @@ describe("sanitizeFilters", () => {
     it("should keep just measure value filters based on measures that exist in extended reference point", () => {
         const newReferencePoint = cloneDeep(referencePointMocks.measureValueFilterReferencePoint);
         newReferencePoint.buckets[0].items.splice(1);
+        newReferencePoint.buckets[1].items = [];
         const extendedReferencePoint: IExtendedReferencePoint = {
             ...newReferencePoint,
             uiConfig: DEFAULT_BASE_CHART_UICONFIG,
@@ -155,7 +156,7 @@ describe("sanitizeFilters", () => {
 
     it("should remove all measure value filters when there is no attribute or date in buckets", () => {
         const newReferencePoint = cloneDeep(referencePointMocks.measureValueFilterReferencePoint);
-        newReferencePoint.buckets[1].items = [];
+        newReferencePoint.buckets[2].items = [];
         const extendedReferencePoint: IExtendedReferencePoint = {
             ...newReferencePoint,
             uiConfig: DEFAULT_BASE_CHART_UICONFIG,

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketRules.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketRules.test.ts
@@ -27,6 +27,26 @@ describe("isShowInPercentAllowed", () => {
             ),
         ).toBeFalsy();
     });
+
+    it("should return true if measure value filter is present", () => {
+        expect(
+            bucketRules.isShowInPercentAllowed(
+                referencePointMocks.measureValueFilterReferencePoint.buckets,
+                referencePointMocks.measureValueFilterReferencePoint.filters,
+                BucketNames.MEASURES,
+            ),
+        ).toBeTruthy();
+    });
+
+    it("should return false if measure value filter by derived measure is present", () => {
+        expect(
+            bucketRules.isShowInPercentAllowed(
+                referencePointMocks.measureValueFilterByDerivedReferencePoint.buckets,
+                referencePointMocks.measureValueFilterByDerivedReferencePoint.filters,
+                BucketNames.MEASURES,
+            ),
+        ).toBeFalsy();
+    });
 });
 
 describe("overTimeComparisonRecommendationEnabled", () => {
@@ -103,6 +123,7 @@ describe("percentRecommendationEnabled", () => {
         expect(
             bucketRules.percentRecommendationEnabled(
                 referencePointMocks.percentRecommendationReferencePoint.buckets,
+                referencePointMocks.percentRecommendationReferencePoint.filters,
             ),
         ).toBeTruthy();
     });
@@ -119,7 +140,12 @@ describe("percentRecommendationEnabled", () => {
 
         set(editedReferencePoint, ["buckets", 2, "items", 0], newStack);
 
-        expect(bucketRules.percentRecommendationEnabled(editedReferencePoint.buckets)).toBeFalsy();
+        expect(
+            bucketRules.percentRecommendationEnabled(
+                editedReferencePoint.buckets,
+                editedReferencePoint.filters,
+            ),
+        ).toBeFalsy();
     });
 });
 

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
@@ -14,7 +14,7 @@ import {
 } from "../../interfaces/Visualization";
 
 import { UICONFIG, RECOMMENDATIONS, OPEN_AS_REPORT, SUPPORTED } from "../../constants/uiConfig";
-import { BUCKETS } from "../../constants/bucket";
+import { BUCKETS, FILTERS } from "../../constants/bucket";
 
 import {
     comparisonAndTrendingRecommendationEnabled,
@@ -140,12 +140,12 @@ export function setBaseChartUiConfigRecommendations(
     visualizationType: string,
     weekFiltersEnabled: boolean,
 ): IExtendedReferencePoint {
-    // Recommendations
     if (visualizationType === VisualizationTypes.COLUMN) {
         const newReferencePoint = cloneDeep(referencePoint);
         const buckets = get(newReferencePoint, BUCKETS);
+        const filters = get(newReferencePoint, FILTERS);
 
-        const percentEnabled = percentRecommendationEnabled(buckets);
+        const percentEnabled = percentRecommendationEnabled(buckets, filters);
         const comparisonAndTrending = comparisonAndTrendingRecommendationEnabled(buckets);
         const overTimeComparison = overTimeComparisonRecommendationEnabled(
             newReferencePoint,


### PR DESCRIPTION
Show in % should not be available in bucket item configuration and in recommendations when measure value filter on derived measure is present in the insight.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
