### PR TITLE
RELATED: RAIL-2710 fix relative date filter handling on reopen

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
@@ -37,7 +37,11 @@ export class DynamicSelect extends React.Component<IDynamicSelectProps, IDynamic
 
         const selectedItem =
             props.value !== undefined
-                ? findRelativeDateFilterOptionByValue(props.getItems(""), props.value)
+                ? findRelativeDateFilterOptionByValue(
+                      // pass the current value to make sure the searched options include it even if it is outside the default range
+                      props.getItems(props.value.toString()),
+                      props.value,
+                  )
                 : null;
 
         this.state = {


### PR DESCRIPTION
Now even values outside of default ranges work properly.

JIRA: RAIL-2710

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
