### PR TITLE
RELATED: RAIL-1815 Add hooks alternative for public HOCs

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/RAIL-2317_2020-10-20-10-06.json
+++ b/common/changes/@gooddata/sdk-ui-all/RAIL-2317_2020-10-20-10-06.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Added hooks alternative for Execute component - useCancelablePromise, useDataView, useExecution and useDataExport",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "matyas.kandl@gooddata.com"
+}

--- a/examples/sdk-examples/src/examples/execution/UseDataViewAttributeValuesExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewAttributeValuesExample.tsx
@@ -1,0 +1,65 @@
+// (C) 2007-2019 GoodData Corporation
+import React from "react";
+import { LoadingComponent, ErrorComponent, useDataView } from "@gooddata/sdk-ui";
+import toPairs from "lodash/toPairs";
+import groupBy from "lodash/groupBy";
+
+import { workspace } from "../../constants/fixtures";
+import { Ldm } from "../../ldm";
+import { useBackend } from "../../context/auth";
+
+const getAttributeHeaderItemName = (x: any) => x.attributeHeaderItem.name;
+const withIndex = (fn: any) => {
+    let index = 0;
+    return (...args: any) => fn(index++, ...args);
+};
+
+export const UseDataViewAttributeValuesExample: React.FC = () => {
+    const backend = useBackend();
+    const execution = backend
+        .workspace(workspace)
+        .execution()
+        .forItems([Ldm.LocationState, Ldm.LocationName.Default]);
+    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+
+    let renderAttributeValues: React.ReactNode = null;
+    if (result) {
+        const [[locationStateHeaders, locationNameHeaders]] = result?.dataView.headerItems;
+        const locationStates = locationStateHeaders.map(getAttributeHeaderItemName);
+        const locations = locationNameHeaders.map(getAttributeHeaderItemName);
+        const locationsByState = groupBy(
+            locations,
+            withIndex((index: number) => locationStates[index]),
+        );
+        const locationStateLocationsPairs = toPairs(locationsByState);
+        renderAttributeValues = (
+            <div>
+                <ul className="attribute-values s-execute-attribute-values">
+                    {locationStateLocationsPairs.map(([locationState, _locations]) => (
+                        <li key={locationState}>
+                            <strong>{locationState}</strong>
+                            <ul>
+                                {_locations.map((location) => (
+                                    <li key={location}>{location}</li>
+                                ))}
+                            </ul>
+                        </li>
+                    ))}
+                </ul>
+            </div>
+        );
+    }
+
+    return (
+        <div>
+            {status === "error" && (
+                <ErrorComponent
+                    message="There was an error getting your execution"
+                    description={JSON.stringify(error, null, "  ")}
+                />
+            )}
+            {status === "loading" && <LoadingComponent />}
+            {status === "success" && renderAttributeValues}
+        </div>
+    );
+};

--- a/examples/sdk-examples/src/examples/execution/UseDataViewWithCustomVisualizationExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewWithCustomVisualizationExample.tsx
@@ -1,0 +1,58 @@
+// (C) 2007-2019 GoodData Corporation
+import React from "react";
+import { LoadingComponent, ErrorComponent, useExecution, useDataView } from "@gooddata/sdk-ui";
+import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Legend, Bar } from "recharts";
+
+import * as LdmExt from "../../ldm/ext";
+
+const seriesBy = [
+    LdmExt.FranchiseFeesAdRoyalty,
+    LdmExt.FranchiseFeesInitialFranchiseFee,
+    LdmExt.FranchiseFeesOngoingRoyalty,
+];
+
+const slicesBy = [LdmExt.monthDate];
+
+const colors = ["rgb(20,178,226)", "rgb(0,193,141)", "rgb(229,77,66)"];
+
+export const UseDataViewWithCustomVisualizationExample: React.FC = () => {
+    const execution = useExecution({
+        seriesBy,
+        slicesBy,
+    });
+    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+    const series = result?.data().series().toArray();
+    const slices = result?.data().slices().toArray();
+
+    const bars = series?.map((value, index) => {
+        return <Bar key={value.id} dataKey={value.id} name={value.measureTitle()} fill={colors[index]} />;
+    });
+
+    const data = slices?.map((slice) => ({
+        label: slice.sliceTitles()[0],
+        ...slice.dataPoints().map((p) => p.rawValue),
+    }));
+
+    return (
+        <>
+            {status === "loading" && <LoadingComponent />}
+            {status === "error" && (
+                <ErrorComponent
+                    message="There was an error getting your execution"
+                    description={JSON.stringify(error, null, 2)}
+                />
+            )}
+            {status === "success" && (
+                <ResponsiveContainer width="100%" height={300}>
+                    <BarChart data={data}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="label" />
+                        <YAxis domain={[0, (dataMax) => dataMax * 1.1]} />
+                        <Legend />
+                        {bars}
+                    </BarChart>
+                </ResponsiveContainer>
+            )}
+        </>
+    );
+};

