### PR TITLE
RELATED: ONE-4693 Add the missing condition when autoresizedColumns do not exist

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -771,7 +771,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
          * Ensures correct autoResizeColumns
          */
         this.updateAutoResizedColumns(gridApi, columnApi);
-        autoresizeAllColumns(this.columnApi!, this.autoResizedColumns);
+        autoresizeAllColumns(columnApi, this.autoResizedColumns);
     };
 
     private shouldPerformAutoresize() {

--- a/libs/sdk-ui-pivot/src/impl/agGridColumnSizing.ts
+++ b/libs/sdk-ui-pivot/src/impl/agGridColumnSizing.ts
@@ -878,7 +878,7 @@ export const autoresizeAllColumns = (
         columns.forEach((column: Column) => {
             const columnDef = column.getColDef();
             const autoResizedColumn = autoResizedColumns[getColumnIdentifier(columnDef)];
-            if (columnDef.field && columnDef.width !== undefined && autoResizedColumn.width) {
+            if (columnDef.field && autoResizedColumn && autoResizedColumn.width) {
                 columnApi.setColumnWidth(columnDef.field, autoResizedColumn.width);
             }
         });
@@ -924,7 +924,6 @@ export const getAutoResizedColumns = (
             separators: options.separators,
             cache: new Map(),
         });
-
         updatedColumDefs.forEach((columnDef: ColDef) => {
             if (columnDef.field && columnDef.width !== undefined) {
                 autoResizedColumns[getColumnIdentifier(columnDef)] = {


### PR DESCRIPTION
BUGFIX: ONE-4693

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
