### PR TITLE
RELATED: RAIL-2818 Add useDashboardViewLayout hook

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -1,14 +1,6 @@
 // (C) 2020 GoodData Corporation
-import React, { useMemo, useCallback } from "react";
-import {
-    IAnalyticalBackend,
-    IDashboard,
-    IWidgetAlert,
-    FluidLayoutTransforms,
-    isWidget,
-    isWidgetDefinition,
-    UnexpectedError,
-} from "@gooddata/sdk-backend-spi";
+import React, { useCallback } from "react";
+import { IAnalyticalBackend, IWidgetAlert } from "@gooddata/sdk-backend-spi";
 import { IFilter } from "@gooddata/sdk-model";
 import {
     IDrillableItem,
@@ -25,7 +17,7 @@ import { DashboardContentRenderer } from "./DashboardContentRenderer";
 import { IDashboardViewLayoutColumnRenderProps } from "../DashboardLayout/interfaces/dashboardLayoutComponents";
 
 interface IDashboardRendererProps {
-    dashboard: IDashboard;
+    dashboardViewLayout: IDashboardViewLayout;
     alerts: IWidgetAlert[];
     backend?: IAnalyticalBackend;
     workspace?: string;
@@ -38,7 +30,7 @@ interface IDashboardRendererProps {
 }
 
 export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
-    dashboard,
+    dashboardViewLayout,
     alerts,
     filters,
     backend,
@@ -54,43 +46,6 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
         // do not render the dashboard until you have the theme to avoid flash of un-styled content
         return <LoadingComponent />;
     }
-
-    // Convert current layout model to "legacy" layout model,
-    // to keep it backward compatible with KD
-    const emptyLayout: IDashboardViewLayout = {
-        ...dashboard.layout,
-        rows: [],
-    };
-
-    const layout = useMemo(
-        () =>
-            FluidLayoutTransforms.for(dashboard.layout).reduceColumns(
-                (acc: IDashboardViewLayout, { column, columnIndex, row, rowIndex }) => {
-                    if (!acc.rows[rowIndex]) {
-                        acc.rows[rowIndex] = {
-                            ...row,
-                            columns: [],
-                        };
-                    }
-                    const currentContent = column.content;
-                    if (isWidget(currentContent) || isWidgetDefinition(currentContent)) {
-                        acc.rows[rowIndex].columns[columnIndex] = {
-                            ...column,
-                            content: {
-                                type: "widget",
-                                widget: currentContent,
-                            },
-                        };
-                    } else {
-                        throw new UnexpectedError("Unknown widget");
-                    }
-
-                    return acc;
-                },
-                emptyLayout,
-            ),
-        [dashboard.layout],
-    );
 
     const contentWithProps = useCallback(
         (props: IDashboardViewLayoutColumnRenderProps) => {
@@ -126,7 +81,7 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
 
     return (
         <DashboardLayout
-            layout={layout}
+            layout={dashboardViewLayout}
             contentRenderer={contentWithProps}
             columnRenderer={(props) => {
                 return (

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
@@ -6,6 +6,7 @@ import { useDashboard } from "../useDashboard";
 import { DashboardRenderer } from "./DashboardRenderer";
 import { useDashboardAlerts } from "../useDashboardAlerts";
 import { IDashboardViewProps } from "./types";
+import { useDashboardViewLayout } from "../useDashboardViewLayout";
 
 export const DashboardView: React.FC<IDashboardViewProps> = ({
     dashboard,
@@ -35,11 +36,22 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
         workspace,
     });
 
+    const {
+        error: dashboardViewLayoutError,
+        result: dashboardViewLayout,
+        status: dashboardViewLayoutStatus,
+    } = useDashboardViewLayout({
+        dashboardLayout: dashboardData?.layout,
+        onError,
+        backend,
+        workspace,
+    });
+
     const isThemeLoading = useThemeIsLoading();
     const hasThemeProvider = isThemeLoading !== undefined;
 
     useEffect(() => {
-        if (alertsData && dashboardData) {
+        if (alertsData && dashboardData && dashboardViewLayout) {
             onDashboardLoaded?.({
                 alerts: alertsData,
                 dashboard: dashboardData,
@@ -47,7 +59,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
         }
     }, [onDashboardLoaded, alertsData, dashboardData]);
 
-    const statuses = [dashboardStatus, alertsStatus];
+    const statuses = [dashboardStatus, alertsStatus, dashboardViewLayoutStatus];
 
     if (statuses.includes("loading") || statuses.includes("pending")) {
         return <LoadingComponent />;
@@ -61,11 +73,15 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
         return <ErrorComponent message={alertsError.message} />;
     }
 
+    if (dashboardViewLayoutError === "error") {
+        return <ErrorComponent message={dashboardViewLayoutError.message} />;
+    }
+
     const dashboardRender = (
         <DashboardRenderer
             backend={backend}
             workspace={workspace}
-            dashboard={dashboardData}
+            dashboardViewLayout={dashboardViewLayout}
             alerts={alertsData}
             filters={filters}
             onDrill={onDrill}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/useDashboardViewLayout.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/useDashboardViewLayout.ts
@@ -1,0 +1,138 @@
+// (C) 2020 GoodData Corporation
+import {
+    IAnalyticalBackend,
+    IDashboardLayout,
+    layoutWidgets,
+    isWidget,
+    UnexpectedError,
+} from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useBackend,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+    useWorkspace,
+} from "@gooddata/sdk-ui";
+import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+import { IDashboardViewLayout } from "./DashboardLayout";
+import { FluidLayoutTransforms } from "@gooddata/sdk-backend-spi";
+import { DashboardViewLayoutWidgetClass } from "./DashboardLayout/interfaces/dashboardLayout";
+
+/**
+ * @beta
+ */
+export interface IUseDashboardViewLayoutConfig
+    extends UseCancelablePromiseCallbacks<IDashboardViewLayout, GoodDataSdkError> {
+    /**
+     * Dashboard layout to transform to view model.
+     */
+    dashboardLayout: IDashboardLayout | undefined;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * Hook allowing to download additional dashboard layout data (visualization classes and insights)
+ * @param config - configuration of the hook
+ * @beta
+ */
+export const useDashboardViewLayout = ({
+    dashboardLayout,
+    backend,
+    workspace,
+    onCancel,
+    onError,
+    onLoading,
+    onPending,
+    onSuccess,
+}: IUseDashboardViewLayoutConfig): UseCancelablePromiseState<IDashboardViewLayout, any> => {
+    const effectiveBackend = useBackend(backend);
+    const effectiveWorkspace = useWorkspace(workspace);
+
+    invariant(
+        effectiveBackend,
+        "The backend in useDashboardViewLayout must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useDashboardViewLayout must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const promise = dashboardLayout
+        ? async () => {
+              const insightRefsToLoad = layoutWidgets(dashboardLayout)
+                  .filter((w) => w.type === "insight")
+                  .map((w) => w.insight);
+
+              const insights = await Promise.all(
+                  insightRefsToLoad.map((ref) =>
+                      effectiveBackend.workspace(effectiveWorkspace).insights().getInsight(ref),
+                  ),
+              );
+
+              const getDashboardViewWidgetClass = (insightRef: ObjRef): DashboardViewLayoutWidgetClass => {
+                  const insight = insights.find((i) => areObjRefsEqual(i.insight.ref, insightRef));
+                  return insight.insight.visualizationUrl.split(":")[1] as DashboardViewLayoutWidgetClass;
+              };
+
+              // Convert current layout model to "legacy" layout model,
+              // to keep it backward compatible with KD
+              const emptyLayout: IDashboardViewLayout = {
+                  ...dashboardLayout,
+                  rows: [],
+              };
+
+              return FluidLayoutTransforms.for(dashboardLayout).reduceColumns(
+                  (acc: IDashboardViewLayout, { column, columnIndex, row, rowIndex }) => {
+                      if (!acc.rows[rowIndex]) {
+                          acc.rows[rowIndex] = {
+                              ...row,
+                              columns: [],
+                          };
+                      }
+                      const currentContent = column.content;
+                      if (isWidget(currentContent)) {
+                          acc.rows[rowIndex].columns[columnIndex] = {
+                              ...column,
+                              content: {
+                                  type: "widget",
+                                  widget: currentContent,
+                                  widgetClass:
+                                      currentContent.type === "insight"
+                                          ? getDashboardViewWidgetClass(currentContent.insight)
+                                          : "kpi",
+                              },
+                          };
+                      } else {
+                          throw new UnexpectedError("Unknown widget");
+                      }
+
+                      return acc;
+                  },
+                  emptyLayout,
+              );
+          }
+        : null;
+
+    return useCancelablePromise({ promise, onCancel, onError, onLoading, onPending, onSuccess }, [
+        effectiveWorkspace,
+        dashboardLayout,
+    ]);
+};

--- a/libs/sdk-ui/src/base/react/useCancelablePromise.ts
+++ b/libs/sdk-ui/src/base/react/useCancelablePromise.ts
@@ -116,16 +116,6 @@ export function useCancelablePromise<TResult, TError = any>(
     });
     const [state, setState] = useState(getInitialState());
 
-    // We want to avoid the return of the old state when some dependency has changed,
-    // before another useEffect hook round starts.
-    const [prevDeps, setDeps] = useState<DependencyList>(deps);
-    if (deps.some((dep, i) => dep !== prevDeps[i])) {
-        setDeps(deps);
-        const currentState = getInitialState();
-        setState(currentState);
-        return currentState;
-    }
-
     useEffect(() => {
         if (!promise) {
             setState({
@@ -183,6 +173,16 @@ export function useCancelablePromise<TResult, TError = any>(
             }
         };
     }, deps);
+
+    // We want to avoid the return of the old state when some dependency has changed,
+    // before another useEffect hook round starts.
+    const [prevDeps, setDeps] = useState<DependencyList>(deps);
+    if (deps.some((dep, i) => dep !== prevDeps[i])) {
+        setDeps(deps);
+        const currentState = getInitialState();
+        setState(currentState);
+        return currentState;
+    }
 
     return state;
 }


### PR DESCRIPTION
Add useDashboardViewLayout hook, that loads required additional data for the layouting, and transforms IDashboardLayout to IDashboardViewLayout model.

JIRA: 2818
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
