### PR TITLE
Handling missing workspace and be in ThemeProvider

### DIFF
--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
@@ -1,11 +1,10 @@
 // (C) 2020 GoodData Corporation
 import React, { useEffect, useState, useRef } from "react";
 import { useBackend, useWorkspace } from "@gooddata/sdk-ui";
-import { InvariantError } from "ts-invariant";
 import { ITheme } from "@gooddata/sdk-backend-spi";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
-import { setCssProperties } from "../cssProperties";
+import { clearCssProperties, setCssProperties } from "../cssProperties";
 import { ThemeContextProvider } from "./Context";
 
 /**
@@ -51,9 +50,9 @@ export const ThemeProvider: React.FC<IThemeProviderProps> = ({
     const workspace = workspaceParam || workspaceFromContext;
 
     if (!backend || !workspace) {
-        throw new InvariantError(
-            "backend and workspace must be either specified explicitly or be provided by context",
-        );
+        clearCssProperties();
+
+        return <>{children}</>;
     }
 
     const [theme, setTheme] = useState<ITheme>({});
@@ -65,6 +64,7 @@ export const ThemeProvider: React.FC<IThemeProviderProps> = ({
     useEffect(() => {
         const fetchData = async () => {
             setIsLoading(true);
+            clearCssProperties();
             const theme = await backend.workspace(workspace).styling().getTheme();
             if (lastWorkspace.current === workspace) {
                 setTheme(theme);

--- a/libs/sdk-ui-theme-provider/src/cssProperties.ts
+++ b/libs/sdk-ui-theme-provider/src/cssProperties.ts
@@ -145,7 +145,7 @@ const generateDerivedColors = (palette: IThemePalette): CssProperty[] =>
     ]) ||
     [];
 
-const clearCssProperties = () => {
+export const clearCssProperties = (): void => {
     const themePropertiesElement = document.getElementById("gdc-theme-properties");
     themePropertiesElement && document.head.removeChild(themePropertiesElement);
 
@@ -169,8 +169,6 @@ const clearCssProperties = () => {
  * @beta
  */
 export function setCssProperties(theme: ITheme): void {
-    clearCssProperties();
-
     const cssProperties = [
         ...parseThemeToCssProperties(theme, customParserFunctions),
         ...generateDerivedColors(theme.palette),

--- a/libs/sdk-ui-theme-provider/src/tests/cssProperties.test.ts
+++ b/libs/sdk-ui-theme-provider/src/tests/cssProperties.test.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 import { ITheme } from "@gooddata/sdk-backend-spi";
 
-import { parseThemeToCssProperties, ParserFunction } from "../cssProperties";
+import { parseThemeToCssProperties, ParserFunction, clearCssProperties } from "../cssProperties";
 
 describe("cssProperties", () => {
     describe("parseThemeToCssProperties", () => {
@@ -72,6 +72,28 @@ describe("cssProperties", () => {
                     value: "#14b2e2",
                 },
             ]);
+        });
+    });
+
+    describe("clearCssProperties", () => {
+        it("should remove properties and custom font style elements from head", () => {
+            const propertiesTagIdentifier = "gdc-theme-properties";
+            const propertiesTag = document.createElement("style");
+            propertiesTag.id = propertiesTagIdentifier;
+            document.head.appendChild(propertiesTag);
+
+            const customFontTagIdentifier = "gdc-theme-custom-font";
+            const customFontTag = document.createElement("style");
+            customFontTag.id = customFontTagIdentifier;
+            document.head.appendChild(customFontTag);
+
+            expect(document.getElementById(propertiesTagIdentifier)).not.toEqual(null);
+            expect(document.getElementById(customFontTagIdentifier)).not.toEqual(null);
+
+            clearCssProperties();
+
+            expect(document.getElementById(propertiesTagIdentifier)).toEqual(null);
+            expect(document.getElementById(customFontTagIdentifier)).toEqual(null);
         });
     });
 });


### PR DESCRIPTION
ThemeProvider renders the children component without invariant when workspace or backend is missing.

JIRA: ONE-4732

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
