### PR TITLE
Handling missing workspace and be in ThemeProvider

### DIFF
--- a/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
+++ b/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
@@ -19,6 +19,7 @@ import { IDataView } from '@gooddata/sdk-backend-spi';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IInsight } from '@gooddata/sdk-model';
 import { ISettings } from '@gooddata/sdk-backend-spi';
+import { ITheme } from '@gooddata/sdk-backend-spi';
 import { IVisualizationClass } from '@gooddata/sdk-model';
 
 // @internal (undocumented)
@@ -116,6 +117,7 @@ export function recordedBackend(index: RecordingIndex, config?: RecordedBackendC
 export type RecordedBackendConfig = IAnalyticalBackendConfig & {
     globalSettings?: ISettings;
     globalPalette?: IColorPalette;
+    theme?: ITheme;
     useRefType?: RecordedRefType;
 };
 

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -154,7 +154,7 @@ function recordedWorkspace(
                     return implConfig.globalPalette ?? [];
                 },
                 async getTheme(): Promise<ITheme> {
-                    return {};
+                    return implConfig.theme ?? {};
                 },
             };
         },

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
@@ -6,6 +6,7 @@ import {
     IAttributeElement,
     ICatalogGroup,
     ISettings,
+    ITheme,
 } from "@gooddata/sdk-backend-spi";
 import { IExecutionDefinition, IInsight, IColorPalette, IVisualizationClass } from "@gooddata/sdk-model";
 
