### PR TITLE
RELATED: RAIL-2652, RAIL-2655, RAIL-2659 example improvements

### DIFF
--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureDrillingExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureDrillingExample.tsx
@@ -5,7 +5,7 @@ import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { measureIdentifier } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
-const measures = [LdmExt.NrRestaurants, LdmExt.TotalSales2, LdmExt.arithmeticMeasure1];
+const measures = [LdmExt.NrRestaurants, LdmExt.TotalSales2, LdmExt.arithmeticMeasure];
 
 const rows = [Ldm.LocationState];
 

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureMultiplicationExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureMultiplicationExample.tsx
@@ -1,9 +1,16 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
+import { newArithmeticMeasure, measureLocalId } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
-const measures = [LdmExt.NrRestaurants, LdmExt.averageRestaurantDailyCosts, LdmExt.arithmeticMeasure2];
+const averageStateDailyCosts = newArithmeticMeasure(
+    [measureLocalId(LdmExt.NrRestaurants), measureLocalId(LdmExt.averageRestaurantDailyCosts)],
+    "multiplication",
+    (m) => m.format("#,##0").title("$ Avg State Daily Costs"),
+);
+
+const measures = [LdmExt.NrRestaurants, LdmExt.averageRestaurantDailyCosts, averageStateDailyCosts];
 
 const rows = [Ldm.LocationState];
 const style = { height: 200 };

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureMultiplicationExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureMultiplicationExample.tsx
@@ -1,11 +1,11 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
-import { newArithmeticMeasure, measureLocalId } from "@gooddata/sdk-model";
+import { newArithmeticMeasure } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
 const averageStateDailyCosts = newArithmeticMeasure(
-    [measureLocalId(LdmExt.NrRestaurants), measureLocalId(LdmExt.averageRestaurantDailyCosts)],
+    [LdmExt.NrRestaurants, LdmExt.averageRestaurantDailyCosts],
     "multiplication",
     (m) => m.format("#,##0").title("$ Avg State Daily Costs"),
 );

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureRatioExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureRatioExample.tsx
@@ -1,11 +1,11 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
-import { measureLocalId, newArithmeticMeasure } from "@gooddata/sdk-model";
+import { newArithmeticMeasure } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
 const averageRestaurantSales = newArithmeticMeasure(
-    [measureLocalId(LdmExt.TotalSales2), measureLocalId(LdmExt.NrRestaurants)],
+    [LdmExt.TotalSales2, LdmExt.NrRestaurants],
     "ratio",
     (m) => m.format("#,##0").title("$ Avg State Daily Sales"),
 );

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureRatioExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureRatioExample.tsx
@@ -1,9 +1,16 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
+import { measureLocalId, newArithmeticMeasure } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
-const measures = [LdmExt.NrRestaurants, LdmExt.TotalSales2, LdmExt.arithmeticMeasure3];
+const averageRestaurantSales = newArithmeticMeasure(
+    [measureLocalId(LdmExt.TotalSales2), measureLocalId(LdmExt.NrRestaurants)],
+    "ratio",
+    (m) => m.format("#,##0").title("$ Avg State Daily Sales"),
+);
+
+const measures = [LdmExt.TotalSales2, LdmExt.NrRestaurants, averageRestaurantSales];
 
 const rows = [Ldm.LocationState];
 const style = { height: 200 };

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureSumExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureSumExample.tsx
@@ -1,17 +1,17 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
-import { newArithmeticMeasure, measureLocalId } from "@gooddata/sdk-model";
+import { newArithmeticMeasure } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
 const sum = newArithmeticMeasure(
-    [measureLocalId(LdmExt.FranchiseFeesOngoingRoyalty), measureLocalId(LdmExt.FranchiseFeesAdRoyalty)],
+    [LdmExt.FranchiseFeesOngoingRoyalty, LdmExt.FranchiseFeesAdRoyalty],
     "sum",
     (m) => m.format("#,##0").title("$ Ongoing / Ad Royalty Sum"),
 );
 
 const difference = newArithmeticMeasure(
-    [measureLocalId(LdmExt.FranchiseFeesOngoingRoyalty), measureLocalId(LdmExt.FranchiseFeesAdRoyalty)],
+    [LdmExt.FranchiseFeesOngoingRoyalty, LdmExt.FranchiseFeesAdRoyalty],
     "difference",
     (m) => m.format("#,##0").title("$ Ongoing / Ad Royalty Difference"),
 );

