### PR TITLE
RELATED: ONE-4678 Fix chart data label style when drilling is active

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
@@ -33,7 +33,6 @@ import {
     isOneOfTypes,
     isRotationInRange,
     isScatterPlot,
-    isTreemap,
     percentFormatter,
 } from "../../utils/common";
 import {
@@ -577,15 +576,6 @@ function getLabelsConfiguration(chartOptions: IChartOptions, _config: any, chart
 
     const style = getLabelStyle(type, stacking);
 
-    const drilldown =
-        stacking || isTreemap(type)
-            ? {
-                  activeDataLabelStyle: {
-                      color: "#ffffff",
-                  },
-              }
-            : {};
-
     const yAxis = yAxes.map((axis: any) => ({
         defaultFormat: get(axis, "format"),
     }));
@@ -606,7 +596,6 @@ function getLabelsConfiguration(chartOptions: IChartOptions, _config: any, chart
     };
 
     return {
-        drilldown,
         plotOptions: {
             gdcOptions: {
                 dataLabels: {


### PR DESCRIPTION
- Fixed in sdk 7.x but missing in 8.x
  https://github.com/gooddata/gooddata-react-components/pull/1412/files#diff-c82cb1765ceb81a02895181091005e69L564



<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)