@@ -29,6 +30,11 @@ export type RecordedBackendConfig = IAnalyticalBackendConfig & {
      * Specify color palette to return
      */
     globalPalette?: IColorPalette;
+
+    /**
+     * Specify theme to return
+     */
+    theme?: ITheme;
 
     /**
      * Specify which ref type should be added to recorded entities. Recording infrastructure does not

--- a/libs/sdk-ui-theme-provider/package.json
+++ b/libs/sdk-ui-theme-provider/package.json
@@ -59,6 +59,8 @@
     },
     "devDependencies": {
         "@gooddata/eslint-config": "^2.0.0",
+        "@gooddata/sdk-backend-mockingbird": "^8.1.0-alpha.26.fix.0",
+        "@gooddata/reference-workspace": "^8.1.0-alpha.26.fix.0",
         "@microsoft/api-extractor": "^7.3.8",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/enzyme": "^3.10.3",

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
@@ -49,35 +49,32 @@ export const ThemeProvider: React.FC<IThemeProviderProps> = ({
     const workspaceFromContext = useWorkspace();
     const workspace = workspaceParam || workspaceFromContext;
 
-    if (!backend || !workspace) {
-        clearCssProperties();
-
-        return <>{children}</>;
-    }
-
     const [theme, setTheme] = useState<ITheme>({});
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
 
     const lastWorkspace = useRef<string>();
     lastWorkspace.current = workspace;
 
     useEffect(() => {
         const fetchData = async () => {
-            setIsLoading(true);
             clearCssProperties();
-            const theme = await backend.workspace(workspace).styling().getTheme();
+
+            if (!backend || !workspace) {
+                return;
+            }
+
+            setIsLoading(true);
+
+            const selectedTheme = await backend.workspace(workspace).styling().getTheme();
             if (lastWorkspace.current === workspace) {
-                setTheme(theme);
+                setTheme(selectedTheme);
                 setIsLoading(false);
+                setCssProperties(selectedTheme);
             }
         };
 
         fetchData();
     }, [workspace, backend]);
-
-    if (!isLoading) {
-        setCssProperties(theme);
-    }
 
     return (
         <ThemeContextProvider theme={theme} themeIsLoading={isLoading}>

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -1,0 +1,139 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import { act } from "react-dom/test-utils";
+import { mount, ReactWrapper } from "enzyme";
+import { recordedBackend } from "@gooddata/sdk-backend-mockingbird";
+import { ReferenceRecordings } from "@gooddata/reference-workspace";
+import { ITheme } from "@gooddata/sdk-backend-spi";
+import { WorkspaceProvider, BackendProvider } from "@gooddata/sdk-ui";
+
+import { ThemeProvider } from "../ThemeProvider";
+import { IThemeContextProviderProps, withTheme } from "../Context";
+
+const renderComponent = async (component: React.ReactElement) => {
+    let wrappedComponent: ReactWrapper;
+    await act(async () => {
+        wrappedComponent = mount(component);
+    });
+    wrappedComponent.update();
+    return wrappedComponent;
+};
+
+describe("ThemeProvider", () => {
+    const workspace = "testWorkspace";
+    const theme: ITheme = {
+        button: {
+            dropShadow: false,
+        },
+    };
+    const backend = recordedBackend(ReferenceRecordings.Recordings, { theme });
+
+    it("should load the theme and set the properties (backend and workspace is provided through context)", async () => {
+        await renderComponent(
+            <BackendProvider backend={backend}>
+                <WorkspaceProvider workspace={workspace}>
+                    <ThemeProvider>
+                        <div>Test</div>
+                    </ThemeProvider>
+                </WorkspaceProvider>
+            </BackendProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties").innerHTML).toEqual(`
+            :root {
+                --gd-button-dropShadow: none;
+            }
+        `);
+    });
+
+    it("should load the theme and set the properties (backend and workspace is provided through props)", async () => {
+        await renderComponent(
+            <ThemeProvider backend={backend} workspace={workspace}>
+                <div>Test</div>
+            </ThemeProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties").innerHTML).toEqual(`
+            :root {
+                --gd-button-dropShadow: none;
+            }
+        `);
+    });
+
+    it("should not load the theme and not set the properties if backend is missing", async () => {
+        await renderComponent(
+            <ThemeProvider workspace={workspace}>
+                <div>Test</div>
+            </ThemeProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties")).toEqual(null);
+    });
+
+    it("should not load the theme and not set the properties if workspace is missing", async () => {
+        const backend = recordedBackend(ReferenceRecordings.Recordings, { theme });
+
+        await renderComponent(
+            <ThemeProvider backend={backend}>
+                <div>Test</div>
+            </ThemeProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties")).toEqual(null);
+    });
+
+    it("should remove properties if workspace is changed to undefined", async () => {
+        const component = await renderComponent(
+            <ThemeProvider backend={backend} workspace={workspace}>
+                <div>Test</div>
+            </ThemeProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties").innerHTML).toEqual(`
+            :root {
+                --gd-button-dropShadow: none;
+            }
+        `);
+
+        component.update();
+        component.setProps({ workspace: undefined });
+
+        expect(document.getElementById("gdc-theme-properties")).toEqual(null);
+    });
+
+    it("should pass theme object and themeIsLoading flag to context", async () => {
+        const TestComponent: React.FC<IThemeContextProviderProps> = () => <div>Test component</div>;
+        const TestComponentWithTheme = withTheme(TestComponent);
+        const component = await renderComponent(
+            <ThemeProvider backend={backend} workspace={workspace}>
+                <TestComponentWithTheme />
+            </ThemeProvider>,
+        );
+
+        expect(component.find(TestComponent).props()).toEqual({ themeIsLoading: false, theme });
+    });
+
+    it("should pass themeIsLoading flag set to false if backend is missing", async () => {
+        const TestComponent: React.FC<IThemeContextProviderProps> = () => <div>Test component</div>;
+        const TestComponentWithTheme = withTheme(TestComponent);
+        const component = await renderComponent(
+            <ThemeProvider workspace={workspace}>
+                <TestComponentWithTheme />
+            </ThemeProvider>,
+        );
+
+        expect(component.find(TestComponent).props().themeIsLoading).toEqual(false);
+    });
+
+    it("should pass themeIsLoading flag set to false if workspace is missing", async () => {
+        const TestComponent: React.FC<IThemeContextProviderProps> = () => <div>Test component</div>;
+        const TestComponentWithTheme = withTheme(TestComponent);
+        const component = await renderComponent(
+            <ThemeProvider backend={backend}>
+                <TestComponentWithTheme />
+            </ThemeProvider>,
+        );
+
+        expect(component.find(TestComponent).props().themeIsLoading).toEqual(false);
+    });
+});


### PR DESCRIPTION
ThemeProvider skips theme loading when workspace or backend is missing.

JIRA: ONE-4732

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
