### PR TITLE
RELATED: ONE-4647 Custom styles for Widget in KD

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1268,7 +1268,7 @@ export interface ITheme {
         navigation?: {
             backgroundColor?: ThemeColor;
             borderColor?: ThemeColor;
-            header?: {
+            title?: {
                 color?: ThemeColor;
             };
             item?: {

--- a/libs/sdk-backend-spi/src/workspace/styling/theme.ts
+++ b/libs/sdk-backend-spi/src/workspace/styling/theme.ts
@@ -411,7 +411,7 @@ export interface ITheme {
             /**
              * Navigation header specific properties
              */
-            header?: {
+            title?: {
                 /**
                  * Header foreground color
                  */

--- a/libs/sdk-ui-theme-provider/src/cssProperties.ts
+++ b/libs/sdk-ui-theme-provider/src/cssProperties.ts
@@ -5,7 +5,6 @@ import { IThemePalette, ITheme } from "@gooddata/sdk-backend-spi";
 
 // keep it in sync with SCSS:$gd-color-text-light
 const GD_COLOR_TEXT_LIGHT = "#fff";
-const GD_COLOR_STATE_BLANK = "#94a1ad";
 
 /**
  *
@@ -48,6 +47,15 @@ const customParserFunctions: ParserFunction[] = [
     { key: "--gd-button-borderRadius", fn: (value: string) => `${value}px` },
     { key: "--gd-button-textCapitalization", fn: (value: boolean) => (value ? "capitalize" : undefined) },
     { key: "--gd-button-dropShadow", fn: (value: boolean) => (value ? undefined : "none") },
+    {
+        key: "--gd-kpiDashboards-content-widget-borderWidth",
+        fn: (value: string) => (value !== undefined ? `${value}px` : undefined),
+    },
+    { key: "--gd-kpiDashboards-content-widget-borderRadius", fn: (value: string) => `${value}px` },
+    {
+        key: "--gd-kpiDashboards-content-widget-dropShadow",
+        fn: (value: boolean) => (value ? undefined : "none"),
+    },
 ];
 
 /**
@@ -91,7 +99,6 @@ const getDashboardsDerivedColors = (palette: IThemePalette): CssProperty[] => [
     getCssProperty("palette-primary-base-t50", transparentize(0.5, palette.primary.base)),
     getCssProperty("palette-primary-base-t85", transparentize(0.85, palette.primary.base)),
     getCssProperty("palette-primary-base-t90", transparentize(0.9, palette.primary.base)),
-    getCssProperty("kpiDashboards-navigation-borderColor-t80", transparentize(0.8, GD_COLOR_STATE_BLANK)),
     getCssProperty(
         "palette-primary-base-mix15-white",
         transparentize(0.075, mix(0.15, palette.primary.base, GD_COLOR_TEXT_LIGHT)),


### PR DESCRIPTION
Custom styles for Widget in KD

- Add custom kpiDashboard keys on Theme Loader 
        -  borderWidth, borderRadius, dropShadow

- Remove derived kpiDashboard color 

JIRA: ONE-4647 

Update kpiDashboards metadata theme object

- Rename MD theme object kpiDashboard to `title`

JIRA: ONE-4647

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
