### PR TITLE
Add logic for ranking filter merging

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/insights/tests/filterMerging.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/tests/filterMerging.test.ts
@@ -8,6 +8,7 @@ import {
     IFilter,
     newAllTimeFilter,
     uriRef,
+    newRankingFilter,
 } from "@gooddata/sdk-model";
 
 describe("appendFilters", () => {
@@ -26,6 +27,15 @@ describe("appendFilters", () => {
     it("should append measure value filters", async () => {
         const insightFilters = [newMeasureValueFilter("foo", "EQUAL_TO", 42)];
         const addedFilters = [newMeasureValueFilter("bar", "BETWEEN", 0, 100)];
+
+        const actual = await appendFilters(insightFilters, addedFilters, uriResolver);
+
+        expect(actual).toEqual([...insightFilters, ...addedFilters]);
+    });
+
+    it("should append ranking filters", async () => {
+        const insightFilters = [newRankingFilter("foo", "TOP", 3)];
+        const addedFilters = [newRankingFilter("bar", "BOTTOM", 10)];
 
         const actual = await appendFilters(insightFilters, addedFilters, uriResolver);
 


### PR DESCRIPTION
It is possible to append filters even if one of them is ranking filter. Previously the exception was thrown. The merge function allows to have multiple ranking filters in the insight as this is legal according to backend.

JIRA: BB-2582

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
