### PR TITLE
All ui-sdk components with customizable primary color

### DIFF
--- a/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
+++ b/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
@@ -1,8 +1,12 @@
 // (C) 2007-2019 GoodData Corporation
 @import "~@gooddata/goodstrap/lib/core/styles/variables.scss";
+@import "~@gooddata/sdk-ui-kit/styles/scss/variables.scss";
 
 $gd-date-range-picker-hover-bgcolor: $is-focused-background;
-$gd-date-range-picker-interval-bgcolor: lighten($gd-color-highlight, 45%);
+$gd-date-range-picker-interval-bgcolor: var(
+    --gd-palette-primary-base-lighten45,
+    lighten($gd-color-highlight, 45%)
+);
 $gd-date-range-picker-shadow-color: #1f354a;
 
 $gd-color-warning-text: #888;
@@ -64,7 +68,7 @@ $gd-day-picker-width: 268px;
             align-items: center;
             height: 100%;
             font-size: 16px;
-            color: $gd-color-highlight;
+            color: $gd-palette-primary-base;
             pointer-events: none;
         }
 
@@ -126,11 +130,11 @@ $gd-day-picker-width: 268px;
                 padding-top: 0.15em;
                 font-family: Indigo;
                 font-size: 18px;
-                color: $gd-color-highlight;
+                color: $gd-palette-primary-base;
             }
 
             &:hover {
-                color: $gd-color-highlight;
+                color: $gd-palette-primary-base;
                 cursor: pointer;
             }
 
@@ -240,7 +244,7 @@ $gd-day-picker-width: 268px;
 
         .DayPicker-Day--selected:not(.DayPicker-Day--disabled) {
             color: $gd-color-text-light;
-            background: $gd-color-highlight;
+            background: $gd-palette-primary-base;
         }
 
         .DayPicker-Day--selected:not(.DayPicker-Day--start):not(.DayPicker-Day--end) {

--- a/libs/sdk-ui-filters/styles/scss/measureValueFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/measureValueFilter.scss
@@ -28,8 +28,8 @@ $dialog_width: 250px;
             margin-top: 4px;
 
             &.gd-mvf-warning-message-low {
-                background: transparentize($gd-color-highlight, 0.85);
-                color: $gd-color-highlight;
+                background: $gd-palette-primary-base-t80;
+                color: $gd-palette-primary-base;
             }
 
             &.gd-mvf-warning-message-medium {

--- a/libs/sdk-ui-filters/styles/scss/rankingFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/rankingFilter.scss
@@ -58,7 +58,7 @@ $measure_sequence_number_font: menlo, monaco, consolas, "Courier New", monospace
     }
 
     .gd-button-link.is-selected {
-        color: $gd-color-highlight;
+        color: $gd-palette-primary-base;
     }
 }
 
