### PR TITLE
RELATED: ONE-4768 LiveExamples extended by ThemeProvider

### DIFF
--- a/examples/sdk-examples/src/constants/customTheme.ts
+++ b/examples/sdk-examples/src/constants/customTheme.ts
@@ -1,0 +1,43 @@
+// (C) 2020 GoodData Corporation
+import { ITheme } from "@gooddata/sdk-backend-spi";
+
+export const customTheme: ITheme = {
+    button: {
+        borderRadius: "15",
+        dropShadow: true,
+        textCapitalization: true,
+    },
+    modal: {
+        borderColor: "#1b4096",
+        borderRadius: "5",
+        borderWidth: "2",
+        dropShadow: false,
+        outsideBackgroundColor: "#e8cda2",
+        title: {
+            color: "#1b4096",
+            lineColor: "#000",
+        },
+    },
+    palette: {
+        error: {
+            base: "#ff2e5f",
+        },
+        primary: {
+            base: "#eba12a",
+        },
+        success: {
+            base: "#13ed4d",
+        },
+        warning: {
+            base: "#ddff19",
+        },
+    },
+    tooltip: {
+        backgroundColor: "#101050",
+        color: "#fff",
+    },
+    typography: {
+        font: "url(https://cdn.jsdelivr.net/npm/roboto-font@0.1.0/fonts/Roboto/roboto-regular-webfont.ttf)",
+        fontBold: "url(https://cdn.jsdelivr.net/npm/roboto-font@0.1.0/fonts/Roboto/roboto-bold-webfont.ttf)",
+    },
+};

--- a/examples/sdk-examples/src/constants/routes.ts
+++ b/examples/sdk-examples/src/constants/routes.ts
@@ -29,6 +29,8 @@ import { GeoPushpin } from "../examples/geoPushpin";
 import { InternationalDateFilterExample } from "../examples/internationalDateFormat/dateFilter";
 import { InternationalDatePickerExample } from "../examples/internationalDateFormat/datePicker";
 
+import { ThemedComponents } from "../examples/theming";
+
 // import { MeasureValueFilter } from "../examples/hidden/measureValueFilter";
 // import { MeasureValueFilterComponent } from "../examples/hidden/measureValueFilterComponent";
 import { OnDrillHandling } from "../examples/hidden/onDrillHandling";
@@ -200,6 +202,7 @@ export const sideNavigationRoutes: RouteDefinition[] = [
         title: "International Date Format",
         Component: InternationalDateFormatUseCasesRoutes,
     },
