### PR TITLE
RELATED: RAIL-2758 Prevent sdk-ui-tests and mock-handling publishing

### DIFF
--- a/rush.json
+++ b/rush.json
@@ -413,7 +413,7 @@
             "packageName": "@gooddata/sdk-ui-tests",
             "projectFolder": "libs/sdk-ui-tests",
             "reviewCategory": "production",
-            "versionPolicyName": "sdk",
+            // "versionPolicyName": "sdk", // until we publish this, we cannot specify the policy, it overrides the shouldPublish
             "shouldPublish": false // skipping publishing for now, the package is not ready for publication yet
         },
         {


### PR DESCRIPTION
Turns out versionPolicyName overrides shouldPublish,
so we comment it out until we want to release the packages for real

JIRA: RAIL-2758

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