@@ -109,7 +109,7 @@ $measure_sequence_number_font: menlo, monaco, consolas, "Courier New", monospace
     }
 
     .gd-button-link.is-selected {
-        color: $gd-color-highlight;
+        color: $gd-palette-primary-base;
     }
 
     .gd-rf-attribute-all-records-icon {
@@ -149,7 +149,7 @@ $measure_sequence_number_font: menlo, monaco, consolas, "Courier New", monospace
     }
 
     .gd-button-link.is-selected {
-        color: $gd-color-highlight;
+        color: $gd-palette-primary-base;
     }
 
     .gd-rf-measure-title {

--- a/libs/sdk-ui-kit/styles/scss/Button/_variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/Button/_variables.scss
@@ -28,18 +28,18 @@ $button-shadow-darker: transparentize($button-shadow-color, 0.85);
 
 // Branded colors calculation
 // primary color
-$button-action-color: var(--gd-palette-primary-base, $gd-color-highlight);
-$button-action-bg: var(--gd-palette-primary-base, $gd-color-highlight);
+$button-action-color: $gd-palette-primary-base;
+$button-action-bg: $gd-palette-primary-base;
 
 $button-action-color-t25: var(--gd-palette-primary-base-t25, transparentize($gd-color-highlight, 0.25));
-$button-action-color-t80: var(--gd-palette-primary-base-t80, transparentize($gd-color-highlight, 0.8));
+$button-action-color-t80: $gd-palette-primary-base-t80;
 $button-action-color-t70: var(--gd-palette-primary-base-t70, transparentize($gd-color-highlight, 0.7));
 
 $button-action-color-d12: var(--gd-palette-primary-base-d12, darken($gd-color-highlight, 12%));
 
 $button-action-disabled-color: transparentize(lighten($gd-color-highlight, 12%), 0.4);
 $button-action-disabled-bg: var(--gd-palette-primary-disabled, $button-action-disabled-color);
-$button-action-hover-bg: $gd-color-highlight-darken06;
+$button-action-hover-bg: $gd-palette-primary-base-darken06;
 $button-action-focus-shadow: var(
     --gd-palette-primary-focus,
     transparentize(lighten($gd-color-highlight, 6%), 0.4)

--- a/libs/sdk-ui-kit/styles/scss/Datepicker/_variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/Datepicker/_variables.scss
@@ -2,7 +2,5 @@
 @import "../variables.scss";
 
 // from goodstrap DatePicker
-
-$gd-date-picker-color: var(--gd-palette-primary-base, $gd-color-highlight);
 $gd-datepicker-hover-bgcolor: $is-focused-background;
 $gd-datepicker-shadow-color: #1f354a;

--- a/libs/sdk-ui-kit/styles/scss/Form/_variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/Form/_variables.scss
@@ -1,9 +1,2 @@
 // (C) 2020 GoodData Corporation
 @import "../variables";
-
-// CSS variables
-$gd-input-focus-color: var(--gd-palette-primary-base, $gd-color-highlight);
-$gd-searchfield-icon-color: var(--gd-palette-primary-base, $gd-color-highlight);
-$gd-searchfield-clear-color: var(--gd-palette-primary-base, $gd-color-highlight);
-$gd-input-checkbox-label-color: var(--gd-palette-primary-base, $gd-color-highlight);
-$gd-input-checkbox-toggle-color: var(--gd-palette-primary-base, $gd-color-highlight);

--- a/libs/sdk-ui-kit/styles/scss/MeasureNumberFormat/_variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/MeasureNumberFormat/_variables.scss
@@ -1,0 +1,6 @@
+// (C) 2020 GoodData Corporation
+
+$measure_number_format_custom_format_dialog_width: 250px;
+$measure_number_format_custom_format_dialog_textarea_height: 100px;
+
+$button_templates_hover_color: var(--gd-palette-primary-base-darken20, darken($gd-color-highlight, 20%));

--- a/libs/sdk-ui-kit/styles/scss/datepicker.scss
+++ b/libs/sdk-ui-kit/styles/scss/datepicker.scss
@@ -41,7 +41,7 @@
     bottom: 0;
     left: 10px;
     line-height: 30px;
-    color: $gd-date-picker-color;
+    color: $gd-palette-primary-base;
     font-size: 18px;
 
     @include transition("color", 0.25s, ease-in-out);
@@ -143,7 +143,7 @@
 
         &::before {
             display: block;
-            color: $gd-date-picker-color;
+            color: $gd-palette-primary-base;
             padding-top: 0.15em;
             font-family: Indigo;
             font-size: 18px;
@@ -172,7 +172,7 @@
 
     .DayPicker-NavButton--next:hover,
     .DayPicker-NavButton--prev:hover {
-        color: $gd-date-picker-color;
+        color: $gd-palette-primary-base;
         cursor: pointer;
     }
 
@@ -253,6 +253,6 @@
 
     .DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside) {
         color: $gd-color-text-light;
-        background: $gd-date-picker-color;
+        background: $gd-palette-primary-base;
     }
 }

--- a/libs/sdk-ui-kit/styles/scss/form.scss
+++ b/libs/sdk-ui-kit/styles/scss/form.scss
@@ -46,7 +46,7 @@
 
     &:focus {
         outline: 0;
-        border-color: $gd-input-focus-color;
+        border-color: $gd-palette-primary-base;
 
         @include box-shadow(inset 0 1px 1px 0 transparentize($gd-input-text-box-shadow-color, 0.8));
     }
@@ -127,7 +127,7 @@ textarea {
     @include transition(all, 0.25s, ease-in-out);
 
     :focus + & {
-        color: $gd-searchfield-icon-color;
+        color: $gd-palette-primary-base;
     }
 }
 
@@ -141,7 +141,7 @@ textarea {
     @include transition(all, 0.25s, ease-in-out);
 
     &:hover {
-        color: $gd-searchfield-clear-color;
+        color: $gd-palette-primary-base;
     }
 }
 
@@ -250,7 +250,7 @@ textarea {
 
         &:focus {
             @include gd-input-and-prefix {
-                border-color: $gd-input-focus-color;
+                border-color: $gd-palette-primary-base;
             }
         }
 
@@ -390,8 +390,8 @@ textarea {
     }
 
     &:active .input-label-text::before {
-        border-color: $gd-input-checkbox-label-color;
-        background-color: $gd-color-highlight-dimmed;
+        border-color: $gd-palette-primary-base;
+        background-color: $gd-palette-primary-base-dimmed;
     }
 
     input {
@@ -402,7 +402,7 @@ textarea {
         &:checked ~ .input-label-text {
             &::before {
                 border-color: transparent;
-                background-color: $gd-input-checkbox-label-color;
+                background-color: $gd-palette-primary-base;
             }
 
             &::after {
@@ -535,8 +535,8 @@ textarea {
     input:checked {
         ~ .input-label-text::after {
             right: 2px;
-            border: 1px solid $gd-color-highlight-darken06;
-            background: $gd-input-checkbox-toggle-color;
+            border: 1px solid $gd-palette-primary-base-darken06;
+            background: $gd-palette-primary-base;
         }
     }
 
@@ -548,7 +548,7 @@ textarea {
         }
 
         input:checked ~ .input-label-text::after {
-            background: $gd-color-highlight-darken06;
+            background: $gd-palette-primary-base-darken06;
         }
     }
 

--- a/libs/sdk-ui-kit/styles/scss/measureNumberFormat.scss
+++ b/libs/sdk-ui-kit/styles/scss/measureNumberFormat.scss
@@ -1,5 +1,6 @@
 // (C) 2020 GoodData Corporation
 @import "./variables.scss";
+@import "./MeasureNumberFormat/_variables";
 
 .gd-measure-number-format-dropdown-body {
     padding: 5px 0;
@@ -20,9 +21,6 @@
         }
     }
 }
-
-$measure_number_format_custom_format_dialog_width: 250px;
-$measure_number_format_custom_format_dialog_textarea_height: 100px;
 
 .gd-measure-custom-format-dialog-body {
     display: flex;
@@ -113,10 +111,10 @@ $measure_number_format_custom_format_dialog_textarea_height: 100px;
         }
 
         .gd-measure-format-button-templates {
-            color: $gd-color-highlight;
+            color: $gd-palette-primary-base;
 
             &:hover {
-                color: darken($gd-color-highlight, 20%);
+                color: $button_templates_hover_color;
             }
         }
 

--- a/libs/sdk-ui-kit/styles/scss/syntaxHighlightingInput.scss
+++ b/libs/sdk-ui-kit/styles/scss/syntaxHighlightingInput.scss
@@ -49,7 +49,7 @@ $cm-color-keyword: #ab55a3;
         }
 
         &.CodeMirror-focused {
-            border-color: $gd-color-highlight;
+            border-color: $gd-palette-primary-base;
             @include box-shadow(inset 0 1px 1px 0 transparentize($gd-input-text-box-shadow-color, 0.85));
         }
     }

--- a/libs/sdk-ui-kit/styles/scss/variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/variables.scss
@@ -23,13 +23,17 @@ $gd-color-text-light: #fff;
 $gd-color-dark: #000;
 
 $border-color: #dde4eb;
+// primary color - must not be used to create derived colors by scss color function
+$gd-palette-primary-base: var(--gd-palette-primary-base, $gd-color-highlight);
 
 // primary derived colors
-$gd-color-highlight-dimmed: var(
+$gd-palette-primary-base-dimmed: var(
     --gd-palette-primary-dimmed,
     mix($gd-color-highlight, $gd-color-text-light, 10%)
 );
-$gd-color-highlight-darken06: var(--gd-palette-primary-base-d06, darken($gd-color-highlight, 6%));
+$gd-palette-primary-base-t80: var(--gd-palette-primary-base-t80, transparentize($gd-color-highlight, 0.8));
+$gd-palette-primary-base-darken06: var(--gd-palette-primary-base-d06, darken($gd-color-highlight, 6%));
+
 // secondary colors
 $gd-color-positive-dimmed: mix($gd-color-positive, $gd-color-text-light, 10%);
 $gd-color-negative-dimmed: mix($gd-color-negative, $gd-color-text-light, 10%);
@@ -54,11 +58,11 @@ $gd-typo: (
 $is-focused-background: #ebeff4;
 $is-focused-color: #000;
 
-$is-selected-color: $gd-color-highlight;
+$is-selected-color: $gd-palette-primary-base;
 $is-selected-background: none;
 
-$is-selected-focused-color: $gd-color-highlight;
-$is-selected-focused-background: $gd-color-highlight-dimmed;
+$is-selected-focused-color: $gd-palette-primary-base;
+$is-selected-focused-background: $gd-palette-primary-base-dimmed;
 
 $is-negative-focused-color: #fff;
 $is-negative-focused-background: mix($gd-color-negative, $gd-color-text-light, 90%);

--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -139,7 +139,7 @@ $header-cell-resize-width: 20px;
                 display: block;
                 width: $header-cell-resize-width / 2;
                 margin-right: $header-cell-resize-width / 2;
-                border-right: 1px solid $gd-color-highlight;
+                border-right: 1px solid $gd-palette-primary-base;
                 text-indent: $header-cell-resize-width / 2;
                 height: 16px;
             }
@@ -148,7 +148,7 @@ $header-cell-resize-width: 20px;
         .gd-column-group-header:hover {
             .gd-pivot-table-header-label--clickable,
             .gd-pivot-table-header-menu ~ .gd-pivot-table-header-label {
-                background-color: $gd-color-highlight-dimmed;
+                background-color: $gd-palette-primary-base-dimmed;
             }
 
             .ag-header-cell-resize {
@@ -333,7 +333,7 @@ $header-cell-resize-width: 20px;
         align-items: center;
         overflow: hidden;
         border-top: 2px solid transparent;
-        background-color: $gd-color-highlight-dimmed;
+        background-color: $gd-palette-primary-base-dimmed;
         opacity: 0;
         cursor: pointer;
         transition: width 200ms, opacity 100ms;


### PR DESCRIPTION
JIRA: ONE-4642

Simplified color variable naming
Customizable primary color in al ui-sdk components (except charts)

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
