### PR TITLE
RELATED: RAIL-2641 improve loading overlay in CorePivotTable

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -556,6 +556,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
                     top: 0,
                     bottom: 0,
                     background: "white",
+                    zIndex: 1, // we need zIndex of at least 1, otherwise some table cells can show through the overlay
                 }}
                 className="s-loading"
             >


### PR DESCRIPTION
We need a zIndex on it, otherwise the first cell of  the first row/column
will show over the loading overlay during resizing.

JIRA: RAIL-2641

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
