### PR TITLE
RELATED: RAIL-1815 - Support execution by reference

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -296,6 +296,26 @@ export function dummyDataView(definition: IExecutionDefinition, result?: IExecut
 // @alpha (undocumented)
 export type ExecutionDecoratorFactory = (executionFactory: IExecutionFactory) => IExecutionFactory;
 
+// @internal
+export class ExecutionFactoryUpgradingToExecByReference extends DecoratedExecutionFactory {
+    constructor(decorated: IExecutionFactory);
+    // (undocumented)
+    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
+}
+
+// @internal
+export class ExecutionFactoryWithFixedFilters extends DecoratedExecutionFactory {
+    constructor(decorated: IExecutionFactory, filters?: IFilter[]);
+    // (undocumented)
+    forBuckets(buckets: IBucket[], filters?: IFilter[]): IPreparedExecution;
+    // (undocumented)
+    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
+    // (undocumented)
+    forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
+    // (undocumented)
+    forItems(items: IAttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution;
+}
+
 // @beta
 export interface IAuthenticatedAsyncCallContext {
     getPrincipal(): Promise<AuthenticatedPrincipal>;

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -29,6 +29,7 @@ import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
 import { IExportResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
+import { IInsight } from '@gooddata/sdk-model';
 import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IPreparedExecution } from '@gooddata/sdk-backend-spi';
 import { IResultHeader } from '@gooddata/sdk-backend-spi';
@@ -49,10 +50,12 @@ export abstract class AbstractExecutionFactory implements IExecutionFactory {
     // (undocumented)
     forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
     // (undocumented)
-    abstract forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
+    forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
     // (undocumented)
     forItems(items: IAttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution;
-    }
+    // (undocumented)
+    protected readonly workspace: string;
+}
 
 // @beta
 export type AnalyticalBackendCallbacks = {
@@ -167,7 +170,7 @@ export class DecoratedExecutionFactory implements IExecutionFactory {
     // (undocumented)
     forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
     // (undocumented)
-    forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
+    forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
     // (undocumented)
     forItems(items: IAttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution;
     protected wrap: (execution: IPreparedExecution) => IPreparedExecution;

--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -327,6 +327,7 @@ export class NoopAuthProvider implements IAuthProviderCallGuard {
 // @beta (undocumented)
 export type NormalizationConfig = {
     normalizationStatus?: (normalizationState: NormalizationState) => void;
+    executeByRefMode?: NormalizationWhenExecuteByRef;
 };
 
 // @beta (undocumented)
@@ -335,6 +336,9 @@ export type NormalizationState = {
     readonly original: IExecutionDefinition;
     readonly n2oMap: LocalIdMap;
 };
+
+// @beta (undocumented)
+export type NormalizationWhenExecuteByRef = "prohibit" | "fallback";
 
 // @internal
 export class Normalizer {

--- a/libs/sdk-backend-base/src/cachingBackend/index.ts
+++ b/libs/sdk-backend-base/src/cachingBackend/index.ts
@@ -257,7 +257,7 @@ function cachedCatalog(ctx: CachingContext): CatalogDecoratorFactory {
 }
 
 function cachingEnabled(desiredSize: number | undefined): boolean {
-    return desiredSize === undefined || desiredSize > 0;
+    return desiredSize !== undefined && desiredSize > 0;
 }
 
 function cacheControl(ctx: CachingContext): CacheControl {

--- a/libs/sdk-backend-base/src/customBackend/execution.ts
+++ b/libs/sdk-backend-base/src/customBackend/execution.ts
@@ -4,7 +4,6 @@ import { AbstractExecutionFactory } from "../toolkit/execution";
 import {
     defFingerprint,
     IExecutionDefinition,
-    IFilter,
     IDimension,
     DimensionGenerator,
     ISortItem,
@@ -44,10 +43,6 @@ export class CustomExecutionFactory extends AbstractExecutionFactory {
 
     public forDefinition = (def: IExecutionDefinition): IPreparedExecution => {
         return new CustomPreparedExecution(def, this, this.config, this.state);
-    };
-
-    public forInsightByRef = (_uri: string, _filters?: IFilter[]): Promise<IPreparedExecution> => {
-        throw new NotSupported("execution by insight reference is not supported");
     };
 }
 

--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -19,6 +19,7 @@ import {
     IFilter,
     IInsightDefinition,
     ISortItem,
+    IInsight,
 } from "@gooddata/sdk-model";
 import identity from "lodash/identity";
 
@@ -57,8 +58,8 @@ export class DecoratedExecutionFactory implements IExecutionFactory {
         return this.wrap(this.decorated.forInsight(insight, filters));
     }
 
-    public forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution> {
-        return this.decorated.forInsightByRef(uri, filters).then(this.wrap);
+    public forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution {
+        return this.wrap(this.decorated.forInsightByRef(insight, filters));
     }
 
     /**

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -16,18 +16,18 @@ import {
     IWorkspaceCatalog,
     IWorkspaceCatalogFactory,
     IWorkspaceCatalogFactoryOptions,
+    IWorkspaceDashboards,
     IWorkspaceDatasetsService,
+    IWorkspaceDateFilterConfigsQuery,
     IWorkspaceInsights,
     IWorkspaceMetadata,
     IWorkspacePermissionsFactory,
     IWorkspaceQueryFactory,
     IWorkspaceSettingsService,
     IWorkspaceStylingService,
+    IWorkspaceUsersQuery,
     NoDataError,
     NotSupported,
-    IWorkspaceDashboards,
-    IWorkspaceUsersQuery,
-    IWorkspaceDateFilterConfigsQuery,
 } from "@gooddata/sdk-backend-spi";
 import {
     CatalogItemType,
@@ -37,9 +37,8 @@ import {
     DimensionGenerator,
     IDimension,
     IExecutionDefinition,
-    IFilter,
-    ObjRef,
     ISortItem,
+    ObjRef,
 } from "@gooddata/sdk-model";
 import isEqual from "lodash/isEqual";
 import { AbstractExecutionFactory } from "../toolkit/execution";
@@ -221,10 +220,6 @@ class DummyExecutionFactory extends AbstractExecutionFactory {
 
     public forDefinition(def: IExecutionDefinition): IPreparedExecution {
         return dummyPreparedExecution(def, this, this.config);
-    }
-
-    public forInsightByRef(_uri: string, _filters?: IFilter[]): Promise<IPreparedExecution> {
-        throw new NotSupported("not yet supported");
     }
 }
 

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -44,7 +44,11 @@ export {
 
 export { TelemetryData } from "./toolkit/backend";
 
-export { AbstractExecutionFactory } from "./toolkit/execution";
+export {
+    AbstractExecutionFactory,
+    ExecutionFactoryWithFixedFilters,
+    ExecutionFactoryUpgradingToExecByReference,
+} from "./toolkit/execution";
 
 export { customBackend } from "./customBackend";
 

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -29,7 +29,7 @@ export {
     DefaultCachingConfiguration,
     CacheControl,
 } from "./cachingBackend";
-export { withNormalization, NormalizationConfig } from "./normalizingBackend";
+export { withNormalization, NormalizationConfig, NormalizationWhenExecuteByRef } from "./normalizingBackend";
 export { Normalizer, Denormalizer, NormalizationState, LocalIdMap } from "./normalizingBackend/normalizer";
 
 export {

--- a/libs/sdk-backend-base/src/toolkit/execution.ts
+++ b/libs/sdk-backend-base/src/toolkit/execution.ts
@@ -22,6 +22,11 @@ import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi
  *
  * This class implements the convenience methods which do not need to change in implementations.
  *
+ * Note: the `forInsightByRef` is implemented as fallback to freeform execution done by `forInsight`. The
+ * rationale is that most backends do not support that anyway so it is a safe default behavior. If the backend
+ * supports execute-by-reference, then overload the method with your own implementation (see sdk-backend-bear for
+ * inspiration)
+ *
  * @internal
  */
 export abstract class AbstractExecutionFactory implements IExecutionFactory {

--- a/libs/sdk-backend-base/src/toolkit/execution.ts
+++ b/libs/sdk-backend-base/src/toolkit/execution.ts
@@ -11,6 +11,7 @@ import {
     newDefForBuckets,
     newDefForInsight,
     newDefForItems,
+    IInsight,
 } from "@gooddata/sdk-model";
 
 import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi";
@@ -24,10 +25,9 @@ import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi
  * @internal
  */
 export abstract class AbstractExecutionFactory implements IExecutionFactory {
-    constructor(private readonly workspace: string) {}
+    constructor(protected readonly workspace: string) {}
 
     public abstract forDefinition(def: IExecutionDefinition): IPreparedExecution;
-    public abstract forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
 
     public forItems(items: IAttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution {
         const def = defWithDimensions(
@@ -54,5 +54,9 @@ export abstract class AbstractExecutionFactory implements IExecutionFactory {
         );
 
         return this.forDefinition(def);
+    }
+
+    public forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution {
+        return this.forInsight(insight, filters);
     }
 }

--- a/libs/sdk-backend-bear/package.json
+++ b/libs/sdk-backend-bear/package.json
@@ -55,6 +55,7 @@
     "devDependencies": {
         "@gooddata/eslint-config": "^2.0.0",
         "@gooddata/reference-workspace": "^8.0.0-beta.76",
+        "@gooddata/sdk-backend-mockingbird": "^8.0.0-beta.76",
         "@microsoft/api-extractor": "^7.3.8",
         "@types/jest": "^26.0.12",
         "@types/json-stable-stringify": "^1.0.32",

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecution.ts
@@ -26,8 +26,6 @@ export class BearPreparedExecution implements IPreparedExecution {
     ) {}
 
     public async execute(): Promise<IExecutionResult> {
-        checkDefIsExecutable(this.definition);
-
         const afmExecution = toAfmExecution(this.definition);
 
         return this.authCall(
@@ -65,8 +63,4 @@ export class BearPreparedExecution implements IPreparedExecution {
     public equals(other: IPreparedExecution): boolean {
         return isEqual(this.definition, other.definition);
     }
-}
-
-function checkDefIsExecutable(_def: IExecutionDefinition): void {
-    return;
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecutionByRef.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecutionByRef.ts
@@ -34,8 +34,6 @@ export class BearPreparedExecutionByRef implements IPreparedExecution {
     ) {}
 
     public async execute(): Promise<IExecutionResult> {
-        checkDefIsExecutable(this.definition);
-
         const execution = await this.createVisualizationExecution();
 
         return this.authCall(
@@ -87,8 +85,4 @@ export class BearPreparedExecutionByRef implements IPreparedExecution {
     public equals(other: IPreparedExecution): boolean {
         return isEqual(this.definition, other.definition);
     }
-}
-
-function checkDefIsExecutable(_def: IExecutionDefinition): void {
-    return;
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecutionByRef.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/preparedExecutionByRef.ts
@@ -1,0 +1,94 @@
+// (C) 2019-2020 GoodData Corporation
+
+import { IExecutionFactory, IExecutionResult, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import {
+    defFingerprint,
+    defWithDimensions,
+    defWithSorting,
+    DimensionGenerator,
+    IDimension,
+    IExecutionDefinition,
+    IFilter,
+    IInsight,
+    insightRef,
+    ISortItem,
+} from "@gooddata/sdk-model";
+import isEqual from "lodash/isEqual";
+import { BearAuthenticatedCallGuard } from "../../../types/auth";
+import { convertExecutionApiError } from "../../../utils/errorHandling";
+import { BearExecutionResult } from "./executionResult";
+import { convertResultSpec } from "../../../convertors/toBackend/afm/ExecutionConverter";
+import { IVisualizationExecution } from "@gooddata/api-client-bear/dist/execution/execute-afm";
+import { objRefToUri } from "../../../utils/api";
+import { convertFilters } from "../../../convertors/toBackend/afm/FilterConverter";
+
+export class BearPreparedExecutionByRef implements IPreparedExecution {
+    private _fingerprint: string | undefined;
+
+    constructor(
+        private readonly authCall: BearAuthenticatedCallGuard,
+        public readonly definition: IExecutionDefinition,
+        private readonly insight: IInsight,
+        private readonly filters: IFilter[] = [],
+        private readonly executionFactory: IExecutionFactory,
+    ) {}
+
+    public async execute(): Promise<IExecutionResult> {
+        checkDefIsExecutable(this.definition);
+
+        const execution = await this.createVisualizationExecution();
+
+        return this.authCall(
+            (sdk) =>
+                sdk.execution
+                    ._getVisExecutionResponse(this.definition.workspace, execution)
+                    .then((response) => {
+                        return new BearExecutionResult(
+                            this.authCall,
+                            this.definition,
+                            this.executionFactory,
+                            response,
+                        );
+                    }),
+            convertExecutionApiError,
+        );
+    }
+
+    private async createVisualizationExecution(): Promise<IVisualizationExecution> {
+        const uri = await objRefToUri(insightRef(this.insight), this.definition.workspace, this.authCall);
+        const resultSpec = convertResultSpec(this.definition);
+        const filters = convertFilters(this.filters);
+
+        return {
+            visualizationExecution: {
+                reference: uri,
+                resultSpec,
+                filters,
+            },
+        };
+    }
+
+    public withDimensions(...dimsOrGen: Array<IDimension | DimensionGenerator>): IPreparedExecution {
+        return this.executionFactory.forDefinition(defWithDimensions(this.definition, ...dimsOrGen));
+    }
+
+    public withSorting(...items: ISortItem[]): IPreparedExecution {
+        return this.executionFactory.forDefinition(defWithSorting(this.definition, items));
+    }
+
+    public fingerprint(): string {
+        if (!this._fingerprint) {
+            this._fingerprint = defFingerprint(this.definition);
+        }
+
+        return this._fingerprint;
+    }
+
+    public equals(other: IPreparedExecution): boolean {
+        return isEqual(this.definition, other.definition);
+    }
+}
+
+function checkDefIsExecutable(_def: IExecutionDefinition): void {
+    return;
+}

--- a/libs/sdk-backend-bear/src/backend/workspace/execution/test/executionFactory.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/execution/test/executionFactory.test.ts
@@ -1,0 +1,41 @@
+// (C) 2020 GoodData Corporation
+
+import { BearExecution } from "../executionFactory";
+import { BearAuthenticatedCallGuard } from "../../../../types/auth";
+import { NotSupported } from "@gooddata/sdk-backend-spi";
+import { ReferenceLdm, ReferenceRecordings } from "@gooddata/reference-workspace";
+import { recordedInsight } from "@gooddata/sdk-backend-mockingbird";
+import { newAttributeSort } from "@gooddata/sdk-model";
+import { withCaching } from "@gooddata/sdk-backend-base";
+import bearFactory from "../../../../index";
+
+const UnsupportedAuthCall: BearAuthenticatedCallGuard = () => {
+    throw new NotSupported("you got too far");
+};
+
+const TestInsight = recordedInsight(ReferenceRecordings.Insights.BarChart.SingleMeasureWithViewBy);
+const TestExtraSort = newAttributeSort(ReferenceLdm.Product.Name);
+
+describe("execution factory", () => {
+    it("should retain execute-by-ref implementation", () => {
+        const factory = new BearExecution(UnsupportedAuthCall, "test-workspace");
+        const initialExecution = factory.forInsightByRef(TestInsight);
+        const withExtraConfiguration = initialExecution.withSorting(TestExtraSort);
+
+        expect(initialExecution.constructor.name).toEqual(withExtraConfiguration.constructor.name);
+    });
+
+    it("should work with decorators", () => {
+        /*
+         * This is here to confirm that the shenanigans related to execute-by-ref play well with the decorators
+         */
+        const cachingBackend = withCaching(bearFactory());
+        const initialExecution = cachingBackend
+            .workspace("test-workspace")
+            .execution()
+            .forInsightByRef(TestInsight);
+        const withExtraConfiguration = initialExecution.withSorting(TestExtraSort);
+
+        expect(initialExecution.constructor.name).toEqual(withExtraConfiguration.constructor.name);
+    });
+});

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -12,6 +12,7 @@ import {
     DateAttributeGranularity,
     IRankingFilter,
     IMeasureValueFilter,
+    uriRef,
 } from "@gooddata/sdk-model";
 import compact from "lodash/compact";
 import isEmpty from "lodash/isEmpty";
@@ -213,6 +214,7 @@ export const convertVisualization = (
         insight: {
             buckets: content.buckets.map(convertBucket),
             filters: content.filters ? compact(content.filters.map(convertFilter)) : [],
+            ref: uriRef(meta.uri),
             // we assume that identifier is always defined for visualizations
             identifier: meta.identifier!,
             properties: parsedProperties,

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/ExecutionConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/ExecutionConverter.ts
@@ -1,8 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
-import compact from "lodash/compact";
 import isEmpty from "lodash/isEmpty";
 import { GdcExecuteAFM } from "@gooddata/api-model-bear";
-import { convertFilter } from "./FilterConverter";
+import { convertFilters } from "./FilterConverter";
 import { convertMeasure } from "./MeasureConverter";
 import {
     dimensionsFindItem,
@@ -32,9 +31,7 @@ function convertAFM(def: IExecutionDefinition): GdcExecuteAFM.IAfm {
     const measures: GdcExecuteAFM.IMeasure[] = def.measures.map(convertMeasure);
     const measuresProp = measures.length ? { measures } : {};
 
-    const filters: GdcExecuteAFM.CompatibilityFilter[] = def.filters
-        ? compact(def.filters.map(convertFilter))
-        : [];
+    const filters: GdcExecuteAFM.CompatibilityFilter[] = convertFilters(def.filters);
     const filtersProp = filters.length ? { filters } : {};
 
     const nativeTotals = convertNativeTotals(def);
@@ -110,7 +107,7 @@ function convertDimensions(def: IExecutionDefinition): GdcExecuteAFM.IDimension[
     });
 }
 
-function convertResultSpec(def: IExecutionDefinition): GdcExecuteAFM.IResultSpec {
+export function convertResultSpec(def: IExecutionDefinition): GdcExecuteAFM.IResultSpec {
     const sortsProp = !isEmpty(def.sortBy) ? { sorts: def.sortBy } : {};
     const dims = convertDimensions(def);
     const dimsProp = !isEmpty(dims) ? { dimensions: dims } : {};

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/FilterConverter.ts
@@ -19,6 +19,7 @@ import {
 } from "@gooddata/sdk-model";
 import isNil from "lodash/isNil";
 import { toBearRef, toScopedBearRef } from "../ObjRefConverter";
+import compact from "lodash/compact";
 
 function convertAttributeFilter(filter: IAttributeFilter): GdcExecuteAFM.FilterItem | null {
     /*
@@ -165,4 +166,8 @@ export function convertMeasureFilter(filter: IMeasureFilter): GdcExecuteAFM.Filt
     } else {
         return convertRelativeDateFilter(filter);
     }
+}
+
+export function convertFilters(filters: IFilter[]): GdcExecuteAFM.CompatibilityFilter[] {
+    return filters ? compact(filters.map(convertFilter)) : [];
 }

--- a/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
+++ b/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
@@ -116,17 +116,17 @@ export function recordedBackend(index: RecordingIndex, config?: RecordedBackendC
 export type RecordedBackendConfig = AnalyticalBackendConfig & {
     globalSettings?: ISettings;
     globalPalette?: IColorPalette;
-    resultDescriptorRefs?: RecordedDescriptorRefType;
+    useRefType?: RecordedRefType;
 };
 
 // @internal
-export function recordedDataView(recording: ScenarioRecording, dataViewId?: string, resultRefType?: RecordedDescriptorRefType): IDataView;
+export function recordedDataView(recording: ScenarioRecording, dataViewId?: string, resultRefType?: RecordedRefType): IDataView;
 
 // @internal
 export function recordedDataViews(recordings: RecordingIndex): NamedDataView[];
 
 // @internal (undocumented)
-export type RecordedDescriptorRefType = "id" | "uri";
+export type RecordedRefType = "id" | "uri";
 
 // @internal (undocumented)
 export type RecordingIndex = {

--- a/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
+++ b/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
@@ -125,6 +125,9 @@ export function recordedDataView(recording: ScenarioRecording, dataViewId?: stri
 // @internal
 export function recordedDataViews(recordings: RecordingIndex): NamedDataView[];
 
+// @internal
+export function recordedInsight(recording: InsightRecording, refType?: RecordedRefType): IInsight;
+
 // @internal (undocumented)
 export type RecordedRefType = "id" | "uri";
 

--- a/libs/sdk-backend-mockingbird/src/index.ts
+++ b/libs/sdk-backend-mockingbird/src/index.ts
@@ -20,6 +20,7 @@ export {
 export {
     recordedDataView,
     recordedDataViews,
+    recordedInsight,
     DataViewAll,
     dataViewWindow,
     DataViewFirstPage,

--- a/libs/sdk-backend-mockingbird/src/index.ts
+++ b/libs/sdk-backend-mockingbird/src/index.ts
@@ -14,7 +14,7 @@ export {
     RecordedBackendConfig,
     CatalogRecording,
     VisClassesRecording,
-    RecordedDescriptorRefType,
+    RecordedRefType,
 } from "./recordedBackend/types";
 
 export {

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -5,30 +5,30 @@ import {
     AuthenticatedPrincipal,
     IAnalyticalBackend,
     IAnalyticalWorkspace,
+    IAttributeDescriptor,
     IAuthenticationProvider,
     IDataView,
+    IDimensionDescriptor,
     IElementQueryFactory,
     IExecutionFactory,
     IExecutionResult,
     IExportConfig,
     IExportResult,
+    IMeasureGroupDescriptor,
     IPreparedExecution,
     IUserService,
     IWorkspaceCatalogFactory,
+    IWorkspaceDashboards,
     IWorkspaceDatasetsService,
+    IWorkspaceDateFilterConfigsQuery,
     IWorkspaceInsights,
     IWorkspaceMetadata,
     IWorkspacePermissionsFactory,
     IWorkspaceQueryFactory,
     IWorkspaceSettingsService,
     IWorkspaceStylingService,
-    NotSupported,
-    IWorkspaceDashboards,
     IWorkspaceUsersQuery,
-    IWorkspaceDateFilterConfigsQuery,
-    IDimensionDescriptor,
-    IAttributeDescriptor,
-    IMeasureGroupDescriptor,
+    NotSupported,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -39,7 +39,6 @@ import {
     IAttributeElement,
     IDimension,
     IExecutionDefinition,
-    IFilter,
     ISortItem,
     uriRef,
 } from "@gooddata/sdk-model";
@@ -205,10 +204,6 @@ class RecordedExecutionFactory extends AbstractExecutionFactory {
 
     public forDefinition(def: IExecutionDefinition): IPreparedExecution {
         return recordedPreparedExecution(def, this, this.recordings);
-    }
-
-    public forInsightByRef(_uri: string, _filters?: IFilter[]): Promise<IPreparedExecution> {
-        throw new NotSupported("not yet supported");
     }
 }
 

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -31,7 +31,7 @@ import {
     uriRef,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
-import { ExecutionRecording, RecordingIndex, ScenarioRecording, RecordedDescriptorRefType } from "./types";
+import { ExecutionRecording, RecordingIndex, ScenarioRecording, RecordedRefType } from "./types";
 import { Denormalizer, NormalizationState, AbstractExecutionFactory } from "@gooddata/sdk-backend-base";
 import flatMap from "lodash/flatMap";
 import isEqual from "lodash/isEqual";
@@ -72,7 +72,7 @@ export class RecordedExecutionFactory extends AbstractExecutionFactory {
     constructor(
         private readonly recordings: RecordingIndex,
         workspace: string,
-        private readonly resultRefType: RecordedDescriptorRefType,
+        private readonly resultRefType: RecordedRefType,
     ) {
         super(workspace);
     }
@@ -95,7 +95,7 @@ function recordedExecutionKey(defOrFingerprint: IExecutionDefinition | string): 
 function recordedPreparedExecution(
     definition: IExecutionDefinition,
     executionFactory: IExecutionFactory,
-    resultRefType: RecordedDescriptorRefType,
+    resultRefType: RecordedRefType,
     recordings: RecordingIndex = {},
 ): IPreparedExecution {
     const fp = defFingerprint(definition);
@@ -142,7 +142,7 @@ function recordedPreparedExecution(
  */
 function enrichDescriptorsWithRefs(
     dims: IDimensionDescriptor[],
-    resultRefType: RecordedDescriptorRefType,
+    resultRefType: RecordedRefType,
 ): IDimensionDescriptor[] {
     const createRef = (type: ObjectType, uri?: string, identifier?: string): ObjRef | undefined => {
         if (resultRefType === "uri" && uri) {
@@ -207,7 +207,7 @@ class RecordedExecutionResult implements IExecutionResult {
     constructor(
         public readonly definition: IExecutionDefinition,
         private readonly executionFactory: IExecutionFactory,
-        readonly resultRefType: RecordedDescriptorRefType,
+        readonly resultRefType: RecordedRefType,
         private readonly recording: ExecutionRecording,
         private readonly denormalizer?: Denormalizer,
     ) {
@@ -317,7 +317,7 @@ function denormalizedDataView(
     recording: ScenarioRecording,
     scenario: any,
     dataViewId: string,
-    resultRefType: RecordedDescriptorRefType,
+    resultRefType: RecordedRefType,
 ): IDataView {
     const { execution } = recording;
     const definition = { ...execution.definition, buckets: scenario.buckets };
@@ -341,7 +341,7 @@ function normalizedDataView(
     recording: ScenarioRecording,
     scenario: any,
     dataViewId: string,
-    resultRefType: RecordedDescriptorRefType,
+    resultRefType: RecordedRefType,
 ): IDataView {
     const { execution } = recording;
 
@@ -389,7 +389,7 @@ function normalizedDataView(
 export function recordedDataView(
     recording: ScenarioRecording,
     dataViewId: string = DataViewAll,
-    resultRefType: RecordedDescriptorRefType = "uri",
+    resultRefType: RecordedRefType = "uri",
 ): IDataView {
     const { execution, scenarioIndex } = recording;
     const scenario = execution.scenarios?.[scenarioIndex];

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/execution.ts
@@ -24,14 +24,20 @@ import {
     IDimension,
     idRef,
     IExecutionDefinition,
-    IFilter,
+    IInsight,
     ISortItem,
     ObjectType,
     ObjRef,
     uriRef,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
-import { ExecutionRecording, RecordingIndex, ScenarioRecording, RecordedRefType } from "./types";
+import {
+    ExecutionRecording,
+    RecordingIndex,
+    ScenarioRecording,
+    RecordedRefType,
+    InsightRecording,
+} from "./types";
 import { Denormalizer, NormalizationState, AbstractExecutionFactory } from "@gooddata/sdk-backend-base";
 import flatMap from "lodash/flatMap";
 import isEqual from "lodash/isEqual";
@@ -79,10 +85,6 @@ export class RecordedExecutionFactory extends AbstractExecutionFactory {
 
     public forDefinition(def: IExecutionDefinition): IPreparedExecution {
         return recordedPreparedExecution(def, this, this.resultRefType, this.recordings);
-    }
-
-    public forInsightByRef(_uri: string, _filters?: IFilter[]): Promise<IPreparedExecution> {
-        throw new NotSupported("not yet supported");
     }
 }
 
@@ -455,4 +457,23 @@ export function recordedDataViews(recordings: RecordingIndex): NamedDataView[] {
     const executionRecordings = Object.values(recordings.executions);
 
     return flatMap(executionRecordings, expandRecordingToDataViews);
+}
+
+/**
+ * Given insight recording (as accessible through Recordings.Insights), this function returns instance of IInsight.
+ *
+ * @param recording - insight recording
+ * @param refType - ref type to have in the insight, default is uri
+ * @internal
+ */
+export function recordedInsight(recording: InsightRecording, refType: RecordedRefType = "uri"): IInsight {
+    return {
+        insight: {
+            ...recording.obj.insight,
+            ref:
+                refType === "uri"
+                    ? uriRef(recording.obj.insight.uri)
+                    : idRef(recording.obj.insight.identifier, "insight"),
+        },
+    };
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -106,11 +106,7 @@ function recordedWorkspace(
     return {
         workspace,
         execution(): IExecutionFactory {
-            return new RecordedExecutionFactory(
-                recordings,
-                workspace,
-                implConfig.resultDescriptorRefs ?? "uri",
-            );
+            return new RecordedExecutionFactory(recordings, workspace, implConfig.useRefType ?? "uri");
         },
         elements(): IElementQueryFactory {
             return new RecordedElementQueryFactory(recordings);
@@ -119,7 +115,7 @@ function recordedWorkspace(
             return new RecordedMetadata(recordings);
         },
         insights(): IWorkspaceInsights {
-            return new RecordedInsights(recordings);
+            return new RecordedInsights(recordings, implConfig.useRefType ?? "uri");
         },
         dashboards(): IWorkspaceDashboards {
             throw new NotSupported("not supported");

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/tests/execution.test.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/tests/execution.test.ts
@@ -57,7 +57,7 @@ describe("execution factory", () => {
     });
 
     it("should load result with idRefs if asked to", async () => {
-        const result = await recordedBackend(ReferenceRecordings.Recordings, { resultDescriptorRefs: "id" })
+        const result = await recordedBackend(ReferenceRecordings.Recordings, { useRefType: "id" })
             .workspace("reference-workspace")
             .execution()
             .forDefinition(

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
@@ -14,7 +14,7 @@ import {
 /**
  * @internal
  */
-export type RecordedDescriptorRefType = "id" | "uri";
+export type RecordedRefType = "id" | "uri";
 
 /**
  * Recorded backend allows convenient programmatic configuration of some services outcomes.
@@ -33,13 +33,15 @@ export type RecordedBackendConfig = AnalyticalBackendConfig & {
     globalPalette?: IColorPalette;
 
     /**
-     * Specify which ref type should be added to result descriptors. In the recording files themselves
-     * the descriptors do not have the 'ref' fields. They will be added dynamically by the recorded backend
-     * according to this setting.
+     * Specify which ref type should be added to recorded entities. Recording infrastructure does not
+     * store 'ref'. Instead, the recorded backend can return refs as either uri or identifier, thus allowing
+     * to simulate behavior of the different backend types.
+     *
+     * Note: this is currently implemented for executions and insights. it is not yet supported in catalog
      *
      * Default: 'uri'
      */
-    resultDescriptorRefs?: RecordedDescriptorRefType;
+    useRefType?: RecordedRefType;
 };
 
 /**

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -486,8 +486,8 @@ export type IElementQueryResult = IPagedResource<IAttributeElement>;
 export interface IExecutionFactory {
     forBuckets(buckets: IBucket[], filters?: IFilter[]): IPreparedExecution;
     forDefinition(def: IExecutionDefinition): IPreparedExecution;
-    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
-    forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
+    forInsight(insightDefinition: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
+    forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
     forItems(items: IAttributeOrMeasure[], filters?: IFilter[]): IPreparedExecution;
 }
 

--- a/libs/sdk-backend-spi/src/workspace/execution/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/execution/index.ts
@@ -8,6 +8,7 @@ import {
     ISortItem,
     IExecutionDefinition,
     DimensionGenerator,
+    IInsight,
 } from "@gooddata/sdk-model";
 import { IExportConfig, IExportResult } from "./export";
 import { DataValue, IDimensionDescriptor, IResultHeader, IResultWarning } from "./results";
@@ -78,28 +79,29 @@ export interface IExecutionFactory {
      * pre-filled dimensions greated using the `defaultDimensionsGenerator` provided by the
      * `@gooddata/sdk-model` package.
      *
-     * @param insight - insight to create execution for, must have buckets which must have some attributes or measures in them
+     * @param insightDefinition - insight definition to create execution for, must have buckets which must have some attributes or measures in them
      * @param filters - optional, may not be provided
      */
-    forInsight(insight: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
+    forInsight(insightDefinition: IInsightDefinition, filters?: IFilter[]): IPreparedExecution;
 
     /**
-     * Prepares new execution for an insight specified by reference =\> a link. This function is asynchronous as
-     * the insight WILL be retrieved from backend at this point.
+     * Prepares new, by-reference execution for an existing insight.
      *
      * Execution prepared using this method MAY be realized using different backend API than the executions where
      * attributes and measures are provided 'freeform'. In return, this different backend API may provide additional
      * authorization guarantees - for instance the backend MAY only allow end user to execute these stored insights
      * and not do any 'freeform' execution.
      *
+     * If the backend does not support execution by reference, then it MUST fall back to freeform execution.
+     *
      * The contract is that prepared executions created by this method MUST be executable and MUST come with
      * pre-filled dimensions created using the `defaultDimensionsGenerator` provided by the
      * `@gooddata/sdk-model` package.
      *
-     * @param uri - link to insight
+     * @param insight - saved insight
      * @param filters - optional list of filters to merge with filters already defined in the insight
      */
-    forInsightByRef(uri: string, filters?: IFilter[]): Promise<IPreparedExecution>;
+    forInsightByRef(insight: IInsight, filters?: IFilter[]): IPreparedExecution;
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
@@ -1,9 +1,9 @@
 // (C) 2019-2020 GoodData Corporation
 
-import { IPreparedExecution, NotImplemented } from "@gooddata/sdk-backend-spi";
-import { IExecutionDefinition, IFilter } from "@gooddata/sdk-model";
+import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { IExecutionDefinition } from "@gooddata/sdk-model";
 import { TigerPreparedExecution } from "./preparedExecution";
-import { AuthenticatedCallGuard, AbstractExecutionFactory } from "@gooddata/sdk-backend-base";
+import { AbstractExecutionFactory, AuthenticatedCallGuard } from "@gooddata/sdk-backend-base";
 import { DateFormatter } from "../../../convertors/fromBackend/dateFormatting/types";
 
 export class TigerExecution extends AbstractExecutionFactory {
@@ -17,9 +17,5 @@ export class TigerExecution extends AbstractExecutionFactory {
 
     public forDefinition(def: IExecutionDefinition): IPreparedExecution {
         return new TigerPreparedExecution(this.authCall, def, this, this.dateFormatter);
-    }
-
-    public forInsightByRef(_uri: string, _filters?: IFilter[]): Promise<IPreparedExecution> {
-        throw new NotImplemented("execution by uri reference not yet implemented");
     }
 }

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionFactory.ts
@@ -6,6 +6,10 @@ import { TigerPreparedExecution } from "./preparedExecution";
 import { AbstractExecutionFactory, AuthenticatedCallGuard } from "@gooddata/sdk-backend-base";
 import { DateFormatter } from "../../../convertors/fromBackend/dateFormatting/types";
 
+/*
+ * Note: if you come here one day to implement the forInsightByRef because tiger supports execute-by-reference,
+ * then you are in for a treat. Check out comments in `tigerFactory` in the root index.
+ */
 export class TigerExecution extends AbstractExecutionFactory {
     constructor(
         private readonly authCall: AuthenticatedCallGuard,

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -20,6 +20,7 @@ import {
     mergeFilters,
     insightFilters,
     insightSetFilters,
+    idRef,
 } from "@gooddata/sdk-model";
 import { VisualizationObject } from "@gooddata/api-client-tiger";
 import uuid4 from "uuid/v4";
@@ -37,6 +38,7 @@ const insightFromInsightDefinition = (insight: IInsightDefinition, id: string, u
             ...insight.insight,
             identifier: id,
             uri,
+            ref: idRef(id),
         },
     };
 };

--- a/libs/sdk-backend-tiger/src/index.ts
+++ b/libs/sdk-backend-tiger/src/index.ts
@@ -27,9 +27,15 @@ function tigerFactory(config?: AnalyticalBackendConfig, implConfig?: any): IAnal
      * tiger backend match the contracts for result dimension and data view header items. To this end, there are
      * couple of alternations / enrichment of tiger's descriptors and header items. Those are done during
      * conversion. See `src/convertors/fromBackend/dimensions.ts` and `result.ts` in the same dir.
+     *
+     * NOTE: since tiger does not yet support true execute-by-reference, and instead always falls back to
+     * freeform execution of the definition derived from the insight itself, it is all good to use fallback mode
+     * in the normalizing backend. However, one day, if tiger supports execute-by-reference, then the normalizing
+     * decorator needs to be removed. and instead the logic to restore titles, aliases and formats must be implemented
+     * in the various convertors in this package.
      */
 
-    return withNormalization(new TigerBackend(config, implConfig));
+    return withNormalization(new TigerBackend(config, implConfig), { executeByRefMode: "fallback" });
 }
 
 export default tigerFactory;

--- a/libs/sdk-model/__mocks__/insights.ts
+++ b/libs/sdk-model/__mocks__/insights.ts
@@ -1,5 +1,5 @@
 // (C) 2019 GoodData Corporation
-import { ISortItem, VisualizationProperties } from "../src";
+import { ISortItem, uriRef, VisualizationProperties } from "../src";
 import { IBucket } from "../src/execution/buckets";
 import { IInsight } from "../src/insight";
 import { IFilter } from "../src/execution/filter";
@@ -31,6 +31,7 @@ export class InsightBuilder {
             properties: {},
             identifier: "random",
             uri: "random",
+            ref: uriRef("random"),
         };
     }
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -732,6 +732,7 @@ export type IInsight = IInsightDefinition & {
     insight: {
         identifier: string;
         uri: string;
+        ref: ObjRef;
         created?: string;
         updated?: string;
         isLocked?: boolean;
@@ -926,6 +927,9 @@ export function insightProperties(insight: IInsightDefinition): VisualizationPro
 
 // @public
 export function insightReduceItems<T extends IInsightDefinition>(insight: T, reducer?: BucketItemReducer): T;
+
+// @public
+export function insightRef(insight: IInsight): ObjRef;
 
 // @public
 export function insightSanitize<T extends IInsightDefinition>(insight: T): T;

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -301,6 +301,7 @@ export {
     VisualizationProperties,
     IColorMappingItem,
     isInsight,
+    insightRef,
     insightId,
     insightItems,
     insightMeasures,

--- a/libs/sdk-model/src/insight/index.ts
+++ b/libs/sdk-model/src/insight/index.ts
@@ -27,6 +27,7 @@ import {
 import invariant from "ts-invariant";
 import { IColor } from "../colors";
 import identity from "lodash/identity";
+import { ObjRef } from "../objRef";
 
 /**
  * Represents an Insight defined in GoodData platform. Insight is typically created using Analytical Designer
@@ -48,6 +49,11 @@ export type IInsight = IInsightDefinition & {
          * Link to the insight.
          */
         uri: string;
+
+        /**
+         * Object to use when referencing insight.
+         */
+        ref: ObjRef;
 
         /**
          * Last update date - YYYY-MM-DD HH:mm:ss
@@ -432,7 +438,7 @@ export function insightVisualizationUrl(insight: IInsightDefinition): string {
 /**
  * Gets the insight title
  *
- * @param insight - insight to title of
+ * @param insight - insight to get title of
  * @returns the insight title
  * @public
  */
@@ -440,6 +446,18 @@ export function insightTitle(insight: IInsightDefinition): string {
     invariant(insight, "insight to get title from must be specified");
 
     return insight.insight.title;
+}
+
+/**
+ * Gets opaque reference to the insight.
+ *
+ * @param insight - insight to get ref of
+ * @public
+ */
+export function insightRef(insight: IInsight): ObjRef {
+    invariant(insight, "insight to get ref of must be specified");
+
+    return insight.insight.ref;
 }
 
 /**

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -38,6 +38,7 @@
         "@gooddata/goodstrap": "^68.20.1",
         "@gooddata/numberjs": "^3.2.4",
         "@gooddata/sdk-backend-spi": "^8.0.0-beta.76",
+        "@gooddata/sdk-backend-base": "^8.0.0-beta.76",
         "@gooddata/sdk-embedding": "^8.0.0-beta.76",
         "@gooddata/sdk-model": "^8.0.0-beta.76",
         "@gooddata/sdk-ui": "^8.0.0-beta.76",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
@@ -71,6 +71,7 @@ const sourceInsight: IInsight = {
         ...sourceInsightDefinition.insight,
         identifier: "sourceInsightIdentifier",
         uri: "/sourceInsightUri",
+        ref: uriRef("/sourceInsightUri"),
     },
 };
 
@@ -150,6 +151,7 @@ const expectedInsight: IInsight = {
         ...expectedInsightDefinition.insight,
         identifier: sourceInsight.insight.identifier,
         uri: sourceInsight.insight.uri,
+        ref: uriRef(sourceInsight.insight.uri),
     },
 };
 
@@ -159,6 +161,7 @@ const expectedInsightWithTotals: IInsight = {
         ...expectedInsightDefinitionWithTotals.insight,
         identifier: sourceInsight.insight.identifier,
         uri: sourceInsight.insight.uri,
+        ref: uriRef(sourceInsight.insight.uri),
     },
 };
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/testHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/testHelpers.ts
@@ -29,6 +29,7 @@ export function insightDefinitionToInsight(
             ...insightDefinition.insight,
             identifier,
             uri,
+            ref: uriRef(uri),
         },
     };
 }

--- a/libs/sdk-ui-tests/tests/_infra/renderPlugVis.tsx
+++ b/libs/sdk-ui-tests/tests/_infra/renderPlugVis.tsx
@@ -5,6 +5,7 @@ import {
     IInsightDefinition,
     insightVisualizationUrl,
     IVisualizationClass,
+    uriRef,
 } from "@gooddata/sdk-model";
 import { BaseVisualization, FullVisualizationCatalog } from "@gooddata/sdk-ui-ext/dist/internal";
 import { backendWithCapturing, ChartInteractions } from "./backendWithCapturing";
@@ -54,6 +55,7 @@ export async function mountInsight(
         insight: {
             identifier: "test",
             uri: "test",
+            ref: uriRef("test"),
             ...insight.insight,
         },
     };

--- a/libs/sdk-ui-tests/tests/smoke-and-capture/allScenarios.test.tsx
+++ b/libs/sdk-ui-tests/tests/smoke-and-capture/allScenarios.test.tsx
@@ -4,7 +4,7 @@ import flatMap from "lodash/flatMap";
 import unionBy from "lodash/unionBy";
 import isArray from "lodash/isArray";
 import isObject from "lodash/isObject";
-import { defFingerprint, IInsight, IInsightDefinition, insightTitle } from "@gooddata/sdk-model";
+import { defFingerprint, IInsight, IInsightDefinition, insightTitle, uriRef } from "@gooddata/sdk-model";
 import * as fs from "fs";
 import * as path from "path";
 import allScenarios from "../../scenarios";
@@ -38,7 +38,7 @@ function scenarioSaveDataCaptureRequests(
             const existingRequests = readJsonSync(requestsFile);
 
             if (!isObject(existingRequests)) {
-                // tslint:disable-next-line:no-console
+                // eslint-disable-next-line no-console
                 console.warn(
                     `The requests file ${requestsFile} seems invalid. It should contain object describing what data view requests should be captured for the recording.`,
                 );
@@ -46,7 +46,7 @@ function scenarioSaveDataCaptureRequests(
                 requests = existingRequests as DataViewRequests;
             }
         } catch (err) {
-            // tslint:disable-next-line:no-console
+            // eslint-disable-next-line no-console
             console.warn("Unable to read or parse exec requests file in ", requestsFile);
         }
     }
@@ -106,7 +106,7 @@ function scenarioSaveDescriptors(
             const existingScenarios = readJsonSync(scenariosFile);
 
             if (!isArray(existingScenarios)) {
-                // tslint:disable-next-line:no-console
+                // eslint-disable-next-line no-console
                 console.warn(
                     `The scenarios file ${scenariosFile} seems invalid. It should contain array of scenario metadata.`,
                 );
@@ -114,7 +114,7 @@ function scenarioSaveDescriptors(
                 scenarioDescriptors = existingScenarios;
             }
         } catch (err) {
-            // tslint:disable-next-line:no-console
+            // eslint-disable-next-line no-console
             console.warn("Unable to read or parse exec definition scenario file in ", scenariosFile);
         }
     }
@@ -201,8 +201,12 @@ function scenarioStoreInsight(scenario: IScenario<any>, def: IInsightDefinition)
     }
 
     const id = scenario.insightId;
+    /*
+     * Note: while the generated insight uses ref as uriRef, the recordedBackend allows to override this at
+     * runtime so then tests can say if they want id or uri
+     */
     const persistentInsight: IInsight = scenario.insightConverter({
-        insight: { identifier: id, uri: id, ...def.insight },
+        insight: { identifier: id, uri: id, ref: uriRef(id), ...def.insight },
     });
     const insightDir = path.join(storeDir, id);
 

--- a/libs/sdk-ui-tests/tests/smoke-and-capture/store.ts
+++ b/libs/sdk-ui-tests/tests/smoke-and-capture/store.ts
@@ -60,7 +60,7 @@ function initializeStore(
     }
 
     if (!fs.statSync(dir).isDirectory()) {
-        // tslint:disable-next-line:no-console
+        // eslint-disable-next-line no-console
         console.error(
             `Path ${dir} already exists but is not a directory. Not going to store any definitions.`,
         );

--- a/libs/sdk-ui/__mocks__/fixtures.ts
+++ b/libs/sdk-ui/__mocks__/fixtures.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import { LegacyExecutionRecording, legacyRecordedDataView } from "@gooddata/sdk-backend-mockingbird";
-import { IInsight } from "@gooddata/sdk-model";
+import { IInsight, uriRef } from "@gooddata/sdk-model";
 import { DataViewFacade } from "../src/base/results/facade";
 
 export const testWorkspace = "testWorkspace";
@@ -21,6 +21,7 @@ export const insightWithPoP: IInsight = {
     insight: {
         identifier: "popMeasureInsight",
         uri: "/some/uri/popMeasureInsight",
+        ref: uriRef("/some/uri/popMeasureInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {
@@ -84,6 +85,7 @@ export const insightWithPoPAndAlias: IInsight = {
     insight: {
         identifier: "popMeasureWithAliasInsight",
         uri: "/some/uri/popMeasureInsight",
+        ref: uriRef("/some/uri/popMeasureInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {
@@ -148,6 +150,7 @@ export const insightWithArithmeticAndDerivedMeasures: IInsight = {
     insight: {
         identifier: "arithmeticAndDerivedMeasureInsight",
         uri: "/some/uri/arithmeticAndDerivedMeasureInsight",
+        ref: uriRef("/some/uri/arithmeticAndDerivedMeasureInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {
@@ -206,6 +209,7 @@ export const insightWithArithmeticMeasureTree: IInsight = {
     insight: {
         identifier: "arithmeticMeasureTreeInsight",
         uri: "/some/uri/arithmeticMeasureTreeInsight",
+        ref: uriRef("/some/uri/arithmeticMeasureTreeInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {
@@ -299,6 +303,7 @@ export const insightWithComplexArithmeticMeasureTree: IInsight = {
     insight: {
         identifier: "complexArithmeticMeasureTreeInsight",
         uri: "/some/uri/complexArithmeticMeasureTreeInsight",
+        ref: uriRef("/some/uri/complexArithmeticMeasureTreeInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {
@@ -565,6 +570,7 @@ export const insightWithMultipleMeasureBuckets: IInsight = {
     insight: {
         identifier: "multipleMeasureBucketsInsight",
         uri: "/some/uri/multipleMeasureBucketsInsight",
+        ref: uriRef("/some/uri/multipleMeasureBucketsInsight"),
         visualizationUrl: "local:test",
         buckets: [
             {

--- a/tools/mock-handling/src/recordings/insights.ts
+++ b/tools/mock-handling/src/recordings/insights.ts
@@ -54,7 +54,7 @@ export class InsightRecording implements IRecording {
         workspace: string,
         newWorkspaceId?: string,
     ): Promise<void> {
-        const obj = await backend.workspace(workspace).insights().getInsight(idRef(this.insightId));
+        const obj: any = await backend.workspace(workspace).insights().getInsight(idRef(this.insightId));
 
         if (!fs.existsSync(this.directory)) {
             fs.mkdirSync(this.directory, { recursive: true });
@@ -63,6 +63,11 @@ export class InsightRecording implements IRecording {
         const replaceString: [string, string] | undefined = newWorkspaceId
             ? [workspace, newWorkspaceId]
             : undefined;
+
+        /*
+         * Do not store ref, let the recorded backend fill-in
+         */
+        delete obj.insight.ref;
 
         writeAsJsonSync(this.objFile, obj, { replaceString });
     }


### PR DESCRIPTION
Updated the `forInsightByRef` signature & contract; implemented it for bear & added `executeByReference` flag to InsightView.

In the end, doing InsightView with the flag on and on top of bear will lead to use of `executeVisualization` endpoint with added filters & resultSpec.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
