### PR TITLE
Add ranking filter to postmessages api

### DIFF
--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -738,6 +738,8 @@ export namespace GdcExecuteAFM {
         measure: ISimpleMeasure;
     }
     // (undocumented)
+    export function isLocalIdentifierQualifier(qualifier: unknown): qualifier is ILocalIdentifierQualifier;
+    // (undocumented)
     export function isMeasureLocatorItem(locator: GdcExecuteAFM.LocatorItem): locator is GdcExecuteAFM.IMeasureLocatorItem;
     // (undocumented)
     export function isMeasureSortItem(sortItem: GdcExecuteAFM.SortItem): sortItem is GdcExecuteAFM.IMeasureSortItem;

--- a/libs/api-model-bear/src/executeAfm/GdcExecuteAFM.ts
+++ b/libs/api-model-bear/src/executeAfm/GdcExecuteAFM.ts
@@ -297,6 +297,13 @@ export namespace GdcExecuteAFM {
         );
     }
 
+    export function isLocalIdentifierQualifier(qualifier: unknown): qualifier is ILocalIdentifierQualifier {
+        return (
+            !isEmpty(qualifier) &&
+            (qualifier as GdcExecuteAFM.ILocalIdentifierQualifier).localIdentifier !== undefined
+        );
+    }
+
     export function isSimpleMeasureDefinition(
         definition: GdcExecuteAFM.MeasureDefinition,
     ): definition is GdcExecuteAFM.ISimpleMeasureDefinition {

--- a/libs/api-model-bear/src/executeAfm/tests/GdcExecuteAFM.fixtures.ts
+++ b/libs/api-model-bear/src/executeAfm/tests/GdcExecuteAFM.fixtures.ts
@@ -62,6 +62,9 @@ export const identifierObjectQualifier: AFM.ObjQualifier = {
 export const uriObjectQualifier: AFM.ObjQualifier = {
     uri: "/gdc/mock/id",
 };
+export const localIdentifierQualifier: AFM.ILocalIdentifierQualifier = {
+    localIdentifier: "localId",
+};
 export const simpleMeasureDefinition: AFM.ISimpleMeasureDefinition = {
     measure: {
         item: {

--- a/libs/api-model-bear/src/executeAfm/tests/GdcExecuteAFM.test.ts
+++ b/libs/api-model-bear/src/executeAfm/tests/GdcExecuteAFM.test.ts
@@ -19,6 +19,7 @@ import {
     attributeLocatorItem,
     measureLocatorItem,
     rankingFilter,
+    localIdentifierQualifier,
 } from "./GdcExecuteAFM.fixtures";
 
 describe("GdcExecuteAFM", () => {
@@ -255,6 +256,19 @@ describe("GdcExecuteAFM", () => {
 
         it.each(Scenarios)("should return %s when input is %s", (expectedResult, _desc, input) => {
             expect(AFM.isSimpleMeasureDefinition(input)).toBe(expectedResult);
+        });
+    });
+
+    describe("isLocalIdentifierQualifier", () => {
+        const Scenarios: Array<[boolean, string, any]> = [
+            ...InvalidInputTestCases,
+            [false, "identifier object qualifier", identifierObjectQualifier],
+            [false, "uri object qualifier", uriObjectQualifier],
+            [true, "local identifier qualifier", localIdentifierQualifier],
+        ];
+
+        it.each(Scenarios)("should return %s when input is %s", (expectedResult, _desc, input) => {
+            expect(AFM.isLocalIdentifierQualifier(input)).toBe(expectedResult);
         });
     });
 

--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -7,6 +7,7 @@
 import { GdcExecuteAFM } from '@gooddata/api-model-bear';
 import { GdcExport } from '@gooddata/api-model-bear';
 import { GdcVisualizationObject } from '@gooddata/api-model-bear';
+import { IInsightDefinition } from '@gooddata/sdk-model';
 
 // @public
 export type CommandFailed<Product> = IGdcMessageEvent<Product, GdcEventType.AppCommandFailed, ICommandFailedBody>;
@@ -50,6 +51,7 @@ export namespace EmbeddedAnalyticalDesigner {
         Drill = "drill",
         ExportFinished = "exportInsightFinished",
         FilterContextChanged = "filterContextChanged",
+        InsightChanged = "insightChanged",
         InsightEditingCancelled = "insightEditingCancelled",
         InsightOpened = "insightOpened",
         InsightRendered = "insightRendered",
@@ -72,9 +74,16 @@ export namespace EmbeddedAnalyticalDesigner {
     export interface IInsightExportConfig extends GdcExport.IBaseExportConfig {
         includeFilterContext?: boolean;
     }
+    // (undocumented)
+    export type InsightChangedBody = IAvailableCommands & {
+        definition: IInsightDefinition;
+    };
+    // (undocumented)
+    export type InsightChangedData = IGdcAdMessageEnvelope<GdcAdEventType.InsightChanged, InsightChangedBody>;
     export type InsightOpened = IGdcAdMessageEvent<GdcAdEventType.InsightOpened, InsightOpenedBody>;
     export type InsightOpenedBody = IAvailableCommands & {
         insight: IObjectMeta;
+        definition: IInsightDefinition;
     };
     export type InsightOpenedData = IGdcAdMessageEnvelope<GdcAdEventType.InsightOpened, InsightOpenedBody>;
     export type InsightRendered = IGdcAdMessageEvent<GdcAdEventType.InsightRendered, InsightRenderedBody>;
@@ -167,7 +176,7 @@ export namespace EmbeddedGdc {
     // (undocumented)
     export type DateString = string;
     // (undocumented)
-    export type FilterItem = DateFilterItem | AttributeFilterItem;
+    export type FilterItem = DateFilterItem | AttributeFilterItem | IRankingFilter;
     // (undocumented)
     export interface IAbsoluteDateFilter {
         // (undocumented)
@@ -218,6 +227,8 @@ export namespace EmbeddedGdc {
         filters: FilterItem[];
     }
     // (undocumented)
+    export type ILocalIdentifierQualifier = GdcExecuteAFM.ILocalIdentifierQualifier;
+    // (undocumented)
     export interface INegativeAttributeFilter {
         // (undocumented)
         negativeAttributeFilter: {
@@ -236,6 +247,16 @@ export namespace EmbeddedGdc {
         };
     }
     // (undocumented)
+    export interface IRankingFilter {
+        // (undocumented)
+        rankingFilter: {
+            measure: ILocalIdentifierQualifier;
+            attributes?: ILocalIdentifierQualifier[];
+            operator: RankingFilterOperator;
+            value: number;
+        };
+    }
+    // (undocumented)
     export interface IRelativeDateFilter {
         // (undocumented)
         relativeDateFilter: {
@@ -245,10 +266,6 @@ export namespace EmbeddedGdc {
             to: number;
         };
     }
-    const // (undocumented)
-    isObjIdentifierQualifier: typeof GdcExecuteAFM.isObjIdentifierQualifier;
-    const // (undocumented)
-    isObjectUriQualifier: typeof GdcExecuteAFM.isObjectUriQualifier;
     // (undocumented)
     export interface IRemoveAttributeFilterItem {
         // (undocumented)
@@ -259,9 +276,18 @@ export namespace EmbeddedGdc {
         // (undocumented)
         dataSet: ObjQualifier;
     }
+    const // (undocumented)
+    isObjIdentifierQualifier: typeof GdcExecuteAFM.isObjIdentifierQualifier;
+    const // (undocumented)
+    isObjectUriQualifier: typeof GdcExecuteAFM.isObjectUriQualifier;
     export interface IRemoveFilterContextContent {
         // (undocumented)
         filters: RemoveFilterItem[];
+    }
+    // (undocumented)
+    export interface IRemoveRankingFilterItem {
+        // (undocumented)
+        removeRankingFilter: unknown;
     }
     // (undocumented)
     export function isAbsoluteDateFilter(filter: unknown): filter is IAbsoluteDateFilter;
@@ -284,17 +310,23 @@ export namespace EmbeddedGdc {
     // (undocumented)
     export function isPositiveAttributeFilter(filter: unknown): filter is IPositiveAttributeFilter;
     // (undocumented)
+    export function isRankingFilter(filter: unknown): filter is IRankingFilter;
+    // (undocumented)
     export function isRelativeDateFilter(filter: unknown): filter is IRelativeDateFilter;
     // (undocumented)
     export function isRemoveAttributeFilter(filter: unknown): filter is EmbeddedGdc.IRemoveAttributeFilterItem;
     // (undocumented)
     export function isRemoveDateFilter(filter: unknown): filter is EmbeddedGdc.IRemoveDateFilterItem;
     // (undocumented)
+    export function isRemoveRankingFilter(filter: unknown): filter is EmbeddedGdc.IRemoveRankingFilterItem;
+    // (undocumented)
     export type ObjQualifier = GdcExecuteAFM.ObjQualifier;
+    // (undocumented)
+    export type RankingFilterOperator = "TOP" | "BOTTOM";
     // (undocumented)
     export type RelativeType = "relative";
     // (undocumented)
-    export type RemoveFilterItem = IRemoveDateFilterItem | IRemoveAttributeFilterItem;
+    export type RemoveFilterItem = IRemoveDateFilterItem | IRemoveAttributeFilterItem | IRemoveRankingFilterItem;
 }
 
 // @public

--- a/libs/sdk-embedding/package.json
+++ b/libs/sdk-embedding/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@gooddata/api-model-bear": "^8.0.0-beta.98",
+        "@gooddata/sdk-model": "^8.0.0-beta.98",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
     },

--- a/libs/sdk-embedding/src/iframe/ad.ts
+++ b/libs/sdk-embedding/src/iframe/ad.ts
@@ -11,6 +11,7 @@ import {
     IDrillableItemsCommandBody,
     EmbeddedGdc,
 } from "./common";
+import { IInsightDefinition } from "@gooddata/sdk-model";
 import { GdcExport, GdcVisualizationObject } from "@gooddata/api-model-bear";
 
 /**
@@ -183,9 +184,14 @@ export namespace EmbeddedAnalyticalDesigner {
         RemoveFilterContextFinished = "removeFilterContextFinished",
 
         /**
-         * Type notify KD that the insight editing has been cancelled
+         * Type notify AD that the insight editing has been cancelled
          */
         InsightEditingCancelled = "insightEditingCancelled",
+
+        /**
+         * Type to notify AD that the insight has been changed and execution started. It contains new insight definition.
+         */
+        InsightChanged = "insightChanged",
     }
 
     /**
@@ -779,6 +785,11 @@ export namespace EmbeddedAnalyticalDesigner {
          * The minimal opened insight information
          */
         insight: IObjectMeta;
+
+        /**
+         * Definition of insight
+         */
+        definition: IInsightDefinition;
     };
 
     /**
@@ -1101,4 +1112,16 @@ export namespace EmbeddedAnalyticalDesigner {
         GdcAdEventType.FilterContextChanged,
         FilterContextChangedBody
     >;
+
+    /**
+     * @public
+     */
+    export type InsightChangedBody = IAvailableCommands & {
+        definition: IInsightDefinition;
+    };
+
+    /**
+     * @public
+     */
+    export type InsightChangedData = IGdcAdMessageEnvelope<GdcAdEventType.InsightChanged, InsightChangedBody>;
 }

--- a/libs/sdk-embedding/src/iframe/common.ts
+++ b/libs/sdk-embedding/src/iframe/common.ts
@@ -293,9 +293,22 @@ export namespace EmbeddedGdc {
             to: number;
         };
     }
+
+    export type RankingFilterOperator = "TOP" | "BOTTOM";
+
+    export interface IRankingFilter {
+        rankingFilter: {
+            measure: ILocalIdentifierQualifier;
+            attributes?: ILocalIdentifierQualifier[];
+            operator: RankingFilterOperator;
+            value: number;
+        };
+    }
+
     export type AttributeFilterItem = IPositiveAttributeFilter | INegativeAttributeFilter;
     export type DateFilterItem = IAbsoluteDateFilter | IRelativeDateFilter;
-    export type FilterItem = DateFilterItem | AttributeFilterItem;
+    export type FilterItem = DateFilterItem | AttributeFilterItem | IRankingFilter;
+    export type ILocalIdentifierQualifier = GdcExecuteAFM.ILocalIdentifierQualifier;
     export type ObjQualifier = GdcExecuteAFM.ObjQualifier;
     export interface IRemoveDateFilterItem {
         dataSet: ObjQualifier;
@@ -303,7 +316,13 @@ export namespace EmbeddedGdc {
     export interface IRemoveAttributeFilterItem {
         displayForm: ObjQualifier;
     }
-    export type RemoveFilterItem = IRemoveDateFilterItem | IRemoveAttributeFilterItem;
+    export interface IRemoveRankingFilterItem {
+        removeRankingFilter: unknown;
+    }
+    export type RemoveFilterItem =
+        | IRemoveDateFilterItem
+        | IRemoveAttributeFilterItem
+        | IRemoveRankingFilterItem;
     export function isDateFilter(filter: unknown): filter is DateFilterItem {
         return !isEmpty(filter) && (isRelativeDateFilter(filter) || isAbsoluteDateFilter(filter));
     }
@@ -326,6 +345,10 @@ export namespace EmbeddedGdc {
     }
     export const isObjIdentifierQualifier = GdcExecuteAFM.isObjIdentifierQualifier;
     export const isObjectUriQualifier = GdcExecuteAFM.isObjectUriQualifier;
+
+    export function isRankingFilter(filter: unknown): filter is IRankingFilter {
+        return !isEmpty(filter) && (filter as IRankingFilter).rankingFilter !== undefined;
+    }
 
     /**
      * The filter context content that is used to exchange the filter context
@@ -354,6 +377,13 @@ export namespace EmbeddedGdc {
     ): filter is EmbeddedGdc.IRemoveAttributeFilterItem {
         return (
             !isEmpty(filter) && (filter as EmbeddedGdc.IRemoveAttributeFilterItem).displayForm !== undefined
+        );
+    }
+
+    export function isRemoveRankingFilter(filter: unknown): filter is EmbeddedGdc.IRemoveRankingFilterItem {
+        return (
+            !isEmpty(filter) &&
+            (filter as EmbeddedGdc.IRemoveRankingFilterItem).removeRankingFilter !== undefined
         );
     }
 


### PR DESCRIPTION
- Added ranking filter to setFilterContext API for AD

JIRA: BB-2497

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
