### PR TITLE
RELATED: RAIL-2792 make sure lodash is imported function-by-function

### DIFF
--- a/examples/sdk-examples/src/examples/hidden/multipleDomains/MultipleDomainsExample.jsx
+++ b/examples/sdk-examples/src/examples/hidden/multipleDomains/MultipleDomainsExample.jsx
@@ -1,6 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import React, { Component } from "react";
-import { keyBy, mapValues } from "lodash";
+import keyBy from "lodash/keyBy";
+import mapValues from "lodash/mapValues";
 import { Kpi } from "@gooddata/sdk-ui";
 import { factory } from "@gooddata/api-client-bear";
 import { Ldm } from "../../../ldm";

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -60,7 +60,8 @@ import {
 import { ObjRef, isUriRef, objRefToString } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import { convertUrisToReferences } from "../fromBackend/ReferenceConverter";
-import { omitBy, isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
+import omitBy from "lodash/omitBy";
 import { serializeProperties } from "../fromBackend/PropertiesConverter";
 
 const refToUri = (ref: ObjRef) => {

--- a/libs/sdk-ui-kit/src/List/InvertableList.tsx
+++ b/libs/sdk-ui-kit/src/List/InvertableList.tsx
@@ -6,7 +6,6 @@ import keyBy from "lodash/keyBy";
 import values from "lodash/values";
 import take from "lodash/take";
 import has from "lodash/has";
-import { Dictionary } from "lodash";
 import { guidFor } from "@gooddata/goodstrap/lib/core/Guid";
 
 import { Message } from "../Messages";
@@ -267,7 +266,7 @@ export class InvertableList<T> extends Component<IInvertableListProps<T>, IInver
         this.props.onSelect(selection, isInverted);
     };
 
-    private isItemChecked = (selectionMap: Dictionary<any>, item: T) => {
+    private isItemChecked = (selectionMap: Record<string, any>, item: T) => {
         const key = this.props.getItemKey(item);
         const itemInSelection = has(selectionMap, key);
 

--- a/libs/sdk-ui-kit/src/List/LegacyInvertableList.tsx
+++ b/libs/sdk-ui-kit/src/List/LegacyInvertableList.tsx
@@ -6,7 +6,6 @@ import keyBy from "lodash/keyBy";
 import values from "lodash/values";
 import take from "lodash/take";
 import has from "lodash/has";
-import { Dictionary } from "lodash";
 import { guidFor } from "@gooddata/goodstrap/lib/core/Guid";
 
 import { Input } from "../Form/Input";
@@ -266,7 +265,7 @@ export class LegacyInvertableList<T> extends Component<
         this.props.onSelect(selection, isInverted);
     }
 
-    private isItemChecked(selectionMap: Dictionary<any>, item: T) {
+    private isItemChecked(selectionMap: Record<string, any>, item: T) {
         const key = this.props.getItemKey(item);
         const itemInSelection = has(selectionMap, key);
 

--- a/libs/sdk-ui-theme-provider/src/cssProperties.ts
+++ b/libs/sdk-ui-theme-provider/src/cssProperties.ts
@@ -1,5 +1,5 @@
 // (C) 2020 GoodData Corporation
-import { isObject } from "lodash";
+import isObject from "lodash/isObject";
 import { transparentize, darken, lighten, mix, setLightness } from "polished";
 import { IThemePalette, ITheme } from "@gooddata/sdk-backend-spi";
 

--- a/tools/applink/src/base/dependencyGraph.ts
+++ b/tools/applink/src/base/dependencyGraph.ts
@@ -3,7 +3,11 @@
 import { readJsonSync } from "./utils";
 import path from "path";
 import { AllDepdencyTypes, DependencyGraph, DependencyType, PackageDescriptor } from "./types";
-import { difference, flatMap, fromPairs, groupBy, intersection } from "lodash";
+import difference from "lodash/difference";
+import flatMap from "lodash/flatMap";
+import fromPairs from "lodash/fromPairs";
+import groupBy from "lodash/groupBy";
+import intersection from "lodash/intersection";
 
 function addDependencies(
     graph: DependencyGraph,

--- a/tools/applink/src/base/sourceDiscovery.ts
+++ b/tools/applink/src/base/sourceDiscovery.ts
@@ -5,7 +5,8 @@ import process from "process";
 import { readJsonSync } from "./utils";
 import { PackageDescriptor, RushPackageDescriptor, SourceDescriptor } from "./types";
 import { createDependencyGraph } from "./dependencyGraph";
-import { identity, keyBy } from "lodash";
+import identity from "lodash/identity";
+import keyBy from "lodash/keyBy";
 
 /*
  * Singleton sdk package descriptor. Loaded the first time it is needed by `getSdkPackages`.

--- a/tools/applink/src/devConsole/pipeline/buildScheduler.ts
+++ b/tools/applink/src/devConsole/pipeline/buildScheduler.ts
@@ -14,7 +14,8 @@ import {
 } from "../events";
 import { DependencyGraph, SourceDescriptor } from "../../base/types";
 import { findDependingPackages, naiveFilterDependencyGraph } from "../../base/dependencyGraph";
-import { flatten, uniq } from "lodash";
+import flatten from "lodash/flatten";
+import uniq from "lodash/uniq";
 import { appLogError, appLogWarn } from "../ui/utils";
 
 type PackageState = {

--- a/tools/applink/src/devConsole/pipeline/changeDetector.ts
+++ b/tools/applink/src/devConsole/pipeline/changeDetector.ts
@@ -12,7 +12,7 @@ import {
     packagesChanged,
 } from "../events";
 import { appLogImportant, appLogWarn } from "../ui/utils";
-import { intersection } from "lodash";
+import intersection from "lodash/intersection";
 
 /**
  * Change detector will wait until it has both source & target descriptors. After that it will determine

--- a/tools/applink/src/devConsole/ui/packageList.ts
+++ b/tools/applink/src/devConsole/ui/packageList.ts
@@ -25,7 +25,7 @@ import {
     naiveFilterDependencyGraph,
 } from "../../base/dependencyGraph";
 import flatten from "lodash/flatten";
-import { intersection } from "lodash";
+import intersection from "lodash/intersection";
 import { ColorCodes } from "./colors";
 
 type PackageListItem = {

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -70,7 +70,6 @@
         "eslint-plugin-prettier": "^3.1.4",
         "jest": "^26.4.2",
         "jest-junit": "^3.0.0",
-        "prettier": "~2.0.5",
         "ts-jest": "^26.3.0",
         "ts-node": "^8.4.1",
         "typescript": "4.0.2"

--- a/tools/catalog-export/src/base/config.ts
+++ b/tools/catalog-export/src/base/config.ts
@@ -1,5 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
-import { get, pick, pickBy, identity } from "lodash";
+import get from "lodash/get";
+import identity from "lodash/identity";
+import pick from "lodash/pick";
+import pickBy from "lodash/pickBy";
 import * as fs from "fs";
 import * as path from "path";
 import { DEFAULT_CONFIG, DEFAULT_CONFIG_FILE_NAME } from "./constants";

--- a/tools/catalog-export/src/base/types.ts
+++ b/tools/catalog-export/src/base/types.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * This exception is thrown when a fatal error occurs during the export processing - be it during interfacing with

--- a/tools/catalog-export/src/loaders/bear/bearCatalog.ts
+++ b/tools/catalog-export/src/loaders/bear/bearCatalog.ts
@@ -1,7 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
 import gooddata from "@gooddata/api-client-bear";
 import pmap from "p-map";
-import { flatMap, range } from "lodash";
+import flatMap from "lodash/flatMap";
+import range from "lodash/range";
 import { isAttribute, isMetric, Catalog, Attribute, Metric, Fact } from "../../base/types";
 
 type CatalogItemsResponse = {

--- a/tools/catalog-export/src/loaders/bear/bearDataDatasets.ts
+++ b/tools/catalog-export/src/loaders/bear/bearDataDatasets.ts
@@ -1,7 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import gooddata from "@gooddata/api-client-bear";
 import { GdcDataSets } from "@gooddata/api-model-bear";
-import { get } from "lodash";
+import get from "lodash/get";
 import { Attribute, DateDataSet, DisplayForm } from "../../base/types";
 
 /**

--- a/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
@@ -9,7 +9,7 @@ import {
     LabelResourceReference,
     AttributeResourceSchema,
 } from "@gooddata/api-client-tiger";
-import { keyBy } from "lodash";
+import keyBy from "lodash/keyBy";
 import { Attribute, DisplayForm } from "../../base/types";
 
 export type TagMap = { [id: string]: TagResourceSchema };

--- a/tools/catalog-export/src/transform/titles.ts
+++ b/tools/catalog-export/src/transform/titles.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { has } from "lodash";
+import has from "lodash/has";
 
 const NonAlphaNumRegex = /[^\w\d$]+/g;
 

--- a/tools/catalog-export/src/transform/toCatalog.ts
+++ b/tools/catalog-export/src/transform/toCatalog.ts
@@ -1,7 +1,12 @@
 // (C) 2007-2020 GoodData Corporation
 import { ProjectMetadata, Attribute } from "../base/types";
 import { createUniqueName } from "./titles";
-import { get, set, cloneDeep, findKey, forOwn, isEmpty } from "lodash";
+import cloneDeep from "lodash/cloneDeep";
+import findKey from "lodash/findKey";
+import forOwn from "lodash/forOwn";
+import get from "lodash/get";
+import isEmpty from "lodash/isEmpty";
+import set from "lodash/set";
 /*
  * This transformation takes project metadata and creates an object that matches the required input of CatalogHelper.
  */

--- a/tools/catalog-export/src/transform/toTypescript.ts
+++ b/tools/catalog-export/src/transform/toTypescript.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import {
     ImportDeclarationStructure,
     OptionalKind,

--- a/tools/mock-handling/src/base/config.ts
+++ b/tools/mock-handling/src/base/config.ts
@@ -1,5 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
-import { get, pick, pickBy, identity } from "lodash";
+import get from "lodash/get";
+import identity from "lodash/identity";
+import pick from "lodash/pick";
+import pickBy from "lodash/pickBy";
 import * as fs from "fs";
 import * as path from "path";
 import { DEFAULT_CONFIG, DEFAULT_CONFIG_FILE_NAME } from "./constants";

--- a/tools/mock-handling/src/base/types.ts
+++ b/tools/mock-handling/src/base/types.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { isEmpty } from "lodash";
+import isEmpty from "lodash/isEmpty";
 
 /**
  * This exception is thrown when a fatal error occurs during the data recording.

--- a/tools/mock-handling/src/base/variableNaming.ts
+++ b/tools/mock-handling/src/base/variableNaming.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { has } from "lodash";
+import has from "lodash/has";
 
 const NonAlphaNumRegex = /[^\w\d$]+/g;
 

--- a/tools/mock-handling/src/interface.ts
+++ b/tools/mock-handling/src/interface.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { range } from "lodash";
+import range from "lodash/range";
 import { IExecutionDefinition, IBucket } from "@gooddata/sdk-model";
 
 /*

--- a/tools/mock-handling/src/recordings/catalogRepository.ts
+++ b/tools/mock-handling/src/recordings/catalogRepository.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import * as path from "path";
 import { findFiles } from "../base/utils";
 import { logWarn } from "../cli/loggers";

--- a/tools/mock-handling/src/recordings/displayForms.ts
+++ b/tools/mock-handling/src/recordings/displayForms.ts
@@ -7,7 +7,7 @@ import {
     IElementsQuery,
     IAttributeDisplayFormMetadataObject,
 } from "@gooddata/sdk-backend-spi";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 import fs from "fs";
 import path from "path";
 import { idRef } from "@gooddata/sdk-model";

--- a/tools/mock-handling/src/recordings/displayFormsRepository.ts
+++ b/tools/mock-handling/src/recordings/displayFormsRepository.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import * as path from "path";
 import { findFiles } from "../base/utils";
 import { logWarn } from "../cli/loggers";

--- a/tools/mock-handling/src/recordings/insightsRepository.ts
+++ b/tools/mock-handling/src/recordings/insightsRepository.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import * as path from "path";
 import { findFiles } from "../base/utils";
 import { logWarn } from "../cli/loggers";

--- a/tools/mock-handling/src/recordings/visClassesRepository.ts
+++ b/tools/mock-handling/src/recordings/visClassesRepository.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { flatMap } from "lodash";
+import flatMap from "lodash/flatMap";
 import * as path from "path";
 import { findFiles } from "../base/utils";
 import { logWarn } from "../cli/loggers";


### PR DESCRIPTION
This is to make sure the resulting bundles for our users are as small as possible.
The rule is enforced everywhere, even in `tools` where it is not so important,
but I think consistency across the whole repo is more important.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
