### PR TITLE
RELATED: SD-1220 Add type for opening delete dashboard dialog on KD

### DIFF
--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -372,6 +372,7 @@ export namespace EmbeddedKpiDashboard {
         Delete = "deleteDashboard",
         DrillableItems = "drillableItems",
         ExportToPdf = "exportToPdf",
+        OpenDeleteDashboardDialog = "openDeleteDashboardDialog",
         OpenScheduleEmailDialog = "openScheduleEmailDialog",
         RemoveFilterContext = "removeFilterContext",
         Save = "saveDashboard",
@@ -388,6 +389,7 @@ export namespace EmbeddedKpiDashboard {
         DashboardLoaded = "loaded",
         DashboardSaved = "dashboardSaved",
         DashboardUpdated = "dashboardUpdated",
+        DeleteDashboardDialogOpened = "deleteDashboardDialogOpened",
         Drill = "drill",
         DrillToUrlResolved = "drillToUrlResolved",
         DrillToUrlStarted = "drillToUrlStarted",
@@ -531,6 +533,7 @@ export namespace EmbeddedKpiDashboard {
     }
     export function isExportToPdfCommandData(obj: unknown): obj is ExportToPdfCommandData;
     export function isIdentifierInsight(obj: unknown): obj is IIdentifierInsightRef;
+    export function isOpenDeleteDashboardDialogCommandData(obj: unknown): obj is OpenDeleteDashboardDialogCommandData;
     export function isOpenScheduleEmailDialogCommandData(obj: unknown): obj is OpenScheduleEmailDialogCommandData;
     export function isRemoveFilterContextCommandData(obj: unknown): obj is RemoveFilterContextCommandData;
     export function isSaveAsDashboardCommandData(obj: unknown): obj is SaveAsDashboardCommandData;
@@ -546,6 +549,9 @@ export namespace EmbeddedKpiDashboard {
         uri: string;
     }
     export type NoPermissionsEventData = IGdcKdMessageEnvelope<GdcKdEventType.NoPermissions, INoPermissionsBody>;
+    export type OpenDeleteDashboardDialogCommand = IGdcKdMessageEvent<GdcKdCommandType.OpenDeleteDashboardDialog, null>;
+    // (undocumented)
+    export type OpenDeleteDashboardDialogCommandData = IGdcKdMessageEnvelope<GdcKdCommandType.OpenDeleteDashboardDialog, null>;
     export type OpenScheduleEmailDialogCommand = IGdcKdMessageEvent<GdcKdCommandType.OpenScheduleEmailDialog, null>;
     // (undocumented)
     export type OpenScheduleEmailDialogCommandData = IGdcKdMessageEnvelope<GdcKdCommandType.OpenScheduleEmailDialog, null>;

--- a/libs/sdk-embedding/src/iframe/kd.ts
+++ b/libs/sdk-embedding/src/iframe/kd.ts
@@ -1284,16 +1284,16 @@ export namespace EmbeddedKpiDashboard {
     >;
 
     /**
-     * Open delete dashboard dialog, user will be able to delete the current existed dashboard
+     * Open delete dashboard dialog, user will be able to delete currently existing dashboard
      *
      * Contract:
      *
-     * if KD is currently editing dashboard, this command will try to open the dialog to delete the current existed dashboard,
+     * if KD is currently editing dashboard, this command will try to open the dialog to delete currently existing dashboard,
      *      on success DeleteDashboardDialogOpened will be posted
      * commandFailed will be posted when:
      *      KD is currently viewing dashboard or
      *      No dashboard showing or
-     *      Donnot have permission delete existing object or
+     *      The current user does not have the permission to delete existing objects or,
      *      Delete dashboard dialog is opened
      *
      * @public

--- a/libs/sdk-embedding/src/iframe/kd.ts
+++ b/libs/sdk-embedding/src/iframe/kd.ts
@@ -105,6 +105,11 @@ export namespace EmbeddedKpiDashboard {
          * The command to set attribute filter parents
          */
         SetFilterParents = "setFilterParents",
+
+        /**
+         * The command open delete existed dashboard dialog
+         */
+        OpenDeleteDashboardDialog = "openDeleteDashboardDialog",
     }
 
     /**
@@ -247,6 +252,11 @@ export namespace EmbeddedKpiDashboard {
          * The event that is emmited if setFilterParents command is not sucessfull it contains `SetFilterParentsErrorCode`
          */
         SetFilterParentsFailed = "setFilterParentsFailed",
+
+        /**
+         * Type represent that the delete dashboard dialog is opened
+         */
+        DeleteDashboardDialogOpened = "deleteDashboardDialogOpened",
     }
 
     /**
@@ -1272,4 +1282,45 @@ export namespace EmbeddedKpiDashboard {
         GdcKdEventType.SetFilterParentsFailed,
         ISetFilterParentsFailedDataBody
     >;
+
+    /**
+     * Open delete dashboard dialog, user will be able to delete the current existed dashboard
+     *
+     * Contract:
+     *
+     * if KD is currently editing dashboard, this command will try to open the dialog to delete the current existed dashboard,
+     *      on success DeleteDashboardDialogOpened will be posted
+     * commandFailed will be posted when:
+     *      KD is currently viewing dashboard or
+     *      No dashboard showing or
+     *      Donnot have permission delete existing object or
+     *      Delete dashboard dialog is opened
+     *
+     * @public
+     */
+    export type OpenDeleteDashboardDialogCommand = IGdcKdMessageEvent<
+        GdcKdCommandType.OpenDeleteDashboardDialog,
+        null
+    >;
+
+    /**
+     * @public
+     */
+    export type OpenDeleteDashboardDialogCommandData = IGdcKdMessageEnvelope<
+        GdcKdCommandType.OpenDeleteDashboardDialog,
+        null
+    >;
+
+    /**
+     * Type-guard checking whether object is an instance of {@link EmbeddedKpiDashboard.OpenDeleteDashboardDialogCommandData}.
+     *
+     * @param obj - object to test
+     *
+     * @public
+     */
+    export function isOpenDeleteDashboardDialogCommandData(
+        obj: unknown,
+    ): obj is OpenDeleteDashboardDialogCommandData {
+        return isObject(obj) && getEventType(obj) === GdcKdCommandType.OpenDeleteDashboardDialog;
+    }
 }


### PR DESCRIPTION
- Add typing for opening delete dashboard dialog on KD

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
