### PR TITLE
CAT-211 added "canManageDomain" to WorkspacePermission

### DIFF
--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -197,6 +197,7 @@ function recordedPermissionsFactory(): IWorkspacePermissionsFactory {
                 canUploadNonProductionCSV: true,
                 canCreateScheduledMail: true,
                 canListUsersInProject: true,
+                canManageDomain: true,
             }),
             hasPermission: (_) => true,
         }),

--- a/libs/sdk-backend-tiger/src/backend/workspace/permissions/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/permissions/index.ts
@@ -23,6 +23,7 @@ export class TigerWorkspacePermissionsFactory implements IWorkspacePermissionsFa
                 canManageReport: true,
                 canCreateScheduledMail: true,
                 canListUsersInProject: true,
+                canManageDomain: true,
             };
             return result;
         });

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1661,7 +1661,7 @@ export type VisualizationProperties = {
 };
 
 // @public
-export type WorkspacePermission = "canInitData" | "canUploadNonProductionCSV" | "canExecuteRaw" | "canExportReport" | "canAccessWorkbench" | "canCreateReport" | "canCreateVisualization" | "canCreateAnalyticalDashboard" | "canManageMetric" | "canManageReport" | "canManageAnalyticalDashboard" | "canManageProject" | "canCreateScheduledMail" | "canListUsersInProject";
+export type WorkspacePermission = "canInitData" | "canUploadNonProductionCSV" | "canExecuteRaw" | "canExportReport" | "canAccessWorkbench" | "canCreateReport" | "canCreateVisualization" | "canCreateAnalyticalDashboard" | "canManageMetric" | "canManageReport" | "canManageAnalyticalDashboard" | "canManageProject" | "canCreateScheduledMail" | "canListUsersInProject" | "canManageDomain";
 
 
 // (No @packageDocumentation comment for this package)

--- a/libs/sdk-model/src/workspace/index.ts
+++ b/libs/sdk-model/src/workspace/index.ts
@@ -33,7 +33,8 @@ export type WorkspacePermission =
     | "canManageAnalyticalDashboard"
     | "canManageProject"
     | "canCreateScheduledMail"
-    | "canListUsersInProject";
+    | "canListUsersInProject"
+    | "canManageDomain";
 
 /**
  * Dictionary of workspace permissions


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