--- a/examples/sdk-examples/src/examples/execution/UseDataViewWithSlicesExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewWithSlicesExample.tsx
@@ -1,0 +1,69 @@
+// (C) 2007-2019 GoodData Corporation
+import React from "react";
+import { ErrorComponent, LoadingComponent, useDataView, useExecution } from "@gooddata/sdk-ui";
+import { Ldm } from "../../ldm";
+import { newAttributeSort, newPositiveAttributeFilter } from "@gooddata/sdk-model";
+const style = { border: "1px black solid" };
+
+const seriesBy = [Ldm.$TotalSales, Ldm.$FranchisedSales];
+const slicesBy = [Ldm.LocationState, Ldm.LocationCity];
+const sortBy = [newAttributeSort(Ldm.LocationState, "asc")];
+const filters = [newPositiveAttributeFilter(Ldm.LocationState, ["Florida", "Texas"])];
+
+export const UseDataViewWithSlicesExample: React.FC = () => {
+    const execution = useExecution({
+        seriesBy,
+        slicesBy,
+        sortBy,
+        filters,
+    });
+    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+    const slices = result?.data().slices().toArray();
+
+    return (
+        <div>
+            {status === "error" && (
+                <div>
+                    <ErrorComponent
+                        message="There was an error getting your execution"
+                        description={JSON.stringify(error, null, 2)}
+                    />
+                </div>
+            )}
+            {status === "loading" && (
+                <div>
+                    <div className="gd-message progress">
+                        <div className="gd-message-text">Loading…</div>
+                    </div>
+                    <LoadingComponent />
+                </div>
+            )}
+            {status === "success" && (
+                <table style={style}>
+                    <tbody>
+                        <tr style={style}>
+                            <th>State</th>
+                            <th>City</th>
+                            <th>Total Sales</th>
+                            <th>Total Franchised Cost</th>
+                        </tr>
+                        {slices?.map((slice) => {
+                            const sliceTitles = slice.sliceTitles();
+                            const sales = slice.dataPoints()[0];
+                            const franchisedSales = slice.dataPoints()[1];
+
+                            return (
+                                <tr key={slice.id} style={style}>
+                                    <td style={style}>{sliceTitles[0]}</td>
+                                    <td style={style}>{sliceTitles[1]}</td>
+                                    <td style={style}>{sales.formattedValue()}</td>
+                                    <td style={style}>{franchisedSales.formattedValue()}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            )}
+        </div>
+    );
+};

--- a/examples/sdk-examples/src/examples/execution/index.tsx
+++ b/examples/sdk-examples/src/examples/execution/index.tsx
@@ -6,17 +6,29 @@ import { ExecuteExample } from "./ExecuteExample";
 import { ExecuteWithSlicesExample } from "./ExecuteWithSlicesExample";
 import { ExecuteAttributeValuesExample } from "./ExecuteAttributeValuesExample";
 import { ExecuteWithCustomVisualizationExample } from "./ExecuteWithCustomVisualizationExample";
+import { UseDataViewExample } from "./UseDataViewExample";
+import { UseDataViewWithSlicesExample } from "./UseDataViewWithSlicesExample";
+import { UseDataViewAttributeValuesExample } from "./UseDataViewAttributeValuesExample";
+import { UseDataViewWithCustomVisualizationExample } from "./UseDataViewWithCustomVisualizationExample";
 import { ExampleWithSource } from "../../components/ExampleWithSource";
 
 import ExecuteExampleSRC from "!raw-loader!./ExecuteExample";
 import ExecuteWithSlicesExampleSRC from "!raw-loader!./ExecuteWithSlicesExample";
 import ExecuteAttributeValuesExampleSRC from "!raw-loader!./ExecuteAttributeValuesExample";
 import ExecuteWithCustomVisualizationExampleSRC from "!raw-loader!./ExecuteWithCustomVisualizationExample";
+import UseDataViewExampleSRC from "!raw-loader!./UseDataViewExample";
+import UseDataViewWithSlicesExampleSRC from "!raw-loader!./UseDataViewWithSlicesExample";
+import UseDataViewAttributeValuesExampleSRC from "!raw-loader!./UseDataViewAttributeValuesExample";
+import UseDataViewWithCustomVisualizationExampleSRC from "!raw-loader!./UseDataViewWithCustomVisualizationExample";
 
 import ExecuteExampleSRCJS from "!raw-loader!../../../examplesJS/execution/ExecuteExample";
 import ExecuteWithSlicesExampleSRCJS from "!raw-loader!../../../examplesJS/execution/ExecuteWithSlicesExample";
 import ExecuteAttributeValuesExampleSRCJS from "!raw-loader!../../../examplesJS/execution/ExecuteAttributeValuesExample";
 import ExecuteWithCustomVisualizationExampleSRCJS from "!raw-loader!../../../examplesJS/execution/ExecuteWithCustomVisualizationExample";
+import UseDataViewExampleSRCJS from "!raw-loader!../../../examplesJS/execution/UseDataViewExample";
+import UseDataViewWithSlicesExampleSRCJS from "!raw-loader!../../../examplesJS/execution/UseDataViewWithSlicesExample";
+import UseDataViewAttributeValuesExampleSRCJS from "!raw-loader!../../../examplesJS/execution/UseDataViewAttributeValuesExample";
+import UseDataViewWithCustomVisualizationExampleSRCJS from "!raw-loader!../../../examplesJS/execution/UseDataViewWithCustomVisualizationExample";
 
 export const Execute: React.FC = () => (
     <div>
@@ -77,6 +89,64 @@ export const Execute: React.FC = () => (
             for={ExecuteAttributeValuesExample}
             source={ExecuteAttributeValuesExampleSRC}
             sourceJS={ExecuteAttributeValuesExampleSRCJS}
+        />
+
+        <h1>useExecution &amp; useDataView</h1>
+
+        <p>
+            useExecution &amp; useDataView hooks are an alternative to Execute &amp; RawExecute components.
+            The advantage of the hooks over these components is that they do not depend on rendering, and it
+            {"'"}s easy to compose them. They are useful for dealing with more complex use cases and data
+            flows (for example, to prevent nested Execute components when one execution depends on another).
+        </p>
+
+        <hr className="separator" />
+
+        <p>
+            This example of useExecution &amp; useDataView hooks shows how to obtain a single formatted value
+            and use it as a custom-made KPI.
+        </p>
+
+        <ExampleWithSource
+            for={UseDataViewExample}
+            source={UseDataViewExampleSRC}
+            sourceJS={UseDataViewExampleSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <p>
+            This example of useExecution &amp; useDataView hooks shows how to obtain and work with data series
+            sliced by multiple attributes.
+        </p>
+
+        <ExampleWithSource
+            for={UseDataViewWithSlicesExample}
+            source={UseDataViewWithSlicesExampleSRC}
+            sourceJS={UseDataViewWithSlicesExampleSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <p>
+            This example of useExecution &amp; useDataView hooks shows how to obtain data and use them in a
+            custom visualization.
+        </p>
+
+        <ExampleWithSource
+            for={UseDataViewWithCustomVisualizationExample}
+            source={UseDataViewWithCustomVisualizationExampleSRC}
+            sourceJS={UseDataViewWithCustomVisualizationExampleSRCJS}
+        />
+
+        <p>RawExecute component replaced by useDataView hook example</p>
+
+        <hr className="separator" />
+
+        <ExampleWithSource
+            for={UseDataViewAttributeValuesExample}
+            source={UseDataViewAttributeValuesExampleSRC}
+            sourceJS={UseDataViewAttributeValuesExampleSRCJS}
         />
     </div>
 );

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -56,6 +56,12 @@ export { ErrorComponent, IErrorProps } from "./react/ErrorComponent";
 export { BackendProvider, useBackend, withBackend } from "./react/BackendContext";
 export { WorkspaceProvider, useWorkspace, withWorkspace } from "./react/WorkspaceContext";
 export { usePagedResource } from "./react/usePagedResource";
+export {
+    UseCancelablePromiseStatus,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+} from "./react/useCancelablePromise";
 export { withContexts } from "./react/withContexts";
 export { wrapDisplayName } from "./react/wrapDisplayName";
 export { CancelError, ICancelablePromise, makeCancelable, isCancelError } from "./react/CancelablePromise";

--- a/libs/sdk-ui/src/base/react/CancelablePromise.ts
+++ b/libs/sdk-ui/src/base/react/CancelablePromise.ts
@@ -8,6 +8,7 @@ export interface ICancelablePromise<T> {
     promise: Promise<T>;
     cancel: (reason?: string) => void;
     getHasFulfilled: () => boolean;
+    getHasCanceled: () => boolean;
 }
 
 /**
@@ -86,6 +87,7 @@ export function makeCancelable<T>(promise: Promise<T>): ICancelablePromise<T> {
             hasCanceled = true;
             cancelReason = reason;
         },
+        getHasCanceled: () => hasCanceled,
         getHasFulfilled: () => hasFulfilled,
     };
 }

--- a/libs/sdk-ui/src/base/react/useCancelablePromise.ts
+++ b/libs/sdk-ui/src/base/react/useCancelablePromise.ts
@@ -1,0 +1,188 @@
+// (C) 2019-2020 GoodData Corporation
+import { DependencyList, useEffect, useState } from "react";
+import { makeCancelable } from "./CancelablePromise";
+import noop from "lodash/noop";
+
+/**
+ * Indicates the current state of the promise inside useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseStatus = "success" | "error" | "loading" | "pending";
+
+/**
+ * Indicates pending state for useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromisePendingState = {
+    result: undefined;
+    error: undefined;
+    status: "pending";
+};
+
+/**
+ * Indicates loading state for useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseLoadingState = {
+    result: undefined;
+    error: undefined;
+    status: "loading";
+};
+
+/**
+ * Indicates error state for useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseErrorState<TError> = {
+    result: undefined;
+    error: TError;
+    status: "error";
+};
+
+/**
+ * Indicates success state for useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseSuccessState<TResult> = {
+    result: TResult;
+    error: undefined;
+    status: "success";
+};
+
+/**
+ * Indicates the current state of useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseState<TResult, TError> =
+    | UseCancelablePromisePendingState
+    | UseCancelablePromiseLoadingState
+    | UseCancelablePromiseErrorState<TError>
+    | UseCancelablePromiseSuccessState<TResult>;
+
+/**
+ * Callbacks for useCancelablePromise hook
+ * @beta
+ */
+export type UseCancelablePromiseCallbacks<TResult, TError> = {
+    /**
+     * onLoading is fired whenever the promise loading starts
+     */
+    onLoading?: () => void;
+    /**
+     * onPending is fired whenever the promise is not provided
+     */
+    onPending?: () => void;
+    /**
+     * onCancel is fired whenever the dependency list changes before the promise resolution
+     */
+    onCancel?: () => void;
+    /**
+     * onPending is fired whenever the promise is fulfilled
+     */
+    onSuccess?: (result: TResult) => void;
+    /**
+     * onError is fired whenever the promise is rejected
+     */
+    onError?: (err: TError) => void;
+};
+
+/**
+ * This hook provides easy way to work with Promise.
+ * You can:
+ * - watch it's status (pending/loading/success/error)
+ * - get it's result/error when the Promise is resolved/rejected,
+ * - attach convenient callbacks to it
+ * - be sure, that when the dependency list changes, result will be still relevant (if previous Promise is still running, it's "canceled").
+ *
+ * @beta
+ */
+export function useCancelablePromise<TResult, TError = any>(
+    {
+        promise,
+        onLoading = noop,
+        onPending = noop,
+        onCancel = noop,
+        onSuccess = noop,
+        onError = noop,
+    }: {
+        promise: (() => Promise<TResult>) | undefined | null;
+    } & UseCancelablePromiseCallbacks<TResult, TError>,
+    deps: DependencyList = [],
+): UseCancelablePromiseState<TResult, TError> {
+    const getInitialState = (): UseCancelablePromiseState<TResult, TError> => ({
+        result: undefined,
+        error: undefined,
+        status: promise ? "loading" : "pending",
+    });
+    const [state, setState] = useState(getInitialState());
+
+    // We want to avoid the return of the old state when some dependency has changed,
+    // before another useEffect hook round starts.
+    const [prevDeps, setDeps] = useState<DependencyList>(deps);
+    if (deps.some((dep, i) => dep !== prevDeps[i])) {
+        setDeps(deps);
+        const currentState = getInitialState();
+        setState(currentState);
+        return currentState;
+    }
+
+    useEffect(() => {
+        if (!promise) {
+            setState({
+                status: "pending",
+                result: undefined,
+                error: undefined,
+            });
+            onPending();
+            return;
+        } else {
+            setState({
+                status: "loading",
+                result: undefined,
+                error: undefined,
+            });
+            onLoading();
+        }
+
+        const cancelablePromise = makeCancelable(promise());
+
+        cancelablePromise.promise
+            .then((result) => {
+                // Because promises have their own lifecycle independent on react lifecycle,
+                // we need to check if cancelable promise was not canceled before it's resolution
+                // and our results are still relevant.
+                if (!cancelablePromise.getHasCanceled()) {
+                    setState({
+                        status: "success",
+                        result,
+                        error: undefined,
+                    });
+                    onSuccess(result);
+                }
+            })
+            .catch((error) => {
+                // Because promises have their own lifecycle independent on react lifecycle,
+                // we need to check if cancelable promise was not canceled before it's resolution
+                // and our results are still relevant.
+                if (!cancelablePromise.getHasCanceled()) {
+                    setState({
+                        status: "error",
+                        result: undefined,
+                        error,
+                    });
+                    onError(error);
+                }
+            });
+
+        return () => {
+            // If promise was not fulfilled before dependencies change, cancel it.
+            // Important notice - request itself is not canceled - we just don't care about unrelevant results anymore.
+            if (!cancelablePromise.getHasFulfilled()) {
+                cancelablePromise.cancel();
+                onCancel();
+            }
+        };
+    }, deps);
+
+    return state;
+}

--- a/libs/sdk-ui/src/execution/createExecution.ts
+++ b/libs/sdk-ui/src/execution/createExecution.ts
@@ -1,0 +1,138 @@
+// (C) 2019-2020 GoodData Corporation
+import {
+    attributeLocalId,
+    DimensionItem,
+    IAttribute,
+    IAttributeOrMeasure,
+    IDimension,
+    INullableFilter,
+    isAttribute,
+    ISortItem,
+    ITotal,
+    MeasureGroupIdentifier,
+    newDimension,
+    newTwoDimensional,
+} from "@gooddata/sdk-model";
+import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import isEmpty from "lodash/isEmpty";
+import { InvariantError } from "ts-invariant";
+
+/**
+ * @internal
+ */
+type CreateExecutionOptions = {
+    /**
+     * Backend to execute against.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace in whose context to perform the execution.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+
+    /**
+     * Data series will be built using the provided measures that are optionally further scoped for
+     * elements of the specified attributes.
+     */
+    seriesBy: IAttributeOrMeasure[];
+
+    /**
+     * Optionally slice all data series by elements of these attributes.
+     */
+    slicesBy?: IAttribute[];
+
+    /**
+     * Optionally include these totals among the data slices.
+     */
+    totals?: ITotal[];
+
+    /**
+     * Optional filters to apply on server side.
+     */
+    filters?: INullableFilter[];
+
+    /**
+     * Optional sorting to apply on server side.
+     */
+    sortBy?: ISortItem[];
+
+    /**
+     * Optional informative name of the component. This value is sent as telemetry information together
+     * with the actual execution request. We recommend to set this because it can be useful for diagnostic
+     * purposes.
+     *
+     * Defaults 'Execute'.
+     */
+    componentName?: string;
+};
+
+/**
+ * When caller desires just data series and no slicing, create a single-dim result.
+ */
+function seriesOnlyDim(seriesBy: IAttributeOrMeasure[]): IDimension[] {
+    return [newDimension(seriesBy.filter(isAttribute).map(attributeLocalId).concat(MeasureGroupIdentifier))];
+}
+
+/**
+ * When caller desires data series to be sliced further by some attributes (and perhaps with totals as well)
+ * then create two-dim result resembling a pivot table:
+ *
+ * -  slices are in rows (first dim)
+ * -  measures & scoping attributes will be in columns (second dim)
+ */
+function seriesAndSlicesDim(
+    seriesBy: IAttributeOrMeasure[],
+    slices: IAttribute[],
+    totals: ITotal[],
+): IDimension[] {
+    const firstDimItems: DimensionItem[] = slices.map(attributeLocalId);
+    firstDimItems.push(...totals);
+
+    return newTwoDimensional(
+        firstDimItems,
+        seriesBy.filter(isAttribute).map(attributeLocalId).concat(MeasureGroupIdentifier),
+    );
+}
+
+/**
+ * Given execute props, this will prepare execution to send to backend.
+ *
+ * @param options - create execution options
+ * @internal
+ */
+export function createExecution(options: CreateExecutionOptions): IPreparedExecution {
+    const {
+        backend,
+        workspace,
+        seriesBy,
+        slicesBy = [],
+        filters = [],
+        sortBy = [],
+        totals = [],
+        componentName = "Execution",
+    } = options;
+    if (!backend || !workspace) {
+        throw new InvariantError(
+            "backend and workspace must be either specified explicitly or be provided by context",
+        );
+    }
+
+    const dimensions = isEmpty(slicesBy)
+        ? seriesOnlyDim(seriesBy)
+        : seriesAndSlicesDim(seriesBy, slicesBy, totals);
+
+    return backend
+        .withTelemetry(componentName, options)
+        .workspace(workspace)
+        .execution()
+        .forItems(seriesBy.concat(slicesBy), filters)
+        .withSorting(...sortBy)
+        .withDimensions(...dimensions);
+}

--- a/libs/sdk-ui/src/execution/index.ts
+++ b/libs/sdk-ui/src/execution/index.ts
@@ -10,3 +10,6 @@ export {
 } from "./withExecutionLoading";
 export { RawExecute, IRawExecuteProps } from "./RawExecute";
 export { Execute, IExecuteProps } from "./Execute";
+export { useDataExport } from "./useDataExport";
+export { useDataView } from "./useDataView";
+export { useExecution } from "./useExecution";

--- a/libs/sdk-ui/src/execution/tests/Execute.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/Execute.test.tsx
@@ -5,9 +5,10 @@ import { dummyBackend, dummyBackendEmptyData } from "@gooddata/sdk-backend-mocki
 import { createDummyPromise } from "../../base/react/tests/toolkit";
 import { DataViewFacade } from "../../base/results/facade";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
-import { createExecution, Execute, IExecuteProps } from "../Execute";
+import { Execute, IExecuteProps } from "../Execute";
 import { ReferenceLdm } from "@gooddata/reference-workspace";
 import { newAttributeSort, newPositiveAttributeFilter, newTotal } from "@gooddata/sdk-model";
+import { createExecution } from "../createExecution";
 
 const DummyBackendEmptyData = dummyBackendEmptyData();
 const makeChild = () => jest.fn((_) => <div />);

--- a/libs/sdk-ui/src/execution/useDataExport.ts
+++ b/libs/sdk-ui/src/execution/useDataExport.ts
@@ -1,0 +1,66 @@
+// (C) 2019-2020 GoodData Corporation
+import { DependencyList } from "react";
+import { IExportConfig, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+} from "../base";
+
+/**
+ * Indicates current state of useDataExport hook
+ * @beta
+ */
+export type UseDataExportState = UseCancelablePromiseState<string, GoodDataSdkError>;
+
+/**
+ * Callbacks for useDataExport hook
+ * @beta
+ */
+export type UseDataExportCallbacks = UseCancelablePromiseCallbacks<string, GoodDataSdkError>;
+
+/**
+ * This hook provides easy way to export data in your prefered format (csv/xlsx/raw) for the provided {@link IPreparedExecution}.
+ * As a result, you will receive a string with uri, so you can easily create a download link.
+ * Be aware that execution is re-executed only on dependency list change, not on execution/exportConfig/callbacks change.
+ *
+ * @beta
+ */
+export function useDataExport(
+    {
+        execution,
+        exportConfig = {},
+        onCancel,
+        onError,
+        onLoading,
+        onPending,
+        onSuccess,
+    }: {
+        execution: IPreparedExecution | undefined | null;
+        exportConfig?: IExportConfig;
+    } & UseDataExportCallbacks,
+    deps?: DependencyList,
+): UseDataExportState {
+    const cancelablePromiseState = useCancelablePromise<string, GoodDataSdkError>(
+        {
+            promise: execution
+                ? () =>
+                      execution
+                          .execute()
+                          .then((executionResult) => executionResult.export(exportConfig))
+                          .then((exportResult) => {
+                              return exportResult.uri;
+                          })
+                : null,
+            onCancel,
+            onError,
+            onLoading,
+            onPending,
+            onSuccess,
+        },
+        deps,
+    );
+
+    return cancelablePromiseState;
+}

--- a/libs/sdk-ui/src/execution/useDataView.ts
+++ b/libs/sdk-ui/src/execution/useDataView.ts
@@ -1,0 +1,72 @@
+// (C) 2019-2020 GoodData Corporation
+import { DependencyList } from "react";
+import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { DataViewWindow } from "./withExecutionLoading";
+import {
+    DataViewFacade,
+    GoodDataSdkError,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+} from "../base";
+
+/**
+ * Indicates current state of useDataView hook
+ * @beta
+ */
+export type UseDataViewState = UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+
+/**
+ * Callbacks for useDataView hook
+ * @beta
+ */
+export type UseDataViewCallbacks = UseCancelablePromiseCallbacks<DataViewFacade, GoodDataSdkError>;
+
+/**
+ * This hook provides easy way to get data for the provided {@link IPreparedExecution}.
+ * You can use it to create custom visualizations on top of GoodData platform.
+ * Be aware that execution is re-executed only on dependency list change, not on execution/window/callbacks change.
+ *
+ * @beta
+ */
+export function useDataView(
+    {
+        execution,
+        window,
+        onCancel,
+        onError,
+        onLoading,
+        onPending,
+        onSuccess,
+    }: {
+        execution: IPreparedExecution | undefined | null;
+        window?: DataViewWindow;
+    } & UseDataViewCallbacks,
+    deps?: DependencyList,
+): UseDataViewState {
+    const cancelablePromiseState = useCancelablePromise<DataViewFacade, GoodDataSdkError>(
+        {
+            promise: execution
+                ? () =>
+                      execution
+                          .execute()
+                          .then((executionResult) =>
+                              window
+                                  ? executionResult.readWindow(window.offset, window.size)
+                                  : executionResult.readAll(),
+                          )
+                          .then((dataView) => {
+                              return DataViewFacade.for(dataView);
+                          })
+                : null,
+            onCancel,
+            onError,
+            onLoading,
+            onPending,
+            onSuccess,
+        },
+        deps,
+    );
+
+    return cancelablePromiseState;
+}

--- a/libs/sdk-ui/src/execution/useExecution.ts
+++ b/libs/sdk-ui/src/execution/useExecution.ts
@@ -1,0 +1,53 @@
+// (C) 2019-2020 GoodData Corporation
+import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { IAttributeOrMeasure, IAttribute, ITotal, INullableFilter, ISortItem } from "@gooddata/sdk-model";
+import { useBackend, useWorkspace } from "../base";
+import { createExecution } from "./createExecution";
+
+/**
+ * This hook provides a simplified interface for creating executions.
+ * It builds the execution on top of the backend passed to the BackendProvider, and workspace passed to the WorkspaceProvider.
+ *
+ * @beta
+ */
+export function useExecution(options: {
+    /**
+     * Data series will be built using the provided measures that are optionally further scoped for
+     * elements of the specified attributes.
+     */
+    seriesBy: IAttributeOrMeasure[];
+
+    /**
+     * Optionally slice all data series by elements of these attributes.
+     */
+    slicesBy?: IAttribute[];
+
+    /**
+     * Optionally include these totals among the data slices.
+     */
+    totals?: ITotal[];
+
+    /**
+     * Optional filters to apply on server side.
+     */
+    filters?: INullableFilter[];
+
+    /**
+     * Optional sorting to apply on server side.
+     */
+    sortBy?: ISortItem[];
+
+    /**
+     * Optional informative name of the component. This value is sent as telemetry information together
+     * with the actual execution request. We recommend to set this because it can be useful for diagnostic
+     * purposes.
+     *
+     * Defaults 'Execute'.
+     */
+    componentName?: string;
+}): IPreparedExecution {
+    const backend = useBackend();
+    const workspace = useWorkspace();
+    const execution = createExecution({ backend, workspace, ...options });
+    return execution;
+}


### PR DESCRIPTION
Goal of this PR is to provide hooks alternative for our public HOCs, which should be easier to understand and compose.

- added useCancelablePromise hook (solves Promise race conditions in useEffect and provides convenient callbacks)
- added useExecution hook to simplify execution creation and backend/workspace injecting
- added useDataView hook to make custom visualisations creation easier
- added useDataExport hook to make data export easier

Mapping for HOCs & hooks is not 1:1, because I wanted to make usage for users easier.

JIRA: RAIL-2317
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
