### PR TITLE
RELATED: ONE-4642 ONE-4639 Input props and dropdown button customization turned off

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -331,7 +331,7 @@ export interface InputPureProps {
     // (undocumented)
     maxlength: number;
     // (undocumented)
-    onBlur: () => void;
+    onBlur: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)
     onChange: (value: string | number, e?: React_2.ChangeEvent<HTMLInputElement>) => void;
     // (undocumented)
@@ -339,7 +339,7 @@ export interface InputPureProps {
     // (undocumented)
     onEscKeyPress: () => void;
     // (undocumented)
-    onFocus: () => void;
+    onFocus: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)
     placeholder: string;
     // (undocumented)
@@ -392,11 +392,11 @@ export class InputWithNumberFormat extends React_2.PureComponent<InputWithNumber
     // (undocumented)
     handleCaretShift(e: React_2.ChangeEvent<HTMLInputElement>): void;
     // (undocumented)
-    onBlur: () => void;
+    onBlur: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)
     onChange: (value: number, e: React_2.ChangeEvent<HTMLInputElement>) => void;
     // (undocumented)
-    onFocus: () => void;
+    onFocus: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)
     render(): React_2.ReactNode;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Form/InputPure.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputPure.tsx
@@ -23,8 +23,8 @@ export interface InputPureProps {
     onChange: (value: string | number, e?: React.ChangeEvent<HTMLInputElement>) => void;
     onEscKeyPress: () => void;
     onEnterKeyPress: () => void;
-    onBlur: () => void;
-    onFocus: () => void;
+    onBlur: (e: React.FocusEvent<HTMLInputElement>) => void;
+    onFocus: (e: React.FocusEvent<HTMLInputElement>) => void;
     placeholder: string;
     prefix: string;
     readonly: boolean;

--- a/libs/sdk-ui-kit/src/Form/InputWithNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputWithNumberFormat.tsx
@@ -150,12 +150,12 @@ export class InputWithNumberFormat extends React.PureComponent<
         onChange(parse(value, separators));
     };
 
-    onFocus = (): void => {
+    onFocus = (e: React.FocusEvent<HTMLInputElement>): void => {
         this.setState({ isFocused: true });
-        this.props.onFocus();
+        this.props.onFocus(e);
     };
 
-    onBlur = (): void => {
+    onBlur = (e: React.FocusEvent<HTMLInputElement>): void => {
         const { separators, onBlur } = this.props;
         const { value } = this.state;
 
@@ -163,7 +163,7 @@ export class InputWithNumberFormat extends React.PureComponent<
             value: format(parse(value, separators), separators),
             isFocused: false,
         });
-        onBlur();
+        onBlur(e);
     };
 
     handleCaretShift(e: React.ChangeEvent<HTMLInputElement>): void {

--- a/libs/sdk-ui-kit/styles/scss/button.scss
+++ b/libs/sdk-ui-kit/styles/scss/button.scss
@@ -354,6 +354,11 @@
 .button-dropdown {
     font-weight: 400;
 
+    &:not(.customizable) {
+        border-radius: 3px;
+        text-transform: "none";
+    }
+
     &::after,
     &::before,
     .gd-button-icon {


### PR DESCRIPTION
Fixes prop types of Input component
Disables customization for dropdown button
---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
