### PR TITLE
RELATED: FET-505: fix rushx dev in sdk-ui-ext, mark sideEffects in sdk-embedding

### DIFF
--- a/libs/sdk-embedding/package.json
+++ b/libs/sdk-embedding/package.json
@@ -9,7 +9,10 @@
     "module": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "dist/internal/messagingUtils.js",
+        "esm/internal/messagingUtils.js"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-ext/tsconfig.dev.json
+++ b/libs/sdk-ui-ext/tsconfig.dev.json
@@ -4,7 +4,6 @@
     "compilerOptions": {
         "noImplicitAny": false,
         "noUnusedLocals": false,
-        "noUnusedParameters": false,
         "pretty": true,
         "baseUrl": null,
         "paths": null


### PR DESCRIPTION
* There is a top-level assignment in messagingUtils.ts so we need to mark it as having a side effect.
* FET-505: fix `rushx dev` in sdk-ui-ext

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
