### PR TITLE
Changes FF enableUiTheming from user to project scope

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/styling/styling.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/styling/styling.ts
@@ -17,13 +17,16 @@ export class BearWorkspaceStyling implements IWorkspaceStylingService {
     };
 
     public getTheme = async (): Promise<ITheme> => {
-        const featureFlags = await this.authCall((sdk) => sdk.user.getFeatureFlags());
-        const enabledByFeatureFlag = featureFlags?.[ENABLED_THEMING_FEATURE_FLAG_SETTINGS_KEY];
+        const config = await this.authCall((sdk) => sdk.project.getConfig(this.workspace));
+
+        const enabledByFeatureFlag = config.find(
+            (item) => item.settingItem.key === ENABLED_THEMING_FEATURE_FLAG_SETTINGS_KEY,
+        )?.settingItem?.value;
+
         if (!enabledByFeatureFlag) {
             return {};
         }
 
-        const config = await this.authCall((sdk) => sdk.project.getConfig(this.workspace));
         const identifier = config.find((item) => item.settingItem.key === SELECTED_UI_THEME_SETTINGS_KEY)
             ?.settingItem?.value;
 


### PR DESCRIPTION
JIRA: ONE-4781

Whole feature of Theming is Project oriented and one particular customer should not be able to turn it off

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
