### PR TITLE
RELATED: RAIL-2724 allow to include deprecated items in getVisualizationClasses

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -597,6 +597,11 @@ export interface IFluidLayoutSize {
 }
 
 // @public
+export interface IGetVisualizationClassesOptions {
+    includeDeprecated?: boolean;
+}
+
+// @public
 export interface IInsightQueryOptions {
     author?: string;
     limit?: number;
@@ -1165,7 +1170,7 @@ export interface IWorkspaceInsights {
     getObjectsReferencing(ref: ObjRef): Promise<IInsightReferencing>;
     getReferencedObjects(insight: IInsight, types?: SupportedInsightReferenceTypes[]): Promise<IInsightReferences>;
     getVisualizationClass(ref: ObjRef): Promise<IVisualizationClass>;
-    getVisualizationClasses(): Promise<IVisualizationClass[]>;
+    getVisualizationClasses(options?: IGetVisualizationClassesOptions): Promise<IVisualizationClass[]>;
     updateInsight(insight: IInsight): Promise<IInsight>;
 }
 

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -52,6 +52,7 @@ export { IWorkspaceSettingsService } from "./workspace/settings";
 
 export {
     IWorkspaceInsights,
+    IGetVisualizationClassesOptions,
     InsightOrdering,
     IInsightQueryOptions,
     IInsightQueryResult,

--- a/libs/sdk-backend-spi/src/workspace/insights/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/insights/index.ts
@@ -13,6 +13,18 @@ import {
 import { IPagedResource } from "../../common/paging";
 
 /**
+ * Additional options for the getVisualizationClasses function.
+ *
+ * @public
+ */
+export interface IGetVisualizationClassesOptions {
+    /**
+     * If true, deprecated visualization classes will be included in the result.
+     */
+    includeDeprecated?: boolean;
+}
+
+/**
  * Service to query, update or delete insights, and other methods related to insights.
  * Check IInsight for more details.
  *
@@ -30,9 +42,10 @@ export interface IWorkspaceInsights {
     /**
      * Request all visualization classes
      *
+     * @param options - optionally specify additional options
      * @returns promise of visualization classes
      */
-    getVisualizationClasses(): Promise<IVisualizationClass[]>;
+    getVisualizationClasses(options?: IGetVisualizationClassesOptions): Promise<IVisualizationClass[]>;
 
     /**
      * Request insight for the given reference


### PR DESCRIPTION
There are cases where you need even the deprecated classes,
for example to display an insight saved before the deprecation of that class.

Also, getInsights needs to use this option in case some of the insights
use deprecated visClasses.

JIRA: RAIL-2724

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
