### PR TITLE
RELATED: RAIL-2769 prevent double parens for empty values in GeoChart

### DIFF
--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
@@ -33,7 +33,7 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
 
     constructor(props: IGeoChartInnerProps) {
         super(props);
-        this.emptyHeaderString = this.getEmptyHeaderString();
+        this.emptyHeaderString = props.intl.formatMessage({ id: "visualization.emptyValue" });
         this.errorMap = newErrorMapping(props.intl);
     }
 
@@ -127,10 +127,6 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
             ...this.props,
             dataView,
         };
-    }
-
-    private getEmptyHeaderString(): string {
-        return `(${this.props.intl.formatMessage({ id: "visualization.emptyValue" })})`;
     }
 }
 


### PR DESCRIPTION
JIRA: RAIL-2769

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
