### PR TITLE
Cut and reverse drill down intersection

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/getInsightWithDrillDownAppliedMock.ts
@@ -1,0 +1,127 @@
+// (C) 2020 GoodData Corporation
+
+import {
+    IInsightDefinition,
+    newAttribute,
+    newBucket,
+    newInsightDefinition,
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+    uriRef,
+} from "@gooddata/sdk-model";
+import { ReferenceData } from "@gooddata/reference-workspace";
+import { Department, Region, Won } from "@gooddata/reference-workspace/dist/ldm/full";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
+
+const regionUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1024";
+const departmentUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1027";
+const westCoastUri = ReferenceData.Region.WestCoast.uri;
+const directSalesUri = ReferenceData.Department.DirectSales.uri;
+
+export const targetUri = "target-uri";
+
+export const intersection: IDrillEventIntersectionElement[] = [
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "Direct Sales",
+                uri: directSalesUri,
+            },
+            attributeHeader: {
+                name: Department.attribute.alias,
+                localIdentifier: Department.attribute.localIdentifier,
+                uri: departmentUri,
+                ref: {
+                    uri: departmentUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "West Coast",
+                uri: westCoastUri,
+            },
+            attributeHeader: {
+                name: Region.attribute.alias,
+                localIdentifier: Region.attribute.localIdentifier,
+                uri: regionUri,
+                ref: {
+                    uri: regionUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            measureHeaderItem: {
+                name: Won.measure.title,
+                format: "#,##0.00",
+                localIdentifier: Won.measure.localIdentifier,
+                uri: "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/9203",
+                identifier: null,
+            },
+        },
+    },
+];
+
+export const sourceInsightDef: IInsightDefinition = newInsightDefinition("visualizationClass-url", (b) => {
+    return b
+        .title("sourceInsight")
+        .buckets([newBucket("measure", Won), newBucket("view", Department), newBucket("segment", Region)])
+        .filters([newNegativeAttributeFilter(Department, [])]);
+});
+
+const replacedAttributeRegion = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Region.attribute.localIdentifier),
+);
+
+const replacedAttributeDepartment = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Department.attribute.localIdentifier),
+);
+
+export const expectedInsightDefRegion: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", Department),
+                newBucket("segment", replacedAttributeRegion),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(regionUri)), {
+                    uris: [westCoastUri],
+                }),
+                newPositiveAttributeFilter(newAttribute(uriRef(departmentUri)), {
+                    uris: [directSalesUri],
+                }),
+            ]);
+    },
+);
+
+export const expectedInsightDefDepartment: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", replacedAttributeDepartment),
+                newBucket("segment", Region),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(departmentUri)), {
+                    uris: [directSalesUri],
+                }),
+            ]);
+    },
+);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
@@ -1,26 +1,30 @@
 // (C) 2020 GoodData Corporation
 import {
+    areObjRefsEqual,
+    attributeLocalId,
+    bucketItemLocalId,
     IAttribute,
     IAttributeOrMeasure,
-    IInsight,
-    isAttribute,
-    VisualizationProperties,
-    insightModifyItems,
-    insightReduceItems,
-    attributeLocalId,
-    modifyAttribute,
-    insightSetProperties,
-    insightSetFilters,
     IFilter,
-    insightProperties,
+    IInsight,
     insightItems,
-    bucketItemLocalId,
+    insightModifyItems,
+    insightProperties,
+    insightReduceItems,
+    insightSetFilters,
+    insightSetProperties,
+    isAttribute,
+    modifyAttribute,
     newPositiveAttributeFilter,
-    areObjRefsEqual,
+    VisualizationProperties,
 } from "@gooddata/sdk-model";
 import { IImplicitDrillDown } from "../../interfaces/Visualization";
-import { isDrillIntersectionAttributeItem, IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
-import { drillDownFromAttributeLocalId, drillDownDisplayForm } from "../../utils/ImplicitDrillDownHelper";
+import {
+    getIntersectionPartAfter,
+    IDrillEventIntersectionElement,
+    isDrillIntersectionAttributeItem,
+} from "@gooddata/sdk-ui";
+import { drillDownDisplayForm, drillDownFromAttributeLocalId } from "../../utils/ImplicitDrillDownHelper";
 import { ColumnWidthItem, isAttributeColumnWidthItem } from "@gooddata/sdk-ui-pivot";
 
 function matchesDrillDownTargetAttribute(
@@ -124,6 +128,19 @@ export function convertIntersectionToFilters(intersections: IDrillEventIntersect
                 uris: [header.attributeHeaderItem.uri],
             }),
         );
