### PR TITLE
RELATED: RAIL-2647 prevent buckets mutation in GeoChart

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -233,7 +233,8 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         const supportedControls: IVisualizationProperties = this.visualizationProperties.controls || {};
         const fullConfig = this.buildVisualizationConfig(options, supportedControls);
 
-        const buckets = insightBuckets(insight);
+        // we need to shallow copy the buckets so that we can add more without mutating the original array
+        const buckets = [...insightBuckets(insight)];
 
         if (supportedControls && supportedControls?.tooltipText) {
             const tooltipText: string = supportedControls?.tooltipText;
@@ -327,6 +328,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
     // https://github.com/basarat/typescript-book/blob/master/docs/arrow-functions.md#tip-arrow-functions-and-inheritance
     private superHandlePushData = this.handlePushData;
 
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     protected handlePushData = (data: any): void => {
         // For pushpin chart we want to allow drill only on the
         // location attribute. Filter out other attributes.


### PR DESCRIPTION
We must not mutate the buckets as it can have unexpected consequences.

JIRA: RAIL-2647

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
