### PR TITLE
Fix Drill Down filters in the PluggablePivotTable

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -1,6 +1,10 @@
 // (C) 2019 GoodData Corporation
 
-import { modifyBucketsAttributesForDrillDown, sanitizeTableProperties } from "../drillDownUtil";
+import {
+    addIntersectionFiltersToInsight,
+    modifyBucketsAttributesForDrillDown,
+    sanitizeTableProperties,
+} from "../drillDownUtil";
 import cloneDeep from "lodash/cloneDeep";
 import flatMap from "lodash/flatMap";
 import get from "lodash/get";
@@ -42,6 +46,7 @@ import {
     IBucketFilter,
     IBucketItem,
     IBucketOfFun,
+    IDrillDownContext,
     IExtendedReferencePoint,
     IGdcConfig,
     IReferencePoint,
@@ -49,7 +54,6 @@ import {
     IVisProps,
     IVisualizationProperties,
     RenderFunction,
-    IDrillDownContext,
 } from "../../../interfaces/Visualization";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 
@@ -224,11 +228,15 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         sourceVisualization: IInsight,
         drillDownContext: IDrillDownContext,
     ): IInsight {
-        const insight = modifyBucketsAttributesForDrillDown(
+        const drillDownInsight = modifyBucketsAttributesForDrillDown(
             sourceVisualization,
             drillDownContext.drillDefinition,
         );
-        return sanitizeTableProperties(insightSanitize(insight));
+        const drillDownInsightWithFilters = addIntersectionFiltersToInsight(
+            drillDownInsight,
+            drillDownContext.event.drillContext.intersection,
+        );
+        return sanitizeTableProperties(insightSanitize(drillDownInsightWithFilters));
     }
 
     private createCorePivotTableProps = () => {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
@@ -49,6 +49,7 @@ import {
     validMeasureSort,
 } from "./sortMocks";
 import { getInsightWithDrillDownApplied } from "./getInsightWithDrillDownAppliedMock";
+import { createDrillEvent } from "../../tests/testHelpers";
 
 describe("PluggablePivotTable", () => {
     const backend = dummyBackend();
@@ -87,7 +88,7 @@ describe("PluggablePivotTable", () => {
                 getInsightWithDrillDownApplied.sourceInsight,
                 {
                     drillDefinition: getInsightWithDrillDownApplied.drillConfig,
-                    event: null,
+                    event: createDrillEvent("column", getInsightWithDrillDownApplied.intersection),
                 },
             );
 
@@ -100,7 +101,7 @@ describe("PluggablePivotTable", () => {
                 getInsightWithDrillDownApplied.sourceInsightWithTotals,
                 {
                     drillDefinition: getInsightWithDrillDownApplied.drillConfig,
-                    event: null,
+                    event: createDrillEvent("column", getInsightWithDrillDownApplied.intersection),
                 },
             );
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/getInsightWithDrillDownAppliedMock.ts
@@ -18,6 +18,9 @@ import {
 import { IImplicitDrillDown, IVisualizationProperties } from "../../../..";
 import { Department, Region, Status, Won } from "@gooddata/reference-workspace/dist/ldm/full";
 import { newWidthForAllMeasureColumns, newWidthForAttributeColumn } from "@gooddata/sdk-ui-pivot";
+import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
+import { IDrillEventIntersectionElement, IDrillIntersectionAttributeItem } from "@gooddata/sdk-ui";
+import { ReferenceData } from "@gooddata/reference-workspace";
 
 const properties: IVisualizationProperties = {
     controls: {
@@ -94,6 +97,88 @@ const drillConfig: IImplicitDrillDown = {
     },
 };
 
+const measureHeader: IMeasureDescriptor = {
+    measureHeaderItem: {
+        name: Won.measure.title,
+        format: "#,##0.00",
+        localIdentifier: Won.measure.localIdentifier,
+        uri: "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/9203",
+        identifier: null,
+    },
+};
+
+const departmentDirectSalesUri = ReferenceData.Department.DirectSales.uri;
+const departmentHeaderAttributeUri = "departmentHeaderAttributeUri";
+const departmentHeader: IDrillIntersectionAttributeItem = {
+    attributeHeaderItem: {
+        name: "Direct Sales",
+        uri: departmentDirectSalesUri,
+    },
+    attributeHeader: {
+        name: Department.attribute.alias,
+        localIdentifier: Department.attribute.localIdentifier,
+        uri: departmentHeaderAttributeUri,
+        ref: {
+            uri: departmentHeaderAttributeUri,
+        },
+        identifier: null,
+        formOf: null,
+    },
+};
+
+const statusLostUri = ReferenceData.Status.Lost.uri;
+const statusHeaderAttributeUri = "statusHeaderAttributeUri";
+const statusHeader: IDrillIntersectionAttributeItem = {
+    attributeHeaderItem: {
+        name: "Lost",
+        uri: statusLostUri,
+    },
+    attributeHeader: {
+        name: Status.attribute.alias,
+        localIdentifier: Status.attribute.localIdentifier,
+        uri: statusHeaderAttributeUri,
+        ref: {
+            uri: statusHeaderAttributeUri,
+        },
+        identifier: null,
+        formOf: null,
+    },
+};
+
+const regionEastCoastUri = ReferenceData.Region.EastCoast.uri;
+const regionHeaderAttributeUri = "regionHeaderAttributeUri";
+const regionHeader: IDrillIntersectionAttributeItem = {
+    attributeHeaderItem: {
+        name: "East Coast",
+        uri: regionEastCoastUri,
+    },
+    attributeHeader: {
+        name: Region.attribute.alias,
+        localIdentifier: Region.attribute.localIdentifier,
+        uri: regionHeaderAttributeUri,
+        ref: {
+            uri: regionHeaderAttributeUri,
+        },
+        identifier: null,
+        formOf: null,
+    },
+};
+
+const intersection: IDrillEventIntersectionElement[] = [
+    {
+        header: measureHeader,
+    },
+    {
+        header: departmentHeader,
+    },
+    {
+        header: statusHeader,
+    },
+    {
+        header: regionHeader,
+    },
+];
+
 const expectedProperties: IVisualizationProperties = {
     ...sourceInsight.insight.properties,
     controls: {
@@ -105,6 +190,22 @@ const expectedProperties: IVisualizationProperties = {
     },
     sortItems: [newAttributeSort(Region, "desc"), newAttributeSort(Status)],
 };
+
+const expectedFilters: IFilter[] = [
+    newPositiveAttributeFilter(Department, ["Inside Sales"]),
+    newPositiveAttributeFilter(
+        modifyAttribute(Department, (a) => a.displayForm(uriRef(departmentHeaderAttributeUri))),
+        { uris: [departmentDirectSalesUri] },
+    ),
+    newPositiveAttributeFilter(
+        modifyAttribute(Status, (a) => a.displayForm(uriRef(statusHeaderAttributeUri))),
+        { uris: [statusLostUri] },
+    ),
+    newPositiveAttributeFilter(
+        modifyAttribute(Region, (a) => a.displayForm(uriRef(regionHeaderAttributeUri))),
+        { uris: [regionEastCoastUri] },
+    ),
+];
 
 const expectedInsightDefinition: IInsightDefinition = newInsightDefinition(
     sourceInsight.insight.visualizationUrl,
@@ -119,7 +220,7 @@ const expectedInsightDefinition: IInsightDefinition = newInsightDefinition(
                 ),
                 bucketSetTotals(newBucket("measure", Won), []),
             ])
-            .filters([newPositiveAttributeFilter(Department, ["Inside Sales"])])
+            .filters(expectedFilters)
             .sorts([newAttributeSort(Department)])
             .properties(expectedProperties);
     },
@@ -138,7 +239,7 @@ const expectedInsightDefinitionWithTotals: IInsightDefinition = newInsightDefini
                 ),
                 newBucket("measure", Won, newTotal("nat", Won, Status)),
             ])
-            .filters([newPositiveAttributeFilter(Department, ["Inside Sales"])])
+            .filters(expectedFilters)
             .sorts([newAttributeSort(Department)])
             .properties(expectedProperties);
     },
@@ -169,4 +270,5 @@ export const getInsightWithDrillDownApplied = {
     drillConfig,
     expectedInsight,
     expectedInsightWithTotals,
+    intersection,
 };


### PR DESCRIPTION
 - include intersection filters when applying Drill Down in the PluggablePivotTable

JIRA: ONE-4654
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
