### PR TITLE
Fix measure value filter percentage NaN

### DIFF
--- a/libs/sdk-ui-filters/src/MeasureValueFilter/DropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/DropdownBody.tsx
@@ -219,9 +219,15 @@ class DropdownBodyWrapped extends React.PureComponent<IDropdownBodyProps, IDropd
 
     private trimToPrecision = (n: number): number => {
         const { valuePrecision = DefaultValuePrecision } = this.props;
-
+        if (!n) {
+            return n;
+        }
         return parseFloat(n.toFixed(valuePrecision));
     };
+
+    private fromPercentToDecimal = (n: number): number => (n ? n / 100 : n);
+
+    private fromDecimalToPercent = (n: number): number => (n ? n * 100 : n);
 
     private convertToRawValue = (
         value: IMeasureValueFilterValue,
@@ -231,8 +237,11 @@ class DropdownBodyWrapped extends React.PureComponent<IDropdownBodyProps, IDropd
             return value;
         }
         return isComparisonConditionOperator(operator)
-            ? { value: this.trimToPrecision(value.value / 100) }
-            : { from: this.trimToPrecision(value.from / 100), to: this.trimToPrecision(value.to / 100) };
+            ? { value: this.trimToPrecision(this.fromPercentToDecimal(value.value)) }
+            : {
+                  from: this.trimToPrecision(this.fromPercentToDecimal(value.from)),
+                  to: this.trimToPrecision(this.fromPercentToDecimal(value.to)),
+              };
     };
 
     private convertToPercentageValue = (
@@ -244,8 +253,11 @@ class DropdownBodyWrapped extends React.PureComponent<IDropdownBodyProps, IDropd
         }
 
         return isComparisonConditionOperator(operator)
-            ? { value: this.trimToPrecision(value.value * 100) }
-            : { from: this.trimToPrecision(value.from * 100), to: this.trimToPrecision(value.to * 100) };
+            ? { value: this.trimToPrecision(this.fromDecimalToPercent(value.value)) }
+            : {
+                  from: this.trimToPrecision(this.fromDecimalToPercent(value.from)),
+                  to: this.trimToPrecision(this.fromDecimalToPercent(value.to)),
+              };
     };
 
     private onApply = () => {

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilterDropdown.test.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/tests/MeasureValueFilterDropdown.test.tsx
@@ -74,6 +74,24 @@ describe("Measure value filter dropdown", () => {
         );
     });
 
+    it("should have empty from and to inputs when filter is empty when using percentage with between operator", () => {
+        const component = renderComponent({ usePercentage: true });
+
+        component.openOperatorDropdown().selectOperator("BETWEEN");
+
+        expect(component.getRangeFromInputValue()).toEqual("");
+        expect(component.getRangeToInputValue()).toEqual("");
+    });
+
+    it("should have empty from and to inputs when filter is empty when using percentage with not between operator", () => {
+        const component = renderComponent({ usePercentage: true });
+
+        component.openOperatorDropdown().selectOperator("NOT_BETWEEN");
+
+        expect(component.getRangeFromInputValue()).toEqual("");
+        expect(component.getRangeToInputValue()).toEqual("");
+    });
+
     it("should render an input suffix for comparison value input field to display percentage sign if the measure is native percent", () => {
         const component = renderComponent({ usePercentage: true });
 

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/tests/fragments/MeasureValueFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/tests/fragments/MeasureValueFilterDropdown.tsx
@@ -53,12 +53,16 @@ export default class MeasureValueFilterFragment {
 
     public getRangeFromInput = () => this.component.find(".s-mvf-range-from-input input");
 
+    public getRangeFromInputValue = () => this.getRangeFromInput().props().value;
+
     public setRangeFrom = (value: string) => {
         this.getRangeFromInput().simulate("change", { target: { value } });
         return this;
     };
 
     public getRangeToInput = () => this.component.find(".s-mvf-range-to-input input");
+
+    public getRangeToInputValue = () => this.getRangeToInput().props().value;
 
     public setRangeTo = (value: string) => {
         this.getRangeToInput().simulate("change", { target: { value } });


### PR DESCRIPTION
Fixed problem when empty measure filter with percentage value displayed NaN in
input.

JIRA: BB-2649

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
