### PR TITLE
RELATED: RAIL-2607 fix error handling in InsightView, improve catalog export

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -232,6 +232,7 @@ class RenderInsightView extends React.Component<
             callbacks: {
                 onError: (error) => {
                     this.setError(error);
+                    this.setIsLoading(false);
                     if (this.props.onError) {
                         this.props.onError(error);
                     }
@@ -410,7 +411,7 @@ export const IntlInsightView = withContexts(injectIntl(RenderInsightView));
  * @public
  */
 export class InsightView extends React.Component<IInsightViewProps, IInsightViewState> {
-    public render() {
+    public render(): React.ReactNode {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <IntlInsightView {...this.props} />

--- a/libs/sdk-ui/src/base/errors/errorHandling.ts
+++ b/libs/sdk-ui/src/base/errors/errorHandling.ts
@@ -32,12 +32,15 @@ export interface IErrorDescriptors {
  * @public
  */
 export function newErrorMapping(intl: IntlShape): IErrorDescriptors {
+    const tooLargeDescriptor: IErrorDescriptors["any"] = {
+        icon: "icon-cloud-rain",
+        message: intl.formatMessage({ id: "visualization.ErrorMessageDataTooLarge" }),
+        description: intl.formatMessage({ id: "visualization.ErrorDescriptionDataTooLarge" }),
+    };
+
     return {
-        [ErrorCodes.DATA_TOO_LARGE_TO_DISPLAY]: {
-            icon: "icon-cloud-rain",
-            message: intl.formatMessage({ id: "visualization.ErrorMessageDataTooLarge" }),
-            description: intl.formatMessage({ id: "visualization.ErrorDescriptionDataTooLarge" }),
-        },
+        [ErrorCodes.DATA_TOO_LARGE_TO_DISPLAY]: tooLargeDescriptor,
+        [ErrorCodes.DATA_TOO_LARGE_TO_COMPUTE]: tooLargeDescriptor,
         [ErrorCodes.NOT_FOUND]: {
             message: intl.formatMessage({ id: "visualization.ErrorMessageNotFound" }),
             description: intl.formatMessage({ id: "visualization.ErrorDescriptionNotFound" }),

--- a/tools/catalog-export/src/transform/toTypescript.ts
+++ b/tools/catalog-export/src/transform/toTypescript.ts
@@ -20,7 +20,7 @@ export type TypescriptOutput = {
 // Constants
 //
 
-const FILE_DIRECTIVES = ["/* eslint-disable header/header */"];
+const FILE_DIRECTIVES = ["/* eslint-disable */"];
 const FILE_HEADER = `/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: ${new Date().toISOString()}; */`;
 const INSIGHT_MAP_VARNAME = "Insights";
 const FACT_AGGREGATIONS = ["sum", "count", "avg", "min", "max", "median", "runsum"];


### PR DESCRIPTION
The problem was twofold:
* InsightView did not stop loading on error
* error mapping for DATA_TOO_LARGE_TO_COMPUTE was missing

Also, while testing, I discovered an error in catalog export where eslint would
complain about missing rule definition so I disabled the eslint
as a whole in the generated files.

JIRA: RAIL-2607

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
