### PR TITLE
RAIL-2722: Enable ranking filter FF (Tiger)

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/user/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/user/settings.ts
@@ -21,7 +21,7 @@ export class TigerUserSettingsService implements IUserSettingsService {
                 enableNewADFilterBar: true,
                 enableMeasureValueFilters: true,
                 enablePushpinGeoChart: true,
-                hidePixelPerfectExperience: false,
+                hidePixelPerfectExperience: true,
                 enableBulletChart: true,
                 enableCsvUploader: true,
                 platformEdition: "enterprise",
@@ -31,6 +31,8 @@ export class TigerUserSettingsService implements IUserSettingsService {
                 enableCustomMeasureFormatting: true,
                 enableAnalyticalDashboards: true,
                 enableHidingOfDataPoints: true,
+                enableAdCatalogRefresh: true,
+                enableAdRankingFilter: true,
             };
         });
     }

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -19,6 +19,8 @@ const HardcodedSettings = {
     enableCustomMeasureFormatting: true,
     ADMeasureValueFilterNullAsZeroOption: "EnabledCheckedByDefault",
     enableHidingOfDataPoints: true,
+    enableAdCatalogRefresh: true,
+    enableAdRankingFilter: true,
 
     // KD specific
     enableAnalyticalDashboards: true,


### PR DESCRIPTION
Also updates other FFs for catalog refresh button (default is true).

JIRA: RAIL-2722

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
