### PR TITLE
RELATED: SD-1233 add API for get all workspace datasets

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/datasets/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/datasets/index.ts
@@ -1,5 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
-import { IWorkspaceDatasetsService, IDataset } from "@gooddata/sdk-backend-spi";
+import { GdcMetadata } from "@gooddata/api-model-bear";
+import { IWorkspaceDatasetsService, IDataset, IMetadataObject } from "@gooddata/sdk-backend-spi";
+import { convertMetadataObjectXrefEntry } from "../../../convertors/fromBackend/MetaConverter";
 import { convertDataSet } from "../../../convertors/fromBackend/DataSetConverter";
 import { BearAuthenticatedCallGuard } from "../../../types/auth";
 
@@ -9,5 +11,15 @@ export class BearWorkspaceDataSets implements IWorkspaceDatasetsService {
     public async getDatasets(): Promise<IDataset[]> {
         const result = await this.authCall((sdk) => sdk.catalogue.loadDataSets(this.workspace));
         return result.map(convertDataSet);
+    }
+
+    public async getAllDatasets(): Promise<IMetadataObject[]> {
+        const datasetsResult: GdcMetadata.IObjectXrefEntry[] = await this.authCall((sdk) =>
+            sdk.project.getDatasets(this.workspace),
+        );
+
+        return datasetsResult.map((dataset: GdcMetadata.IObjectXrefEntry) =>
+            convertMetadataObjectXrefEntry("dataSet", dataset),
+        );
     }
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/datasets/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/datasets/index.ts
@@ -13,7 +13,7 @@ export class BearWorkspaceDataSets implements IWorkspaceDatasetsService {
         return result.map(convertDataSet);
     }
 
-    public async getAllDatasets(): Promise<IMetadataObject[]> {
+    public async getAllDatasetsMeta(): Promise<IMetadataObject[]> {
         const datasetsResult: GdcMetadata.IObjectXrefEntry[] = await this.authCall((sdk) =>
             sdk.project.getDatasets(this.workspace),
         );

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1535,7 +1535,7 @@ export interface IWorkspaceDashboardsService {
 
 // @public
 export interface IWorkspaceDatasetsService {
-    getAllDatasets(): Promise<IMetadataObject[]>;
+    getAllDatasetsMeta(): Promise<IMetadataObject[]>;
     getDatasets(): Promise<IDataset[]>;
 }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1535,6 +1535,7 @@ export interface IWorkspaceDashboardsService {
 
 // @public
 export interface IWorkspaceDatasetsService {
+    getAllDatasets(): Promise<IMetadataObject[]>;
     getDatasets(): Promise<IDataset[]>;
 }
 

--- a/libs/sdk-backend-spi/src/workspace/ldm/datasets.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/datasets.ts
@@ -17,9 +17,9 @@ export interface IWorkspaceDatasetsService {
     getDatasets(): Promise<IDataset[]>;
 
     /**
-     * Receive all workspace all datasets
+     * Receive all workspace datasets metadata
      *
-     * @returns promise of workspace datasets
+     * @returns promise of workspace datasets metadata
      */
-    getAllDatasets(): Promise<IMetadataObject[]>;
+    getAllDatasetsMeta(): Promise<IMetadataObject[]>;
 }

--- a/libs/sdk-backend-spi/src/workspace/ldm/datasets.ts
+++ b/libs/sdk-backend-spi/src/workspace/ldm/datasets.ts
@@ -1,6 +1,7 @@
 // (C) 2019-2020 GoodData Corporation
 
 import { IDataset } from "../fromModel/ldm/datasets";
+import { IMetadataObject } from "../fromModel/ldm/metadata";
 
 /**
  * Service for querying workspace datasets
@@ -9,9 +10,16 @@ import { IDataset } from "../fromModel/ldm/datasets";
  */
 export interface IWorkspaceDatasetsService {
     /**
-     * Receive all workspace datasets
+     * Receive all workspace csv datasets
+     *
+     * @returns promise of workspace csv datasets
+     */
+    getDatasets(): Promise<IDataset[]>;
+
+    /**
+     * Receive all workspace all datasets
      *
      * @returns promise of workspace datasets
      */
-    getDatasets(): Promise<IDataset[]>;
+    getAllDatasets(): Promise<IMetadataObject[]>;
 }

--- a/libs/sdk-backend-tiger/src/backend/workspace/datasets/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/datasets/index.ts
@@ -9,7 +9,7 @@ export class TigerWorkspaceDataSets implements IWorkspaceDatasetsService {
         return this.authCall(async () => []);
     }
 
-    public async getAllDatasets(): Promise<IMetadataObject[]> {
+    public async getAllDatasetsMeta(): Promise<IMetadataObject[]> {
         return this.authCall(async () => []);
     }
 }

--- a/libs/sdk-backend-tiger/src/backend/workspace/datasets/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/datasets/index.ts
@@ -1,11 +1,15 @@
 // (C) 2019-2020 GoodData Corporation
-import { IWorkspaceDatasetsService, IDataset } from "@gooddata/sdk-backend-spi";
+import { IWorkspaceDatasetsService, IDataset, IMetadataObject } from "@gooddata/sdk-backend-spi";
 import { TigerAuthenticatedCallGuard } from "../../../types";
 
 export class TigerWorkspaceDataSets implements IWorkspaceDatasetsService {
     constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}
 
     public async getDatasets(): Promise<IDataset[]> {
+        return this.authCall(async () => []);
+    }
+
+    public async getAllDatasets(): Promise<IMetadataObject[]> {
         return this.authCall(async () => []);
     }
 }


### PR DESCRIPTION
- Add new API for   (`/gdc/md/${projectId}/query/datasets`) in workspace datasets service that return IMetadataObject[] items. That API needed on AD/KD to check workspace has existed datasets or not to route Data tab for navigation of freemium users

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
