### PR TITLE
RAIL-2691: All AFM usecases migrated to new workspaces specific API

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -10680,8 +10680,8 @@ export const tigerClientFactory: (axios: AxiosInstance) => ITigerClient;
 
 // @public
 export const tigerExecutionClientFactory: (axios: AxiosInstance) => {
-    executeAfm: (workspace: string, execution: ExecuteAFM.IExecution) => Promise<Execution.IExecutionResponse>;
-    executionResult: (workspace: string, resultId: string, offset?: number[] | undefined, size?: number[] | undefined) => Promise<Execution.IExecutionResult>;
+    executeAfm: (workspaceId: string, execution: ExecuteAFM.IExecution) => Promise<Execution.IExecutionResponse>;
+    executionResult: (workspaceId: string, resultId: string, offset?: number[] | undefined, size?: number[] | undefined) => Promise<Execution.IExecutionResult>;
 };
 
 // @public (undocumented)

--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -30,67 +30,56 @@ export interface AFM {
 // @public
 export class AfmControllerApi extends LabelElementsBaseApi implements AfmControllerApiInterface {
     processAfmRequest(params: {
+        workspaceId: string;
         afmExecution: AfmExecution;
         skipCache?: boolean;
         timestamp?: string;
     }, options?: any): AxiosPromise<AfmExecutionResponse>;
-    processAfmValidObjectsQuery(params: {
-        afmValidObjectsQuery: AfmValidObjectsQuery;
-    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
 }
 
 // @public
 export const AfmControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
     processAfmRequest(params: {
+        workspaceId: string;
         afmExecution: AfmExecution;
         skipCache?: boolean | undefined;
         timestamp?: string | undefined;
-    }, options?: any): LabelElementsRequestArgs;
-    processAfmValidObjectsQuery(params: {
-        afmValidObjectsQuery: AfmValidObjectsQuery;
     }, options?: any): LabelElementsRequestArgs;
 };
 
 // @public
 export const AfmControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     processAfmRequest(params: {
+        workspaceId: string;
         afmExecution: AfmExecution;
         skipCache?: boolean;
         timestamp?: string;
     }, options?: any): AxiosPromise<AfmExecutionResponse>;
-    processAfmValidObjectsQuery(params: {
-        afmValidObjectsQuery: AfmValidObjectsQuery;
-    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
 };
 
 // @public
 export const AfmControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
     processAfmRequest(params: {
+        workspaceId: string;
         afmExecution: AfmExecution;
         skipCache?: boolean;
         timestamp?: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmExecutionResponse>;
-    processAfmValidObjectsQuery(params: {
-        afmValidObjectsQuery: AfmValidObjectsQuery;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmValidObjectsResponse>;
 };
 
 // @public
 export interface AfmControllerApiInterface {
     processAfmRequest(params: {
+        workspaceId: string;
         afmExecution: AfmExecution;
         skipCache?: boolean;
         timestamp?: string;
     }, options?: any): AxiosPromise<AfmExecutionResponse>;
-    processAfmValidObjectsQuery(params: {
-        afmValidObjectsQuery: AfmValidObjectsQuery;
-    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
 }
 
 // @public
 export interface AfmExecution {
     execution: AFM;
-    project: string;
     resultSpec: ResultSpec;
 }
 
@@ -8820,7 +8809,7 @@ export { Element_2 as Element }
 // @public
 export class ElementsControllerApi extends LabelElementsBaseApi implements ElementsControllerApiInterface {
     processElementsRequest(params: {
-        workspace: string;
+        workspaceId: string;
         label: string;
         sortOrder?: "ASC" | "DESC";
         includeTotalWithoutFilters?: boolean;
@@ -8835,7 +8824,7 @@ export class ElementsControllerApi extends LabelElementsBaseApi implements Eleme
 // @public
 export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
     processElementsRequest(params: {
-        workspace: string;
+        workspaceId: string;
         label: string;
         sortOrder?: "ASC" | "DESC" | undefined;
         includeTotalWithoutFilters?: boolean | undefined;
@@ -8850,7 +8839,7 @@ export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelEleme
 // @public
 export const ElementsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     processElementsRequest(params: {
-        workspace: string;
+        workspaceId: string;
         label: string;
         sortOrder?: "ASC" | "DESC";
         includeTotalWithoutFilters?: boolean;
@@ -8865,7 +8854,7 @@ export const ElementsControllerApiFactory: (configuration?: LabelElementsConfigu
 // @public
 export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
     processElementsRequest(params: {
-        workspace: string;
+        workspaceId: string;
         label: string;
         sortOrder?: "ASC" | "DESC";
         includeTotalWithoutFilters?: boolean;
@@ -8880,7 +8869,7 @@ export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguratio
 // @public
 export interface ElementsControllerApiInterface {
     processElementsRequest(params: {
-        workspace: string;
+        workspaceId: string;
         label: string;
         sortOrder?: "ASC" | "DESC";
         includeTotalWithoutFilters?: boolean;
@@ -9018,8 +9007,6 @@ export namespace ExecuteAFM {
     export interface IExecution {
         // (undocumented)
         execution: IAfm;
-        // (undocumented)
-        project: string;
         // (undocumented)
         resultSpec?: IResultSpec;
     }
@@ -9526,6 +9513,14 @@ export enum FormOfGranularityEnum {
     DAYOFWEEK = "DAY_OF_WEEK",
     // (undocumented)
     DAYOFYEAR = "DAY_OF_YEAR",
+    // (undocumented)
+    HOUR = "HOUR",
+    // (undocumented)
+    HOUROFDAY = "HOUR_OF_DAY",
+    // (undocumented)
+    MINUTE = "MINUTE",
+    // (undocumented)
+    MINUTEOFHOUR = "MINUTE_OF_HOUR",
     // (undocumented)
     MONTH = "MONTH",
     // (undocumented)
@@ -10152,13 +10147,9 @@ export interface RelativeDateFilterRelativeDateFilter {
 }
 
 // @public
-export interface ResultDimension {
-    headers: Array<MeasureGroupHeader | AttributeHeader>;
-}
-
-// @public
-export class ResultServiceControllerApi extends LabelElementsBaseApi implements ResultServiceControllerApiInterface {
+export class ResultControllerApi extends LabelElementsBaseApi implements ResultControllerApiInterface {
     getResult(params: {
+        workspaceId: string;
         resultId: string;
         offset?: Array<number>;
         limit?: Array<number>;
@@ -10166,8 +10157,9 @@ export class ResultServiceControllerApi extends LabelElementsBaseApi implements 
 }
 
 // @public
-export const ResultServiceControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+export const ResultControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
     getResult(params: {
+        workspaceId: string;
         resultId: string;
         offset?: number[] | undefined;
         limit?: number[] | undefined;
@@ -10175,8 +10167,9 @@ export const ResultServiceControllerApiAxiosParamCreator: (configuration?: Label
 };
 
 // @public
-export const ResultServiceControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+export const ResultControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     getResult(params: {
+        workspaceId: string;
         resultId: string;
         offset?: Array<number>;
         limit?: Array<number>;
@@ -10184,8 +10177,9 @@ export const ResultServiceControllerApiFactory: (configuration?: LabelElementsCo
 };
 
 // @public
-export const ResultServiceControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+export const ResultControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
     getResult(params: {
+        workspaceId: string;
         resultId: string;
         offset?: Array<number>;
         limit?: Array<number>;
@@ -10193,12 +10187,18 @@ export const ResultServiceControllerApiFp: (configuration?: LabelElementsConfigu
 };
 
 // @public
-export interface ResultServiceControllerApiInterface {
+export interface ResultControllerApiInterface {
     getResult(params: {
+        workspaceId: string;
         resultId: string;
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): AxiosPromise<ExecutionResult>;
+}
+
+// @public
+export interface ResultDimension {
+    headers: Array<MeasureGroupHeader | AttributeHeader>;
 }
 
 // @public
@@ -10680,8 +10680,8 @@ export const tigerClientFactory: (axios: AxiosInstance) => ITigerClient;
 
 // @public
 export const tigerExecutionClientFactory: (axios: AxiosInstance) => {
-    executeAfm: (execution: ExecuteAFM.IExecution) => Promise<Execution.IExecutionResponse>;
-    executionResult: (resultId: string, offset?: number[] | undefined, size?: number[] | undefined) => Promise<Execution.IExecutionResult>;
+    executeAfm: (workspace: string, execution: ExecuteAFM.IExecution) => Promise<Execution.IExecutionResponse>;
+    executionResult: (workspace: string, resultId: string, offset?: number[] | undefined, size?: number[] | undefined) => Promise<Execution.IExecutionResult>;
 };
 
 // @public (undocumented)
@@ -10691,7 +10691,47 @@ export const tigerLabelElementsClientFactory: (axios: AxiosInstance) => Elements
 export const tigerMetadataClientFactory: (axios: AxiosInstance) => DefaultApiInterface;
 
 // @public (undocumented)
-export const tigerValidObjectsClientFactory: (axios: AxiosInstance) => AfmControllerApiInterface;
+export const tigerValidObjectsClientFactory: (axios: AxiosInstance) => ValidObjectsControllerApiInterface;
+
+// @public
+export class ValidObjectsControllerApi extends LabelElementsBaseApi implements ValidObjectsControllerApiInterface {
+    processAfmValidObjectsQuery(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
+}
+
+// @public
+export const ValidObjectsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    processAfmValidObjectsQuery(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): LabelElementsRequestArgs;
+};
+
+// @public
+export const ValidObjectsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    processAfmValidObjectsQuery(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
+};
+
+// @public
+export const ValidObjectsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    processAfmValidObjectsQuery(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmValidObjectsResponse>;
+};
+
+// @public
+export interface ValidObjectsControllerApiInterface {
+    processAfmValidObjectsQuery(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
+}
 
 // @public (undocumented)
 export namespace VisualizationObject {

--- a/libs/api-client-tiger/scripts/generate.js
+++ b/libs/api-client-tiger/scripts/generate.js
@@ -22,7 +22,7 @@ program
 
 const specs = [
     { path: "/api/metadata/japi-schema", name: "metadata-json-api" },
-    { path: "/api/afm/api-schema", name: "afm-rest-api" },
+    { path: "/api/schema-afm", name: "afm-rest-api" },
 ];
 
 const downloadSpec = async (specMeta, outputDir, outputFile) => {

--- a/libs/api-client-tiger/src/execution.ts
+++ b/libs/api-client-tiger/src/execution.ts
@@ -11,8 +11,12 @@ import { Execution } from "./gd-tiger-model/Execution";
 export const tigerExecutionClientFactory = (
     axios: AxiosInstance,
 ): {
-    executeAfm: (execution: ExecuteAFM.IExecution) => Promise<Execution.IExecutionResponse>;
+    executeAfm: (
+        workspaceId: string,
+        execution: ExecuteAFM.IExecution,
+    ) => Promise<Execution.IExecutionResponse>;
     executionResult: (
+        workspaceId: string,
         resultId: string,
         offset?: number[] | undefined,
         size?: number[] | undefined,
@@ -22,23 +26,31 @@ export const tigerExecutionClientFactory = (
      * Starts a new AFM execution.
      *
      * @param axios - instance of configured http client to use
+     * @param workspaceId workspace identifier
      * @param execution - execution to send as-is in request body
      * @public
      */
-    const executeAfm = (execution: ExecuteAFM.IExecution): Promise<Execution.IExecutionResponse> => {
-        return axios.post("/api/afm", execution).then((res: AxiosResponse<Execution.IExecutionResponse>) => {
-            return res.data;
-        });
+    const executeAfm = (
+        workspaceId: string,
+        execution: ExecuteAFM.IExecution,
+    ): Promise<Execution.IExecutionResponse> => {
+        return axios
+            .post(`/api/workspaces/${workspaceId}/afm`, execution)
+            .then((res: AxiosResponse<Execution.IExecutionResponse>) => {
+                return res.data;
+            });
     };
 
     /**
      * Retrieves result of execution. All calculated data is returned, no paging yet.
      *
      * @param axios - instance of configured http client to use
+     * @param workspaceId workspace identifier
      * @param resultId - ID of AFM execution result
      * @public
      */
     const executionResult = (
+        workspaceId: string,
         resultId: string,
         offset?: number[],
         size?: number[],
@@ -46,7 +58,7 @@ export const tigerExecutionClientFactory = (
         const params = { limit: size && size.join(","), offset: offset && offset.join(",") };
 
         return axios
-            .get(`/api/result/${resultId}`, { params })
+            .get(`/api/workspaces/${workspaceId}/result/${resultId}`, { params })
             .then((res: AxiosResponse<Execution.IExecutionResult>) => {
                 return res.data;
             });

--- a/libs/api-client-tiger/src/gd-tiger-model/ExecuteAFM.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/ExecuteAFM.ts
@@ -2,7 +2,6 @@
 
 export namespace ExecuteAFM {
     export interface IExecution {
-        project: string;
         resultSpec?: IResultSpec;
         execution: IAfm;
     }

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -1,3 +1,5 @@
+// (C) 2020 GoodData Corporation
+
 /* eslint-disable */
 /**
  * OpenAPI definition
@@ -103,12 +105,6 @@ export interface AfmExecution {
      * @memberof AfmExecution
      */
     execution: AFM;
-    /**
-     * Id of the workspace where analytical request will be executed.
-     * @type {string}
-     * @memberof AfmExecution
-     */
-    project: string;
     /**
      *
      * @type {ResultSpec}
@@ -711,6 +707,8 @@ export interface FormOf {
 export enum FormOfGranularityEnum {
     YEAR = "YEAR",
     DAY = "DAY",
+    HOUR = "HOUR",
+    MINUTE = "MINUTE",
     QUARTER = "QUARTER",
     MONTH = "MONTH",
     WEEK = "WEEK",
@@ -719,6 +717,8 @@ export enum FormOfGranularityEnum {
     DAYOFYEAR = "DAY_OF_YEAR",
     DAYOFWEEK = "DAY_OF_WEEK",
     DAYOFMONTH = "DAY_OF_MONTH",
+    HOUROFDAY = "HOUR_OF_DAY",
+    MINUTEOFHOUR = "MINUTE_OF_HOUR",
     WEEKOFYEAR = "WEEK_OF_YEAR",
 }
 
@@ -1427,6 +1427,7 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
         /**
          * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
          * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
          * @param {AfmExecution} afmExecution
          * @param {boolean} [skipCache] Ignore all caches during execution of current request.
          * @param {string} [timestamp]
@@ -1435,13 +1436,21 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
          */
         processAfmRequest(
             params: {
+                workspaceId: string;
                 afmExecution: AfmExecution;
                 skipCache?: boolean;
                 timestamp?: string;
             },
             options: any = {},
         ): RequestArgs {
-            const { afmExecution, skipCache, timestamp } = params;
+            const { workspaceId, afmExecution, skipCache, timestamp } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling processAfmRequest.",
+                );
+            }
             // verify required parameter 'afmExecution' is not null or undefined
             if (afmExecution === null || afmExecution === undefined) {
                 throw new RequiredError(
@@ -1449,7 +1458,10 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
                     "Required parameter afmExecution was null or undefined when calling processAfmRequest.",
                 );
             }
-            const localVarPath = `/api/afm`;
+            const localVarPath = `/api/workspaces/{workspaceId}/afm`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -1485,55 +1497,6 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
                 options: localVarRequestOptions,
             };
         },
-        /**
-         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
-         * @summary Valid objects
-         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        processAfmValidObjectsQuery(
-            params: {
-                afmValidObjectsQuery: AfmValidObjectsQuery;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { afmValidObjectsQuery } = params;
-            // verify required parameter 'afmValidObjectsQuery' is not null or undefined
-            if (afmValidObjectsQuery === null || afmValidObjectsQuery === undefined) {
-                throw new RequiredError(
-                    "afmValidObjectsQuery",
-                    "Required parameter afmValidObjectsQuery was null or undefined when calling processAfmValidObjectsQuery.",
-                );
-            }
-            const localVarPath = `/api/validObjects`;
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            localVarHeaderParameter["Content-Type"] = "application/json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof afmValidObjectsQuery !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(afmValidObjectsQuery !== undefined ? afmValidObjectsQuery : {})
-                : afmValidObjectsQuery || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
     };
 };
 
@@ -1546,6 +1509,7 @@ export const AfmControllerApiFp = function (configuration?: Configuration) {
         /**
          * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
          * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
          * @param {AfmExecution} afmExecution
          * @param {boolean} [skipCache] Ignore all caches during execution of current request.
          * @param {string} [timestamp]
@@ -1554,6 +1518,7 @@ export const AfmControllerApiFp = function (configuration?: Configuration) {
          */
         processAfmRequest(
             params: {
+                workspaceId: string;
                 afmExecution: AfmExecution;
                 skipCache?: boolean;
                 timestamp?: string;
@@ -1564,30 +1529,6 @@ export const AfmControllerApiFp = function (configuration?: Configuration) {
                 params,
                 options,
             );
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
-         * @summary Valid objects
-         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        processAfmValidObjectsQuery(
-            params: {
-                afmValidObjectsQuery: AfmValidObjectsQuery;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmValidObjectsResponse> {
-            const localVarAxiosArgs = AfmControllerApiAxiosParamCreator(
-                configuration,
-            ).processAfmValidObjectsQuery(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -1612,6 +1553,7 @@ export const AfmControllerApiFactory = function (
         /**
          * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
          * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
          * @param {AfmExecution} afmExecution
          * @param {boolean} [skipCache] Ignore all caches during execution of current request.
          * @param {string} [timestamp]
@@ -1620,6 +1562,7 @@ export const AfmControllerApiFactory = function (
          */
         processAfmRequest(
             params: {
+                workspaceId: string;
                 afmExecution: AfmExecution;
                 skipCache?: boolean;
                 timestamp?: string;
@@ -1627,24 +1570,6 @@ export const AfmControllerApiFactory = function (
             options?: any,
         ): AxiosPromise<AfmExecutionResponse> {
             return AfmControllerApiFp(configuration).processAfmRequest(params, options)(axios, basePath);
-        },
-        /**
-         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
-         * @summary Valid objects
-         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        processAfmValidObjectsQuery(
-            params: {
-                afmValidObjectsQuery: AfmValidObjectsQuery;
-            },
-            options?: any,
-        ): AxiosPromise<AfmValidObjectsResponse> {
-            return AfmControllerApiFp(configuration).processAfmValidObjectsQuery(params, options)(
-                axios,
-                basePath,
-            );
         },
     };
 };
@@ -1658,6 +1583,7 @@ export interface AfmControllerApiInterface {
     /**
      * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
      * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
      * @param {AfmExecution} afmExecution
      * @param {boolean} [skipCache] Ignore all caches during execution of current request.
      * @param {string} [timestamp]
@@ -1667,27 +1593,13 @@ export interface AfmControllerApiInterface {
      */
     processAfmRequest(
         params: {
+            workspaceId: string;
             afmExecution: AfmExecution;
             skipCache?: boolean;
             timestamp?: string;
         },
         options?: any,
     ): AxiosPromise<AfmExecutionResponse>;
-
-    /**
-     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
-     * @summary Valid objects
-     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof AfmControllerApiInterface
-     */
-    processAfmValidObjectsQuery(
-        params: {
-            afmValidObjectsQuery: AfmValidObjectsQuery;
-        },
-        options?: any,
-    ): AxiosPromise<AfmValidObjectsResponse>;
 }
 
 /**
@@ -1700,6 +1612,7 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
     /**
      * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
      * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
      * @param {AfmExecution} afmExecution
      * @param {boolean} [skipCache] Ignore all caches during execution of current request.
      * @param {string} [timestamp]
@@ -1709,6 +1622,7 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
      */
     public processAfmRequest(
         params: {
+            workspaceId: string;
             afmExecution: AfmExecution;
             skipCache?: boolean;
             timestamp?: string;
@@ -1716,26 +1630,6 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
         options?: any,
     ) {
         return AfmControllerApiFp(this.configuration).processAfmRequest(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
-     * @summary Valid objects
-     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof AfmControllerApi
-     */
-    public processAfmValidObjectsQuery(
-        params: {
-            afmValidObjectsQuery: AfmValidObjectsQuery;
-        },
-        options?: any,
-    ) {
-        return AfmControllerApiFp(this.configuration).processAfmValidObjectsQuery(params, options)(
             this.axios,
             this.basePath,
         );
@@ -1751,7 +1645,7 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
-         * @param {string} workspace Workspace on which to run request.
+         * @param {string} workspaceId Workspace identifier
          * @param {string} label Requested label.
          * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
          * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
@@ -1765,7 +1659,7 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
          */
         processElementsRequest(
             params: {
-                workspace: string;
+                workspaceId: string;
                 label: string;
                 sortOrder?: "ASC" | "DESC";
                 includeTotalWithoutFilters?: boolean;
@@ -1778,7 +1672,7 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
             options: any = {},
         ): RequestArgs {
             const {
-                workspace,
+                workspaceId,
                 label,
                 sortOrder,
                 includeTotalWithoutFilters,
@@ -1788,11 +1682,11 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
                 limit,
                 skipCache,
             } = params;
-            // verify required parameter 'workspace' is not null or undefined
-            if (workspace === null || workspace === undefined) {
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
-                    "workspace",
-                    "Required parameter workspace was null or undefined when calling processElementsRequest.",
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling processElementsRequest.",
                 );
             }
             // verify required parameter 'label' is not null or undefined
@@ -1802,7 +1696,10 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
                     "Required parameter label was null or undefined when calling processElementsRequest.",
                 );
             }
-            const localVarPath = `/api/labelElements`;
+            const localVarPath = `/api/workspaces/{workspaceId}/label-elements`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -1811,14 +1708,6 @@ export const ElementsControllerApiAxiosParamCreator = function (configuration?: 
             const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
             const localVarHeaderParameter = {} as any;
             const localVarQueryParameter = {} as any;
-
-            if (workspace !== undefined) {
-                if (typeof workspace === "object") {
-                    addFlattenedObjectTo(workspace, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["workspace"] = workspace;
-                }
-            }
 
             if (label !== undefined) {
                 if (typeof label === "object") {
@@ -1902,7 +1791,7 @@ export const ElementsControllerApiFp = function (configuration?: Configuration) 
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
-         * @param {string} workspace Workspace on which to run request.
+         * @param {string} workspaceId Workspace identifier
          * @param {string} label Requested label.
          * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
          * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
@@ -1916,7 +1805,7 @@ export const ElementsControllerApiFp = function (configuration?: Configuration) 
          */
         processElementsRequest(
             params: {
-                workspace: string;
+                workspaceId: string;
                 label: string;
                 sortOrder?: "ASC" | "DESC";
                 includeTotalWithoutFilters?: boolean;
@@ -1955,7 +1844,7 @@ export const ElementsControllerApiFactory = function (
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
-         * @param {string} workspace Workspace on which to run request.
+         * @param {string} workspaceId Workspace identifier
          * @param {string} label Requested label.
          * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
          * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
@@ -1969,7 +1858,7 @@ export const ElementsControllerApiFactory = function (
          */
         processElementsRequest(
             params: {
-                workspace: string;
+                workspaceId: string;
                 label: string;
                 sortOrder?: "ASC" | "DESC";
                 includeTotalWithoutFilters?: boolean;
@@ -1998,7 +1887,7 @@ export interface ElementsControllerApiInterface {
     /**
      * Returns paged list of elements (values) of given label satisfying given filtering criteria.
      * @summary Listing of label values.
-     * @param {string} workspace Workspace on which to run request.
+     * @param {string} workspaceId Workspace identifier
      * @param {string} label Requested label.
      * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
      * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
@@ -2013,7 +1902,7 @@ export interface ElementsControllerApiInterface {
      */
     processElementsRequest(
         params: {
-            workspace: string;
+            workspaceId: string;
             label: string;
             sortOrder?: "ASC" | "DESC";
             includeTotalWithoutFilters?: boolean;
@@ -2037,7 +1926,7 @@ export class ElementsControllerApi extends BaseAPI implements ElementsController
     /**
      * Returns paged list of elements (values) of given label satisfying given filtering criteria.
      * @summary Listing of label values.
-     * @param {string} workspace Workspace on which to run request.
+     * @param {string} workspaceId Workspace identifier
      * @param {string} label Requested label.
      * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
      * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
@@ -2052,7 +1941,7 @@ export class ElementsControllerApi extends BaseAPI implements ElementsController
      */
     public processElementsRequest(
         params: {
-            workspace: string;
+            workspaceId: string;
             label: string;
             sortOrder?: "ASC" | "DESC";
             includeTotalWithoutFilters?: boolean;
@@ -2072,14 +1961,15 @@ export class ElementsControllerApi extends BaseAPI implements ElementsController
 }
 
 /**
- * ResultServiceControllerApi - axios parameter creator
+ * ResultControllerApi - axios parameter creator
  * @export
  */
-export const ResultServiceControllerApiAxiosParamCreator = function (configuration?: Configuration) {
+export const ResultControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
          * Gets a single execution result.
          * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
          * @param {string} resultId Result ID
          * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
          * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
@@ -2088,13 +1978,21 @@ export const ResultServiceControllerApiAxiosParamCreator = function (configurati
          */
         getResult(
             params: {
+                workspaceId: string;
                 resultId: string;
                 offset?: Array<number>;
                 limit?: Array<number>;
             },
             options: any = {},
         ): RequestArgs {
-            const { resultId, offset, limit } = params;
+            const { workspaceId, resultId, offset, limit } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getResult.",
+                );
+            }
             // verify required parameter 'resultId' is not null or undefined
             if (resultId === null || resultId === undefined) {
                 throw new RequiredError(
@@ -2102,10 +2000,9 @@ export const ResultServiceControllerApiAxiosParamCreator = function (configurati
                     "Required parameter resultId was null or undefined when calling getResult.",
                 );
             }
-            const localVarPath = `/api/result/{resultId}`.replace(
-                `{${"resultId"}}`,
-                encodeURIComponent(String(resultId)),
-            );
+            const localVarPath = `/api/workspaces/{workspaceId}/result/{resultId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"resultId"}}`, encodeURIComponent(String(resultId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -2137,14 +2034,15 @@ export const ResultServiceControllerApiAxiosParamCreator = function (configurati
 };
 
 /**
- * ResultServiceControllerApi - functional programming interface
+ * ResultControllerApi - functional programming interface
  * @export
  */
-export const ResultServiceControllerApiFp = function (configuration?: Configuration) {
+export const ResultControllerApiFp = function (configuration?: Configuration) {
     return {
         /**
          * Gets a single execution result.
          * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
          * @param {string} resultId Result ID
          * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
          * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
@@ -2153,13 +2051,14 @@ export const ResultServiceControllerApiFp = function (configuration?: Configurat
          */
         getResult(
             params: {
+                workspaceId: string;
                 resultId: string;
                 offset?: Array<number>;
                 limit?: Array<number>;
             },
             options: any = {},
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ExecutionResult> {
-            const localVarAxiosArgs = ResultServiceControllerApiAxiosParamCreator(configuration).getResult(
+            const localVarAxiosArgs = ResultControllerApiAxiosParamCreator(configuration).getResult(
                 params,
                 options,
             );
@@ -2175,10 +2074,10 @@ export const ResultServiceControllerApiFp = function (configuration?: Configurat
 };
 
 /**
- * ResultServiceControllerApi - factory interface
+ * ResultControllerApi - factory interface
  * @export
  */
-export const ResultServiceControllerApiFactory = function (
+export const ResultControllerApiFactory = function (
     configuration?: Configuration,
     basePath?: string,
     axios?: AxiosInstance,
@@ -2187,6 +2086,7 @@ export const ResultServiceControllerApiFactory = function (
         /**
          * Gets a single execution result.
          * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
          * @param {string} resultId Result ID
          * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
          * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
@@ -2195,35 +2095,38 @@ export const ResultServiceControllerApiFactory = function (
          */
         getResult(
             params: {
+                workspaceId: string;
                 resultId: string;
                 offset?: Array<number>;
                 limit?: Array<number>;
             },
             options?: any,
         ): AxiosPromise<ExecutionResult> {
-            return ResultServiceControllerApiFp(configuration).getResult(params, options)(axios, basePath);
+            return ResultControllerApiFp(configuration).getResult(params, options)(axios, basePath);
         },
     };
 };
 
 /**
- * ResultServiceControllerApi - interface
+ * ResultControllerApi - interface
  * @export
- * @interface ResultServiceControllerApi
+ * @interface ResultControllerApi
  */
-export interface ResultServiceControllerApiInterface {
+export interface ResultControllerApiInterface {
     /**
      * Gets a single execution result.
      * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
      * @param {string} resultId Result ID
      * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
      * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof ResultServiceControllerApiInterface
+     * @memberof ResultControllerApiInterface
      */
     getResult(
         params: {
+            workspaceId: string;
             resultId: string;
             offset?: Array<number>;
             limit?: Array<number>;
@@ -2233,31 +2136,225 @@ export interface ResultServiceControllerApiInterface {
 }
 
 /**
- * ResultServiceControllerApi - object-oriented interface
+ * ResultControllerApi - object-oriented interface
  * @export
- * @class ResultServiceControllerApi
+ * @class ResultControllerApi
  * @extends {BaseAPI}
  */
-export class ResultServiceControllerApi extends BaseAPI implements ResultServiceControllerApiInterface {
+export class ResultControllerApi extends BaseAPI implements ResultControllerApiInterface {
     /**
      * Gets a single execution result.
      * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
      * @param {string} resultId Result ID
      * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
      * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
-     * @memberof ResultServiceControllerApi
+     * @memberof ResultControllerApi
      */
     public getResult(
         params: {
+            workspaceId: string;
             resultId: string;
             offset?: Array<number>;
             limit?: Array<number>;
         },
         options?: any,
     ) {
-        return ResultServiceControllerApiFp(this.configuration).getResult(params, options)(
+        return ResultControllerApiFp(this.configuration).getResult(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+}
+
+/**
+ * ValidObjectsControllerApi - axios parameter creator
+ * @export
+ */
+export const ValidObjectsControllerApiAxiosParamCreator = function (configuration?: Configuration) {
+    return {
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        processAfmValidObjectsQuery(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, afmValidObjectsQuery } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling processAfmValidObjectsQuery.",
+                );
+            }
+            // verify required parameter 'afmValidObjectsQuery' is not null or undefined
+            if (afmValidObjectsQuery === null || afmValidObjectsQuery === undefined) {
+                throw new RequiredError(
+                    "afmValidObjectsQuery",
+                    "Required parameter afmValidObjectsQuery was null or undefined when calling processAfmValidObjectsQuery.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/valid-objects`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof afmValidObjectsQuery !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(afmValidObjectsQuery !== undefined ? afmValidObjectsQuery : {})
+                : afmValidObjectsQuery || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    };
+};
+
+/**
+ * ValidObjectsControllerApi - functional programming interface
+ * @export
+ */
+export const ValidObjectsControllerApiFp = function (configuration?: Configuration) {
+    return {
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        processAfmValidObjectsQuery(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmValidObjectsResponse> {
+            const localVarAxiosArgs = ValidObjectsControllerApiAxiosParamCreator(
+                configuration,
+            ).processAfmValidObjectsQuery(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+    };
+};
+
+/**
+ * ValidObjectsControllerApi - factory interface
+ * @export
+ */
+export const ValidObjectsControllerApiFactory = function (
+    configuration?: Configuration,
+    basePath?: string,
+    axios?: AxiosInstance,
+) {
+    return {
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        processAfmValidObjectsQuery(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options?: any,
+        ): AxiosPromise<AfmValidObjectsResponse> {
+            return ValidObjectsControllerApiFp(configuration).processAfmValidObjectsQuery(params, options)(
+                axios,
+                basePath,
+            );
+        },
+    };
+};
+
+/**
+ * ValidObjectsControllerApi - interface
+ * @export
+ * @interface ValidObjectsControllerApi
+ */
+export interface ValidObjectsControllerApiInterface {
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApiInterface
+     */
+    processAfmValidObjectsQuery(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ): AxiosPromise<AfmValidObjectsResponse>;
+}
+
+/**
+ * ValidObjectsControllerApi - object-oriented interface
+ * @export
+ * @class ValidObjectsControllerApi
+ * @extends {BaseAPI}
+ */
+export class ValidObjectsControllerApi extends BaseAPI implements ValidObjectsControllerApiInterface {
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApi
+     */
+    public processAfmValidObjectsQuery(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ) {
+        return ValidObjectsControllerApiFp(this.configuration).processAfmValidObjectsQuery(params, options)(
             this.axios,
             this.basePath,
         );

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -11,13 +11,23 @@
         }
     ],
     "paths": {
-        "/api/afm": {
+        "/api/workspaces/{workspaceId}/afm": {
             "post": {
                 "tags": ["afm-controller"],
                 "summary": "Executes analytical request and returns link to the result",
                 "description": "AFM is a combination of attributes, measures and filters that describe a query you want to execute.",
                 "operationId": "processAfmRequest",
                 "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
                     {
                         "name": "skip-cache",
                         "in": "header",
@@ -62,12 +72,24 @@
                 }
             }
         },
-        "/api/validObjects": {
+        "/api/workspaces/{workspaceId}/valid-objects": {
             "post": {
-                "tags": ["afm-controller"],
+                "tags": ["valid-objects-controller"],
                 "summary": "Valid objects",
                 "description": "Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.",
                 "operationId": "processAfmValidObjectsQuery",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    }
+                ],
                 "requestBody": {
                     "content": {
                         "application/json": {
@@ -92,7 +114,7 @@
                 }
             }
         },
-        "/api/labelElements": {
+        "/api/workspaces/{workspaceId}/label-elements": {
             "get": {
                 "tags": ["elements-controller"],
                 "summary": "Listing of label values.",
@@ -100,12 +122,13 @@
                 "operationId": "processElementsRequest",
                 "parameters": [
                     {
-                        "name": "workspace",
-                        "in": "query",
-                        "description": "Workspace on which to run request.",
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
                         "required": true,
                         "schema": {
-                            "type": "string"
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
                         }
                     },
                     {
@@ -203,13 +226,23 @@
                 }
             }
         },
-        "/api/result/{resultId}": {
+        "/api/workspaces/{workspaceId}/result/{resultId}": {
             "get": {
-                "tags": ["result-service-controller"],
+                "tags": ["result-controller"],
                 "summary": "Get a single execution result",
                 "description": "Gets a single execution result.",
                 "operationId": "getResult",
                 "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
                     {
                         "name": "resultId",
                         "in": "path",
@@ -324,16 +357,11 @@
                 }
             },
             "AfmExecution": {
-                "required": ["execution", "project", "resultSpec"],
+                "required": ["execution", "resultSpec"],
                 "type": "object",
                 "properties": {
                     "execution": {
                         "$ref": "#/components/schemas/AFM"
-                    },
-                    "project": {
-                        "description": "Id of the workspace where analytical request will be executed.",
-                        "example": "sampleWorkspace",
-                        "type": "string"
                     },
                     "resultSpec": {
                         "$ref": "#/components/schemas/ResultSpec"
@@ -1103,6 +1131,8 @@
                         "enum": [
                             "YEAR",
                             "DAY",
+                            "HOUR",
+                            "MINUTE",
                             "QUARTER",
                             "MONTH",
                             "WEEK",
@@ -1111,6 +1141,8 @@
                             "DAY_OF_YEAR",
                             "DAY_OF_WEEK",
                             "DAY_OF_MONTH",
+                            "HOUR_OF_DAY",
+                            "MINUTE_OF_HOUR",
                             "WEEK_OF_YEAR"
                         ]
                     }
@@ -1213,7 +1245,7 @@
                     "next": {
                         "type": "string",
                         "description": "Link to next page, or null if this is last page.",
-                        "example": "https://sample.gooddata.com/api/labelElements?workspace=sampleWorkspace&label=sample.price&limit=5&offset=10"
+                        "example": "https://sample.gooddata.com/api/workspaces/sampleWorkspace/label-elements?label=sample.price&limit=5&offset=10"
                     }
                 },
                 "description": "Current page description."

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -551,21 +551,21 @@ export interface ApiErrorSource {
  * @enum {string}
  */
 export enum AttributeGranularityResourceAttribute {
-    Year = "year",
-    Day = "day",
-    Hour = "hour",
     Minute = "minute",
-    Quarter = "quarter",
-    Month = "month",
+    Hour = "hour",
+    Day = "day",
     Week = "week",
-    QuarterOfYear = "quarterOfYear",
-    MonthOfYear = "monthOfYear",
-    DayOfYear = "dayOfYear",
+    Month = "month",
+    Quarter = "quarter",
+    Year = "year",
+    MinuteOfHour = "minuteOfHour",
+    HourOfDay = "hourOfDay",
     DayOfWeek = "dayOfWeek",
     DayOfMonth = "dayOfMonth",
-    HourOfDay = "hourOfDay",
-    MinuteOfHour = "minuteOfHour",
+    DayOfYear = "dayOfYear",
     WeekOfYear = "weekOfYear",
+    MonthOfYear = "monthOfYear",
+    QuarterOfYear = "quarterOfYear",
 }
 /**
  *

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -1257,17 +1257,21 @@
             },
             "AttributeGranularityResourceAttribute": {
                 "enum": [
-                    "year",
+                    "minute",
+                    "hour",
                     "day",
-                    "quarter",
-                    "month",
                     "week",
-                    "quarterOfYear",
-                    "monthOfYear",
-                    "dayOfYear",
+                    "month",
+                    "quarter",
+                    "year",
+                    "minuteOfHour",
+                    "hourOfDay",
                     "dayOfWeek",
                     "dayOfMonth",
-                    "weekOfYear"
+                    "dayOfYear",
+                    "weekOfYear",
+                    "monthOfYear",
+                    "quarterOfYear"
                 ],
                 "nullable": true,
                 "type": "string"

--- a/libs/api-client-tiger/src/validObjects.ts
+++ b/libs/api-client-tiger/src/validObjects.ts
@@ -1,6 +1,6 @@
 // (C) 2019-2020 GoodData Corporation
 import { AxiosInstance } from "axios";
-import { AfmControllerApi, AfmControllerApiInterface } from "./generated/afm-rest-api";
+import { ValidObjectsControllerApi, ValidObjectsControllerApiInterface } from "./generated/afm-rest-api";
 
-export const tigerValidObjectsClientFactory = (axios: AxiosInstance): AfmControllerApiInterface =>
-    new AfmControllerApi({}, "", axios);
+export const tigerValidObjectsClientFactory = (axios: AxiosInstance): ValidObjectsControllerApiInterface =>
+    new ValidObjectsControllerApi({}, "", axios);

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -142,6 +142,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
             : items;
         const availableItemsResponse = await this.authCall((sdk) =>
             sdk.validObjects.processAfmValidObjectsQuery({
+                workspaceId: this.workspace,
                 afmValidObjectsQuery: {
                     types: relevantRestrictingTypes.map(mapToTigerType),
                     afm: {

--- a/libs/sdk-backend-tiger/src/backend/workspace/elements/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/elements/index.ts
@@ -74,7 +74,7 @@ class TigerWorkspaceElementsQuery implements IElementQuery {
                 limit,
                 offset,
                 label: ref.identifier,
-                workspace: this.workspace,
+                workspaceId: this.workspace,
             };
 
             return sdk.labelElements.processElementsRequest(elementsRequest);

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -41,6 +41,7 @@ function sanitizeSize(size: number[]): number[] {
 }
 
 export class TigerExecutionResult implements IExecutionResult {
+    private readonly workspace: string;
     public readonly dimensions: IDimensionDescriptor[];
     private readonly resultId: string;
     private readonly _fingerprint: string;
@@ -56,12 +57,15 @@ export class TigerExecutionResult implements IExecutionResult {
             execResponse.executionResponse.dimensions,
             this.definition,
         );
+        this.workspace = this.definition.workspace;
         this.resultId = execResponse.executionResponse.links.executionResult;
         this._fingerprint = SparkMD5.hash(this.resultId);
     }
 
     public async readAll(): Promise<IDataView> {
-        const executionResultPromise = this.authCall((sdk) => sdk.execution.executionResult(this.resultId));
+        const executionResultPromise = this.authCall((sdk) =>
+            sdk.execution.executionResult(this.workspace, this.resultId),
+        );
 
         return this.asDataView(executionResultPromise);
     }
@@ -71,7 +75,7 @@ export class TigerExecutionResult implements IExecutionResult {
         const saneSize = sanitizeSize(size);
 
         const executionResultPromise = this.authCall((sdk) =>
-            sdk.execution.executionResult(this.resultId, saneOffset, saneSize),
+            sdk.execution.executionResult(this.workspace, this.resultId, saneOffset, saneSize),
         );
 
         return this.asDataView(executionResultPromise);

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
@@ -31,15 +31,17 @@ export class TigerPreparedExecution implements IPreparedExecution {
 
         const afmExecution = toAfmExecution(this.definition);
 
-        return this.authCall((sdk) => sdk.execution.executeAfm(afmExecution)).then((response) => {
-            return new TigerExecutionResult(
-                this.authCall,
-                this.definition,
-                this.executionFactory,
-                response,
-                this.dateFormatter,
-            );
-        });
+        return this.authCall((sdk) => sdk.execution.executeAfm(this.definition.workspace, afmExecution)).then(
+            (response) => {
+                return new TigerExecutionResult(
+                    this.authCall,
+                    this.definition,
+                    this.executionFactory,
+                    response,
+                    this.dateFormatter,
+                );
+            },
+        );
     }
 
     public withDimensions(...dimsOrGen: Array<IDimension | DimensionGenerator>): IPreparedExecution {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
@@ -91,7 +91,6 @@ Object {
       },
     ],
   },
-  "project": "test workspace",
   "resultSpec": Object {},
 }
 `;
@@ -103,7 +102,6 @@ Object {
     "filters": Array [],
     "measures": Array [],
   },
-  "project": "test workspace",
   "resultSpec": Object {},
 }
 `;
@@ -135,7 +133,6 @@ Object {
     "filters": Array [],
     "measures": Array [],
   },
-  "project": "test workspace",
   "resultSpec": Object {},
 }
 `;
@@ -147,7 +144,6 @@ Object {
     "filters": Array [],
     "measures": Array [],
   },
-  "project": "test workspace",
   "resultSpec": Object {
     "dimensions": Array [
       Object {
@@ -168,7 +164,6 @@ Object {
     "filters": Array [],
     "measures": Array [],
   },
-  "project": "test workspace",
   "resultSpec": Object {},
 }
 `;
@@ -180,7 +175,6 @@ Object {
     "filters": Array [],
     "measures": Array [],
   },
-  "project": "test workspace",
   "resultSpec": Object {},
 }
 `;

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
@@ -43,7 +43,6 @@ function convertResultSpec(def: IExecutionDefinition): ExecuteAFM.IResultSpec {
  */
 export function toAfmExecution(def: IExecutionDefinition): ExecuteAFM.IExecution {
     return {
-        project: def.workspace,
         resultSpec: convertResultSpec(def),
         execution: {
             ...convertAFM(def),


### PR DESCRIPTION
Applies for original:
```
/api/afm
/api/result
/api/validObjects
/api/labelElements
```

See individual commits for the specific changes.

OpenAPI is updated according to latest state (with new APIs only, not keeping the backward compatible ones).

afm/result are not yet using the generated OpenAPI definitions, the other 2 yes
---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
