### PR TITLE
RELATED: SD-1180 add missing default dateFormat to Datepicker

### DIFF
--- a/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
@@ -17,6 +17,7 @@ import DayPickerInput from "react-day-picker/DayPickerInput";
 import { IAlignPoint } from "../typings/positioning";
 import { getOptimalAlignment } from "../utils/overlay";
 import { elementRegion } from "../utils/domUtilities";
+import { DEFAULT_DATE_FORMAT } from "../constants/platform";
 
 const DATEPICKER_OUTSIDE_DAY_SELECTOR = "DayPicker-Day--outside";
 
@@ -75,6 +76,7 @@ export class WrappedDatePicker extends React.PureComponent<DatePickerProps, IDat
         tabIndex: 0,
         alignPoints: [{ align: "bl tl" }, { align: "br tr" }, { align: "tl bl" }, { align: "tr br" }],
         onAlign: (): void => {},
+        dateFormat: DEFAULT_DATE_FORMAT,
     };
     constructor(props: DatePickerProps) {
         super(props);

--- a/libs/sdk-ui-kit/src/constants/platform.ts
+++ b/libs/sdk-ui-kit/src/constants/platform.ts
@@ -1,0 +1,4 @@
+// (C) 2020 GoodData Corporation
+
+// default date format used on client
+export const DEFAULT_DATE_FORMAT = "MM/dd/yyyy";


### PR DESCRIPTION
Now that the dateFormat is optional, we need to provide a default,
otherwise the parsing produces unexpected results.

JIRA: SD-1180

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
