### PR TITLE
Fix the STACK bucket check in PluggableColumnBarCharts

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
@@ -2,21 +2,19 @@
 import get from "lodash/get";
 import set from "lodash/set";
 import {
-    IInsight,
-    bucketsItems,
-    IInsightDefinition,
-    insightBuckets,
-    bucketsFind,
-    IBucket,
-    idMatchBucket,
     bucketIsEmpty,
+    bucketsItems,
+    IInsight,
+    IInsightDefinition,
+    insightBucket,
+    insightBuckets,
 } from "@gooddata/sdk-model";
 import { arrayUtils } from "@gooddata/util";
 import {
     BucketNames,
+    getIntersectionPartAfter,
     IDrillEvent,
     IDrillEventIntersectionElement,
-    getIntersectionPartAfter,
 } from "@gooddata/sdk-ui";
 import { AXIS } from "../../constants/axis";
 import { BUCKETS } from "../../constants/bucket";
@@ -24,11 +22,11 @@ import { MAX_CATEGORIES_COUNT, MAX_STACKS_COUNT, UICONFIG, UICONFIG_AXIS } from 
 import { drillDownFromAttributeLocalId } from "../../utils/ImplicitDrillDownHelper";
 import {
     IBucketOfFun,
+    IDrillDownContext,
     IExtendedReferencePoint,
+    IImplicitDrillDown,
     IReferencePoint,
     IVisConstruct,
-    IImplicitDrillDown,
-    IDrillDownContext,
 } from "../../interfaces/Visualization";
 import {
     getAllCategoriesAttributeItems,
@@ -47,7 +45,7 @@ import {
 } from "../../utils/propertiesHelper";
 import { setColumnBarChartUiConfig } from "../../utils/uiConfigHelpers/columnBarChartUiConfigHelper";
 import { PluggableBaseChart } from "./baseChart/PluggableBaseChart";
-import { modifyBucketsAttributesForDrillDown, addIntersectionFiltersToInsight } from "./drillDownUtil";
+import { addIntersectionFiltersToInsight, modifyBucketsAttributesForDrillDown } from "./drillDownUtil";
 
 export class PluggableColumnBarCharts extends PluggableBaseChart {
     constructor(props: IVisConstruct) {
@@ -90,9 +88,8 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
         source: IInsight,
         event: IDrillEvent,
     ): IDrillEventIntersectionElement[] {
-        const hasStackByAttributes = bucketsFind(insightBuckets(source), (bucket: IBucket) => {
-            return idMatchBucket(BucketNames.STACK) && !bucketIsEmpty(bucket);
-        });
+        const stackBucket = insightBucket(source, BucketNames.STACK);
+        const hasStackByAttributes = stackBucket && !bucketIsEmpty(stackBucket);
 
         const intersection = event.drillContext.intersection;
         return hasStackByAttributes ? arrayUtils.shiftArrayRight(intersection) : intersection;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/getInsightWithDrillDownAppliedMock.ts
@@ -1,13 +1,13 @@
 // (C) 2020 GoodData Corporation
 import {
     IInsightDefinition,
+    modifyAttribute,
+    newAttribute,
     newBucket,
     newInsightDefinition,
     newNegativeAttributeFilter,
     newPositiveAttributeFilter,
-    newAttribute,
     uriRef,
-    modifyAttribute,
 } from "@gooddata/sdk-model";
 import { ReferenceData } from "@gooddata/reference-workspace";
 import { Department, Region, Won } from "@gooddata/reference-workspace/dist/ldm/full";
@@ -106,10 +106,6 @@ export const expectedInsightDefinitionDrillToRegion: IInsightDefinition = newIns
                 newPositiveAttributeFilter(
                     modifyAttribute(Region, (a) => a.displayForm(uriRef(regionUri))),
                     { uris: [westCoastUri] },
-                ),
-                newPositiveAttributeFilter(
-                    modifyAttribute(Department, (a) => a.displayForm(uriRef(departmentUri))),
-                    { uris: [directSalesUri] },
                 ),
             ]);
     },


### PR DESCRIPTION
 - properly call the returned predicate

JIRA: ONE-4624

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
