### PR TITLE
Update the warning message when an invalid date is entered in static section of DateFilter component

### DIFF
--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -803,8 +803,8 @@
         "limit": 0
     },
     "filters.staticPeriod.incorrectFormat": {
-        "value": "The date must be in {format} format",
-        "comment": "Placeholder '{format}' is used for showing date format. Example 'The date must be in MM/dd/yyyy format'. Don't translate placeholder '{format}'.",
+        "value": "The date must be in the {format} format",
+        "comment": "Placeholder '{format}' is used for showing date format. Example 'The date must be in the MM/dd/yyyy format'. Don't translate placeholder '{format}'.",
         "limit": 0
     },
     "mvf.operator.all": {


### PR DESCRIPTION
JIRA: SD-1264

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
