### PR TITLE
RELATED: SD-1173 Make date filter's custom filter name to be fully visible in SDK example

### DIFF
--- a/examples/sdk-examples/src/examples/internationalDateFormat/dateFilter/DateFilterWithColumnChartExample_DDMMYYYY.tsx
+++ b/examples/sdk-examples/src/examples/internationalDateFormat/dateFilter/DateFilterWithColumnChartExample_DDMMYYYY.tsx
@@ -104,7 +104,7 @@ interface IDateFilterComponentExampleState {
     excludeCurrentPeriod: boolean;
 }
 
-const dateFilterContainerStyle = { width: 200 };
+const dateFilterContainerStyle = { width: 300 };
 const columnChartContainerStyle = { height: 300 };
 
 export const DateFilterWithColumnChartExample_DDMMYYYY: React.FC = () => {

--- a/examples/sdk-examples/src/examples/internationalDateFormat/dateFilter/DateFilterWithColumnChartExample_MDYY.tsx
+++ b/examples/sdk-examples/src/examples/internationalDateFormat/dateFilter/DateFilterWithColumnChartExample_MDYY.tsx
@@ -104,7 +104,7 @@ interface IDateFilterComponentExampleState {
     excludeCurrentPeriod: boolean;
 }
 
-const dateFilterContainerStyle = { width: 200 };
+const dateFilterContainerStyle = { width: 300 };
 const columnChartContainerStyle = { height: 300 };
 
 export const DateFilterWithColumnChartExample_MDYY: React.FC = () => {


### PR DESCRIPTION
JIRA: SD-1173

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
