### PR TITLE
RELATED: RAIL-2810 improve contribution guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Supported PR commands:
 # PR Checklist
 
 -   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
+-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
 -   [ ] `check` passes
 -   [ ] `check-extended` passes
 -   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -76,6 +76,10 @@ On top of Rush built-in commands, we have added our own custom commands (see [co
 | `rush prettier-write` | Formats code in all projects.                                                                               |
 | `rush populate-ref`   | Makes projects populate reference workspace with recording definitions.                                     |
 
+## How do I...?
+
+This section should answer most of the contribution questions for the practical side of things.
+
 ### How do I add new / update existing dependency in a project?
 
 You must use Rush to add a new dependency to a project and use the `make-consistent` parameter. This parameter
@@ -181,6 +185,21 @@ RELATED: RAIL-1234 add [feature name] to [package]
 This is to keep the PR title structure in line with our other frontend repositories.
 
 In the PR body, please follow the checklist and really try to explain the changes happening in the PR (for single commit PR this will be pre-filled from your well described commit already). All the communication about the PR should happen in the PR via comments so that the process is transparent and traceable.
+
+### How do I tell if my Pull Request needs approval by a Code Owner?
+
+If your Pull Request meets **any** of the following points, please ask some [Code Owner](../.github/CODEOWNERS) for review before merging:
+
+-   introduces a breaking change
+-   adds a new package
+-   adds a new feature
+-   adds a new dependency to any package published to NPM or upgrades it to a new major
+-   changes the architecture in a non-trivial way
+-   changes the implementation/behavior of any public functionality in a non-trivial way
+-   changes CI scripts
+-   changes package.json scripts
+
+If your PR does not meet any of the aforementioned criteria, it can be merged by anyone with the necessary rights.
 
 ### How do I describe my changes for the CHANGELOG?
 


### PR DESCRIPTION
* Add guide for telling if a Code Owner approval is necessary
* Improve the docs structure

JIRA: RAIL-2810

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