+    { path: "/theming", title: "Custom Theming", Component: ThemedComponents },
 ];
 
 export const hiddenPaths = [

--- a/examples/sdk-examples/src/examples/rankingFilter/RankingFilterExample.tsx
+++ b/examples/sdk-examples/src/examples/rankingFilter/RankingFilterExample.tsx
@@ -15,7 +15,7 @@ import { RankingFilter, IMeasureDropdownItem, IAttributeDropdownItem } from "@go
 const measures = [LdmExt.TotalSales2, LdmExt.FranchisedSales];
 const attributes = [LdmExt.LocationState, LdmExt.LocationName];
 
-const measureDropdownItems: IMeasureDropdownItem[] = [
+export const measureDropdownItems: IMeasureDropdownItem[] = [
     {
         title: "$ Total sales",
         ref: localIdRef(measureLocalId(LdmExt.TotalSales2)),
@@ -28,7 +28,7 @@ const measureDropdownItems: IMeasureDropdownItem[] = [
     },
 ];
 
-const attributeDropdownItems: IAttributeDropdownItem[] = [
+export const attributeDropdownItems: IAttributeDropdownItem[] = [
     {
         title: "Location state",
         ref: localIdRef(attributeLocalId(LdmExt.LocationState)),

--- a/examples/sdk-examples/src/examples/theming/ThemedComponentsExample.tsx
+++ b/examples/sdk-examples/src/examples/theming/ThemedComponentsExample.tsx
@@ -1,0 +1,97 @@
+// (C) 2020 GoodData Corporation
+
+import React, { useState } from "react";
+import { Button, ExportDialog } from "@gooddata/sdk-ui-kit";
+import { ThemeProvider, useTheme, useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
+import { newPositiveAttributeFilter, newRankingFilter } from "@gooddata/sdk-model";
+import { AttributeFilter, RankingFilter } from "@gooddata/sdk-ui-filters";
+
+import { attributeDropdownItems, measureDropdownItems } from "../rankingFilter/RankingFilterExample";
+import { DateFilterComponentExample } from "../dateFilter/DateFilterComponentExample";
+import { Ldm, LdmExt } from "../../ldm";
+import { customTheme } from "../../constants/customTheme";
+
+export const ThemeProviderExample: React.FC = () => {
+    return (
+        <div className="s-theme-provider">
+            <ThemeProvider theme={customTheme}>
+                <ThemedComponentsExample />
+            </ThemeProvider>
+        </div>
+    );
+};
+
+const ThemedComponentsExample: React.FC = () => {
+    const theme = useTheme();
+    const themeIsLoading = useThemeIsLoading();
+    const [showExportDialog, setShowExportDialog] = useState(false);
+    return (
+        <div className="s-themed-components">
+            {themeIsLoading ? (
+                <div>...</div>
+            ) : (
+                <div>
+                    <pre>{JSON.stringify(theme, null, "  ")}</pre>
+                    <br />
+                    Button
+                    <br />
+                    <Button className="gd-button-action" value="Themed button" />
+                    <br />
+                    <br />
+                    AttributeFilter
+                    <br />
+                    <AttributeFilter
+                        filter={newPositiveAttributeFilter(Ldm.EmployeeName.Default, ["Abbie Adams"])}
+                        onApply={() => {}}
+                    />
+                    <br />
+                    <br />
+                    RankingFilter
+                    <br />
+                    <RankingFilter
+                        measureItems={measureDropdownItems}
+                        attributeItems={attributeDropdownItems}
+                        filter={newRankingFilter(LdmExt.franchiseSalesLocalId, "TOP", 3)}
+                        onApply={() => {}}
+                        buttonTitle={"Ranking filter configuration"}
+                    />
+                    <br />
+                    <br />
+                    DateFilter
+                    <br />
+                    <DateFilterComponentExample />
+                    <br />
+                    <br />
+                    ExportDialog
+                    <br />
+                    <Button
+                        className="gd-button-secondary"
+                        onClick={() => {
+                            setShowExportDialog(true);
+                        }}
+                        value={"Open Export Dialog"}
+                    />
+                    {showExportDialog && (
+                        <ExportDialog
+                            headline="Export to XLSX"
+                            cancelButtonText="Cancel"
+                            submitButtonText="Export"
+                            isPositive
+                            className="s-dialog"
+                            mergeHeaders
+                            mergeHeadersDisabled={false}
+                            mergeHeadersText="Keep attribute cells merged"
+                            mergeHeadersTitle="CELLS"
+                            onCancel={() => {
+                                setShowExportDialog(false);
+                            }}
+                            onSubmit={() => {
+                                setShowExportDialog(false);
+                            }}
+                        />
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/examples/sdk-examples/src/examples/theming/index.tsx
+++ b/examples/sdk-examples/src/examples/theming/index.tsx
@@ -1,0 +1,37 @@
+// (C) 2007-2019 GoodData Corporation
+import React from "react";
+
+import { ExampleWithSource } from "../../components/ExampleWithSource";
+
+import { ThemeProviderExample } from "./ThemedComponentsExample";
+
+// eslint-disable-next-line import/no-unresolved
+import ThemeProviderExampleSrc from "!raw-loader!./ThemedComponentsExample";
+
+// eslint-disable-next-line import/default
+import ThemeProviderExampleSrcJS from "!raw-loader!../../../examplesJS/theming/ThemedComponentsExample";
+
+export const ThemedComponents: React.FC = () => (
+    <div>
+        <h1>Custom Themed components</h1>
+        <p>
+            These examples show how to use ThemeProvider component to theme the UI components which support
+            customization.
+        </p>
+        <p>
+            NOTE: Even when the ThemeProvider component encapsulates just a sub-tree of yours application the
+            custom theme is used globally for all GoodData.UI customizable components in your application.
+        </p>
+
+        <hr className="separator" />
+
+        <h2>Custom Theme for supported components</h2>
+        <ExampleWithSource
+            for={ThemeProviderExample}
+            source={ThemeProviderExampleSrc}
+            sourceJS={ThemeProviderExampleSrcJS}
+        />
+
+        <hr className="separator" />
+    </div>
+);

--- a/libs/sdk-ui-theme-provider/api/sdk-ui-theme-provider.api.md
+++ b/libs/sdk-ui-theme-provider/api/sdk-ui-theme-provider.api.md
@@ -17,6 +17,7 @@ export interface IThemeContextProviderProps {
 // @beta (undocumented)
 export interface IThemeProviderProps {
     backend?: IAnalyticalBackend;
+    theme?: ITheme;
     workspace?: string;
 }
 

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/tests/ThemeProvider.test.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/tests/ThemeProvider.test.tsx
@@ -60,6 +60,25 @@ describe("ThemeProvider", () => {
         `);
     });
 
+    it("should not load the theme and use custom theme from prop instead", async () => {
+        const customTheme: ITheme = {
+            button: {
+                borderRadius: "15",
+            },
+        };
+        await renderComponent(
+            <ThemeProvider theme={customTheme} backend={backend} workspace={workspace}>
+                <div>Test</div>
+            </ThemeProvider>,
+        );
+
+        expect(document.getElementById("gdc-theme-properties").innerHTML).toEqual(`
+            :root {
+                --gd-button-borderRadius: 15px;
+            }
+        `);
+    });
+
     it("should not load the theme and not set the properties if backend is missing", async () => {
         await renderComponent(
             <ThemeProvider workspace={workspace}>


### PR DESCRIPTION
JIRA: ONE-4768

Extend LiveExamples by ThemeProvider and some themed components example. Using externally provided theme instead of loading one from workspace as we don't want to use theming on whole workspace to keep current state intact

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