--- a/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureSumExample.tsx
+++ b/examples/sdk-examples/src/examples/arithmeticMeasures/ArithmeticMeasureSumExample.tsx
@@ -1,14 +1,22 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
+import { newArithmeticMeasure, measureLocalId } from "@gooddata/sdk-model";
 import { Ldm, LdmExt } from "../../ldm";
 
-const measures = [
-    LdmExt.FranchiseFeesAdRoyalty,
-    LdmExt.FranchiseFeesOngoingRoyalty,
-    LdmExt.arithmeticMeasure4,
-    LdmExt.arithmeticMeasure5,
-];
+const sum = newArithmeticMeasure(
+    [measureLocalId(LdmExt.FranchiseFeesOngoingRoyalty), measureLocalId(LdmExt.FranchiseFeesAdRoyalty)],
+    "sum",
+    (m) => m.format("#,##0").title("$ Ongoing / Ad Royalty Sum"),
+);
+
+const difference = newArithmeticMeasure(
+    [measureLocalId(LdmExt.FranchiseFeesOngoingRoyalty), measureLocalId(LdmExt.FranchiseFeesAdRoyalty)],
+    "difference",
+    (m) => m.format("#,##0").title("$ Ongoing / Ad Royalty Difference"),
+);
+
+const measures = [LdmExt.FranchiseFeesAdRoyalty, LdmExt.FranchiseFeesOngoingRoyalty, sum, difference];
 
 const rows = [Ldm.LocationState];
 

