### PR TITLE
BUGFIX: SD-1211 - The Data value of insight is hidden after zooming the insight

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/adapter/chartPlugins.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/chartPlugins.ts
@@ -6,6 +6,7 @@ import { linearTickPositions } from "./plugins/linearTickPositions";
 import { groupCategoriesWrapper } from "./plugins/group-categories-wrapper";
 import { renderBubbles } from "./plugins/renderBubbles";
 import { adjustTickAmount } from "./plugins/adjustTickAmount";
+import { customAfterDrawDataLabels } from "./plugins/customAfterDrawDataLabels";
 
 const extendRenderStackTotals = (Highcharts: any) => {
     Highcharts.wrap(Highcharts.Axis.prototype, "renderStackTotals", function (proceed: any) {
@@ -44,4 +45,5 @@ export function initChartPlugins(Highcharts: any): void {
     adjustTickAmount(Highcharts);
     // modify rendering bubbles in bubble chart after upgrade to Highcharts v7.1.1
     renderBubbles(Highcharts);
+    customAfterDrawDataLabels(Highcharts);
 }

--- a/libs/sdk-ui-charts/src/highcharts/adapter/plugins/customAfterDrawDataLabels.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/plugins/customAfterDrawDataLabels.ts
@@ -1,0 +1,21 @@
+// (C) 2007-2020 GoodData Corporation
+
+/**
+ * TODO: this is a workaround function to display the data label in Highcharts when zooming the charts or resizing the browsers.
+ * It should be remove when we upgrade new version of Highcharts.
+ */
+export function customAfterDrawDataLabels(Highcharts: any): void {
+    Highcharts.addEvent(Highcharts.Series, "afterDrawDataLabels", (e: any) => {
+        const points = e.target.points;
+        points.forEach((point: any) => {
+            if (!point && !point.dataLabels) {
+                return;
+            }
+            point.dataLabels.forEach((label: any) => {
+                label.hide = () => {
+                    label.placed = false;
+                };
+            });
+        });
+    });
+}


### PR DESCRIPTION
The data labels are hidden when we zoom the charts, fixing this issue by adding the workaround function

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
