### PR TITLE
RELATED: RAIL-2653 clear child filters on parent filters change in examples

### DIFF
--- a/examples/sdk-examples/src/examples/advanced/parentFilter/ParentFilterExample.tsx
+++ b/examples/sdk-examples/src/examples/advanced/parentFilter/ParentFilterExample.tsx
@@ -106,13 +106,19 @@ export const ParentFilterExample: React.FC = () => {
             : undefined;
     }, [stateFilterValues]);
 
+    const onStateValueChange = (values: IFilterValue[] | null) => {
+        setStateFilterValues(values);
+        // clear cities on state change to avoid possible invalid state - city combinations
+        setCityFilterValues(null);
+    };
+
     return (
         <div>
             <span>Total Sales per site in&emsp;</span>
             <CustomFilter
                 displayForm={attributeDisplayFormRef(Ldm.LocationState)}
                 filterValues={stateFilterValues}
-                onChange={setStateFilterValues}
+                onChange={onStateValueChange}
                 placeholder="all states"
                 className="s-select-state"
             />


### PR DESCRIPTION
This avoids the posibility to create a filter cobination yielding NO_DATA.

JIRA: RAIL-2653

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
