### PR TITLE
RELATED: SD-1100 - enable the animation for Highcharts when the zoomInsight is enabled

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chart/highcharts/customConfiguration.ts
@@ -1167,6 +1167,7 @@ function getZoomingAndPanningConfiguration(
     return chartConfig?.zoomInsight
         ? {
               chart: {
+                  animation: true,
                   zoomType: "x",
                   panKey: "shift",
                   panning: true,

--- a/libs/sdk-ui-charts/src/highcharts/chart/highcharts/test/customConfiguration.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chart/highcharts/test/customConfiguration.test.ts
@@ -216,6 +216,7 @@ describe("getCustomizedConfiguration", () => {
             };
             const chartResult = {
                 ...result.chart,
+                animation: true,
                 zoomType: "x",
                 panKey: "shift",
                 panning: true,


### PR DESCRIPTION
Enable the animation for Highcharts when the zoomInsight is enabled:
_ The chart animation is disabled by default. It should be enabled when the zooming feature is enabled.
JIRA: SD-1187

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
is 