### PR TITLE
Fix redundant padding of RF dropdown component

### DIFF
--- a/libs/sdk-ui-kit/styles/scss/dialog.scss
+++ b/libs/sdk-ui-kit/styles/scss/dialog.scss
@@ -17,7 +17,6 @@
 .modalityPlugin-mask-visible {
     display: block;
 }
-//
 
 .gd-dialog:not(.gd-dropdown),
 .overlay.gd-dialog:not(.gd-dropdown) {

--- a/libs/sdk-ui-kit/styles/scss/overlay.scss
+++ b/libs/sdk-ui-kit/styles/scss/overlay.scss
@@ -2,6 +2,11 @@
 @import "mixins";
 @import "typo-mixins";
 
+.gd-dropdown.overlay {
+    // reset overlays padding
+    padding: 0;
+}
+
 .overlay-wrapper {
     z-index: 5001;
 }


### PR DESCRIPTION
 - Add style to reset dropdown overlay padding

JIRA: ONE-4760

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
