### PR TITLE
RELATED: ONE-4714, ONE-4715: AD/KD use normal font on `Header` and update DateRangePicker to use customize font

### DIFF
--- a/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
+++ b/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
@@ -161,7 +161,8 @@ $gd-day-picker-width: 268px;
             margin-left: 0.25em;
             margin-right: 0.25em;
             margin-bottom: 1em;
-            font-family: Avenir;
+            font-family: $gd-font-primary;
+            font-weight: 400;
             font-size: 17px;
             text-align: center;
             color: #000;
@@ -179,7 +180,7 @@ $gd-day-picker-width: 268px;
         .DayPicker-Weekday {
             display: table-cell;
             padding-bottom: 0.5em;
-            font-family: Avenir;
+            font-family: $gd-font-primary;
             font-weight: 400;
             font-size: 13px;
             text-align: center;
@@ -203,7 +204,7 @@ $gd-day-picker-width: 268px;
         .DayPicker-Day {
             display: table-cell;
             padding: 0.3125em 0.55em;
-            font-family: Avenir;
+            font-family: $gd-font-primary;
             font-size: 14px;
             font-weight: 700;
             text-align: center;

--- a/libs/sdk-ui-kit/styles/scss/header.scss
+++ b/libs/sdk-ui-kit/styles/scss/header.scss
@@ -19,6 +19,7 @@ $gd-header-project-width: 230px;
     padding: 0 0 0 20px;
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
     color: $gd-color-text-light;
+    font-family: $gd-font-primary-without-custom;
     background: #000;
 
     &.is-not-loaded {


### PR DESCRIPTION
AppHeader navigation won't use custom fonts
Update DateRangeFilter to use custom fonts
---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
