### PR TITLE
RELATED: RAIL-2732 fix PluggableBulletChart primary measure detection

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -66,10 +66,6 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
 
     protected isLoading: boolean;
 
-    protected setIsError = (value: boolean): void => {
-        this.hasError = value;
-    };
-
     protected getIsError = (): boolean => {
         return this.hasEmptyAfm || this.hasError;
     };

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -231,24 +231,6 @@ describe("PluggableBulletChart", () => {
         });
     });
 
-    describe("isError property", () => {
-        it("should set to true if primary measure is missing", async () => {
-            await bulletChart.getExtendedReferencePoint(
-                referencePointMocks.secondaryAndTertiaryMeasuresWithTwoAttributesReferencePoint,
-            );
-
-            expect((bulletChart as any).getIsError()).toEqual(true);
-        });
-
-        it("should set to false if primary measure is present", async () => {
-            await bulletChart.getExtendedReferencePoint(
-                referencePointMocks.multipleMetricsNoCategoriesReferencePoint,
-            );
-
-            expect((bulletChart as any).getIsError()).toEqual(false);
-        });
-    });
-
     describe("Arithmetic measures", () => {
         it("should add AM that does fit", async () => {
             const extendedReferencePoint = await bulletChart.getExtendedReferencePoint({


### PR DESCRIPTION
This makes the detection idiomatic (similar to `PluggableBaseChart`) and removes a side effect in its `getExtendedReferencePoint`.

Also removes the `AbstractPluggableVisualization.setIsError` methond which is no longer used (and should not ever be).

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