--- a/examples/sdk-examples/src/examples/drill/EmployeeProfile.tsx
+++ b/examples/sdk-examples/src/examples/drill/EmployeeProfile.tsx
@@ -44,7 +44,7 @@ export const EmployeeProfile: React.FC<IEmployeeProfileProps> = ({
                 }
                 .text {
                     flex: 1 1 auto;
-                    zzmargin-left: 20px;
+                    margin-left: 20px;
                 }
             `}</style>
             <div>

--- a/examples/sdk-examples/src/examples/drill/PivotTableDrillExample.tsx
+++ b/examples/sdk-examples/src/examples/drill/PivotTableDrillExample.tsx
@@ -14,7 +14,7 @@ const measures = [
 
 const attributes = [LdmExt.LocationState, LdmExt.LocationName, LdmExt.MenuCategory];
 
-const columns = [LdmExt.quaterDate, LdmExt.monthDate];
+const columns = [LdmExt.quarterDate, LdmExt.monthDate];
 
 const totals: ITotal[] = [
     {

--- a/examples/sdk-examples/src/examples/hidden/pivotTableDynamic/PivotTableDynamicExample.tsx
+++ b/examples/sdk-examples/src/examples/hidden/pivotTableDynamic/PivotTableDynamicExample.tsx
@@ -23,7 +23,7 @@ const measureAdRoyalty = LdmExt.FranchiseFeesAdRoyalty;
 const attributeLocationState = LdmExt.LocationState;
 const attributeLocationName = LdmExt.LocationName;
 const attributeMenuCategory = LdmExt.MenuCategory;
-const attributeQuarter = LdmExt.quaterDate;
+const attributeQuarter = LdmExt.quarterDate;
 const attributeMonth = LdmExt.monthDate;
 
 const measures = [measureFranchiseFees, measureAdRoyalty];
@@ -132,7 +132,7 @@ const drillingPresets: any = {
     attributeQuarter: {
         label: "Attribute Quarter",
         key: "attributeQuarter",
-        drillableItem: HeaderPredicates.identifierMatch(attributeIdentifier(LdmExt.quaterDate)!),
+        drillableItem: HeaderPredicates.identifierMatch(attributeIdentifier(LdmExt.quarterDate)!),
     },
     attributeLocationState: {
         label: "Attribute Location state",

--- a/examples/sdk-examples/src/examples/hidden/pivotTableSizing/PivotTableSizingComplexExample.tsx
+++ b/examples/sdk-examples/src/examples/hidden/pivotTableSizing/PivotTableSizingComplexExample.tsx
@@ -19,7 +19,7 @@ const measures = [LdmExt.FranchiseFees];
 
 const attributes = [LdmExt.LocationState];
 
-const columns = [LdmExt.quaterDate];
+const columns = [LdmExt.quarterDate];
 
 const attributeWidth = (width: number) => newWidthForAttributeColumn(attributes[0], width);
 

--- a/examples/sdk-examples/src/examples/insightView/InsightViewComboChartByIdentifierExample.tsx
+++ b/examples/sdk-examples/src/examples/insightView/InsightViewComboChartByIdentifierExample.tsx
@@ -4,9 +4,11 @@ import { InsightView } from "@gooddata/sdk-ui-ext";
 
 import { Ldm } from "../../ldm";
 
+const style = { height: 300 };
+
 export const InsightViewComboChartByIdentifierExample: React.FC = () => {
     return (
-        <div className="s-insightView-chart">
+        <div style={style} className="s-insightView-chart">
             <InsightView insight={Ldm.Insights.JZACombo} />
         </div>
     );

--- a/examples/sdk-examples/src/examples/pivotTable/PivotTableDrillExample.tsx
+++ b/examples/sdk-examples/src/examples/pivotTable/PivotTableDrillExample.tsx
@@ -15,7 +15,7 @@ const measures = [
 
 const attributes = [LdmExt.LocationState, LdmExt.LocationName, LdmExt.MenuCategory];
 
-const columns = [LdmExt.quaterDate, LdmExt.monthDate];
+const columns = [LdmExt.quarterDate, LdmExt.monthDate];
 
 const totals: ITotal[] = [
     {

--- a/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
+++ b/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
@@ -16,14 +16,14 @@ const measures = [LdmExt.FranchiseFees];
 
 const attributes = [LdmExt.LocationState];
 
-const columns = [LdmExt.quaterDate];
+const columns = [LdmExt.quarterDate];
 
 const attributeWidth = (width: number) => newWidthForAttributeColumn(attributes[0], width);
 
 const measureWidth = (width: number) =>
     newWidthForSelectedColumns(
         LdmExt.FranchiseFees,
-        [newAttributeColumnLocator(LdmExt.quaterDate, `/gdc/md/${workspace}/obj/2009/elements?id=1`)],
+        [newAttributeColumnLocator(LdmExt.quarterDate, `/gdc/md/${workspace}/obj/2009/elements?id=1`)],
         width,
     );
 

--- a/examples/sdk-examples/src/ldm/ext.ts
+++ b/examples/sdk-examples/src/ldm/ext.ts
@@ -17,14 +17,10 @@ import * as Ldm from "./full";
 
 export const numberOfRestaurantsLocalId = "numberOfRestaurants";
 export const averageRestaurantDailyCostsLocalId = "averageRestaurantDailyCosts";
-export const averageStateDailyCostsLocalId = "averageStateDailyCosts";
 export const totalCostsLocalId = "totalCosts";
 export const totalSalesLocalId = "totalSales";
-export const averageRestaurantSalesLocalId = "averageRestaurantSales";
 export const franchiseFeesAdRoyaltyLocalId = "franchiseFeesAdRoyalty";
 export const franchiseFeesOngoingRoyaltyLocalId = "franchiseFeesOngoingRoyalty";
-export const franchiseFeesSumLocalId = "franchiseFeesSum";
-export const franchiseFeesDifferenceLocalId = "franchiseFeesDifference";
 export const franchiseFeesLocalId = "franchiseFees";
 export const franchiseSalesLocalId = "franchiseSales";
 export const franchiseSalesAsPercentageLocalId = "franchiseSalesFormattedAsPercentage";
@@ -37,7 +33,7 @@ export const LocationResortLocalId = "a1";
 export const MenuCategoryLocalId = "menu";
 export const LocationStateLocalId = "locationState";
 export const LocationCityLocalId = "locationCity";
-export const quaterDateLocalId = "quarter";
+export const quarterDateLocalId = "quarter";
 export const franchiseSalesComputeRatioLocalId = "franchiseSalesComputeRatio";
 
 // ===============================================================================================
@@ -112,7 +108,7 @@ export const LocationCity = modifyAttribute(Ldm.LocationCity, (a) => a.localId(L
 export const monthDate = modifyAttribute(Ldm.DateMonth.Short, (a) =>
     a.alias("Month").localId(monthDateLocalId),
 );
-export const quaterDate = modifyAttribute(Ldm.DateQuarter, (a) => a.localId(quaterDateLocalId));
+export const quarterDate = modifyAttribute(Ldm.DateQuarter, (a) => a.localId(quarterDateLocalId));
 export const MenuItemName = modifyAttribute(Ldm.MenuItemName, (a) => a.alias("Menu Item name"));
 export const AvgDailyTotalSales = modifyMeasure(Ldm.$AvgDailyTotalSales, (m) =>
     m.alias("$ Avg Daily Total Sales").format("$#,##0").localId(averageDailyTotalSalesLocalId),
@@ -124,35 +120,12 @@ export const NrRestaurants = modifyMeasure(Ldm.NrRestaurants, (m) =>
     m.format("#,##0").localId(numberOfRestaurantsLocalId),
 );
 
-export const arithmeticMeasure1 = newArithmeticMeasure(
+export const arithmeticMeasure = newArithmeticMeasure(
     [totalSalesLocalId, numberOfRestaurantsLocalId],
     "ratio",
     (m) => m.format("#,##0").title("$ Avg Restaurant Sales"),
 );
-export const arithmeticMeasure2 = newArithmeticMeasure(
-    [numberOfRestaurantsLocalId, averageRestaurantDailyCostsLocalId],
-    "multiplication",
-    (m) => m.format("#,##0").title("$ Avg State Daily Costs").localId(averageStateDailyCostsLocalId),
-);
-export const arithmeticMeasure3 = newArithmeticMeasure(
-    [numberOfRestaurantsLocalId, totalSalesLocalId],
-    "ratio",
-    (m) => m.format("#,##0").title("$ Avg State Daily Sales").localId(averageRestaurantSalesLocalId),
-);
-export const arithmeticMeasure4 = newArithmeticMeasure(
-    [franchiseFeesOngoingRoyaltyLocalId, franchiseFeesAdRoyaltyLocalId],
-    "sum",
-    (m) => m.format("#,##0").title("$ Ongoing / Ad Royalty Sum").localId(franchiseFeesSumLocalId),
-);
-export const arithmeticMeasure5 = newArithmeticMeasure(
-    [franchiseFeesOngoingRoyaltyLocalId, franchiseFeesAdRoyaltyLocalId],
-    "difference",
-    (m) =>
-        m.format("#,##0").title("$ Ongoing / Ad Royalty Difference").localId(franchiseFeesDifferenceLocalId),
-);
-export const arithmeticMeasure6 = newArithmeticMeasure([FranchisedSales, FranchiseFees], "change", (m) =>
-    m.localId("franchiseFeesFormattedAsPercentage").title("Change formatted as %").format("#,##0%"),
-);
+
 export const averageRestaurantDailyCosts = newMeasure(averageRestaurantDailyCostsIdentifier, (m) =>
     m.format("#,##0").localId(averageRestaurantDailyCostsLocalId),
 );


### PR DESCRIPTION
* RAIL-2652: Fix styles in ComboChart InsightView example
* RAIL-2655: Improve Arithmetic measure examples - inlined the defintions (so that the sample source code is useful on its own), made sure the data is meaningful with no zeroes
* RAIL-2659: Fxed DrillingWithExternalData - re-renders, broken drilling, missing style, messy code

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
