### PR TITLE
RELATED: RAIL-2754, RAIL-2761 add hooks for getting dashboard and dashboard alerts

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1520,6 +1520,7 @@ export interface IWorkspaceDashboardsService {
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
     getDashboard(ref: ObjRef, filterContextRef?: ObjRef): Promise<IDashboard>;
     getDashboards(): Promise<IListedDashboard[]>;
+    getDashboardWidgetAlertsForCurrentUser(ref: ObjRef): Promise<IWidgetAlert[]>;
     getScheduledMailsCountForDashboard(ref: ObjRef): Promise<number>;
     getWidgetAlertsCountForWidgets(refs: ObjRef[]): Promise<IWidgetAlertCount[]>;
     getWidgetReferencedObjects(widget: IWidget, types?: SupportedWidgetReferenceTypes[]): Promise<IWidgetReferences>;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/index.ts
@@ -84,7 +84,7 @@ export interface IWorkspaceDashboardsService {
      * Get the number of scheduled emails for particular dashboard
      *
      * @param ref - dashboard reference
-     * @returns promise with the number of scheduled emails connected to the dashborad
+     * @returns promise with the number of scheduled emails connected to the dashboard
      */
     getScheduledMailsCountForDashboard(ref: ObjRef): Promise<number>;
 
@@ -94,6 +94,14 @@ export interface IWorkspaceDashboardsService {
      * @returns promise with all user widget alerts
      */
     getAllWidgetAlertsForCurrentUser(): Promise<IWidgetAlert[]>;
+
+    /**
+     * Get all widget alerts for the current user for the given dashboard
+     *
+     * @param ref - dashboard reference
+     * @returns promise with all user widget alerts for the dashboard
+     */
+    getDashboardWidgetAlertsForCurrentUser(ref: ObjRef): Promise<IWidgetAlert[]>;
 
     /**
      * Get the number of widget alerts (created by any user) for particular widgets

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -58,6 +58,10 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
         throw new NotSupported("Not supported");
     };
 
+    public getDashboardWidgetAlertsForCurrentUser = async () => {
+        throw new NotSupported("Not supported");
+    };
+
     public getWidgetAlertsCountForWidgets = async () => {
         throw new NotSupported("Not supported");
     };

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -73,6 +73,7 @@
         "lru-cache": "^4.1.5",
         "react-intl": "^3.6.0",
         "react-measure": "^2.3.0",
+        "ts-invariant": "^0.4.4",
         "tslib": "^2.0.0",
         "uuid": "^3.3.3"
     },

--- a/libs/sdk-ui-ext/src/dashboardEmbedding/index.ts
+++ b/libs/sdk-ui-ext/src/dashboardEmbedding/index.ts
@@ -1,0 +1,3 @@
+// (C) 2020 GoodData Corporation
+export { useDashboard, IUseDashboardConfig } from "./useDashboard";
+export { useDashboardAlerts, IUseDashboardAlertsConfig } from "./useDashboardAlerts";

--- a/libs/sdk-ui-ext/src/dashboardEmbedding/useDashboard.ts
+++ b/libs/sdk-ui-ext/src/dashboardEmbedding/useDashboard.ts
@@ -1,0 +1,77 @@
+// (C) 2020 GoodData Corporation
+import { IAnalyticalBackend, IDashboard } from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useBackend,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+    useWorkspace,
+} from "@gooddata/sdk-ui";
+import { ObjRef, objRefToString } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+
+/**
+ * @beta
+ */
+export interface IUseDashboardConfig extends UseCancelablePromiseCallbacks<IDashboard, GoodDataSdkError> {
+    /**
+     * Reference to the dashboard to get.
+     */
+    ref: ObjRef;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * Hook allowing to download dashboard data
+ * @param config - configuration of the hook
+ * @beta
+ */
+export function useDashboard({
+    ref,
+    backend,
+    onCancel,
+    onError,
+    onLoading,
+    onPending,
+    onSuccess,
+    workspace,
+}: IUseDashboardConfig): UseCancelablePromiseState<IDashboard, any> {
+    const backendFromContext = useBackend();
+    const workspaceFromContext = useWorkspace();
+
+    const effectiveBackend = backend ?? backendFromContext;
+    const effectiveWorkspace = workspace ?? workspaceFromContext;
+
+    invariant(
+        effectiveBackend,
+        "The backend in useLoadDashboard must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useLoadDashboard must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const promise = () => effectiveBackend.workspace(effectiveWorkspace).dashboards().getDashboard(ref);
+
+    return useCancelablePromise({ promise, onCancel, onError, onLoading, onPending, onSuccess }, [
+        effectiveWorkspace,
+        objRefToString(ref),
+    ]);
+}

--- a/libs/sdk-ui-ext/src/dashboardEmbedding/useDashboardAlerts.ts
+++ b/libs/sdk-ui-ext/src/dashboardEmbedding/useDashboardAlerts.ts
@@ -1,0 +1,82 @@
+// (C) 2020 GoodData Corporation
+import { IAnalyticalBackend, IWidgetAlert } from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useBackend,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+    useWorkspace,
+} from "@gooddata/sdk-ui";
+import { ObjRef, objRefToString } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+
+/**
+ * @beta
+ */
+export interface IUseDashboardAlertsConfig
+    extends UseCancelablePromiseCallbacks<IWidgetAlert[], GoodDataSdkError> {
+    /**
+     * Reference to the dashboard to get alerts for.
+     */
+    ref: ObjRef;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * Hook allowing to download dashboard alerts data for the current user
+ * @param config - configuration of the hook
+ * @beta
+ */
+export function useDashboardAlerts({
+    ref,
+    backend,
+    onCancel,
+    onError,
+    onLoading,
+    onPending,
+    onSuccess,
+    workspace,
+}: IUseDashboardAlertsConfig): UseCancelablePromiseState<IWidgetAlert[], GoodDataSdkError> {
+    const backendFromContext = useBackend();
+    const workspaceFromContext = useWorkspace();
+
+    const effectiveBackend = backend ?? backendFromContext;
+    const effectiveWorkspace = workspace ?? workspaceFromContext;
+
+    invariant(
+        effectiveBackend,
+        "The backend in useLoadDashboardAlerts must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useLoadDashboardAlerts must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const promise = () =>
+        effectiveBackend
+            .workspace(effectiveWorkspace)
+            .dashboards()
+            .getDashboardWidgetAlertsForCurrentUser(ref);
+
+    return useCancelablePromise({ promise, onCancel, onError, onLoading, onPending, onSuccess }, [
+        effectiveWorkspace,
+        objRefToString(ref),
+    ]);
+}

--- a/libs/sdk-ui-ext/src/index.ts
+++ b/libs/sdk-ui-ext/src/index.ts
@@ -1,3 +1,4 @@
 // (C) 2007-2020 GoodData Corporation
 
 export * from "./insightView";
+export * from "./dashboardEmbedding";


### PR DESCRIPTION
Also, a necessary backend endpoint was added to get alerts only relevant to a given dashboard for current user.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
