### PR TITLE
RELATED: RAIL-2819 add Dashboard item components 

### DIFF
--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -347,6 +347,10 @@
       "allowedCategories": [ "production" ]
     },
     {
+      "name": "@types/react-truncate",
+      "allowedCategories": [ "production" ]
+    },
+    {
       "name": "@types/react-window",
       "allowedCategories": [ "production" ]
     },
@@ -784,6 +788,10 @@
     },
     {
       "name": "react-transition-group",
+      "allowedCategories": [ "production" ]
+    },
+    {
+      "name": "react-truncate",
       "allowedCategories": [ "production" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -37,7 +37,7 @@ dependencies:
   '@types/node': 12.12.62
   lru-cache: 4.1.5
   prettier: 2.0.5
-  pretty-quick: 2.0.2_prettier@2.0.5
+  pretty-quick: 2.0.2
   ts-node: 8.10.2_typescript@4.0.2
   tslib: 2.0.1
   typescript: 4.0.2
@@ -3725,6 +3725,12 @@ packages:
     dev: false
     resolution:
       integrity: sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==
+  /@types/react-truncate/2.3.3:
+    dependencies:
+      '@types/react': 16.9.49
+    dev: false
+    resolution:
+      integrity: sha512-wtbubWJSvT+A3zzacmxpXE1nkHKX0nybSXfwNTdHtBfwJEzm1Caau9AGAS6R7uBuYw0sHcK/DoqRALfSOexLew==
   /@types/react-window/1.8.2:
     dependencies:
       '@types/react': 16.9.49
@@ -15016,7 +15022,7 @@ packages:
       node: '>= 0.8'
     resolution:
       integrity: sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
-  /pretty-quick/2.0.2_prettier@2.0.5:
+  /pretty-quick/2.0.2:
     dependencies:
       chalk: 2.4.2
       execa: 2.1.0
@@ -15024,7 +15030,6 @@ packages:
       ignore: 5.1.8
       mri: 1.1.6
       multimatch: 4.0.0
-      prettier: 2.0.5
     dev: false
     engines:
       node: '>=8'
@@ -15951,6 +15956,15 @@ packages:
       react-dom: '>=16.6.0'
     resolution:
       integrity: sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
+  /react-truncate/2.4.0_react@16.13.1:
+    dependencies:
+      react: 16.13.1
+    dev: false
+    peerDependencies:
+      prop-types: <= 15.x.x
+      react: <= 16.x.x
+    resolution:
+      integrity: sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA==
   /react-window/1.8.5_react-dom@16.13.1+react@16.13.1:
     dependencies:
       '@babel/runtime': 7.11.2
@@ -20056,7 +20070,7 @@ packages:
     dev: false
     name: '@rush-temp/api-client-bear'
     resolution:
-      integrity: sha512-s48qqY31XwCuzaUawaBnm/qKWZlYi8oLGoxKZZwb4KqXIZt3ZxY7zdoUC2eq+IvV6pkADmKxRk/J48UjOKxb1Q==
+      integrity: sha512-h7jn0ATIbAbhQFyPlgrjNaYni8gtPbVLiJkTIG/Of4RPTFNZMcIthtZsMdj3dY4zXCgu/bm7xpHEFVNqvQYh8A==
       tarball: 'file:projects/api-client-bear.tgz'
     version: 0.0.0
   'file:projects/api-client-tiger.tgz':
@@ -20093,7 +20107,7 @@ packages:
     dev: false
     name: '@rush-temp/api-client-tiger'
     resolution:
-      integrity: sha512-HPJiqfXdK1QA0J1J4PZ3e9gEKuOVe0eCYzDMG1ytrB0QviLaUlMlg8LVYQc486NmB9UJwkuui4MO6tCgMO0Szw==
+      integrity: sha512-IgSj4xVl3LGtItasCdwKCP0gfs871vnLILEZwGsA5sW/wgPRpVAobmPG9chDZEEUIzY+1lwrIzhRlQjnsD+mgw==
       tarball: 'file:projects/api-client-tiger.tgz'
     version: 0.0.0
   'file:projects/api-model-bear.tgz':
@@ -20199,7 +20213,7 @@ packages:
     dev: false
     name: '@rush-temp/catalog-export'
     resolution:
-      integrity: sha512-LOm9877KZWxW/3OoE1zqPqIyLFr3nD69Pe4YDno05PvZeLlACmjrKBIb1ES+w2vja7cnpopZ3+nQ15MnJkjF6g==
+      integrity: sha512-BgD42QgY7X0Tm7TfA0HC4sKAPyV0rdaZodyKVTpR6OIxGbEYGcrpz6TufYZnVr+Yl34oC6ZCyG1VH559KwHA5Q==
       tarball: 'file:projects/catalog-export.tgz'
     version: 0.0.0
   'file:projects/experimental-workspace.tgz':
@@ -20227,7 +20241,7 @@ packages:
     dev: false
     name: '@rush-temp/experimental-workspace'
     resolution:
-      integrity: sha512-X+LWTC45CU9xsNwDJy8TbUpiMSiH4yl8slzpSK4w/czc8MUKYpQMTSGkjEFiQEWgmVCAIez4wv+T/HJsn8nwlA==
+      integrity: sha512-2lvoyfntUJOuq7t+LmhoBUpkUDPSdhxyurPXVVArw7BzRcRIi9EC/BDleeS8KTQnZzwlNF1UxrV3WJ3cw41CYA==
       tarball: 'file:projects/experimental-workspace.tgz'
     version: 0.0.0
   'file:projects/live-examples-workspace.tgz':
@@ -20254,7 +20268,7 @@ packages:
     dev: false
     name: '@rush-temp/live-examples-workspace'
     resolution:
-      integrity: sha512-96Tb6xwR34WSUpjONeERvcgqzAmcSb598x+WuCd3I/CGrthwi8U3BGyfmPynjs4J747fZ07Xsjx75hPewIpCQg==
+      integrity: sha512-4MMejDXe1dVkwVsLt6ZKKeCWcVhKy5HO7w9pmC6AVR6lDbDIGU06avqdb7Kbaq3G8MBPoAdExUTmABQjABwzFg==
       tarball: 'file:projects/live-examples-workspace.tgz'
     version: 0.0.0
   'file:projects/mock-handling.tgz':
@@ -20296,7 +20310,7 @@ packages:
     dev: false
     name: '@rush-temp/mock-handling'
     resolution:
-      integrity: sha512-lszsn7C0E+K54g2GlAwB/g1fbKSnz02+UKxfwoUOKYbG9W87J8bfPe27d4NPYmYrvGtyOnNkNDWcit9aCJA+Lw==
+      integrity: sha512-2X6T4vC/+I1Q64QX1bxtT+ZVZUcoQ6MEo4A/HyiVUVUQwojz17X448T306/9bo5kUSO3OjAO1oVj+aXv+7yDEA==
       tarball: 'file:projects/mock-handling.tgz'
     version: 0.0.0
   'file:projects/reference-workspace-mgmt.tgz':
@@ -20322,7 +20336,7 @@ packages:
     dev: false
     name: '@rush-temp/reference-workspace-mgmt'
     resolution:
-      integrity: sha512-YAWUo/rYV247gEk4WpXJUmxGuNfNZXuhQG4KH1C8OwrhFoHiEcvn6UgVWOlC2n5zpgKKFKvIkHlG1B4MM9Jr5w==
+      integrity: sha512-/WzL5BJNSwUo8LUxuAOqWZJQaRDEcJSdVkGQnwJ5aoWo90EfsB6zAr4rmXx0fLq4tFvR3QR3yeiPjAXCJL68Mw==
       tarball: 'file:projects/reference-workspace-mgmt.tgz'
     version: 0.0.0
   'file:projects/reference-workspace.tgz':
@@ -20349,7 +20363,7 @@ packages:
     dev: false
     name: '@rush-temp/reference-workspace'
     resolution:
-      integrity: sha512-lghfq4IppI0Bii0j1q0siZ2tpu2Mkuad3opMmHvvOcWz24tSQV09UC/GlJrA4v9433ph0VjPLxFb8jkoJIQhcw==
+      integrity: sha512-aq+eV3xqsvwO66zwBOM/iU4uM8s35jcZORtKfrtAOscOuYPqlWIphE9Hebs4MLZugIw/CAVKj3hh7AhCy/Jj+Q==
       tarball: 'file:projects/reference-workspace.tgz'
     version: 0.0.0
   'file:projects/sdk-backend-base.tgz':
@@ -20384,7 +20398,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-backend-base'
     resolution:
-      integrity: sha512-Zv9oP+GAR8X96Q8z64AYgF92nhfRbckSQDZktWSmJ6ULJLa4UEYB3rPDEFSs+g+LmbdrB/0macnMkWWHPjqYvw==
+      integrity: sha512-CxPBmpGGLouZCvuUZ5L0uUA92BPp0auN55zZIhDjQ9Vo+BT2RdnBqTeyBHiJB564T/vqIm8ZuuSixLl83T0pUw==
       tarball: 'file:projects/sdk-backend-base.tgz'
     version: 0.0.0
   'file:projects/sdk-backend-bear.tgz':
@@ -20422,7 +20436,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-backend-bear'
     resolution:
-      integrity: sha512-zLzSLGH/zxkxFKvsMbLqihHY2GQ8vBm/oBBV48zn2H8/mjKj86ZvThuTlSt9jvIHF6oyNRqYlg6OWRHt8RWR1g==
+      integrity: sha512-lyrAqbNJKrw5K6kFYtJDdYXyVHFHx5PZspuaHkMf0qQOgCcZ2Gh+TQhgHqDMVkOwEI0zw8zbPxi3m9gzfD58rw==
       tarball: 'file:projects/sdk-backend-bear.tgz'
     version: 0.0.0
   'file:projects/sdk-backend-mockingbird.tgz':
@@ -20452,7 +20466,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-backend-mockingbird'
     resolution:
-      integrity: sha512-wOfjYdnNVgjx/GnYSJpr+3cQN8KQCm8e/vPQ6YIhXcJAYz+ezhhH3uvDCJ3F3JlEEsqKk4NnZ6Tx/tFXEIiJpA==
+      integrity: sha512-R1GvVt2S0f+/uKvCQHPwJi1my/OwVPW9a/0taSys8JJBUCgc6Z5Ox8Ntpgl7irQauuiSn6AdoOU5pjm2KKUfbA==
       tarball: 'file:projects/sdk-backend-mockingbird.tgz'
     version: 0.0.0
   'file:projects/sdk-backend-spi.tgz':
@@ -20483,7 +20497,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-backend-spi'
     resolution:
-      integrity: sha512-5eD2ksMDhM1wsTwFn+0b3cGhNtbWGJ5Bfi6OTKw+SqdUtCMB+6xCKUKk0zQ4pz2GHMGxODXMW8Hz+IAqyaVAFQ==
+      integrity: sha512-N/zCeYyYOqQLtqrkrqjzdq0fUgAG1YuIWlbUzjMKe65ExcOwPs25x7jBfwP64oJsu8pr7j9hE5ejNqIOA2ZuqA==
       tarball: 'file:projects/sdk-backend-spi.tgz'
     version: 0.0.0
   'file:projects/sdk-backend-tiger.tgz':
@@ -20519,7 +20533,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-backend-tiger'
     resolution:
-      integrity: sha512-P4gqcy5ZV4LBsjd1V5l5uuzSxkZxwNGD9oXQQQOXxyGX8nNWVV3SjAr/oXMUv6fIhclHruOi86F6jWPW9TUKlg==
+      integrity: sha512-7q04ocR+jvnIUItKLQS4vs+tKA9jAC3+9MarkLrfrLIO/5zw+Vf4SS6lM3I9+9WzygHZB2LJDYWxuGJBIJXVcg==
       tarball: 'file:projects/sdk-backend-tiger.tgz'
     version: 0.0.0
   'file:projects/sdk-embedding.tgz':
@@ -20549,7 +20563,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-embedding'
     resolution:
-      integrity: sha512-YP/DWctqzOy4ftNzBBcw4vSDN27NcrYIdKmXCAxuA1sR9TaYZLs9VMJNoQ6PhyMbm+Plo8qAFMBGFzfg3lvPdg==
+      integrity: sha512-I5vI9ZesHKFl2ezeyYMmU9AYLjkSkJpQjmf4cIUG/1GpbqQ276GLs96mjvGgfbJnvMO8QlbrjSOa/Ma9uiMfUg==
       tarball: 'file:projects/sdk-embedding.tgz'
     version: 0.0.0
   'file:projects/sdk-examples.tgz':
@@ -20646,7 +20660,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-examples'
     resolution:
-      integrity: sha512-EKySo5rkFgiXdc4AiOFItKVcgzC3nT9qIPfjqVDkVYRbrWXPh3e80LHatcLMHb7fc8AzQfg1jkLMIILqS8ELLQ==
+      integrity: sha512-kiyqamU7o5NEn65Use5J7tSF/jFmEA26MN6ypbXZRyZ8xk429IRYoL4f3ZLE5LJZk3Q8InAxDNBqFW5mX9M/lQ==
       tarball: 'file:projects/sdk-examples.tgz'
     version: 0.0.0
   'file:projects/sdk-model.tgz':
@@ -20782,7 +20796,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-all'
     resolution:
-      integrity: sha512-O8B65JC/ORqL57YHyS63A0ZeaVnR7i42j6c62DmQb650St75if9U3YXuzw2/5/4CiZRyCMRVXOnt/5SEhkKnnQ==
+      integrity: sha512-yS6EWG+YYf0KDT4WultHEXY5pQFFxxQ1qrAAQPxneeGKUE/Tw/ttd7rqMYClWckh2A7Xo0HFQG286gtpYrIZkw==
       tarball: 'file:projects/sdk-ui-all.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-charts.tgz':
@@ -20842,7 +20856,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-charts'
     resolution:
-      integrity: sha512-SCV8xRUXCF3MuRzFXpJBn9xL/sU4PtmYSDF9aEWZcDOuipwgDyv2lezEBzzdCDIqb0zcqjYUffRZXtaI89/Jew==
+      integrity: sha512-Cw3hu+crISsx2SiOgRz6RhkkonexvvKH6M5NELTkWlLIcLQ2vdGlDYE5ReSVE9HO2SuK9M55iq5m64rn1FlFPw==
       tarball: 'file:projects/sdk-ui-charts.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-ext.tgz':
@@ -20864,6 +20878,7 @@ packages:
       '@types/react': 16.9.49
       '@types/react-dom': 16.9.8
       '@types/react-measure': 2.0.5
+      '@types/react-truncate': 2.3.3
       '@types/uuid': 3.4.9
       '@typescript-eslint/eslint-plugin': 3.10.1_08da1fbcd1c22c8d57ca8c2ea832e291
       '@typescript-eslint/parser': 3.10.1_eslint@7.10.0+typescript@4.0.2
@@ -20897,6 +20912,7 @@ packages:
       react-grid-system: 7.1.1_react@16.13.1
       react-intl: 3.12.1_react@16.13.1
       react-measure: 2.5.2_react-dom@16.13.1+react@16.13.1
+      react-truncate: 2.4.0_react@16.13.1
       rollup: 2.32.0
       rollup-plugin-typescript2: 0.27.3_rollup@2.32.0+typescript@4.0.2
       ts-invariant: 0.5.1
@@ -20907,7 +20923,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-ext'
     resolution:
-      integrity: sha512-bHhwMPUIPlyGVn39mOqi9cCxaAKkZC/ISnhZ85lYuwMDB8JURR0sIdG7sLTvvVhSxRrMWBqnsbUv6nlj6j24fg==
+      integrity: sha512-PdZY23iVOujSpkzriG2KgNCGzXZRtDuALA9zvrDIRKavrj18TRjgJLft4q21g2bEJPQFaUejbpRTDWgLmdA0nQ==
       tarball: 'file:projects/sdk-ui-ext.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-filters.tgz':
@@ -20971,7 +20987,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-filters'
     resolution:
-      integrity: sha512-KZCvR6w61aPBqe2s9jENT8GD29VQzRNKnQ1aKvOWty2R31bEKE5PLIzQG/SYDLWlCLZ/GRA5J8bIdnIWY+uLBw==
+      integrity: sha512-E6WeGUp58GjEhjI7QslTVYiPnH5mMJfGYDy045QvvwL3ODsm74qhtD0qg/pOQTrmSV1K4QiNxFx4QiSvTIkq6g==
       tarball: 'file:projects/sdk-ui-filters.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-geo.tgz':
@@ -21026,7 +21042,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-geo'
     resolution:
-      integrity: sha512-i6Quhy1+p1Fz1XKsy9383xF992naBjjajq8lspxK1/yszt+rlQYeBzMO1gGFCmPBwYJTJHG5OIsjdwnDgMOPBA==
+      integrity: sha512-VR5yZTa1/tBOTZaXrDbqb+0b0MWwZrBa32wVINWr59Jniypwwmw5KGcD9EMmapQbAs4Lqf3dqVixso0G7alDJQ==
       tarball: 'file:projects/sdk-ui-geo.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-kit.tgz':
@@ -21091,7 +21107,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-kit'
     resolution:
-      integrity: sha512-43fsSRM4sNPMkbwoUUDvh67RRAzymklbajjghuaxsxcc6fXGuoEfZucT+6qDDlLh+zmBcCSw7BQhE1qGcebtGg==
+      integrity: sha512-N7CLYWGQxLBpSmZ86nlL8/P1p8xdkFGuPwIVCLAqBz4KEjiVSrAOV+BBckFGih4IuCM85gxJLYO/2VX0b/ndgQ==
       tarball: 'file:projects/sdk-ui-kit.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-pivot.tgz':
@@ -21149,7 +21165,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-pivot'
     resolution:
-      integrity: sha512-+dEKFFYQ+o52Jeaixv5iGn4exC/1i8bhJKhxBQoXkFsxMAjK5fwE3kPpplUqPrspj6EOtcBIgkBXVRGBTVfC/w==
+      integrity: sha512-wl1sXVBv1jFAK7f6vqIGSNy4nkxPy6DUoFquLMPn92hZVNsA9vznz8jHUCf/cBe60PJ5wQOY1VEwKVX3QT+7KA==
       tarball: 'file:projects/sdk-ui-pivot.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-tests.tgz':
@@ -21218,7 +21234,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-tests'
     resolution:
-      integrity: sha512-Tr0X4MhNjuxmYDHmPfjgRp4tDHq2zJgelpdj3V0ZAPgtNJQx0rqomcgXkE7Zw3wKtAU8Z3C7Nyj9IRg0Uuq8Ag==
+      integrity: sha512-Ze6J8mp5XqGvFOWR0sL+AB+ZfBaTovtKCMtS5D3VW58JKtTIocfHhO3mAOs2a9pp6rB1yTk0LOF0udEhc3LC8w==
       tarball: 'file:projects/sdk-ui-tests.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-theme-provider.tgz':
@@ -21266,7 +21282,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-theme-provider'
     resolution:
-      integrity: sha512-gStM0b+5sSVC9xPzrQvgIQCglF0/4gwiXELSO8NAwxjz5LjDz57mXJcmy8xZqDB0x7BCYYPsP2/PHmO9dkYc+Q==
+      integrity: sha512-kl3mTyG1cMz/bNAQ9U1A1iTomdwF3yAoBc1RC62kzpKk44cMtq4qN1vV7UfpcwZdibb3dn651TomL6PNl36idw==
       tarball: 'file:projects/sdk-ui-theme-provider.tgz'
     version: 0.0.0
   'file:projects/sdk-ui-vis-commons.tgz':
@@ -21317,7 +21333,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui-vis-commons'
     resolution:
-      integrity: sha512-IrTB049yTKcHP5yXvOYAoz6PJqU7ngonmCpafLrG1lwLhYRmWHQuC0HYhfoETdDmDn5B1gzUzVjMSaa/qDZhbQ==
+      integrity: sha512-ebOz0lYptlw07MUXzTPlHr4HvMvBgnAZkoTxipbp3f24H5pEHMbONyFQhra7anBcsMI/kwnwSnhe3FrP02IMhA==
       tarball: 'file:projects/sdk-ui-vis-commons.tgz'
     version: 0.0.0
   'file:projects/sdk-ui.tgz':
@@ -21368,7 +21384,7 @@ packages:
     dev: false
     name: '@rush-temp/sdk-ui'
     resolution:
-      integrity: sha512-bzhE3yz6XOc6rxltlPeJ8F0DC6QwkzBmmZdWVSEvwBxnCctIXOQCuqBiriDeeJ4uR5LNdNOZgLF0/a5K1SnfTg==
+      integrity: sha512-M7oz/zrlx/vpTqTwssF5r5Khv7n/0JU6z08iAWtgc0UmASWZaamPSHGicgw3qPCGhySg3KZER67AtXpQ3IgrUA==
       tarball: 'file:projects/sdk-ui.tgz'
     version: 0.0.0
   'file:projects/util.tgz':

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -72,12 +72,13 @@
         "fixed-data-table-2": "^0.8.21",
         "lodash": "^4.17.19",
         "lru-cache": "^4.1.5",
+        "react-grid-system": "^7.1.1",
         "react-intl": "^3.6.0",
         "react-measure": "^2.3.0",
+        "react-truncate": "^2.4.0",
         "ts-invariant": "^0.5.1",
         "tslib": "^2.0.0",
-        "uuid": "^3.3.3",
-        "react-grid-system": "^7.1.1"
+        "uuid": "^3.3.3"
     },
     "peerDependencies": {
         "react": "^16.10.0",
@@ -100,6 +101,7 @@
         "@types/react": "^16.9.11",
         "@types/react-dom": "^16.9.3",
         "@types/react-measure": "2.0.5",
+        "@types/react-truncate": "^2.3.3",
         "@types/uuid": "^3.4.5",
         "@typescript-eslint/eslint-plugin": "^3.7.1",
         "@typescript-eslint/parser": "^3.7.1",

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItem.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItem.tsx
@@ -1,0 +1,21 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+import { ResponsiveScreenType } from "@gooddata/sdk-backend-spi";
+
+interface IDashboardItemProps extends React.HTMLAttributes<HTMLDivElement> {
+    screen: ResponsiveScreenType;
+}
+
+// done like this instead of a template string so that the code is greppable for the individual classes
+const screenClasses: { [S in ResponsiveScreenType]: string } = {
+    xs: "layout-xs",
+    sm: "layout-sm",
+    md: "layout-md",
+    lg: "layout-lg",
+    xl: "layout-xl",
+};
+
+export const DashboardItem: React.FC<IDashboardItemProps> = ({ className, screen, ...props }) => {
+    return <div {...props} className={cx(className, "dash-item", "s-dash-item", screenClasses[screen])} />;
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemBase.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemBase.tsx
@@ -1,0 +1,75 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+
+import { DashboardItemContent } from "./DashboardItemContent";
+import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
+
+export interface IDashboardItemBaseProps {
+    /**
+     * Render prop for the content itself.
+     */
+    children: (params: { clientWidth: number }) => React.ReactNode;
+    /**
+     * Render prop for the item headline.
+     */
+    renderHeadline?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content before the visualization container.
+     */
+    renderBeforeVisualization?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content after the visualization container.
+     */
+    renderAfterVisualization?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered before the main content.
+     */
+    renderBeforeContent?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered after the main content.
+     */
+    renderAfterContent?: () => React.ReactNode;
+    /**
+     * Class name applied to the main content.
+     */
+    contentClassName?: string;
+    /**
+     * Class name applied to the visualization container.
+     */
+    visualizationClassName?: string;
+    /**
+     * Ref forwarded to the main content container.
+     */
+    contentRef?: React.Ref<HTMLDivElement>;
+}
+
+export const DashboardItemBase: React.FC<IDashboardItemBaseProps> = ({
+    children,
+    contentClassName,
+    visualizationClassName,
+    renderHeadline = () => null,
+    renderBeforeVisualization = () => null,
+    renderAfterVisualization = () => null,
+    renderBeforeContent = () => null,
+    renderAfterContent = () => null,
+    contentRef,
+}) => {
+    return (
+        <DashboardItemContentWrapper>
+            {({ clientWidth }) => (
+                <>
+                    {renderBeforeContent()}
+                    <DashboardItemContent className={contentClassName} ref={contentRef}>
+                        {renderBeforeVisualization()}
+                        <div className={visualizationClassName}>
+                            {renderHeadline()}
+                            {children({ clientWidth })}
+                        </div>
+                        {renderAfterVisualization()}
+                    </DashboardItemContent>
+                    {renderAfterContent()}
+                </>
+            )}
+        </DashboardItemContentWrapper>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContent.tsx
@@ -1,0 +1,20 @@
+// (C) 2020 GoodData Corporation
+import React, { forwardRef } from "react";
+import cx from "classnames";
+
+interface IDashboardItemContentProps {
+    className?: string;
+    children?: React.ReactNode;
+}
+
+export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemContentProps>(
+    ({ children, className }, ref) => {
+        return (
+            <div className={cx("dash-item-content", className)} ref={ref}>
+                {children}
+            </div>
+        );
+    },
+);
+
+DashboardItemContent.displayName = "DashboardItemContent";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContentWrapper.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContentWrapper.tsx
@@ -1,0 +1,18 @@
+// (C) 2020 GoodData Corporation
+import React, { useRef } from "react";
+
+interface IDashboardItemContentWrapperProps {
+    children: (params: { clientWidth: number }) => React.ReactNode;
+}
+
+export const DashboardItemContentWrapper: React.FC<IDashboardItemContentWrapperProps> = ({ children }) => {
+    const containerRef = useRef<HTMLDivElement>();
+
+    const clientWidth = containerRef.current?.clientWidth ?? 0;
+
+    return (
+        <div className="dash-item-content-wrapper" ref={containerRef}>
+            {children({ clientWidth })}
+        </div>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemHeadline.tsx
@@ -1,0 +1,19 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import Truncate from "react-truncate";
+
+import { DashboardItemHeadlineContainer } from "./DashboardItemHeadlineContainer";
+
+interface IDashboardItemHeadlineProps {
+    title: string;
+}
+
+export const DashboardItemHeadline: React.FC<IDashboardItemHeadlineProps> = ({ title }) => {
+    return (
+        <DashboardItemHeadlineContainer>
+            <Truncate lines={2} ellipsis={"..."} className="item-headline-inner s-headline">
+                {title}
+            </Truncate>
+        </DashboardItemHeadlineContainer>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemHeadlineContainer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemHeadlineContainer.tsx
@@ -1,0 +1,10 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+
+export const DashboardItemHeadlineContainer: React.FC = ({ children }) => {
+    return (
+        <div className="item-headline-outer">
+            <div className="item-headline">{children}</div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemKpi.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemKpi.tsx
@@ -1,0 +1,76 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+
+import { DashboardItemContent } from "./DashboardItemContent";
+import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
+
+interface IDashboardItemKpiProps {
+    /**
+     * Render prop for the content itself.
+     */
+    children: (params: { clientWidth: number }) => React.ReactNode;
+    /**
+     * Render prop for the item headline.
+     */
+    renderHeadline?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content before the kpi container.
+     */
+    renderBeforeKpi?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content after the kpi container.
+     */
+    renderAfterKpi?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered before the main content.
+     */
+    renderBeforeContent?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered after the main content.
+     */
+    renderAfterContent?: () => React.ReactNode;
+    /**
+     * Class name applied to the main content.
+     */
+    contentClassName?: string;
+    /**
+     * Class name applied to the kpi container.
+     */
+    kpiClassName?: string;
+    /**
+     * Ref forwarded to the main content container.
+     */
+    contentRef?: React.Ref<HTMLDivElement>;
+}
+
+export const DashboardItemKpi: React.FC<IDashboardItemKpiProps> = ({
+    children,
+    contentClassName,
+    kpiClassName,
+    renderHeadline = () => null,
+    renderBeforeKpi = () => null,
+    renderAfterKpi = () => null,
+    renderBeforeContent = () => null,
+    renderAfterContent = () => null,
+    contentRef,
+}) => {
+    return (
+        <DashboardItemContentWrapper>
+            {({ clientWidth }) => (
+                <>
+                    {renderBeforeContent()}
+                    <DashboardItemContent className={contentClassName} ref={contentRef}>
+                        {renderBeforeKpi()}
+                        <div className={cx("kpi", kpiClassName)}>
+                            {renderHeadline()}
+                            {children({ clientWidth })}
+                        </div>
+                        {renderAfterKpi()}
+                    </DashboardItemContent>
+                    {renderAfterContent()}
+                </>
+            )}
+        </DashboardItemContentWrapper>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemKpi.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemKpi.tsx
@@ -2,75 +2,8 @@
 import React from "react";
 import cx from "classnames";
 
-import { DashboardItemContent } from "./DashboardItemContent";
-import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
+import { IDashboardItemBaseProps, DashboardItemBase } from "./DashboardItemBase";
 
-interface IDashboardItemKpiProps {
-    /**
-     * Render prop for the content itself.
-     */
-    children: (params: { clientWidth: number }) => React.ReactNode;
-    /**
-     * Render prop for the item headline.
-     */
-    renderHeadline?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered inside the main content before the kpi container.
-     */
-    renderBeforeKpi?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered inside the main content after the kpi container.
-     */
-    renderAfterKpi?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered before the main content.
-     */
-    renderBeforeContent?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered after the main content.
-     */
-    renderAfterContent?: () => React.ReactNode;
-    /**
-     * Class name applied to the main content.
-     */
-    contentClassName?: string;
-    /**
-     * Class name applied to the kpi container.
-     */
-    kpiClassName?: string;
-    /**
-     * Ref forwarded to the main content container.
-     */
-    contentRef?: React.Ref<HTMLDivElement>;
-}
-
-export const DashboardItemKpi: React.FC<IDashboardItemKpiProps> = ({
-    children,
-    contentClassName,
-    kpiClassName,
-    renderHeadline = () => null,
-    renderBeforeKpi = () => null,
-    renderAfterKpi = () => null,
-    renderBeforeContent = () => null,
-    renderAfterContent = () => null,
-    contentRef,
-}) => {
-    return (
-        <DashboardItemContentWrapper>
-            {({ clientWidth }) => (
-                <>
-                    {renderBeforeContent()}
-                    <DashboardItemContent className={contentClassName} ref={contentRef}>
-                        {renderBeforeKpi()}
-                        <div className={cx("kpi", kpiClassName)}>
-                            {renderHeadline()}
-                            {children({ clientWidth })}
-                        </div>
-                        {renderAfterKpi()}
-                    </DashboardItemContent>
-                    {renderAfterContent()}
-                </>
-            )}
-        </DashboardItemContentWrapper>
-    );
+export const DashboardItemKpi: React.FC<IDashboardItemBaseProps> = ({ visualizationClassName, ...props }) => {
+    return <DashboardItemBase {...props} visualizationClassName={cx("kpi", visualizationClassName)} />;
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemVisualization.tsx
@@ -1,0 +1,71 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+
+import { DashboardItemContent } from "./DashboardItemContent";
+import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
+
+interface IDashboardItemVisualizationProps {
+    /**
+     * Render prop for the content itself.
+     */
+    children: (params: { clientWidth: number }) => React.ReactNode;
+    /**
+     * Render prop for the item headline.
+     */
+    renderHeadline?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content before the visualization container.
+     */
+    renderBeforeVisualization?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered inside the main content after the visualization container.
+     */
+    renderAfterVisualization?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered before the main content.
+     */
+    renderBeforeContent?: () => React.ReactNode;
+    /**
+     * Render prop for content rendered after the main content.
+     */
+    renderAfterContent?: () => React.ReactNode;
+    /**
+     * Class name applied to the main content.
+     */
+    contentClassName?: string;
+    /**
+     * Class name applied to the visualization container.
+     */
+    visualizationClassName?: string;
+}
+
+export const DashboardItemVisualization: React.FC<IDashboardItemVisualizationProps> = ({
+    children,
+    contentClassName,
+    visualizationClassName,
+    renderHeadline = () => null,
+    renderBeforeVisualization = () => null,
+    renderAfterVisualization = () => null,
+    renderBeforeContent = () => null,
+    renderAfterContent = () => null,
+}) => {
+    return (
+        <DashboardItemContentWrapper>
+            {({ clientWidth }) => (
+                <>
+                    {renderBeforeContent()}
+                    <DashboardItemContent className={contentClassName}>
+                        {renderBeforeVisualization()}
+                        <div className={cx("visualization", visualizationClassName)}>
+                            {renderHeadline()}
+                            {children({ clientWidth })}
+                        </div>
+                        {renderAfterVisualization()}
+                    </DashboardItemContent>
+                    {renderAfterContent()}
+                </>
+            )}
+        </DashboardItemContentWrapper>
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemVisualization.tsx
@@ -2,70 +2,13 @@
 import React from "react";
 import cx from "classnames";
 
-import { DashboardItemContent } from "./DashboardItemContent";
-import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
+import { DashboardItemBase, IDashboardItemBaseProps } from "./DashboardItemBase";
 
-interface IDashboardItemVisualizationProps {
-    /**
-     * Render prop for the content itself.
-     */
-    children: (params: { clientWidth: number }) => React.ReactNode;
-    /**
-     * Render prop for the item headline.
-     */
-    renderHeadline?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered inside the main content before the visualization container.
-     */
-    renderBeforeVisualization?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered inside the main content after the visualization container.
-     */
-    renderAfterVisualization?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered before the main content.
-     */
-    renderBeforeContent?: () => React.ReactNode;
-    /**
-     * Render prop for content rendered after the main content.
-     */
-    renderAfterContent?: () => React.ReactNode;
-    /**
-     * Class name applied to the main content.
-     */
-    contentClassName?: string;
-    /**
-     * Class name applied to the visualization container.
-     */
-    visualizationClassName?: string;
-}
-
-export const DashboardItemVisualization: React.FC<IDashboardItemVisualizationProps> = ({
-    children,
-    contentClassName,
+export const DashboardItemVisualization: React.FC<IDashboardItemBaseProps> = ({
     visualizationClassName,
-    renderHeadline = () => null,
-    renderBeforeVisualization = () => null,
-    renderAfterVisualization = () => null,
-    renderBeforeContent = () => null,
-    renderAfterContent = () => null,
+    ...props
 }) => {
     return (
-        <DashboardItemContentWrapper>
-            {({ clientWidth }) => (
-                <>
-                    {renderBeforeContent()}
-                    <DashboardItemContent className={contentClassName}>
-                        {renderBeforeVisualization()}
-                        <div className={cx("visualization", visualizationClassName)}>
-                            {renderHeadline()}
-                            {children({ clientWidth })}
-                        </div>
-                        {renderAfterVisualization()}
-                    </DashboardItemContent>
-                    {renderAfterContent()}
-                </>
-            )}
-        </DashboardItemContentWrapper>
+        <DashboardItemBase {...props} visualizationClassName={cx("visualization", visualizationClassName)} />
     );
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/index.ts
@@ -1,0 +1,6 @@
+// (C) 2020 GoodData Corporation
+export { DashboardItemContent } from "./DashboardItemContent";
+export { DashboardItemHeadline } from "./DashboardItemHeadline";
+export { DashboardItemHeadlineContainer } from "./DashboardItemHeadlineContainer";
+export { DashboardItemKpi } from "./DashboardItemKpi";
+export { DashboardItemVisualization } from "./DashboardItemVisualization";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardContentRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardContentRenderer.tsx
@@ -19,6 +19,10 @@ import {
     IDashboardViewLayoutRow,
 } from "../DashboardLayout";
 import { IFluidLayoutContentRenderer } from "../FluidLayout";
+import { DashboardItemKpi } from "../DashboardItem/DashboardItemKpi";
+import { DashboardItemHeadline } from "../DashboardItem/DashboardItemHeadline";
+import { DashboardItemVisualization } from "../DashboardItem/DashboardItemVisualization";
+import { DashboardItem } from "../DashboardItem/DashboardItem";
 
 export type IDashboardContentRenderer = IFluidLayoutContentRenderer<
     IDashboardViewLayoutContent,
@@ -74,6 +78,7 @@ export const DashboardWidgetRenderer: IDashboardContentRenderer = (props) => {
         onDrill,
         onError,
         workspace,
+        screen,
     } = props;
     switch (content.type) {
         case "rowHeader": {
@@ -87,35 +92,51 @@ export const DashboardWidgetRenderer: IDashboardContentRenderer = (props) => {
         case "widget": {
             if (content.widget.type === "insight") {
                 return (
-                    <InsightRenderer
-                        insightWidget={content.widget as IWidget}
-                        backend={backend}
-                        workspace={workspace}
-                        filters={filters}
-                        drillableItems={drillableItems}
-                        onDrill={onDrill}
-                        onError={onError}
-                        ErrorComponent={ErrorComponent}
-                        LoadingComponent={LoadingComponent}
-                    />
+                    <DashboardItem className="type-visualization" screen={screen}>
+                        <DashboardItemVisualization
+                            renderHeadline={() => <DashboardItemHeadline title={content.widget.title} />}
+                        >
+                            {() => (
+                                <InsightRenderer
+                                    insightWidget={content.widget as IWidget}
+                                    backend={backend}
+                                    workspace={workspace}
+                                    filters={filters}
+                                    drillableItems={drillableItems}
+                                    onDrill={onDrill}
+                                    onError={onError}
+                                    ErrorComponent={ErrorComponent}
+                                    LoadingComponent={LoadingComponent}
+                                />
+                            )}
+                        </DashboardItemVisualization>
+                    </DashboardItem>
                 );
             }
 
             const relevantAlert = alerts?.find((alert) => areObjRefsEqual(alert.widget, content.widget.ref));
 
             return (
-                <KpiView
-                    kpiWidget={content.widget as IWidget}
-                    alert={relevantAlert}
-                    backend={backend}
-                    workspace={workspace}
-                    filters={filters}
-                    drillableItems={drillableItems}
-                    onDrill={onDrill}
-                    onError={onError}
-                    ErrorComponent={ErrorComponent}
-                    LoadingComponent={LoadingComponent}
-                />
+                <DashboardItem className="type-kpi" screen={screen}>
+                    <DashboardItemKpi
+                        renderHeadline={() => <DashboardItemHeadline title={content.widget.title} />}
+                    >
+                        {() => (
+                            <KpiView
+                                kpiWidget={content.widget as IWidget}
+                                alert={relevantAlert}
+                                backend={backend}
+                                workspace={workspace}
+                                filters={filters}
+                                drillableItems={drillableItems}
+                                onDrill={onDrill}
+                                onError={onError}
+                                ErrorComponent={ErrorComponent}
+                                LoadingComponent={LoadingComponent}
+                            />
+                        )}
+                    </DashboardItemKpi>
+                </DashboardItem>
             );
         }
         case "custom": {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiExecutor.tsx
@@ -28,7 +28,6 @@ import compact from "lodash/compact";
 import { IKpiValueInfo, KpiRenderer } from "./KpiRenderer";
 
 interface IKpiExecutorProps {
-    title: string;
     primaryMeasure: IMeasure;
     secondaryMeasure?: IMeasure<IPoPMeasureDefinition> | IMeasure<IPreviousPeriodMeasureDefinition>;
     alert?: IWidgetAlert;
@@ -47,7 +46,6 @@ interface IKpiExecutorProps {
  * @internal
  */
 export const KpiExecutor: React.FC<IKpiExecutorProps> = ({
-    title,
     primaryMeasure,
     secondaryMeasure,
     alert,
@@ -89,7 +87,7 @@ export const KpiExecutor: React.FC<IKpiExecutorProps> = ({
 
     if (status === "error") {
         return isNoDataError(error) ? (
-            <KpiRenderer title={title} onDrill={handleOnDrill} />
+            <KpiRenderer onDrill={handleOnDrill} />
         ) : (
             <ErrorComponent message={error.message} />
         );
@@ -108,7 +106,6 @@ export const KpiExecutor: React.FC<IKpiExecutorProps> = ({
             secondaryValue={secondaryValue}
             alert={alert}
             onDrill={handleOnDrill}
-            title={title}
         />
     );
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiRenderer.tsx
@@ -12,7 +12,6 @@ export interface IKpiValueInfo {
 }
 
 interface IKpiRendererProps {
-    title: string;
     primaryValue?: IKpiValueInfo;
     secondaryValue?: IKpiValueInfo;
     alert?: IWidgetAlert;
@@ -24,7 +23,6 @@ interface IKpiRendererProps {
  * @internal
  */
 export const KpiRenderer: React.FC<IKpiRendererProps> = ({
-    title,
     primaryValue,
     secondaryValue,
     alert,
@@ -48,7 +46,6 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
         <div>
             <div onClick={onPrimaryValueClick}>
                 <div>
-                    {title}
                     {!!alert && <span>{alert.isTriggered ? "Triggered alert" : "Not triggered alert"}</span>}
                 </div>
                 <div>{primaryValue?.formattedValue ?? "—"}</div>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/index.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/index.tsx
@@ -118,7 +118,6 @@ export const KpiView: React.FC<IKpiViewProps> = ({
 
     return (
         <KpiExecutor
-            title={kpiWidget.title}
             primaryMeasure={result.primaryMeasure}
             secondaryMeasure={result.secondaryMeasure}
             alert={alert}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
@@ -80,3 +80,4 @@ export {
     IFluidLayoutComponentProps,
     IFluidLayoutRowProps,
 } from "./FluidLayout";
+export * from "./DashboardItem";

--- a/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
@@ -1,0 +1,159 @@
+// (C) 2007-2020 GoodData Corporation
+@import "./variables";
+
+.dash-item {
+    position: relative;
+    box-sizing: border-box;
+    display: flex;
+    align-items: stretch;
+    min-height: $item-min-height;
+    padding: $item-outer-padding;
+    // Grid definition
+
+    @media #{$small-up} {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    @media #{$medium-up} {
+        flex: 0 0 50%;
+        max-width: 50%;
+    }
+
+    @media #{$large-up} {
+        flex: 0 0 25%;
+        max-width: 25%;
+    }
+
+    @media #{$xxlarge-up} {
+        flex: 0 0 percentage(1/6);
+        max-width: percentage(1/6);
+    }
+
+    @media #{$xsmall-only}, #{$small-only} {
+        flex-direction: column;
+
+        &::after {
+            content: "";
+            position: absolute;
+            right: 10px;
+            bottom: 5px;
+            left: 10px;
+            height: 0;
+            border-bottom: 1px dashed $gd-color-disabled;
+        }
+
+        &:last-child::after {
+            display: none;
+        }
+    }
+
+    &.layout-xl {
+        flex: 0 0 100%;
+        max-width: 100%;
+    }
+
+    &.type-visualization {
+        .viz-line-family-chart {
+            width: 100%;
+            min-width: 0;
+        }
+    }
+
+    &:hover {
+        a.kpi-link {
+            .kpi-value {
+                color: $gd-kpi-primaryMeasureColor;
+            }
+        }
+    }
+}
+
+.dash-item-content-wrapper,
+.dash-item-content {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    justify-content: flex-start;
+    width: 99.999%; /* 100% has issue in IE (wrong kpi width) */
+}
+
+.dash-item-content {
+    position: relative;
+    padding: $item-inner-padding;
+    border-width: $gd-dashboards-content-widget-borderWidth;
+    border-style: solid;
+    border-color: $gd-dashboards-content-widget-borderColor;
+    border-radius: $gd-dashboards-content-widget-borderRadius;
+    box-shadow: $gd-dashboards-content-widget-dropShadow;
+    line-height: 0;
+    background-color: $gd-color-white;
+    transition: $transition-length;
+
+    @media #{$xsmall-only}, #{$small-only} {
+        padding: 5px;
+    }
+
+    &::before {
+        content: "";
+        position: absolute;
+        top: 50%;
+        right: 50%;
+        bottom: 50%;
+        left: 50%;
+        display: block;
+        border-radius: inherit;
+    }
+}
+
+.type-kpi,
+.viz-type-headline {
+    .dash-item-content {
+        border-width: $gd-dashboards-content-kpiWidget-borderWidth;
+        border-style: solid;
+        border-color: $gd-dashboards-content-kpiWidget-borderColor;
+        border-radius: $gd-dashboards-content-kpiWidget-borderRadius;
+        background-color: $gd-dashboards-content-kpiWidget-backgroundColor;
+        box-shadow: $gd-dashboards-content-kpiWidget-dropShadow;
+    }
+
+    .item-headline {
+        text-align: $gd-dashboards-content-kpiWidget-title-textAlign;
+        color: $gd-dashboards-content-kpiWidget-title-color;
+    }
+}
+
+.item-headline-outer {
+    position: relative;
+    z-index: 1;
+    height: ($item-headline-lineHeight + $item-headline-padding-vertical) * 2 + 2; // relate SD-956: please update HEADLINE_OUTER_HEIGHT in widgetHeightUtil.ts when height is changed
+    margin-top: 10px;
+    line-height: ($item-headline-lineHeight + $item-headline-padding-vertical) * 2;
+
+    @media #{$xsmall-only}, #{$small-only} {
+        margin-top: 0;
+        padding: 0;
+    }
+
+    .visualization & {
+        margin-bottom: 10px;
+    }
+}
+
+.item-headline {
+    position: relative;
+    display: inline-block;
+    width: 100%;
+    max-height: ($item-headline-lineHeight + $item-headline-padding-vertical) * 2;
+    font-size: 17px;
+    line-height: $item-headline-lineHeight;
+    vertical-align: middle;
+    text-align: $gd-dashboards-content-widget-title-textAlign;
+    color: $gd-dashboards-content-widget-title-color;
+}
+
+.item-headline-inner {
+    display: inline-block;
+    overflow: hidden;
+    vertical-align: middle;
+}

--- a/libs/sdk-ui-ext/styles/internal/scss/layout.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/layout.scss
@@ -46,6 +46,14 @@ $gd-dashboards-section-description-color: var(
         flex: 1 1 auto;
         flex-direction: column;
     }
+
+    .dash-item {
+        max-width: 100%;
+        height: 100%;
+        max-height: 100%;
+        min-height: inherit;
+        flex-direction: column;
+    }
 }
 
 .gd-fluidlayout-layout {

--- a/libs/sdk-ui-ext/styles/internal/scss/variables.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/variables.scss
@@ -1,2 +1,51 @@
 // (C) 2007-2019 GoodData Corporation
 @import "~@gooddata/sdk-ui-kit/styles/scss/variables";
+
+$item-border: 2px;
+$item-min-height: 178px;
+$item-inner-padding: 8px;
+$item-outer-padding: 10px;
+$item-headline-lineHeight: 21px;
+$item-headline-padding-vertical: 2px;
+$widget-drop-shadow: none;
+
+$transition-length: 0.2s;
+
+// WIDGETS
+$gd-dashboards-content-widget-title-color: var(--gd-dashboards-content-widget-title-color, $gd-color-text);
+$gd-dashboards-content-widget-title-textAlign: var(--gd-dashboards-content-widget-title-textAlign, "center");
+$gd-dashboards-content-widget-borderRadius: var(--gd-dashboards-content-widget-borderRadius, 15px);
+$gd-dashboards-content-widget-borderColor: var(--gd-dashboards-content-widget-borderColor, transparent);
+$gd-dashboards-content-widget-borderWidth: var(--gd-dashboards-content-widget-borderWidth, $item-border);
+$gd-dashboards-content-widget-dropShadow: var(--gd-dashboards-content-widget-dropShadow, $widget-drop-shadow);
+
+// HEADLINES
+$gd-dashboards-content-kpiWidget-title-color: var(
+    --gd-dashboards-content-kpiWidget-title-color,
+    $gd-dashboards-content-widget-title-color
+);
+$gd-dashboards-content-kpiWidget-title-textAlign: var(
+    --gd-dashboards-content-kpiWidget-title-textAlign,
+    $gd-dashboards-content-widget-title-textAlign
+);
+$gd-dashboards-content-kpiWidget-backgroundColor: var(
+    --gd-dashboards-content-kpiWidget-backgroundColor,
+    $gd-color-white
+);
+$gd-dashboards-content-kpiWidget-borderRadius: var(
+    --gd-dashboards-content-kpiWidget-borderRadius,
+    $gd-dashboards-content-widget-borderRadius
+);
+$gd-dashboards-content-kpiWidget-borderColor: var(
+    --gd-dashboards-content-kpiWidget-borderColor,
+    $gd-dashboards-content-widget-borderColor
+);
+$gd-dashboards-content-kpiWidget-borderWidth: var(
+    --gd-dashboards-content-kpiWidget-borderWidth,
+    $gd-dashboards-content-widget-borderWidth
+);
+$gd-dashboards-content-kpiWidget-dropShadow: var(
+    --gd-dashboards-content-kpiWidget-dropShadow,
+    $gd-dashboards-content-widget-dropShadow
+);
+$gd-kpi-primaryMeasureColor: var(--gd-dashboards-content-kpiWidget-kpi-primaryMeasureColor, $gd-color-link);


### PR DESCRIPTION
Adds visual components for the dashboard items along with their CSS.
The clientWidth of the DashboardItemContent is not used for now, but it will be necessary once we have the whole KPI component migrated and when we use the InsightView more directly (it may need a new prop for this to pass it to the PlugVis).
Also, KpiView and friends had the title prop removed as it is handled higher up the tree now.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
