### PR TITLE
Update headers for insight retrieval

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -174,28 +174,32 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
 
     public createInsight = async (insight: IInsightDefinition): Promise<IInsight> => {
         const createResponse = await this.authCall((sdk) => {
-            return sdk.workspaceModel.createEntity({
-                entity: "visualizationObjects",
-                workspaceId: this.workspace,
-                analyticsObject: {
-                    data: {
-                        id: uuid4(),
-                        type: "visualizationObject",
-                        attributes: {
-                            description: insightTitle(insight),
-                            content: convertInsight(insight),
-                            title: insightTitle(insight),
+            return sdk.workspaceModel.createEntity(
+                {
+                    entity: "visualizationObjects",
+                    workspaceId: this.workspace,
+                    analyticsObject: {
+                        data: {
+                            id: uuid4(),
+                            type: "visualizationObject",
+                            attributes: {
+                                description: insightTitle(insight),
+                                content: convertInsight(insight),
+                                title: insightTitle(insight),
+                            },
                         },
                     },
                 },
-            });
+                {
+                    headers: {
+                        Accept: "application/vnd.gooddata.api+json",
+                        "Content-Type": "application/vnd.gooddata.api+json",
+                    },
+                },
+            );
         });
-
-        return insightFromInsightDefinition(
-            insight,
-            createResponse.data.data.id,
-            createResponse.data.links!.self,
-        );
+        const insightData = createResponse.data as VisualizationObjectSchema;
+        return insightFromInsightDefinition(insight, insightData.data.id, insightData.links!.self);
     };
 
     public updateInsight = async (insight: IInsight): Promise<IInsight> => {


### PR DESCRIPTION
Accept header was missing to retrieve the object in the required json+api format.

Now it's possible to save, list and open insights.

JIRA: RAIL-2822

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
