### PR TITLE
RELATED: ONE-4711: fix dropShadow and textCapitalization css var

### DIFF
--- a/libs/sdk-ui-kit/styles/scss/Button/_variables.scss
+++ b/libs/sdk-ui-kit/styles/scss/Button/_variables.scss
@@ -70,14 +70,15 @@ $button-border-radius: var(--gd-button-borderRadius, 3px);
 $button-group-border-radius: 0;
 
 // text-capitalization
-$button-text-capitalization: var(--gd-button-text-capitalization, none);
+$button-text-capitalization: var(--gd-button-textCapitalization, none);
 
 // box-shadow - remove it from all states except 'hover' if customer specifies
-$button-box-shadow-x-offset: var(--gd-button-box-shadow, 0 1px 1px 0);
-$button-box-shadow-focus-x-offset: var(--gd-button-box-shadow, 0 0 3px 1px);
-$button-box-shadow-focus-y-offset: var(--gd-button-box-shadow, 0 1px 2px 0);
-$button-action-box-shadow-x-offset: var(--gd-button-box-shadow, 1px 1px 0);
-$button-link-box-shadow-x-offset: var(--gd-button-box-shadow, 0 0 3px 0);
-$button-positive-box-shadow-focus-y-offset: var(--gd-button-box-shadow, 0 1px 1px 0);
-$button-negative-box-shadow-focus-y-offset: var(--gd-button-box-shadow, 0 1px 1px 0);
-$button-action-box-shadow-focus-y-offset: var(--gd-button-box-shadow, 0 1px 1px 0);
+
+$button-box-shadow-x-offset: var(--gd-button-dropShadow, 0 1px 1px 0);
+$button-box-shadow-focus-x-offset: var(--gd-button-dropShadow, 0 0 3px 1px);
+$button-box-shadow-focus-y-offset: var(--gd-button-dropShadow, 0 1px 2px 0);
+$button-action-box-shadow-x-offset: var(--gd-button-dropShadow, 1px 1px 0);
+$button-link-box-shadow-x-offset: var(--gd-button-dropShadow, 0 0 3px 0);
+$button-positive-box-shadow-focus-y-offset: var(--gd-button-dropShadow, 0 1px 1px 0);
+$button-negative-box-shadow-focus-y-offset: var(--gd-button-dropShadow, 0 1px 1px 0);
+$button-action-box-shadow-focus-y-offset: var(--gd-button-dropShadow, 0 1px 1px 0);


### PR DESCRIPTION
Fix button dropShadow and textCapitalization css variables to match MD theme object ones
---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
