### PR TITLE
RELATED: RAIL-2607 improve BadRequest error handling

### DIFF
--- a/libs/sdk-ui/src/base/errors/errorHandling.ts
+++ b/libs/sdk-ui/src/base/errors/errorHandling.ts
@@ -38,6 +38,11 @@ export function newErrorMapping(intl: IntlShape): IErrorDescriptors {
         description: intl.formatMessage({ id: "visualization.ErrorDescriptionDataTooLarge" }),
     };
 
+    const genericDescriptor: IErrorDescriptors["any"] = {
+        message: intl.formatMessage({ id: "visualization.ErrorMessageGeneric" }),
+        description: intl.formatMessage({ id: "visualization.ErrorDescriptionGeneric" }),
+    };
+
     return {
         [ErrorCodes.DATA_TOO_LARGE_TO_DISPLAY]: tooLargeDescriptor,
         [ErrorCodes.DATA_TOO_LARGE_TO_COMPUTE]: tooLargeDescriptor,
@@ -58,10 +63,8 @@ export function newErrorMapping(intl: IntlShape): IErrorDescriptors {
             message: intl.formatMessage({ id: "visualization.ErrorDescriptionMissingMapboxToken" }),
             description: intl.formatMessage({ id: "visualization.ErrorDescriptionMissingMapboxToken" }),
         },
-        [ErrorCodes.UNKNOWN_ERROR]: {
-            message: intl.formatMessage({ id: "visualization.ErrorMessageGeneric" }),
-            description: intl.formatMessage({ id: "visualization.ErrorDescriptionGeneric" }),
-        },
+        [ErrorCodes.BAD_REQUEST]: genericDescriptor,
+        [ErrorCodes.UNKNOWN_ERROR]: genericDescriptor,
     };
 }
 


### PR DESCRIPTION
Now it returns a generic "Sorry, we can't display this insight" message
for 400 response errors.

JIRA: RAIL-2607

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
