### PR TITLE
FEATURE: BB-2568 Disable show in percent when ranking filter is used

### DIFF
--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -291,6 +291,17 @@ export const attributeFilterBucketItem: IFilters = {
     ],
 };
 
+export const rankingFilterBucketItem: IFiltersBucketItem = {
+    localIdentifier: "rf1",
+    filters: [
+        {
+            measure: masterMeasureItems[0].localIdentifier,
+            operator: "TOP",
+            value: 3,
+        },
+    ],
+};
+
 export const emptyReferencePoint: IReferencePoint = {
     buckets: [
         {

--- a/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
@@ -25,6 +25,7 @@ import {
     getAttributeItemsWithoutStacks,
     isDateBucketItem,
     isMeasureValueFilter,
+    isRankingFilter,
 } from "./bucketHelper";
 
 import { FILTERS, GRANULARITY, ALL_TIME, ATTRIBUTE, BUCKETS, METRIC } from "../constants/bucket";
@@ -185,6 +186,11 @@ export function hasNonAllTimeFilter(filters: IFilters): boolean {
     return !isEmpty(filterInterval);
 }
 
+export function hasRankingFilter(filters: IFilters): boolean {
+    const allBucketFilters = flatMap(filters.items, (filterItem) => filterItem.filters);
+    return allBucketFilters.some(isRankingFilter);
+}
+
 export function isShowInPercentAllowed(
     buckets: IBucketOfFun[],
     filters: IFilters,
@@ -195,7 +201,8 @@ export function isShowInPercentAllowed(
     return (
         allRulesMet(rules, buckets, filters) &&
         hasOneMasterMeasureInBucket(buckets, bucketLocalIdentifier) &&
-        !filteredByDerivedMeasure(buckets, filters)
+        !filteredByDerivedMeasure(buckets, filters) &&
+        !hasRankingFilter(filters)
     );
 }
 

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketRules.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketRules.test.ts
@@ -47,6 +47,21 @@ describe("isShowInPercentAllowed", () => {
             ),
         ).toBeFalsy();
     });
+
+    it("should return false if ranking filter is present", () => {
+        const editedReferencePoint = cloneDeep(
+            referencePointMocks.metricWithViewByDateAndDateFilterReferencePoint,
+        );
+        set(editedReferencePoint, ["filters", "items", 1], referencePointMocks.rankingFilterBucketItem);
+
+        expect(
+            bucketRules.isShowInPercentAllowed(
+                editedReferencePoint.buckets,
+                editedReferencePoint.filters,
+                BucketNames.MEASURES,
+            ),
+        ).toBeFalsy();
+    });
 });
 
 describe("overTimeComparisonRecommendationEnabled", () => {
@@ -529,6 +544,26 @@ describe("partial rules", () => {
             expect(
                 bucketRules.hasGlobalDateFilterIgnoreAllTime(referencePointMocks.attributeFilterBucketItem),
             ).toBeFalsy();
+        });
+    });
+
+    describe("hasRankingFilter", () => {
+        it("should return false when ranking filter is not in filter bucket", () => {
+            const filters: IFilters = {
+                localIdentifier: "filters",
+                items: [...referencePointMocks.attributeFilters],
+            };
+
+            expect(bucketRules.hasRankingFilter(filters)).toBeFalsy();
+        });
+
+        it("should return true when ranking filter is not in filter bucket", () => {
+            const filters: IFilters = {
+                localIdentifier: "filters",
+                items: [...referencePointMocks.attributeFilters, referencePointMocks.rankingFilterBucketItem],
+            };
+
+            expect(bucketRules.hasRankingFilter(filters)).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
Using percentage in measure config should not be allowed when ranking filter is in filter buckets.

JIRA: BB-2568

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
