### PR TITLE
RELATED: RAIL-2753 Correct layout path in walkLayout

### DIFF
--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/utils.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/utils.ts
@@ -140,7 +140,7 @@ export function walkLayout(
         columnCallback?: (column: IDashboardLayoutColumn, columnPath: LayoutPath) => void;
         widgetCallback?: (widget: IWidget | IWidgetDefinition, widgetPath: LayoutPath) => void;
     },
-    path: LayoutPath = ["fluidLayout", "rows"],
+    path: LayoutPath = ["rows"],
 ): void {
     layout.rows.forEach((row, rowIndex) => {
         const rowPath = [...path, rowIndex];


### PR DESCRIPTION
- Correct layout path in walkLayout util (fluidLayout is not nested under "fluidLayout" propa anymore)

JIRA: RAIL-2753

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
