### PR TITLE
RELATED: ONE-4642 Adds another dimmed primary color

### DIFF
--- a/libs/sdk-ui-theme-provider/src/cssProperties.ts
+++ b/libs/sdk-ui-theme-provider/src/cssProperties.ts
@@ -84,6 +84,7 @@ const getCssProperty = (key: string, value: string): CssProperty => ({
 
 const getCommonDerivedColors = (palette: IThemePalette): CssProperty[] => [
     getCssProperty("palette-primary-dimmed", mix(0.1, palette.primary.base, GD_COLOR_TEXT_LIGHT)),
+    getCssProperty("palette-primary-dimmed50", mix(0.5, palette.primary.base, GD_COLOR_TEXT_LIGHT)),
     getCssProperty("palette-primary-lightest", setLightness(0.96, palette.primary.base)),
 ];
 


### PR DESCRIPTION
JIRA: ONE-4642

Added forgotten derivation of primary color used in AD

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
