### PR TITLE
RELATED: RAIL-2651 add hour and minute date granularities

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -342,6 +342,14 @@ export enum AttributeGranularityResourceAttribute {
     // (undocumented)
     DayOfYear = "dayOfYear",
     // (undocumented)
+    Hour = "hour",
+    // (undocumented)
+    HourOfDay = "hourOfDay",
+    // (undocumented)
+    Minute = "minute",
+    // (undocumented)
+    MinuteOfHour = "minuteOfHour",
+    // (undocumented)
     Month = "month",
     // (undocumented)
     MonthOfYear = "monthOfYear",

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -1,3 +1,5 @@
+// (C) 2020 GoodData Corporation
+
 /* eslint-disable */
 /**
  * Metadata JSON:API
@@ -551,6 +553,8 @@ export interface ApiErrorSource {
 export enum AttributeGranularityResourceAttribute {
     Year = "year",
     Day = "day",
+    Hour = "hour",
+    Minute = "minute",
     Quarter = "quarter",
     Month = "month",
     Week = "week",
@@ -559,6 +563,8 @@ export enum AttributeGranularityResourceAttribute {
     DayOfYear = "dayOfYear",
     DayOfWeek = "dayOfWeek",
     DayOfMonth = "dayOfMonth",
+    HourOfDay = "hourOfDay",
+    MinuteOfHour = "minuteOfHour",
     WeekOfYear = "weekOfYear",
 }
 /**

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueParser.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/dateValueParser.ts
@@ -17,6 +17,10 @@ const granularityParseValueTransformations: {
 };
 
 const granularityParsePatterns: { [granularity in DateAttributeGranularity]?: string } = {
+    "GDC.time.minute": "yyyy-MM-dd HH:mm", // 2020-01-31 14:01
+    "GDC.time.minute_in_hour": "mm", // 00-59
+    "GDC.time.hour": "yyyy-MM-dd HH", // 2020-01-31 14
+    "GDC.time.hour_in_day": "HH", // 00-23
     "GDC.time.date": "yyyy-MM-dd", // 2020-01-31
     "GDC.time.day_in_month": "d", // 1-31
     "GDC.time.day_in_week": "i", // 1-7

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/defaultDateFormatter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateFormatting/defaultDateFormatter.ts
@@ -8,6 +8,10 @@ import { DateFormatter } from "./types";
 const granularityFormatPatterns: {
     [granularity in DateAttributeGranularity]?: string;
 } = {
+    "GDC.time.minute": "P HH:mm", // 01/31/2020 14:01
+    "GDC.time.minute_in_hour": "mm", // 01-59
+    "GDC.time.hour": "P HH':00'", // 01/31/2020 14:00
+    "GDC.time.hour_in_day": "HH", // 01-23
     "GDC.time.date": "P", // 01/31/2020
     "GDC.time.day_in_month": "dd", // 01-31
     "GDC.time.day_in_week": "EEEE", // Monday-Sunday

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
@@ -14,6 +14,9 @@ type SdkToTiger = {
 /*
     Year = "year",
     Day = "day",
+    Hour = "hour",
+    Minute = "minute",
+    Day = "day",
     Quarter = "quarter",
     Month = "month",
     Week = "week",
@@ -22,11 +25,16 @@ type SdkToTiger = {
     DayOfYear = "dayOfYear",
     DayOfWeek = "dayOfWeek",
     DayOfMonth = "dayOfMonth",
+    HourOfDay = "hourOfDay",
+    MinuteOfHour = "minuteOfHour",
     WeekOfYear = "weekOfYear",
  */
 
 const TigerToSdkGranularityMap: TigerToSdk = {
     [AttributeGranularityResourceAttribute.Year]: "GDC.time.year",
+    [AttributeGranularityResourceAttribute.Day]: "GDC.time.date",
+    [AttributeGranularityResourceAttribute.Hour]: "GDC.time.hour",
+    [AttributeGranularityResourceAttribute.Minute]: "GDC.time.minute",
     [AttributeGranularityResourceAttribute.Day]: "GDC.time.date",
     [AttributeGranularityResourceAttribute.Quarter]: "GDC.time.quarter",
     [AttributeGranularityResourceAttribute.Month]: "GDC.time.month",
@@ -38,6 +46,8 @@ const TigerToSdkGranularityMap: TigerToSdk = {
     [AttributeGranularityResourceAttribute.DayOfYear]: "GDC.time.day_in_year",
     [AttributeGranularityResourceAttribute.DayOfWeek]: "GDC.time.day_in_week",
     [AttributeGranularityResourceAttribute.DayOfMonth]: "GDC.time.day_in_month",
+    [AttributeGranularityResourceAttribute.HourOfDay]: "GDC.time.hour_in_day",
+    [AttributeGranularityResourceAttribute.MinuteOfHour]: "GDC.time.minute_in_hour",
     [AttributeGranularityResourceAttribute.WeekOfYear]: "GDC.time.week_in_year",
 };
 
@@ -55,6 +65,8 @@ export function toSdkGranularity(
 const SdkToTigerGranularityMap: SdkToTiger = {
     "GDC.time.year": AttributeGranularityResourceAttribute.Year,
     "GDC.time.date": AttributeGranularityResourceAttribute.Day,
+    "GDC.time.hour": AttributeGranularityResourceAttribute.Hour,
+    "GDC.time.minute": AttributeGranularityResourceAttribute.Minute,
     "GDC.time.quarter": AttributeGranularityResourceAttribute.Quarter,
     "GDC.time.month": AttributeGranularityResourceAttribute.Month,
     "GDC.time.week_us": AttributeGranularityResourceAttribute.Week,
@@ -67,6 +79,8 @@ const SdkToTigerGranularityMap: SdkToTiger = {
     "GDC.time.day_in_week": AttributeGranularityResourceAttribute.DayOfWeek,
     "GDC.time.day_in_month": AttributeGranularityResourceAttribute.DayOfMonth,
     "GDC.time.week_in_year": AttributeGranularityResourceAttribute.WeekOfYear,
+    "GDC.time.hour_in_day": AttributeGranularityResourceAttribute.HourOfDay,
+    "GDC.time.minute_in_hour": AttributeGranularityResourceAttribute.MinuteOfHour,
 
     "GDC.time.day_in_euweek": undefined,
     "GDC.time.day_in_quarter": undefined,

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -300,7 +300,7 @@ export class DataSetMetadataObjectBuilder<T extends IDataSetMetadataObject = IDa
 }
 
 // @public
-export type DateAttributeGranularity = "GDC.time.year" | "GDC.time.week_us" | "GDC.time.week_in_year" | "GDC.time.week_in_quarter" | "GDC.time.week" | "GDC.time.euweek_in_year" | "GDC.time.euweek_in_quarter" | "GDC.time.quarter" | "GDC.time.quarter_in_year" | "GDC.time.month" | "GDC.time.month_in_quarter" | "GDC.time.month_in_year" | "GDC.time.day_in_year" | "GDC.time.day_in_quarter" | "GDC.time.day_in_month" | "GDC.time.day_in_week" | "GDC.time.day_in_euweek" | "GDC.time.date";
+export type DateAttributeGranularity = "GDC.time.year" | "GDC.time.week_us" | "GDC.time.week_in_year" | "GDC.time.week_in_quarter" | "GDC.time.week" | "GDC.time.euweek_in_year" | "GDC.time.euweek_in_quarter" | "GDC.time.quarter" | "GDC.time.quarter_in_year" | "GDC.time.month" | "GDC.time.month_in_quarter" | "GDC.time.month_in_year" | "GDC.time.day_in_year" | "GDC.time.day_in_quarter" | "GDC.time.day_in_month" | "GDC.time.day_in_week" | "GDC.time.day_in_euweek" | "GDC.time.date" | "GDC.time.hour" | "GDC.time.hour_in_day" | "GDC.time.minute" | "GDC.time.minute_in_hour";
 
 // @public
 export const DateGranularity: {

--- a/libs/sdk-model/src/base/dateGranularities.ts
+++ b/libs/sdk-model/src/base/dateGranularities.ts
@@ -27,7 +27,11 @@ export type DateAttributeGranularity =
     | "GDC.time.day_in_month"
     | "GDC.time.day_in_week"
     | "GDC.time.day_in_euweek"
-    | "GDC.time.date";
+    | "GDC.time.date"
+    | "GDC.time.hour"
+    | "GDC.time.hour_in_day"
+    | "GDC.time.minute"
+    | "GDC.time.minute_in_hour";
 
 /**
  * Special granularity used to indicate there should be no date filtering for the given dimension.


### PR DESCRIPTION
Only into Tiger backend

JIRA: RAIL-2651

Add hour / minute chronological granularities
- YYYY-MM-DD HH24
- YYYY-MM-DD HH24:MI

Add hour / minute periodical granularities
- hour in day - 00-23
- minute in hour - 00-59
