### PR TITLE
Rename `IImplicitDrillDown.target` to `IImplicitDrillDown.drillDownStep`

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
@@ -17,7 +17,7 @@ import {
 } from "@gooddata/sdk-model";
 import { IImplicitDrillDown, IVisualizationProperties } from "../../../..";
 import { Department, Region, Status, Won } from "@gooddata/reference-workspace/dist/ldm/full";
-import { newWidthForAttributeColumn, newWidthForAllMeasureColumns } from "@gooddata/sdk-ui-pivot";
+import { newWidthForAllMeasureColumns, newWidthForAttributeColumn } from "@gooddata/sdk-ui-pivot";
 
 const properties: IVisualizationProperties = {
     controls: {
@@ -86,7 +86,7 @@ const implicitTargetDF = uriRef("implicitDrillDown-target-uri");
 const drillConfig: IImplicitDrillDown = {
     implicitDrillDown: {
         from: { drillFromAttribute: { localIdentifier: Status.attribute.localIdentifier } },
-        target: {
+        drillDownStep: {
             drillToAttribute: {
                 attributeDisplayForm: implicitTargetDF,
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/drillDownUtil.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/drillDownUtil.test.ts
@@ -1,9 +1,9 @@
 // (C) 2020 GoodData Corporation
 
-import { newInsightDefinition, newBucket, newAttribute } from "@gooddata/sdk-model";
+import { newAttribute, newBucket, newInsightDefinition } from "@gooddata/sdk-model";
 import { IImplicitDrillDown } from "../../..";
 import { modifyBucketsAttributesForDrillDown } from "../drillDownUtil";
-import { Won, Department, Region, Status, Account } from "@gooddata/reference-workspace/dist/ldm/full";
+import { Account, Department, Region, Status, Won } from "@gooddata/reference-workspace/dist/ldm/full";
 import { insightDefinitionToInsight } from "./testHelpers";
 
 describe("drillDownUtil", () => {
@@ -18,7 +18,7 @@ describe("drillDownUtil", () => {
             const drillConfig: IImplicitDrillDown = {
                 implicitDrillDown: {
                     from: { drillFromAttribute: { localIdentifier: Department.attribute.localIdentifier } },
-                    target: {
+                    drillDownStep: {
                         drillToAttribute: {
                             attributeDisplayForm: Account.Default.attribute.displayForm,
                         },
@@ -56,7 +56,7 @@ describe("drillDownUtil", () => {
             const drillConfig: IImplicitDrillDown = {
                 implicitDrillDown: {
                     from: { drillFromAttribute: { localIdentifier: Region.attribute.localIdentifier } },
-                    target: {
+                    drillDownStep: {
                         drillToAttribute: {
                             attributeDisplayForm: Department.attribute.displayForm,
                         },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/testHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/testHelpers.ts
@@ -1,14 +1,15 @@
 // (C) 2020 GoodData Corporation
 import { IImplicitDrillDown } from "../../../interfaces/Visualization";
-import { IDrillEventIntersectionElement, IDrillEvent, VisType } from "@gooddata/sdk-ui";
+import { IDrillEvent, IDrillEventIntersectionElement, VisType } from "@gooddata/sdk-ui";
 import { IAttribute, IInsight, IInsightDefinition, uriRef } from "@gooddata/sdk-model";
+
 export function createDrillDefinition(fromAttribute: IAttribute, targetUri: string): IImplicitDrillDown {
     return {
         implicitDrillDown: {
             from: {
                 drillFromAttribute: { localIdentifier: fromAttribute.attribute.localIdentifier },
             },
-            target: {
+            drillDownStep: {
                 drillToAttribute: {
                     attributeDisplayForm: uriRef(targetUri),
                 },

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -424,7 +424,7 @@ export interface IDrillToAttribute {
 export interface IImplicitDrillDown {
     implicitDrillDown: {
         from: IDrillFromAttribute;
-        target: IDrillToAttribute;
+        drillDownStep: IDrillToAttribute;
     };
 }
 

--- a/libs/sdk-ui-ext/src/internal/utils/ImplicitDrillDownHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/ImplicitDrillDownHelper.ts
@@ -8,5 +8,5 @@ export function drillDownFromAttributeLocalId(drillDefinition: IImplicitDrillDow
 }
 
 export function drillDownDisplayForm(drillDefinition: IImplicitDrillDown): ObjRef {
-    return drillDefinition.implicitDrillDown.target.drillToAttribute.attributeDisplayForm;
+    return drillDefinition.implicitDrillDown.drillDownStep.drillToAttribute.attributeDisplayForm;
 }


### PR DESCRIPTION
 - by convention, the drill types use `target` field to define the place for drilling (modal, new window, new tab...)

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
