### PR TITLE
RELATED: SD-1247 The mouse cursor auto move to last number (last of the year number) when inputting the day or month on DatePicker

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputField.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputField.tsx
@@ -27,8 +27,19 @@ function parseDate(str: string, dateFormat: string): Date | undefined {
     try {
         const parsedDate: Date = parse(str, dateFormat, new Date());
         // parse only dates with 4-digit years. this mimics moment.js behavior - it parses only dates above 1900
-        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020
-        if (isValid(parsedDate) && parsedDate.getFullYear() >= 1000) {
+        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020.
+        //
+        // it's also necessary to parse only when the input string fully matches with the desired format
+        // to make sure that the picker input is not overwritten in the middle of writing.
+        // e.g, let's consider a case where dateFormat is "dd/MM/yyyy" and the DayPickerInput has already been filled with a valid string "13/09/2020",
+        // then an user wants to change only the month "13/09/2020" -> "13/11/2020" by removing "09" and typing "11".
+        // in such case the parsing should wait until the user completes typing "11" (otherwise if parsing is done right after the first "1" is typed,
+        // the cursor automatically moves to the end of the string in the middle of writing, causing a bad experience for the user).
+        if (
+            isValid(parsedDate) &&
+            parsedDate.getFullYear() >= 1000 &&
+            str === formatDate(parsedDate, dateFormat)
+        ) {
             return parsedDate;
         }
         return;

--- a/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
@@ -54,8 +54,19 @@ function parseDate(str: string, dateFormat: string): Date | undefined {
     try {
         const parsedDate: Date = parse(str, dateFormat, new Date());
         // parse only dates with 4-digit years. this mimics moment.js behavior - it parses only dates above 1900
-        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020
-        if (isValid(parsedDate) && parsedDate.getFullYear() >= 1000) {
+        // this is to make sure that the picker input is not overwritten in the middle of writing the year with year "0002" when writing 2020.
+        //
+        // it's also necessary to parse only when the input string fully matches with the desired format
+        // to make sure that the picker input is not overwritten in the middle of writing.
+        // e.g, let's consider a case where dateFormat is "dd/MM/yyyy" and the DayPickerInput has already been filled with a valid string "13/09/2020",
+        // then an user wants to change only the month "13/09/2020" -> "13/11/2020" by removing "09" and typing "11".
+        // in such case the parsing should wait until the user completes typing "11" (otherwise if parsing is done right after the first "1" is typed,
+        // the cursor automatically moves to the end of the string in the middle of writing, causing a bad experience for the user).
+        if (
+            isValid(parsedDate) &&
+            parsedDate.getFullYear() >= 1000 &&
+            str === formatDate(parsedDate, dateFormat)
+        ) {
             return parsedDate;
         }
         return;

--- a/libs/sdk-ui-kit/src/Datepicker/tests/Datepicker.test.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/tests/Datepicker.test.tsx
@@ -217,7 +217,7 @@ describe("DatePicker", () => {
                     });
                     const event = {
                         target: {
-                            value: "1/1/2015",
+                            value: "01/01/2015",
                         },
                     };
                     getDatePickerInputField(component).simulate("blur", event);


### PR DESCRIPTION
JIRA: SD-1247

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