+}
+
+export function reverseAndTrimIntersection(
+    drillConfig: IImplicitDrillDown,
+    intersection?: IDrillEventIntersectionElement[],
+): IDrillEventIntersectionElement[] {
+    if (!intersection || intersection.length === 0) {
+        return intersection;
+    }
+
+    const clicked = drillDownFromAttributeLocalId(drillConfig);
+    const reorderedIntersection = intersection.slice().reverse();
+    return getIntersectionPartAfter(reorderedIntersection, clicked);
 }
 
 export function addIntersectionFiltersToInsight(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/getInsightWithDrillDownAppliedMock.ts
@@ -1,0 +1,124 @@
+// (C) 2020 GoodData Corporation
+
+import {
+    IInsightDefinition,
+    newAttribute,
+    newBucket,
+    newInsightDefinition,
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+    uriRef,
+} from "@gooddata/sdk-model";
+import { ReferenceData } from "@gooddata/reference-workspace";
+import { Department, Region, Won } from "@gooddata/reference-workspace/dist/ldm/full";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
+
+const regionUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1024";
+const departmentUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1027";
+const westCoastUri = ReferenceData.Region.WestCoast.uri;
+const directSalesUri = ReferenceData.Department.DirectSales.uri;
+
+export const targetUri = "target-uri";
+
+export const intersection: IDrillEventIntersectionElement[] = [
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "Direct Sales",
+                uri: directSalesUri,
+            },
+            attributeHeader: {
+                name: Department.attribute.alias,
+                localIdentifier: Department.attribute.localIdentifier,
+                uri: departmentUri,
+                ref: {
+                    uri: departmentUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "West Coast",
+                uri: westCoastUri,
+            },
+            attributeHeader: {
+                name: Region.attribute.alias,
+                localIdentifier: Region.attribute.localIdentifier,
+                uri: regionUri,
+                ref: {
+                    uri: regionUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            measureHeaderItem: {
+                name: Won.measure.title,
+                format: "#,##0.00",
+                localIdentifier: Won.measure.localIdentifier,
+                uri: "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/9203",
+                identifier: null,
+            },
+        },
+    },
+];
+
+export const sourceInsightDef: IInsightDefinition = newInsightDefinition("visualizationClass-url", (b) => {
+    return b
+        .title("sourceInsight")
+        .buckets([newBucket("measure", Won), newBucket("view", Department), newBucket("stack", Region)])
+        .filters([newNegativeAttributeFilter(Department, [])]);
+});
+
+const replacedAttributeRegion = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Region.attribute.localIdentifier),
+);
+
+const replacedAttributeDepartment = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Department.attribute.localIdentifier),
+);
+
+export const expectedInsightDefRegion: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", Department),
+                newBucket("stack", replacedAttributeRegion),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(regionUri)), {
+                    uris: [westCoastUri],
+                }),
+            ]);
+    },
+);
+
+export const expectedInsightDefDepartment: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", replacedAttributeDepartment),
+                newBucket("stack", Region),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(departmentUri)), {
+                    uris: [directSalesUri],
+                }),
+            ]);
+    },
+);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/getInsightWithDrillDownAppliedMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/getInsightWithDrillDownAppliedMock.ts
@@ -1,0 +1,127 @@
+// (C) 2020 GoodData Corporation
+
+import {
+    IInsightDefinition,
+    newAttribute,
+    newBucket,
+    newInsightDefinition,
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+    uriRef,
+} from "@gooddata/sdk-model";
+import { ReferenceData } from "@gooddata/reference-workspace";
+import { Department, Region, Won } from "@gooddata/reference-workspace/dist/ldm/full";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
+
+const regionUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1024";
+const departmentUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1027";
+const westCoastUri = ReferenceData.Region.WestCoast.uri;
+const directSalesUri = ReferenceData.Department.DirectSales.uri;
+
+export const targetUri = "target-uri";
+
+export const intersection: IDrillEventIntersectionElement[] = [
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "Direct Sales",
+                uri: directSalesUri,
+            },
+            attributeHeader: {
+                name: Department.attribute.alias,
+                localIdentifier: Department.attribute.localIdentifier,
+                uri: departmentUri,
+                ref: {
+                    uri: departmentUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            attributeHeaderItem: {
+                name: "West Coast",
+                uri: westCoastUri,
+            },
+            attributeHeader: {
+                name: Region.attribute.alias,
+                localIdentifier: Region.attribute.localIdentifier,
+                uri: regionUri,
+                ref: {
+                    uri: regionUri,
+                },
+                identifier: null,
+                formOf: null,
+            },
+        },
+    },
+    {
+        header: {
+            measureHeaderItem: {
+                name: Won.measure.title,
+                format: "#,##0.00",
+                localIdentifier: Won.measure.localIdentifier,
+                uri: "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/9203",
+                identifier: null,
+            },
+        },
+    },
+];
+
+export const sourceInsightDef: IInsightDefinition = newInsightDefinition("visualizationClass-url", (b) => {
+    return b
+        .title("sourceInsight")
+        .buckets([newBucket("measure", Won), newBucket("view", Department), newBucket("segment", Region)])
+        .filters([newNegativeAttributeFilter(Department, [])]);
+});
+
+const replacedAttributeRegion = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Region.attribute.localIdentifier),
+);
+
+const replacedAttributeDepartment = newAttribute(uriRef(targetUri), (b) =>
+    b.localId(Department.attribute.localIdentifier),
+);
+
+export const expectedInsightDefRegion: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", Department),
+                newBucket("segment", replacedAttributeRegion),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(regionUri)), {
+                    uris: [westCoastUri],
+                }),
+                newPositiveAttributeFilter(newAttribute(uriRef(departmentUri)), {
+                    uris: [directSalesUri],
+                }),
+            ]);
+    },
+);
+
+export const expectedInsightDefDepartment: IInsightDefinition = newInsightDefinition(
+    "visualizationClass-url",
+    (b) => {
+        return b
+            .title("sourceInsight")
+            .buckets([
+                newBucket("measure", Won),
+                newBucket("view", replacedAttributeDepartment),
+                newBucket("segment", Region),
+            ])
+            .filters([
+                newNegativeAttributeFilter(Department, []),
+                newPositiveAttributeFilter(newAttribute(uriRef(departmentUri)), {
+                    uris: [directSalesUri],
+                }),
+            ]);
+    },
+);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/drillDownUtil.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/drillDownUtil.test.ts
@@ -2,9 +2,11 @@
 
 import { newAttribute, newBucket, newInsightDefinition } from "@gooddata/sdk-model";
 import { IImplicitDrillDown } from "../../..";
