### PR TITLE
RELATED: SD-1187 - Should not set the minRange for X-Axis when the data categories less than 2.

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -1106,7 +1106,10 @@ function getAxesConfiguration(chartOptions: IChartOptions, _config: any, chartCo
 
             const tickConfiguration = getXAxisTickConfiguration(chartOptions);
             // for minimum zoom level value
-            const minRange = get(chartConfig, "zoomInsight", false) ? MIN_RANGE : undefined;
+            const minRange =
+                get(chartConfig, "zoomInsight", false) && get(chartOptions, "data.categories", []).length > 2
+                    ? MIN_RANGE
+                    : undefined;
 
             // for bar chart take y axis options
             return {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
@@ -201,10 +201,14 @@ describe("getCustomizedConfiguration", () => {
             expect(result.chart).toEqual(undefined);
         });
 
-        it("should set chart and X axis configurations when the zooming is enabled", () => {
+        it("should set chart and X axis configurations with the minRange = 2 when the zooming is enabled and the categories are larger than 2", () => {
             const result = getCustomizedConfiguration(
                 {
                     ...chartOptions,
+                    data: {
+                        ...chartOptions.data,
+                        categories: ["column 1", "column 2", "column 3"],
+                    },
                 },
                 {
                     zoomInsight: true,
@@ -213,6 +217,40 @@ describe("getCustomizedConfiguration", () => {
             const expectedResult = {
                 ...result.xAxis[0],
                 minRange: 2,
+            };
+            const chartResult = {
+                ...result.chart,
+                animation: true,
+                zoomType: "x",
+                panKey: "shift",
+                panning: true,
+                resetZoomButton: {
+                    theme: {
+                        display: "none",
+                    },
+                },
+            };
+
+            expect(result.xAxis[0]).toEqual(expectedResult);
+            expect(result.chart).toEqual(chartResult);
+        });
+
+        it("should set chart and X axis configurations with the minRange is default value (undefined) when the zooming is enabled and the categories <= 2", () => {
+            const result = getCustomizedConfiguration(
+                {
+                    ...chartOptions,
+                    data: {
+                        ...chartOptions.data,
+                        categories: ["column 1", "column 2"],
+                    },
+                },
+                {
+                    zoomInsight: true,
+                },
+            );
+            const expectedResult = {
+                ...result.xAxis[0],
+                minRange: undefined,
             };
             const chartResult = {
                 ...result.chart,


### PR DESCRIPTION
Improve the zoom level logic:
_ Should not set the minRange for X-Axis when the data categories less than 2.
JIRA: SD-1187

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
