### PR TITLE
RELATED: SD-1180 fix date parsing in date pickers

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputField.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputField.tsx
@@ -26,7 +26,9 @@ function formatDate(date: Date, dateFormat: string): string {
 function parseDate(str: string, dateFormat: string): Date | undefined {
     try {
         const parsedDate: Date = parse(str, dateFormat, new Date());
-        if (isValid(parsedDate)) {
+        // parse only dates with 4-digit years. this mimics moment.js behavior - it parses only dates above 1900
+        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020
+        if (isValid(parsedDate) && parsedDate.getFullYear() >= 1000) {
             return parsedDate;
         }
         return;

--- a/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
@@ -53,7 +53,9 @@ function formatDate(date: Date, dateFormat: string): string {
 function parseDate(str: string, dateFormat: string): Date | undefined {
     try {
         const parsedDate: Date = parse(str, dateFormat, new Date());
-        if (isValid(parsedDate)) {
+        // parse only dates with 4-digit years. this mimics moment.js behavior - it parses only dates above 1900
+        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020
+        if (isValid(parsedDate) && parsedDate.getFullYear() >= 1000) {
             return parsedDate;
         }
         return;


### PR DESCRIPTION
Moment.js does not parse dates lower than 1900, but date-fns do.
To retain the UX we had to add an extra condition (see code).

JIRA: SD-1180

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
