### PR TITLE
RELATED: RAIL-1815 upgrade backstop docker image 5.0.4 -> 5.0.6

### DIFF
--- a/libs/sdk-ui-tests/backstop/run-backstop.sh
+++ b/libs/sdk-ui-tests/backstop/run-backstop.sh
@@ -65,7 +65,7 @@ docker network create "${BACKSTOP_NET}" || { echo "Network creation failed" && e
             --env BACKSTOP_COMPARE_LIMIT \
             --user $UID:$GID \
             --net ${BACKSTOP_NET} --net-alias backstop \
-            --volume ${BACKSTOP_DIR}:/src:Z backstopjs/backstopjs:5.0.4 \
+            --volume ${BACKSTOP_DIR}:/src:Z backstopjs/backstopjs:5.0.6 \
             --config=/src/backstop.config.js "$@"
 
         echo "BackstopJS finished. Killing nginx container ${NGINX_CONTAINER}"


### PR DESCRIPTION
Version 5.0.4 had a bug with missing library libXss.so.1 ([details](https://github.com/garris/BackstopJS/issues/1225))
This was fixed in 5.0.6.

JIRA: RAIL-1815

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
