### PR TITLE
RELATED: RAIL-2807 make settings APIs not fail for anonymous users

### DIFF
--- a/libs/sdk-backend-bear/src/backend/constants.ts
+++ b/libs/sdk-backend-bear/src/backend/constants.ts
@@ -1,0 +1,10 @@
+// (C) 2020 GoodData Corporation
+import { IUserSettings } from "@gooddata/sdk-backend-spi";
+
+export const DEFAULT_LOCALE = "en-US";
+export const ANONYMOUS_USER_ID = "Anonymous";
+
+export const ANONYMOUS_USER_SETTINGS: IUserSettings = {
+    locale: DEFAULT_LOCALE,
+    userId: ANONYMOUS_USER_ID,
+};

--- a/libs/sdk-backend-bear/src/backend/user/settings.ts
+++ b/libs/sdk-backend-bear/src/backend/user/settings.ts
@@ -1,14 +1,20 @@
 // (C) 2020 GoodData Corporation
 import { IUserSettingsService, IUserSettings } from "@gooddata/sdk-backend-spi";
-import { userLoginMd5FromAuthenticatedPrincipal } from "../../utils/api";
+import { userLoginMd5FromAuthenticatedPrincipalWithAnonymous } from "../../utils/api";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
+import { ANONYMOUS_USER_SETTINGS } from "../constants";
 
 export class BearUserSettingsService implements IUserSettingsService {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
 
     public async getSettings(): Promise<IUserSettings> {
         return this.authCall(async (sdk, { getPrincipal }) => {
-            const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
+            const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipalWithAnonymous(getPrincipal);
+
+            // for anonymous users, return defaults
+            if (!userLoginMd5) {
+                return ANONYMOUS_USER_SETTINGS;
+            }
 
             const [flags, currentProfile] = await Promise.all([
                 sdk.user.getUserFeatureFlags(userLoginMd5),

--- a/libs/sdk-backend-bear/src/utils/api.ts
+++ b/libs/sdk-backend-bear/src/utils/api.ts
@@ -25,6 +25,23 @@ export const userUriFromAuthenticatedPrincipal = async (
 
 /**
  * Returns a user login md5. This is used in some bear client calls as a userId.
+ * If there is no user available, returns null instead.
+ * @param getPrincipal - function to obtain currently authenticated principal to get the data from
+ *
+ * @internal
+ */
+export const userLoginMd5FromAuthenticatedPrincipalWithAnonymous = async (
+    getPrincipal: () => Promise<IAuthenticatedPrincipal>,
+): Promise<string | null> => {
+    const principal = await getPrincipal();
+    const selfLink: string = principal.userMeta?.links?.self ?? "";
+    const userLoginMd5 = last(selfLink.split("/"));
+    return userLoginMd5 ?? null;
+};
+
+/**
+ * Returns a user login md5. This is used in some bear client calls as a userId.
+ * If there is no user available, throws an error.
  * @param getPrincipal - function to obtain currently authenticated principal to get the data from
  *
  * @internal
@@ -32,9 +49,7 @@ export const userUriFromAuthenticatedPrincipal = async (
 export const userLoginMd5FromAuthenticatedPrincipal = async (
     getPrincipal: () => Promise<IAuthenticatedPrincipal>,
 ): Promise<string> => {
-    const principal = await getPrincipal();
-    const selfLink: string = principal.userMeta?.links?.self ?? "";
-    const userLoginMd5 = last(selfLink.split("/"));
+    const userLoginMd5 = await userLoginMd5FromAuthenticatedPrincipalWithAnonymous(getPrincipal);
 
     if (!userLoginMd5) {
         throw new UnexpectedError("Cannot obtain the current user login md5");


### PR DESCRIPTION
In case there is no authenticated principal, we return just empty defaults.

JIRA: RAIL-2807

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
