### PR TITLE
BUGFIX: SD-1245 - Zooming behaves incorrectly

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/helpers.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/helpers.ts
@@ -13,6 +13,7 @@ import minBy from "lodash/minBy";
 import min from "lodash/min";
 import max from "lodash/max";
 import isNil from "lodash/isNil";
+import compact from "lodash/compact";
 
 import { VisualizationTypes, VisType } from "@gooddata/sdk-ui";
 import { isInvertedChartType } from "../_util/common";
@@ -60,7 +61,7 @@ export const getHiddenSeries = (chart: Highcharts.Chart): Highcharts.Series[] =>
     chart.series && chart.series.filter((s: Highcharts.Series) => !s.visible);
 
 export const getDataPoints = (series: Highcharts.Series[]): Highcharts.Point[] =>
-    flatten(unzip(map(series, (s: Highcharts.Series) => s.points)));
+    compact(flatten(unzip(map(series, (s: Highcharts.Series) => s.points))));
 
 export const getDataPointsOfVisibleSeries = (chart: Highcharts.Chart): Highcharts.Point[] =>
     getDataPoints(getVisibleSeries(chart));


### PR DESCRIPTION
A javascript error exception when checking autohideLabels after zooming the charts:

_ Some data points are undefined that cause of the issue. So we should filter the valid data points.
Jira: SD-1245

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
