### PR TITLE
RELATED: RAIL-2711 - Update release scripts to correctly add NPM tags

### DIFF
--- a/common/scripts/ci/do_publish.sh
+++ b/common/scripts/ci/do_publish.sh
@@ -49,12 +49,20 @@ if [ $dry_run_rc -ne 0 ]; then
 fi
 
 #
+# Default to `prerelease`
+#
+if [ -z ${TAG_NPM} ]; then
+  echo "Please specify TAG_NPM env variable. This is used to tag the release on NPM (latest for major and minor, prerelease for alpha or beta)."
+  exit 1
+fi
+
+#
 # All good, do the real thing
 #
 echo "Publishing to NPM"
 
 # forcing restricted access level; switch this to public
-${_RUSH} publish -n "${NPM_PUBLISH_TOKEN}" -p --include-all --set-access-level public
+${_RUSH} publish -n "${NPM_PUBLISH_TOKEN}" -p --include-all --tag "${TAG_NPM}" --set-access-level public
 publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then

--- a/common/scripts/ci/run_major_release.sh
+++ b/common/scripts/ci/run_major_release.sh
@@ -44,13 +44,12 @@ fi
 # Perform release; this will create commits & tags with the major release in it.
 #
 export TAG_VERSION=TRUE
+export TAG_NPM="latest"
 ${DIR}/do_publish.sh
 publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then
   echo "Publishing major version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
-
-  exit 1
 else
   #
   # Now that the major is published and commit created, prepare for the next minor release.
@@ -62,7 +61,5 @@ else
   # stage all modified json files
   git ls-files | grep '\.json' | xargs git add
   git commit -m "Prepare for next minor release ${NEXT_MINOR}"
-
-  exit 0
 fi
 

--- a/common/scripts/ci/run_minor_release.sh
+++ b/common/scripts/ci/run_minor_release.sh
@@ -46,13 +46,12 @@ fi
 # Perform release; this will create commits & tags with the major release in it.
 #
 export TAG_VERSION=TRUE
+export TAG_NPM="latest"
 ${DIR}/do_publish.sh
 publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then
   echo "Publishing minor version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
-
-  exit 1
 else
   #
   # Now that the mior is published and commit created, prepare for the next minor release.
@@ -64,6 +63,4 @@ else
   # stage all modified json files
   git ls-files | grep '\.json' | xargs git add
   git commit -m "Prepare for next minor release ${NEXT_MINOR}"
-
-  exit 0
 fi

--- a/common/scripts/ci/run_prerelease.sh
+++ b/common/scripts/ci/run_prerelease.sh
@@ -44,4 +44,5 @@ if [ $bump_rc -ne 0 ]; then
     exit 1
 fi
 
+export TAG_NPM="prerelease"
 ${DIR}/do_publish.sh

--- a/common/scripts/ci/run_prerelease_switch.sh
+++ b/common/scripts/ci/run_prerelease_switch.sh
@@ -49,4 +49,5 @@ if [ $bump_rc -ne 0 ]; then
     exit 1
 fi
 
+export TAG_NPM="prerelease"
 ${DIR}/do_publish.sh


### PR DESCRIPTION
-  Only minor and major releases are tagged as 'latest'
-  All types of prereleases are tagged as 'prerelease'
-  Shotgun attempt to fix abrupt halt in CI release script execution

JIRA: RAIL-2711

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