-import { modifyBucketsAttributesForDrillDown } from "../drillDownUtil";
+import { reverseAndTrimIntersection, modifyBucketsAttributesForDrillDown } from "../drillDownUtil";
 import { Account, Department, Region, Status, Won } from "@gooddata/reference-workspace/dist/ldm/full";
 import { insightDefinitionToInsight } from "./testHelpers";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
+import { reverseAndTrimIntersectionMock } from "./reverseAndTrimIntersectionMock";
 
 describe("drillDownUtil", () => {
     describe("modifyBucketsAttributesForDrillDown", () => {
@@ -82,6 +84,39 @@ describe("drillDownUtil", () => {
 
             const expectedInsight = insightDefinitionToInsight(expected, "uri", "id");
             expect(result).toEqual(expectedInsight);
+        });
+    });
+
+    describe("reverseAndTrimIntersection", () => {
+        const {
+            drillConfigRegion,
+            intersectionWithOuterDepartment,
+            intersectionWithOuterRegion,
+            intersectionWithOuterDepartmentResult,
+            intersectionWithOuterRegionResult,
+        } = reverseAndTrimIntersectionMock;
+
+        const invalidScenarios: Array<[string, IDrillEventIntersectionElement[]?]> = [
+            ["undefined", undefined],
+            ["null", null],
+            ["empty", []],
+        ];
+        it.each(invalidScenarios)(
+            "should handle '%s' intersection and return the original intersection",
+            (_name, intersection?) => {
+                const actual = reverseAndTrimIntersection(drillConfigRegion, intersection);
+                expect(actual).toEqual(intersection);
+            },
+        );
+
+        it("should cut and reverse the intersection when drilling to inner attribute", () => {
+            const actual = reverseAndTrimIntersection(drillConfigRegion, intersectionWithOuterDepartment);
+            expect(actual).toEqual(intersectionWithOuterDepartmentResult);
+        });
+
+        it("should cut and reverse the intersection when drilling to outer attribute", () => {
+            const actual = reverseAndTrimIntersection(drillConfigRegion, intersectionWithOuterRegion);
+            expect(actual).toEqual(intersectionWithOuterRegionResult);
         });
     });
 });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/reverseAndTrimIntersectionMock.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/reverseAndTrimIntersectionMock.ts
