### PR TITLE
Revert "Show single point in series despite dataPoints.visible set to false"

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chart/chartOptionsBuilder.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chart/chartOptionsBuilder.ts
@@ -239,8 +239,6 @@ export function getSeriesItemData(
     type: string,
     colorStrategy: IColorStrategy,
 ): IPointData[] {
-    const singlePointInSeries = seriesItem.length < 2;
-
     return seriesItem.map((pointValue: string, pointIndex: number) => {
         // by default seriesIndex corresponds to measureGroup label index
         let measureIndex = seriesIndex;
@@ -267,12 +265,19 @@ export function getSeriesItemData(
             };
         }
 
-        const pointData: IPointData = {
-            ...valueProp,
-            format: unwrap(measureGroup.items[measureIndex]).format,
-            ...(singlePointInSeries ? { marker: { enabled: true } } : null),
-            ...(pointValue === null ? { marker: { enabled: false } } : null),
-        };
+        const pointData: IPointData = Object.assign(
+            {
+                ...valueProp,
+                format: unwrap(measureGroup.items[measureIndex]).format,
+            },
+            pointValue === null
+                ? {
+                      marker: {
+                          enabled: false,
+                      },
+                  }
+                : {},
+        );
 
         if (stackByAttribute) {
             // if there is a stackBy attribute, then seriesIndex corresponds to stackBy label index


### PR DESCRIPTION
This reverts commit ea85d2bb87b677caa75abd416e38e34c54da3357.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
