### PR TITLE
RELATED: BB-2494 - Restore ability to specify MVF using full ObjRef

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
@@ -1,11 +1,18 @@
 // (C) 2007-2020 GoodData Corporation
-import isEmpty from "lodash/isEmpty";
-import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
-import { isUriRef, ObjRef, ObjectType, isLocalIdRef, ObjRefInScope, isObjRef } from "@gooddata/sdk-model";
 import { ExecuteAFM } from "@gooddata/api-client-tiger";
-import ObjQualifier = ExecuteAFM.ObjQualifier;
-import ILocalIdentifierQualifier = ExecuteAFM.ILocalIdentifierQualifier;
+import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
+import {
+    isIdentifierRef,
+    isLocalIdRef,
+    isUriRef,
+    ObjectType,
+    ObjRef,
+    ObjRefInScope,
+} from "@gooddata/sdk-model";
+import isEmpty from "lodash/isEmpty";
 import { TigerAfmType } from "../../types";
+import ILocalIdentifierQualifier = ExecuteAFM.ILocalIdentifierQualifier;
+import ObjQualifier = ExecuteAFM.ObjQualifier;
 
 type AfmObjectType = Exclude<ObjectType, "tag" | "insight" | "analyticalDashboard">;
 
@@ -95,7 +102,12 @@ export function toMeasureValueFilterMeasureQualifier(
 ): ExecuteAFM.ILocalIdentifierQualifier | ExecuteAFM.IObjIdentifierQualifier {
     if (isLocalIdRef(ref)) {
         return toLocalIdentifier(ref.localIdentifier);
-    } else if (isObjRef(ref)) {
+    } else if (isIdentifierRef(ref)) {
+        if (!ref.type) {
+            throw new UnexpectedError(
+                "Please explicitly specify idRef for measure value filter. You must provide both identifier and type of object you want to reference.",
+            );
+        }
         return toObjQualifier(ref);
     } else {
         throw new UnexpectedError(

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
@@ -151,6 +151,9 @@ export function convertVisualizationObjectFilter(filter: IFilter): ExecuteAFM.Fi
     } else if (isMeasureValueFilter(filter)) {
         return convertMeasureValueFilter(filter);
     } else {
-        throw new NotSupported("Tiger backend does not support measure value filters");
+        // eslint-disable-next-line no-console
+        console.warn("Tiger does not support ranking filters. The filter will be ignored");
+
+        return null;
     }
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
@@ -1,6 +1,7 @@
 // (C) 2020 GoodData Corporation
 import {
     convertAbsoluteDateFilter,
+    convertMeasureValueFilter,
     convertRelativeDateFilter,
     convertVisualizationObjectFilter,
 } from "../FilterConverter";
@@ -12,10 +13,49 @@ import {
     newPositiveAttributeFilter,
     newNegativeAttributeFilter,
     newMeasureValueFilter,
+    IMeasureValueFilter,
+    idRef,
+    uriRef,
 } from "@gooddata/sdk-model";
 import { ReferenceLdmExt, ReferenceLdm } from "@gooddata/reference-workspace";
 
 describe("tiger filter converter from model to AFM", () => {
+    describe("convert measure value filter", () => {
+        const Scenarios: Array<[string, IMeasureValueFilter]> = [
+            [
+                "specified using id of metric",
+                newMeasureValueFilter(idRef("measureId", "measure"), "GREATER_THAN", 10),
+            ],
+            [
+                "specified using id of metric",
+                newMeasureValueFilter(idRef("factId", "fact"), "GREATER_THAN", 10),
+            ],
+            [
+                "specified using localId of metric specified as string",
+                newMeasureValueFilter("localId", "GREATER_THAN", 10),
+            ],
+            [
+                "specified using localId of metric specified by value",
+                newMeasureValueFilter(ReferenceLdm.Amount, "GREATER_THAN", 10),
+            ],
+        ];
+
+        it.each(Scenarios)("should convert %s", (_desc, filter) => {
+            expect(convertMeasureValueFilter(filter)).toMatchSnapshot();
+        });
+
+        it("should throw exception if filter has idRef without type", () => {
+            expect(() => {
+                convertMeasureValueFilter(newMeasureValueFilter(idRef("ambiguous"), "GREATER_THAN", 10));
+            }).toThrow();
+        });
+
+        it("should throw exception if filter is using uriRef", () => {
+            expect(() => {
+                convertMeasureValueFilter(newMeasureValueFilter(uriRef("unsupported"), "GREATER_THAN", 10));
+            }).toThrow();
+        });
+    });
     describe("convert absolute date filter", () => {
         const Scenarios: Array<[string, any]> = [
             ["absolute date filter without 'to' attribute", absoluteFilter.withoutTo],

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -19,6 +19,64 @@ exports[`tiger filter converter from model to AFM convert absolute date filter s
 
 exports[`tiger filter converter from model to AFM convert absolute date filter should convert absolute date filter without 'to' attribute 1`] = `null`;
 
+exports[`tiger filter converter from model to AFM convert measure value filter should convert specified using id of metric 1`] = `
+Object {
+  "comparisonMeasureValueFilter": Object {
+    "measure": Object {
+      "identifier": Object {
+        "id": "measureId",
+        "type": "metric",
+      },
+    },
+    "operator": "GREATER_THAN",
+    "treatNullValuesAs": undefined,
+    "value": 10,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert measure value filter should convert specified using id of metric 2`] = `
+Object {
+  "comparisonMeasureValueFilter": Object {
+    "measure": Object {
+      "identifier": Object {
+        "id": "factId",
+        "type": "fact",
+      },
+    },
+    "operator": "GREATER_THAN",
+    "treatNullValuesAs": undefined,
+    "value": 10,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert measure value filter should convert specified using localId of metric specified as string 1`] = `
+Object {
+  "comparisonMeasureValueFilter": Object {
+    "measure": Object {
+      "localIdentifier": "localId",
+    },
+    "operator": "GREATER_THAN",
+    "treatNullValuesAs": undefined,
+    "value": 10,
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert measure value filter should convert specified using localId of metric specified by value 1`] = `
+Object {
+  "comparisonMeasureValueFilter": Object {
+    "measure": Object {
+      "localIdentifier": "m_aangOxLSeztu",
+    },
+    "operator": "GREATER_THAN",
+    "treatNullValuesAs": undefined,
+    "value": 10,
+  },
+}
+`;
+
 exports[`tiger filter converter from model to AFM convert relative date filter should return AFM relative date filter with date granularity 1`] = `
 Object {
   "relativeDateFilter": Object {

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -815,7 +815,7 @@ export interface IMeasureTitle {
 export interface IMeasureValueFilter {
     // (undocumented)
     measureValueFilter: {
-        measure: UriRef | LocalIdRef;
+        measure: ObjRefInScope;
         condition?: MeasureValueFilterCondition;
     };
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1523,10 +1523,10 @@ export const newMeasureMetadataObject: (ref: ObjRef, modifications?: BuilderModi
 export function newMeasureSort(measureOrId: IMeasure | string, sortDirection?: SortDirection, attributeLocators?: IAttributeLocatorItem[]): IMeasureSortItem;
 
 // @public
-export function newMeasureValueFilter(measureOrRef: IMeasure | UriRef | LocalIdRef | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;
+export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;
 
 // @public
-export function newMeasureValueFilter(measureOrRef: IMeasure | UriRef | LocalIdRef | string, operator: RangeConditionOperator, from: number, to: number, treatNullValuesAs?: number): IMeasureValueFilter;
+export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | LocalIdRef | string, operator: RangeConditionOperator, from: number, to: number, treatNullValuesAs?: number): IMeasureValueFilter;
 
 // @public
 export function newNegativeAttributeFilter(attributeOrRef: IAttribute | ObjRef | Identifier, notInValues: IAttributeElements | string[]): INegativeAttributeFilter;

--- a/libs/sdk-model/src/execution/filter/factory.ts
+++ b/libs/sdk-model/src/execution/filter/factory.ts
@@ -12,7 +12,7 @@ import {
     RangeConditionOperator,
 } from "./index";
 import { attributeDisplayFormRef, IAttribute } from "../attribute";
-import { Identifier, isObjRef, LocalIdRef, ObjRef, UriRef } from "../../objRef";
+import { Identifier, isObjRef, LocalIdRef, ObjRef, ObjRefInScope } from "../../objRef";
 import { IMeasure, isMeasure, measureLocalId } from "../measure";
 import { idRef, localIdRef } from "../../objRef/factory";
 import { DateAttributeGranularity } from "../../base/dateGranularities";
@@ -156,7 +156,7 @@ export function newAllTimeFilter(dateDataSet: ObjRef | Identifier): IRelativeDat
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
+    measureOrRef: IMeasure | ObjRefInScope | string,
     operator: ComparisonConditionOperator,
     value: number,
     treatNullValuesAs?: number,
@@ -175,7 +175,7 @@ export function newMeasureValueFilter(
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
+    measureOrRef: IMeasure | ObjRefInScope | LocalIdRef | string,
     operator: RangeConditionOperator,
     from: number,
     to: number,
@@ -195,13 +195,13 @@ export function newMeasureValueFilter(
  * @public
  */
 export function newMeasureValueFilter(
-    measureOrRef: IMeasure | UriRef | LocalIdRef | string,
+    measureOrRef: IMeasure | ObjRefInScope | string,
     operator: ComparisonConditionOperator | RangeConditionOperator,
     val1: number,
     val2OrTreatNullValuesAsInComparison?: number,
     treatNullValuesAsInRange?: number,
 ): IMeasureValueFilter {
-    const ref: UriRef | LocalIdRef = isMeasure(measureOrRef)
+    const ref: ObjRefInScope = isMeasure(measureOrRef)
         ? { localIdentifier: measureLocalId(measureOrRef) }
         : typeof measureOrRef === "string"
         ? localIdRef(measureOrRef)

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import invariant from "ts-invariant";
-import { LocalIdRef, ObjRef, ObjRefInScope, UriRef } from "../../objRef";
+import { ObjRef, ObjRefInScope } from "../../objRef";
 import { DateAttributeGranularity, AllTimeGranularity } from "../../base/dateGranularities";
 
 /**
@@ -191,7 +191,7 @@ export type MeasureValueFilterCondition = IComparisonCondition | IRangeCondition
  */
 export interface IMeasureValueFilter {
     measureValueFilter: {
-        measure: UriRef | LocalIdRef; // keeping UriRef for the sake of legacy code
+        measure: ObjRefInScope;
         condition?: MeasureValueFilterCondition;
     };
 }


### PR DESCRIPTION
-  This was removed because of mis-understanding in Tiger behavior. idRefs on tiger
   require type.
-  Before RAIL-2485: we had defaulting in place if type is not specified by user. for MVF, tiger conversion was defaulting
   to 'metric'; which works ok if the id is actually for metric. But for facts, this would not work - resulting in
   the QA reported 400s
-  After RAIL-2485: idRef was removed as option. even if it is supported by both bear and tiger
-  Now: idRef is restored. bear can accept it, tiger does conversion and will blow up if the type is not specified.

JIRA: BB-2494

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
