### PR TITLE
Fix AD Insights are broken after change of default label

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/anvuong-sd1107_2020-10-08-11-57.json
+++ b/common/changes/@gooddata/sdk-ui-all/anvuong-sd1107_2020-10-08-11-57.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Passes all fetched display forms of each attribute in an insight to AD in an InsightReferencesQuery",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "an.vuong@gooddata.com"
+}

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/CatalogConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/CatalogConverter.ts
@@ -198,6 +198,13 @@ export const convertWrappedAttribute = (attribute: GdcMetadata.IWrappedAttribute
     return newCatalogAttribute((catalogAttr) => {
         let result = catalogAttr
             .attribute(attrRef, (a) => a.modify(commonMetadataModifications(meta)))
+            .displayForms(
+                displayForms.map((displayForm) =>
+                    newAttributeDisplayFormMetadataObject(uriRef(displayForm.meta.uri), (df) =>
+                        df.modify(commonMetadataModifications(displayForm.meta)).attribute(attrRef),
+                    ),
+                ),
+            )
             .geoPinDisplayForms(
                 geoPinDisplayForms.map((geoDisplayForm) =>
                     newAttributeDisplayFormMetadataObject(uriRef(geoDisplayForm.meta.uri), (df) =>

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -62,7 +62,7 @@ function createNonDateAttributes(attributes: AttributeResourcesResponseSchema): 
         const geoLabels = allLabels.filter(isGeoLabel);
         const defaultLabel = nonGeoLabels[0] ?? geoLabels[0];
 
-        return convertAttribute(attribute, defaultLabel, geoLabels);
+        return convertAttribute(attribute, defaultLabel, geoLabels, allLabels);
     });
 }
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
@@ -63,8 +63,15 @@ export const convertAttribute = (
     attribute: AttributeResourceSchema,
     defaultLabel: LabelResourceSchema,
     geoLabels: LabelResourceSchema[],
+    allLabels: LabelResourceSchema[],
 ): ICatalogAttribute => {
     const geoPinDisplayForms = geoLabels.map((label) => {
+        return newAttributeDisplayFormMetadataObject(
+            idRef(label.id, "displayForm"),
+            commonMetadataObjectModifications(label),
+        );
+    });
+    const displayForms = allLabels.map((label) => {
         return newAttributeDisplayFormMetadataObject(
             idRef(label.id, "displayForm"),
             commonMetadataObjectModifications(label),
@@ -80,6 +87,7 @@ export const convertAttribute = (
                 df.modify(commonMetadataObjectModifications(defaultLabel)),
             )
             .geoPinDisplayForms(geoPinDisplayForms)
+            .displayForms(displayForms)
             .modify(commonGroupableCatalogItemModifications(attribute)),
     );
 };

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -228,6 +228,8 @@ export class CatalogAttributeBuilder<T extends ICatalogAttribute = ICatalogAttri
     // (undocumented)
     defaultDisplayForm(displayFormOrRef: IAttributeDisplayFormMetadataObject | ObjRef, modifications?: BuilderModifications<AttributeDisplayFormMetadataObjectBuilder>): this;
     // (undocumented)
+    displayForms(displayForms: IAttributeDisplayFormMetadataObject[]): this;
+    // (undocumented)
     geoPinDisplayForms(displayForms: IAttributeDisplayFormMetadataObject[]): this;
     // (undocumented)
     toExecutionModel(modifications?: AttributeModifications): IAttribute;
@@ -528,6 +530,7 @@ export interface IBuilder<T> {
 export interface ICatalogAttribute extends IGroupableCatalogItemBase {
     attribute: IAttributeMetadataObject;
     defaultDisplayForm: IAttributeDisplayFormMetadataObject;
+    displayForms: IAttributeDisplayFormMetadataObject[];
     geoPinDisplayForms: IAttributeDisplayFormMetadataObject[];
     type: "attribute";
 }

--- a/libs/sdk-model/src/ldm/catalog/attribute/factory.ts
+++ b/libs/sdk-model/src/ldm/catalog/attribute/factory.ts
@@ -53,6 +53,11 @@ export class CatalogAttributeBuilder<
         return this;
     }
 
+    public displayForms(displayForms: IAttributeDisplayFormMetadataObject[]): this {
+        this.item.displayForms = displayForms;
+        return this;
+    }
+
     public geoPinDisplayForms(displayForms: IAttributeDisplayFormMetadataObject[]): this {
         this.item.geoPinDisplayForms = displayForms;
 

--- a/libs/sdk-model/src/ldm/catalog/attribute/index.ts
+++ b/libs/sdk-model/src/ldm/catalog/attribute/index.ts
@@ -26,6 +26,11 @@ export interface ICatalogAttribute extends IGroupableCatalogItemBase {
     defaultDisplayForm: IAttributeDisplayFormMetadataObject;
 
     /**
+     * Display forms of the attribute
+     */
+    displayForms: IAttributeDisplayFormMetadataObject[];
+
+    /**
      * Attribute's display forms that contain geo pins (lat; lng) pairs.
      */
     geoPinDisplayForms: IAttributeDisplayFormMetadataObject[];


### PR DESCRIPTION
JIRA: SD-1196

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
