### PR TITLE
Remove temporary measure format override

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/MeasureConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/MeasureConverter.ts
@@ -15,7 +15,7 @@ import { GdcExecuteAFM } from "@gooddata/api-model-bear";
 import { convertMeasureFilter } from "./FilterConverter";
 import { toBearRef } from "../ObjRefConverter";
 import compact from "lodash/compact";
-import { DEFAULT_INTEGER_FORMAT, DEFAULT_PERCENTAGE_FORMAT, DEFAULT_DECIMAL_FORMAT } from "./constants";
+import { DEFAULT_INTEGER_FORMAT, DEFAULT_PERCENTAGE_FORMAT } from "./constants";
 
 export function convertMeasure(measure: IMeasure): GdcExecuteAFM.IMeasure {
     const {
@@ -119,24 +119,6 @@ function getFormat(measure: IMeasure): string | undefined {
     const {
         measure: { definition, format },
     } = measure;
-
-    // Override incorrect formats of ad-hoc measures with computeRatio
-    // and use decimal percentage  instead.
-    // This code will be removed once saved viz. objects are fixed in BB-2287
-    if (isMeasureDefinition(definition)) {
-        const { measureDefinition } = definition;
-        if (measureDefinition.computeRatio && measureDefinition.aggregation) {
-            if (measureDefinition.aggregation === "count") {
-                if (format === DEFAULT_INTEGER_FORMAT) {
-                    return DEFAULT_PERCENTAGE_FORMAT;
-                }
-            } else {
-                if (format === DEFAULT_DECIMAL_FORMAT) {
-                    return DEFAULT_PERCENTAGE_FORMAT;
-                }
-            }
-        }
-    }
 
     if (format) {
         return format;

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/MeasureConverter.test.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/MeasureConverter.test.ts
@@ -10,7 +10,6 @@ import {
     newMeasure,
     newPositiveAttributeFilter,
 } from "@gooddata/sdk-model";
-import { DEFAULT_DECIMAL_FORMAT, DEFAULT_INTEGER_FORMAT } from "../constants";
 
 describe("measure converter", () => {
     const Scenarios: Array<[string, any]> = [
@@ -46,14 +45,6 @@ describe("measure converter", () => {
             newPreviousPeriodMeasure("foo", [{ dataSet: "bar", periodsAgo: 3 }], (m) =>
                 m.format("custom #,##0,00"),
             ),
-        ],
-        [
-            "custom format: sum measure override",
-            newMeasure("foo", (m) => m.format(DEFAULT_DECIMAL_FORMAT).ratio().aggregation("sum")),
-        ],
-        [
-            "custom format: count measure override",
-            newMeasure("foo", (m) => m.format(DEFAULT_INTEGER_FORMAT).ratio().aggregation("count")),
         ],
     ];
     it.each(Scenarios)("should return %s", (_disc, input) => {

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/__snapshots__/MeasureConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/__snapshots__/MeasureConverter.test.ts.snap
@@ -105,22 +105,6 @@ Object {
 }
 `;
 
-exports[`measure converter should return custom format: count measure override 1`] = `
-Object {
-  "definition": Object {
-    "measure": Object {
-      "aggregation": "count",
-      "computeRatio": true,
-      "item": Object {
-        "identifier": "foo",
-      },
-    },
-  },
-  "format": "#,##0.00%",
-  "localIdentifier": "m_061abd71_foo_count_ratio",
-}
-`;
-
 exports[`measure converter should return custom format: pop measure 1`] = `
 Object {
   "definition": Object {
@@ -167,22 +151,6 @@ Object {
   },
   "format": "custom #,##0,00",
   "localIdentifier": "m_e70a9702_foo",
-}
-`;
-
-exports[`measure converter should return custom format: sum measure override 1`] = `
-Object {
-  "definition": Object {
-    "measure": Object {
-      "aggregation": "sum",
-      "computeRatio": true,
-      "item": Object {
-        "identifier": "foo",
-      },
-    },
-  },
-  "format": "#,##0.00%",
-  "localIdentifier": "m_a183b5ef_foo_sum_ratio",
 }
 `;
 


### PR DESCRIPTION
When implementing custom measure format we found out that some measures have incorrect format saved in viz. object. As we started to respect the format saved in viz. object the measures would be formatted wrongly so we introduced this fix for them. These viz. objects have been fixed so that the override is not needed any more

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
