### PR TITLE
RELATED: RAIL-2791 prepare CI scripts for gitflow

### DIFF
--- a/common/scripts/ci/run_major_release.sh
+++ b/common/scripts/ci/run_major_release.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #
-# This script bumps from prerelease to real major, creates release, makes commit, tags, updates changelogs. After
-# that it creates prerelease for the first minor of the new major and creates commit.
+# This script bumps from prerelease to real major, creates release, makes commit, tags, updates changelogs.
 #
 # See docs/releases.md for more information how rush version bump behaves
 #
@@ -30,7 +29,9 @@ fi
 ${_RUSH} install
 ${_RUSH} build
 
+#
 # First bump to the next major
+#
 ${_RUSH} version --bump --override-bump major
 bump_rc=$?
 
@@ -50,16 +51,4 @@ publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then
   echo "Publishing major version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
-else
-  #
-  # Now that the major is published and commit created, prepare for the next minor release.
-  # This is done by using the 'preminor' bump (see docs/releases.md for more info about the bump behavior)
-  #
-
-  ${_RUSH} version --bump --override-bump preminor --override-prerelease-id alpha
-  NEXT_MINOR=$(get_current_version)
-  # stage all modified json files
-  git ls-files | grep '\.json' | xargs git add
-  git commit -m "Prepare for next minor release ${NEXT_MINOR}"
 fi
-

--- a/common/scripts/ci/run_minor_release.sh
+++ b/common/scripts/ci/run_minor_release.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #
-# This script bumps from prerelease to real minor, creates release, makes commit, tags, updates changelogs. After
-# that it creates prerelease for the next minor and creates commit.
+# This script bumps from prerelease to real minor, creates release, makes commit, tags, updates changelogs.
 #
 # See docs/releases.md for more information how rush version bump behaves
 #
@@ -52,15 +51,4 @@ publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then
   echo "Publishing minor version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
-else
-  #
-  # Now that the mior is published and commit created, prepare for the next minor release.
-  # This is done by using the 'preminor' bump (see docs/releases.md for more info about the bump behavior)
-  #
-
-  ${_RUSH} version --bump --override-bump preminor --override-prerelease-id alpha
-  NEXT_MINOR=$(get_current_version)
-  # stage all modified json files
-  git ls-files | grep '\.json' | xargs git add
-  git commit -m "Prepare for next minor release ${NEXT_MINOR}"
 fi

--- a/common/scripts/ci/run_preminor.sh
+++ b/common/scripts/ci/run_preminor.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# This script creates prerelease version for the next minor, creates release and creates commit.
+#
+# See docs/releases.md for more information how rush version bump behaves
+#
+
+DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))
+_RUSH="${DIR}/docker_rush.sh"
+
+source ${DIR}/utils.sh
+
+${_RUSH} version --bump --override-bump preminor --override-prerelease-id alpha
+bump_rc=$?
+
+if [ $bump_rc -ne 0 ]; then
+    echo "Version bump failed. Stopping."
+
+    exit 1
+fi
+
+export TAG_NPM="prerelease"
+${DIR}/do_publish.sh

--- a/common/scripts/ci/run_preminor.sh
+++ b/common/scripts/ci/run_preminor.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# This script creates prerelease version for the next minor, creates release and creates commit.
+# This script creates prerelease version for the next minor and creates commit.
 #
 # See docs/releases.md for more information how rush version bump behaves
 #
@@ -20,5 +20,7 @@ if [ $bump_rc -ne 0 ]; then
     exit 1
 fi
 
-export TAG_NPM="prerelease"
-${DIR}/do_publish.sh
+NEXT_MINOR=$(get_current_version)
+# stage all modified json files
+git ls-files | grep '\.json' | xargs git add
+git commit -m "Prepare for next minor release ${NEXT_MINOR}"


### PR DESCRIPTION
Split the creation of the next preminor alpha into a separate script.
This is needed, because on gitflow, the next alpha is created before
the minor/major is actually released (it is done on release branch creation).

JIRA: RAIL-2791

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