@@ -1,0 +1,99 @@
+// (C) 2020 GoodData Corporation
+
+import { Department, Region, Won } from "@gooddata/reference-workspace/dist/ldm/full";
+import { IImplicitDrillDown } from "../../..";
+import { ReferenceData } from "@gooddata/reference-workspace";
+import { IDrillEventIntersectionElement } from "@gooddata/sdk-ui";
+
+const drillConfigRegion: IImplicitDrillDown = {
+    implicitDrillDown: {
+        from: { drillFromAttribute: { localIdentifier: Region.attribute.localIdentifier } },
+        drillDownStep: {
+            drillToAttribute: {
+                attributeDisplayForm: Department.attribute.displayForm,
+            },
+        },
+    },
+};
+
+const regionUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1024";
+const departmentUri = "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/1027";
+const westCoastUri = ReferenceData.Region.WestCoast.uri;
+const directSalesUri = ReferenceData.Department.DirectSales.uri;
+
+const directSalesHeader: IDrillEventIntersectionElement = {
+    header: {
+        attributeHeaderItem: {
+            name: "Direct Sales",
+            uri: directSalesUri,
+        },
+        attributeHeader: {
+            name: Department.attribute.alias,
+            localIdentifier: Department.attribute.localIdentifier,
+            uri: departmentUri,
+            ref: {
+                uri: departmentUri,
+            },
+            identifier: null,
+            formOf: null,
+        },
+    },
+};
+
+const westCoastHeader: IDrillEventIntersectionElement = {
+    header: {
+        attributeHeaderItem: {
+            name: "West Coast",
+            uri: westCoastUri,
+        },
+        attributeHeader: {
+            name: Region.attribute.alias,
+            localIdentifier: Region.attribute.localIdentifier,
+            uri: regionUri,
+            ref: {
+                uri: regionUri,
+            },
+            identifier: null,
+            formOf: null,
+        },
+    },
+};
+
+const measureHeader: IDrillEventIntersectionElement = {
+    header: {
+        measureHeaderItem: {
+            name: Won.measure.title,
+            format: "#,##0.00",
+            localIdentifier: Won.measure.localIdentifier,
+            uri: "/gdc/md/lmnivlu3sowt63jvr2mo1wlse5fyv203/obj/9203",
+            identifier: null,
+        },
+    },
+};
+
+const intersectionWithOuterDepartment: IDrillEventIntersectionElement[] = [
+    directSalesHeader,
+    westCoastHeader,
+    measureHeader,
+];
+
+const intersectionWithOuterRegion: IDrillEventIntersectionElement[] = [
+    westCoastHeader,
+    directSalesHeader,
+    measureHeader,
+];
+
+const intersectionWithOuterDepartmentResult: IDrillEventIntersectionElement[] = [
+    westCoastHeader,
+    directSalesHeader,
+];
+
+const intersectionWithOuterRegionResult: IDrillEventIntersectionElement[] = [westCoastHeader];
+
+export const reverseAndTrimIntersectionMock = {
+    drillConfigRegion,
+    intersectionWithOuterDepartment,
+    intersectionWithOuterRegion,
+    intersectionWithOuterDepartmentResult,
+    intersectionWithOuterRegionResult,
+};


### PR DESCRIPTION
 - line chart, area chart and treemap should use the same logic when
 generating filters from intersection
 - for the generated drill down `IInsight` taget, only the outer attributes
 should be included in filters

JIRA: ONE-4624

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
