### PR TITLE
FEATURE: SD-1130 add type for email schedule in sdk embedding on KD

### DIFF
--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -339,6 +339,7 @@ export namespace EmbeddedKpiDashboard {
         Delete = "deleteDashboard",
         DrillableItems = "drillableItems",
         ExportToPdf = "exportToPdf",
+        OpenScheduleEmailDialog = "openScheduleEmailDialog",
         RemoveFilterContext = "removeFilterContext",
         Save = "saveDashboard",
         SaveAsDashboard = "saveAsDashboard",
@@ -365,6 +366,7 @@ export namespace EmbeddedKpiDashboard {
         Platform = "platform",
         RemoveFilterContextFinished = "removeFilterContextFinished",
         Resized = "resized",
+        ScheduleEmailDialogOpened = "scheduleEmailDialogOpened",
         SetFilterContextFinished = "setFilterContextFinished",
         SwitchedToEdit = "switchedToEdit",
         SwitchedToView = "switchedToView",
@@ -472,6 +474,7 @@ export namespace EmbeddedKpiDashboard {
     }
     export function isExportToPdfCommandData(obj: unknown): obj is ExportToPdfCommandData;
     export function isIdentifierInsight(obj: unknown): obj is IIdentifierInsightRef;
+    export function isOpenScheduleEmailDialogCommandData(obj: unknown): obj is OpenScheduleEmailDialogCommandData;
     export function isRemoveFilterContextCommandData(obj: unknown): obj is RemoveFilterContextCommandData;
     export function isSaveAsDashboardCommandData(obj: unknown): obj is SaveAsDashboardCommandData;
     export function isSaveDashboardCommandData(obj: unknown): obj is SaveDashboardCommandData;
@@ -485,6 +488,9 @@ export namespace EmbeddedKpiDashboard {
         uri: string;
     }
     export type NoPermissionsEventData = IGdcKdMessageEnvelope<GdcKdEventType.NoPermissions, INoPermissionsBody>;
+    export type OpenScheduleEmailDialogCommand = IGdcKdMessageEvent<GdcKdCommandType.OpenScheduleEmailDialog, null>;
+    // (undocumented)
+    export type OpenScheduleEmailDialogCommandData = IGdcKdMessageEnvelope<GdcKdCommandType.OpenScheduleEmailDialog, null>;
     // (undocumented)
     export type PlaformData = IGdcKdMessageEnvelope<GdcKdEventType.Platform, IPlaformBody>;
     export type RemoveFilterContextCommand = IGdcKdMessageEvent<GdcKdCommandType.RemoveFilterContext, EmbeddedGdc.IRemoveFilterContextContent>;

--- a/libs/sdk-embedding/src/iframe/kd.ts
+++ b/libs/sdk-embedding/src/iframe/kd.ts
@@ -94,6 +94,11 @@ export namespace EmbeddedKpiDashboard {
          * The command to duplicate a KPI Dashboard
          */
         SaveAsDashboard = "saveAsDashboard",
+
+        /**
+         * The command to open schedule email dialog
+         */
+        OpenScheduleEmailDialog = "openScheduleEmailDialog",
     }
 
     /**
@@ -221,6 +226,11 @@ export namespace EmbeddedKpiDashboard {
          * DrillToUrlStarted event.
          */
         DrillToUrlResolved = "drillToUrlResolved",
+
+        /**
+         * Type represent that the schedule email dialog is opened.
+         */
+        ScheduleEmailDialogOpened = "scheduleEmailDialogOpened",
     }
 
     /**
@@ -976,4 +986,42 @@ export namespace EmbeddedKpiDashboard {
         GdcKdEventType.DrillToUrlResolved,
         IDrillToUrlResolvedDataBody
     >;
+
+    /**
+     * Open the schedule email dialog, user will be able to schedule periodic exports of the current dashboard
+     *
+     * Contract:
+     *
+     * -  if KD is currently viewing dashboard, this command will try to open the dialog to schedule an email,
+     *    on success ScheduleEmailDialogOpened will be posted
+     * -  if KD is currently editing dashboard or is not currently showing any dashboard or schedule email dialog is opened,
+     *    commandFailed will be posted
+     *
+     * @public
+     */
+    export type OpenScheduleEmailDialogCommand = IGdcKdMessageEvent<
+        GdcKdCommandType.OpenScheduleEmailDialog,
+        null
+    >;
+
+    /**
+     * @public
+     */
+    export type OpenScheduleEmailDialogCommandData = IGdcKdMessageEnvelope<
+        GdcKdCommandType.OpenScheduleEmailDialog,
+        null
+    >;
+
+    /**
+     * Type-guard checking whether object is an instance of {@link EmbeddedKpiDashboard.OpenScheduleEmailDialogCommandData}.
+     *
+     * @param obj - object to test
+     *
+     * @public
+     */
+    export function isOpenScheduleEmailDialogCommandData(
+        obj: unknown,
+    ): obj is OpenScheduleEmailDialogCommandData {
+        return getEventType(obj) === GdcKdCommandType.OpenScheduleEmailDialog;
+    }
 }


### PR DESCRIPTION
Add schedule emailing type for KD:
- When KD is currently viewing dashboard, this will trigger openScheduleEmailDialog, On success ScheduleEmailDialogOpened will be posted
- When KD is currently editing dashboard or is not currently showing any dashboard or schedule email dialog is opened, CommandFailed will be posted
---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)

# Related Ticked
https://jira.intgdc.com/browse/SD-1130