### PR TITLE
RELATED: RAIL-1815 fix release scripts

### DIFF
--- a/common/scripts/ci/run_major_release.sh
+++ b/common/scripts/ci/run_major_release.sh
@@ -28,7 +28,7 @@ fi
 
 
 ${_RUSH} install
-${_RUSH} build
+${_RUSH} build-all
 
 # First bump to the next major
 ${_RUSH} version --bump --override-bump major

--- a/common/scripts/ci/run_minor_release.sh
+++ b/common/scripts/ci/run_minor_release.sh
@@ -28,7 +28,7 @@ fi
 
 
 ${_RUSH} install
-${_RUSH} build
+${_RUSH} build-all
 
 #
 # First bump to the next minor

--- a/common/scripts/ci/run_prerelease.sh
+++ b/common/scripts/ci/run_prerelease.sh
@@ -33,7 +33,7 @@ fi
 
 
 ${_RUSH} install
-${_RUSH} build
+${_RUSH} build-all
 
 ${_RUSH} version --bump --override-bump prerelease
 bump_rc=$?

--- a/common/scripts/ci/run_prerelease_fix.sh
+++ b/common/scripts/ci/run_prerelease_fix.sh
@@ -17,7 +17,7 @@ _RUSH="${DIR}/docker_rush.sh"
 source ${DIR}/utils.sh
 
 ${_RUSH} install
-${_RUSH} build
+${_RUSH} build-all
 
 export TAG_NPM="hotfix"
 ${DIR}/do_publish.sh

--- a/common/scripts/ci/run_prerelease_switch.sh
+++ b/common/scripts/ci/run_prerelease_switch.sh
@@ -38,7 +38,7 @@ fi
 
 
 ${_RUSH} install
-${_RUSH} build
+${_RUSH} build-all
 
 ${_RUSH} version --bump --override-bump prerelease --override-prerelease-id ${PRERELEASE_ID}
 bump_rc=$?

--- a/common/scripts/ci/run_release_examples.sh
+++ b/common/scripts/ci/run_release_examples.sh
@@ -22,7 +22,7 @@ export EXAMPLES_BUILD_TYPE=${EXAMPLES_BUILD_TYPE:-"public"}
 export EXAMPLE_MAPBOX_ACCESS_TOKEN=${MAPBOX_TOKEN}
 
 $_RUSH install
-$_RUSH build -t @gooddata/sdk-examples
+$_RUSH build-all -t @gooddata/sdk-examples
 
 #
 # Create ${PUBLIC_APP_NAME} application


### PR DESCRIPTION
They need to run build-all to include both esm and cjs versions.

JIRA: RAIL-1815

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
