### PR TITLE
FIX: ONE-4642 Timepicker fix export naming

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -641,7 +641,7 @@ export interface ISyntaxHighlightingInputProps {
 }
 
 // @internal (undocumented)
-export interface ITimePickerOwnProps {
+export interface ITimepickerOwnProps {
     // (undocumented)
     className?: string;
     // (undocumented)
@@ -721,7 +721,7 @@ export enum SnapPoint {
 export const SyntaxHighlightingInput: React_2.FC<ISyntaxHighlightingInputProps>;
 
 // @internal (undocumented)
-export class TimePicker extends React_2.PureComponent<ITimePickerOwnProps> {
+export class Timepicker extends React_2.PureComponent<ITimepickerOwnProps> {
     // (undocumented)
     render(): React_2.ReactNode;
 }

--- a/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
+++ b/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
@@ -25,7 +25,7 @@ export const normalizeTime = normalizeTimeForPicker;
 /**
  * @internal
  */
-export interface ITimePickerOwnProps {
+export interface ITimepickerOwnProps {
     time: Date;
     className?: string;
     maxVisibleItemsCount?: number;
@@ -35,7 +35,7 @@ export interface ITimePickerOwnProps {
     locale?: string;
 }
 
-export type TimePickerProps = ITimePickerOwnProps & WrappedComponentProps;
+export type TimePickerProps = ITimepickerOwnProps & WrappedComponentProps;
 
 interface ITimePickerState {
     dropdownWidth: number;
@@ -158,7 +158,7 @@ const TimePickerWithIntl = injectIntl(WrappedTimepicker);
 /**
  * @internal
  */
-export class TimePicker extends React.PureComponent<ITimePickerOwnProps> {
+export class Timepicker extends React.PureComponent<ITimepickerOwnProps> {
     public render(): React.ReactNode {
         return (
             <IntlWrapper locale={this.props.locale}>

--- a/libs/sdk-ui-kit/src/Timepicker/index.ts
+++ b/libs/sdk-ui-kit/src/Timepicker/index.ts
@@ -1,4 +1,4 @@
 // (C) 2020 GoodData Corporation
 
 export * from "./typings";
-export { TimePicker, ITimePickerOwnProps } from "./Timepicker";
+export { Timepicker, ITimepickerOwnProps } from "./Timepicker";

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Timepicker/Timepicker.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Timepicker/Timepicker.tsx
@@ -1,6 +1,6 @@
 // (C) 2019-2020 GoodData Corporation
 import React, { useState } from "react";
-import { TimePicker } from "@gooddata/sdk-ui-kit";
+import { Timepicker } from "@gooddata/sdk-ui-kit";
 import { storiesOf } from "@storybook/react";
 import { UiKit } from "../../../_infra/storyGroups";
 
@@ -13,11 +13,11 @@ const TimePickerExamples: React.FC = () => {
     return (
         <div className="library-component screenshot-target gd-timepicker">
             <h4>Basic picker</h4>
-            <TimePicker time={new Date()} />
+            <Timepicker time={new Date()} />
 
             <h4>Set time externally</h4>
             <div>
-                <TimePicker time={time} />
+                <Timepicker time={time} />
                 <br />
                 <br />
                 <button onClick={() => setTime(new Date())}>Externally set current time</button>


### PR DESCRIPTION
Fix export naming

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
