### PR TITLE
RELATED: RAIL-21697 - Enhance applink to discover and report missing 3rd party deps

### DIFF
--- a/tools/applink/src/base/targetDiscovery.ts
+++ b/tools/applink/src/base/targetDiscovery.ts
@@ -3,7 +3,7 @@
 import * as path from "path";
 import * as fs from "fs";
 import { readJsonSync } from "../base/utils";
-import { SourceDescriptor, TargetDependency, TargetDescriptor } from "../base/types";
+import { PackageJson, SourceDescriptor, TargetDependency, TargetDescriptor } from "../base/types";
 
 /**
  * Given app's root directory, this function finds all source packages on which the app depends. This is done
@@ -20,11 +20,12 @@ export function getTargetDescriptor(target: string, sourceDescriptor: SourceDesc
         const directory = path.join(root, "node_modules", ...pkg.installDir);
 
         if (fs.existsSync(directory) && fs.statSync(directory).isDirectory()) {
-            const packageJson = readJsonSync(path.join(directory, "package.json"));
+            const installedPackageJson = readJsonSync(path.join(directory, "package.json")) as PackageJson;
 
             dependencies.push({
                 directory,
-                version: packageJson.version,
+                packageJson: installedPackageJson,
+                version: installedPackageJson.version,
                 pkg,
             });
         }

--- a/tools/applink/src/base/types.ts
+++ b/tools/applink/src/base/types.ts
@@ -89,7 +89,9 @@ export type RushPackageDescriptor = {
  * Minimalistic typing for the package json. Contains just the properties that applink needs.
  */
 export type PackageJson = {
+    version: string;
     scripts?: Record<string, string>;
+    dependencies?: Record<string, string>;
     files?: string[];
 };
 
@@ -174,7 +176,12 @@ export type TargetDependency = {
     version: string;
 
     /**
-     * Full information about the SDK package on which the app depends.
+     * Package JSON of the installed package.
+     */
+    packageJson: PackageJson;
+
+    /**
+     * Full information about the source SDK package on which the app depends.
      */
     pkg: PackageDescriptor;
 };


### PR DESCRIPTION
-  Applink does not do anything with 3rd party deps. If the version in the source repo has different 3rd party
   dependencies compared to version in the target repo, then the app will likely stop working because
   the synced code relies on 3rd party modules that are not there.

-  This is a known limitation of the file-syncing approach. Applink discovers this and reports to the user
   via a message + entry in the log

JIRA: RAIL-2697

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
