### PR TITLE
Replaces usage of GS components by ui-kit ones (apart of charts)

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/MinMaxControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/MinMaxControl.tsx
@@ -1,8 +1,10 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import get from "lodash/get";
-import Message from "@gooddata/goodstrap/lib/Messages/Message";
+
 import { WrappedComponentProps, injectIntl } from "react-intl";
+
+import { Message } from "@gooddata/sdk-ui-kit";
 
 import ConfigSubsection from "../configurationControls/ConfigSubsection";
 import InputControl from "../configurationControls/InputControl";

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorOverlay.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorOverlay.tsx
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "@gooddata/sdk-ui-kit";
 
 export enum DropdownVersionType {
     ColorPalette,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/tests/ColorOverlay.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/tests/ColorOverlay.test.tsx
@@ -3,7 +3,8 @@ import React from "react";
 import { mount } from "enzyme";
 import noop from "lodash/noop";
 import cloneDeep from "lodash/cloneDeep";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "@gooddata/sdk-ui-kit";
+
 import ColorOverlay, { IColorOverlayProps, DropdownVersionType } from "../ColorOverlay";
 
 const defaultProps: IColorOverlayProps = {

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -246,7 +246,7 @@ export interface IMeasureValueFilterCommonProps {
 // @beta (undocumented)
 export interface IMeasureValueFilterDropdownProps extends IMeasureValueFilterCommonProps {
     // (undocumented)
-    anchorEl?: EventTarget | string;
+    anchorEl?: HTMLElement | string;
     // (undocumented)
     onCancel: () => void;
 }
@@ -268,7 +268,7 @@ export interface IMeasureValueFilterState {
 // @beta (undocumented)
 export interface IRankingFilterDropdownProps {
     // (undocumented)
-    anchorEl?: EventTarget | string;
+    anchorEl?: HTMLElement | string;
     // (undocumented)
     attributeItems: IAttributeDropdownItem[];
     // (undocumented)

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IntlWrapper, ISeparators } from "@gooddata/sdk-ui";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "@gooddata/sdk-ui-kit";
 import { DropdownBody } from "./DropdownBody";
 import { MeasureValueFilterOperator, IMeasureValueFilterValue } from "./types";
 import { WarningMessage } from "./typings";
@@ -23,7 +23,7 @@ interface IDropdownOwnProps {
     usePercentage?: boolean;
     warningMessage?: WarningMessage;
     locale?: string;
-    anchorEl: EventTarget | string;
+    anchorEl: HTMLElement | string;
     separators?: ISeparators;
     displayTreatNullAsZeroOption?: boolean;
     treatNullAsZeroValue?: boolean;

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
@@ -19,7 +19,7 @@ import { IMeasureValueFilterCommonProps } from "./typings";
  */
 export interface IMeasureValueFilterDropdownProps extends IMeasureValueFilterCommonProps {
     onCancel: () => void;
-    anchorEl?: EventTarget | string;
+    anchorEl?: HTMLElement | string;
 }
 
 const getFilterValue = (filter: IMeasureValueFilter | undefined): IMeasureValueFilterValue => {

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdownBody.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
-import { Separator } from "@gooddata/sdk-ui-kit";
+import { Separator, Overlay } from "@gooddata/sdk-ui-kit";
 
 import OperatorDropdownItem from "./OperatorDropdownItem";
 import { MeasureValueFilterOperator } from "./types";

--- a/libs/sdk-ui-filters/src/RankingFilter/AttributeDropdown/AttributeDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/RankingFilter/AttributeDropdown/AttributeDropdownBody.tsx
@@ -1,7 +1,7 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ObjRefInScope, areObjRefsEqual, objRefToString } from "@gooddata/sdk-model";
+import { Overlay } from "@gooddata/sdk-ui-kit";
 import { AttributeItem } from "./DropdownItems/AttributeItem";
 import { IAttributeDropdownItem, ICustomGranularitySelection } from "../types";
 import { AllRecordsItem } from "./DropdownItems/AllRecordsItem";

--- a/libs/sdk-ui-filters/src/RankingFilter/MeasureDropdown/MeasureDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/RankingFilter/MeasureDropdown/MeasureDropdownBody.tsx
@@ -1,7 +1,7 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { objRefToString, areObjRefsEqual, ObjRefInScope } from "@gooddata/sdk-model";
+import { Overlay } from "@gooddata/sdk-ui-kit";
 import { MeasureDropdownItem } from "./MeasureDropdownItem";
 import { IMeasureDropdownItem } from "../types";
 

--- a/libs/sdk-ui-filters/src/RankingFilter/OperatorDropdown/OperatorDropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/RankingFilter/OperatorDropdown/OperatorDropdownBody.tsx
@@ -1,9 +1,10 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
-import { RankingFilterOperator } from "@gooddata/sdk-model";
-import { OperatorDropdownItem } from "./OperatorDropdownItem";
 import { injectIntl, WrappedComponentProps } from "react-intl";
+import { RankingFilterOperator } from "@gooddata/sdk-model";
+import { Overlay } from "@gooddata/sdk-ui-kit";
+
+import { OperatorDropdownItem } from "./OperatorDropdownItem";
 import { IOperatorDropdownItem } from "../types";
 
 interface IOperatorDropdownBodyComponentOwnProps {

--- a/libs/sdk-ui-filters/src/RankingFilter/RankingFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/RankingFilter/RankingFilterDropdown.tsx
@@ -1,8 +1,8 @@
 // (C) 2020 GoodData Corporation
 import React, { useState } from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { IRankingFilter, ObjRefInScope } from "@gooddata/sdk-model";
 import { IntlWrapper } from "@gooddata/sdk-ui";
+import { Overlay } from "@gooddata/sdk-ui-kit";
 import { RankingFilterDropdownBody } from "./RankingFilterDropdownBody";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IMeasureDropdownItem, IAttributeDropdownItem, ICustomGranularitySelection } from "./types";
@@ -37,7 +37,7 @@ export interface IRankingFilterDropdownProps {
     onCancel?: () => void;
     onDropDownItemMouseOver?: (ref: ObjRefInScope) => void;
     onDropDownItemMouseOut?: () => void;
-    anchorEl?: EventTarget | string;
+    anchorEl?: HTMLElement | string;
     customGranularitySelection?: ICustomGranularitySelection;
     locale?: string;
 }

--- a/libs/sdk-ui-filters/styles/scss/components/SelectMenu.scss
+++ b/libs/sdk-ui-filters/styles/scss/components/SelectMenu.scss
@@ -1,6 +1,6 @@
 // (C) 2019 GoodData Corporation
 @import "~@gooddata/sdk-ui-kit/styles/scss/variables.scss";
-@import "~@gooddata/goodstrap/lib/core/styles/mixins.scss";
+@import "~@gooddata/sdk-ui-kit/styles/scss/mixins.scss";
 
 .gd-select-menu {
     & * {

--- a/libs/sdk-ui-filters/styles/scss/dateFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/dateFilter.scss
@@ -2,15 +2,15 @@
 $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
 
 @import "~@gooddata/goodstrap/lib/core/styles/IndigoFont";
-@import "~@gooddata/goodstrap/lib/core/styles/Overlay";
-@import "~@gooddata/goodstrap/lib/Dialog/styles/Dialog";
-@import "~@gooddata/sdk-ui-kit/styles/scss/list";
 @import "~@gooddata/goodstrap/lib/Dropdown/styles/Dropdown";
 
+@import "~@gooddata/sdk-ui-kit/styles/scss/list";
+@import "~@gooddata/sdk-ui-kit/styles/scss/overlay";
 @import "~@gooddata/sdk-ui-kit/styles/scss/tabs";
 @import "~@gooddata/sdk-ui-kit/styles/scss/form";
 @import "~@gooddata/sdk-ui-kit/styles/scss/button";
 @import "~@gooddata/sdk-ui-kit/styles/scss/bubble";
+@import "~@gooddata/sdk-ui-kit/styles/scss/dialog";
 
 @import "./components/DynamicSelect.scss";
 @import "./components/Select.scss";

--- a/libs/sdk-ui-filters/styles/scss/measureValueFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/measureValueFilter.scss
@@ -2,13 +2,13 @@
 $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
 
 @import "~@gooddata/sdk-ui/styles/scss/settings";
-@import "~@gooddata/goodstrap/lib/core/styles/Overlay";
 @import "~@gooddata/goodstrap/lib/core/styles/SVGIcons";
 @import "~@gooddata/goodstrap/lib/Dropdown/styles/Dropdown";
 @import "~@gooddata/goodstrap/lib/core/styles/IndigoFont";
 @import "~@gooddata/sdk-ui-kit/styles/scss/typo-mixins";
 @import "~@gooddata/sdk-ui-kit/styles/scss/form";
 @import "~@gooddata/sdk-ui-kit/styles/scss/button";
+@import "~@gooddata/sdk-ui-kit/styles/scss/overlay";
 
 $dialog_width: 250px;
 

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -245,13 +245,7 @@ export class FullScreenOverlay extends Overlay<IOverlayState> {
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    getOverlayStyles(): {
-        position: string;
-        left: number;
-        top: number;
-        bottom: number;
-        right: number;
-    };
+    protected getOverlayStyles: () => React.CSSProperties;
 }
 
 // @internal (undocumented)
@@ -1469,7 +1463,7 @@ export interface IOverlayProps<T> {
     // (undocumented)
     isModal?: boolean;
     // (undocumented)
-    onAlign?: (optiimalAlign: Alignment) => void;
+    onAlign?: (optimalAlign: Alignment) => void;
     // (undocumented)
     onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     // (undocumented)
@@ -1478,7 +1472,7 @@ export interface IOverlayProps<T> {
     onMouseOver?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     // (undocumented)
     onMouseUp?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    positionType?: string;
+    positionType?: OverlayPositionType;
     // (undocumented)
     shouldCloseOnClick?: (e: React.MouseEvent) => boolean;
     // (undocumented)
@@ -1787,14 +1781,14 @@ export const MultiSelectList: React_2.ForwardRefExoticComponent<Pick<IMultiSelec
 export function normalizeTime(time: Date): Date;
 
 // @internal (undocumented)
-export class Overlay<T> extends React_2.Component<IOverlayProps<T>, IOverlayState> {
+export class Overlay<T = HTMLElement> extends React_2.Component<IOverlayProps<T>, IOverlayState> {
     constructor(props: IOverlayProps<T>);
     // (undocumented)
-    clickedInside: boolean;
+    align: () => void;
     // (undocumented)
     closeOnEscape(e: React_2.KeyboardEvent): void;
     // (undocumented)
-    closeOnMouseDrag(): void;
+    closeOnMouseDrag: () => void;
     // (undocumented)
     closeOnOutsideClick(e: React_2.MouseEvent): void;
     // (undocumented)
@@ -1808,15 +1802,9 @@ export class Overlay<T> extends React_2.Component<IOverlayProps<T>, IOverlayStat
     // (undocumented)
     static defaultProps: Partial<IOverlayProps<any>>;
     // (undocumented)
-    getOverlayClasses(): string;
-    // (undocumented)
-    getOverlayStyles(): any;
-    // (undocumented)
-    isComponentMounted: boolean;
+    protected getOverlayStyles: () => React_2.CSSProperties;
     // (undocumented)
     onDocumentMouseDown(e: React_2.MouseEvent): void;
-    // (undocumented)
-    portalNode: HTMLDivElement;
     // (undocumented)
     render(): React_2.ReactNode;
     // (undocumented)
@@ -1826,13 +1814,16 @@ export class Overlay<T> extends React_2.Component<IOverlayProps<T>, IOverlayStat
     }
 
 // @internal (undocumented)
-export type OverlayPositionType = "absolute" | "fixed" | "sameAsTarget";
+export type OverlayPositionType = "absolute" | "fixed" | SameAsTargetPosition;
 
 // @internal (undocumented)
 export enum PresetType {
     // (undocumented)
     CUSTOM_FORMAT = "customFormat"
 }
+
+// @internal (undocumented)
+export type SameAsTargetPosition = "sameAsTarget";
 
 // @internal (undocumented)
 export type ScrollCallback = (visibleRowsStartIndex: number, visibleRowsEndIndex: number) => void;

--- a/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
@@ -5,11 +5,11 @@ import cloneDeep from "lodash/cloneDeep";
 import isEqual from "lodash/isEqual";
 import result from "lodash/result";
 import cx from "classnames";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { propsEqual } from "@gooddata/goodstrap/lib/core/immutable";
 
 import { IAlignPoint } from "../typings/positioning";
 import { ArrowDirections, ArrowOffsets } from "./typings";
+import { Overlay } from "../Overlay";
 
 const ARROW_DIRECTIONS: ArrowDirections = {
     ".. cc": "none",

--- a/libs/sdk-ui-kit/src/Dialog/ConfirmDialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ConfirmDialog.tsx
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { PureComponent } from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "../Overlay";
 import { ConfirmDialogBase } from "./ConfirmDialogBase";
 import { IConfirmDialogBaseProps } from "./typings";
 

--- a/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { Component } from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "../Overlay";
 import { DialogBase } from "./DialogBase";
 import { IDialogBaseProps } from "./typings";
 

--- a/libs/sdk-ui-kit/src/Dialog/ExportDialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ExportDialog.tsx
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
+import { Overlay } from "../Overlay";
 import { ExportDialogBase } from "./ExportDialogBase";
 import { IExportDialogBaseProps } from "./typings";
 

--- a/libs/sdk-ui-kit/src/Dialog/tests/ConfirmDialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/ConfirmDialog.test.tsx
@@ -1,8 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
 import { shallow } from "enzyme";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ConfirmDialog } from "../ConfirmDialog";
+import { Overlay } from "../../Overlay";
 
 describe("ConfirmDialog", () => {
     it("should render content", () => {

--- a/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
@@ -1,8 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
 import { shallow } from "enzyme";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { Dialog } from "../Dialog";
+import { Overlay } from "../../Overlay";
 
 describe("Dialog", () => {
     it("should render content", () => {

--- a/libs/sdk-ui-kit/src/Dialog/tests/ExportDialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/ExportDialog.test.tsx
@@ -1,8 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
 import { mount } from "enzyme";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ExportDialog } from "../ExportDialog";
+import { Overlay } from "../../Overlay";
 
 describe("ExportDialog", () => {
     it("should render content", () => {

--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -8,13 +8,13 @@ import uniqueId from "lodash/uniqueId";
 import debounce from "lodash/debounce";
 
 import addCSS from "@gooddata/goodstrap/lib/core/addCSS";
-import { removeFromDom } from "@gooddata/goodstrap/lib/core/domUtilities";
+
 import HeaderMenu from "@gooddata/goodstrap/lib/Header/HeaderMenu";
 import HeaderAccount from "@gooddata/goodstrap/lib/Header/HeaderAccount";
 import HeaderHelp from "@gooddata/goodstrap/lib/Header/HeaderHelp";
-import Overlay from "@gooddata/goodstrap/lib/@next/Overlay";
 
 import { Button } from "../Button";
+import { Overlay } from "../Overlay";
 
 import {
     getItemActiveColor,
@@ -23,6 +23,7 @@ import {
     getSeparatorColor,
     getWorkspacePickerHoverColor,
 } from "./colors";
+import { removeFromDom } from "../utils/domUtilities";
 
 function getOuterWidth(element: HTMLDivElement) {
     const width = element.offsetWidth;

--- a/libs/sdk-ui-kit/src/Messages/Messages.tsx
+++ b/libs/sdk-ui-kit/src/Messages/Messages.tsx
@@ -3,10 +3,10 @@ import React, { useState, useCallback } from "react";
 import { CSSTransitionGroup } from "react-transition-group";
 import noop from "lodash/noop";
 import cx from "classnames";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 
 import { Message } from "./Message";
 import { IMessage, IMessagesProps } from "./typings";
+import { Overlay } from "../Overlay";
 
 /**
  * @internal

--- a/libs/sdk-ui-kit/src/Overlay/FullScreenOverlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/FullScreenOverlay.tsx
@@ -18,7 +18,7 @@ export class FullScreenOverlay extends Overlay<IOverlayState> {
         });
     }
 
-    componentWillMount() {
+    componentWillMount(): void {
         const { body } = document;
 
         const { overflow } = getComputedStyle(body);
@@ -33,7 +33,7 @@ export class FullScreenOverlay extends Overlay<IOverlayState> {
         body.scrollTop = 0;
     }
 
-    componentWillUnmount() {
+    componentWillUnmount(): void {
         super.componentWillUnmount();
 
         const { body } = document;
@@ -41,7 +41,7 @@ export class FullScreenOverlay extends Overlay<IOverlayState> {
         body.scrollTop = this.state.scrollTop;
     }
 
-    getOverlayStyles() {
+    protected getOverlayStyles = (): React.CSSProperties => {
         return {
             position: "fixed",
             left: 0,
@@ -49,5 +49,5 @@ export class FullScreenOverlay extends Overlay<IOverlayState> {
             bottom: 0,
             right: 0,
         };
-    }
+    };
 }

--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -1,19 +1,21 @@
-// (C) 2007-2020 GoodData Corporation
-import React from "react";
+// (C) 2020 GoodData Corporation
+import React, { createRef } from "react";
 import cx from "classnames";
 import { Portal } from "react-portal";
+
 import bindAll from "lodash/bindAll";
 import pick from "lodash/pick";
 import isEqual from "lodash/isEqual";
 import findIndex from "lodash/findIndex";
 import debounce from "lodash/debounce";
+import noop from "lodash/noop";
 import "element-closest-polyfill";
 import { propsEqual } from "@gooddata/goodstrap/lib/core/immutable";
 import { DEFAULT_ALIGN_POINTS, getOptimalAlignment } from "../utils/overlay";
 import { elementRegion, isFixedPosition } from "../utils/domUtilities";
 import { ENUM_KEY_CODE } from "../typings/utilities";
 import { IOverlayProps, IOverlayState } from "./typings";
-import { Alignment } from "../typings/overlay";
+import { Alignment, OverlayPositionType, SameAsTargetPosition } from "../typings/overlay";
 
 const events = [
     { name: "click", handler: "closeOnOutsideClick", target: document },
@@ -46,43 +48,38 @@ function alignExceedsThreshold(firstAlignment: Alignment, secondAlignment: Align
     );
 }
 
-const stopPropagation = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    e.stopPropagation();
-};
+const stopPropagation = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => e.stopPropagation();
 
 /**
  * @internal
  */
-export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState> {
-    private containerRef = React.createRef<HTMLElement>();
-    private overlayRef = React.createRef<HTMLDivElement>();
-
-    static defaultProps: Partial<IOverlayProps<any>> = {
+export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, IOverlayState> {
+    public static defaultProps: Partial<IOverlayProps<any>> = {
         alignPoints: DEFAULT_ALIGN_POINTS,
         alignTo: "body",
         children: false,
         className: "",
         containerClassName: "",
-        closeOnMouseDrag: false,
-        closeOnOutsideClick: false,
-        closeOnParentScroll: false,
-        closeOnEscape: false,
+        positionType: "absolute",
+
         ignoreClicksOn: [],
         ignoreClicksOnByClass: [],
-        isModal: false,
-        onAlign: (): void => {},
-        onClose: (): void => {},
-        positionType: "absolute",
+
         shouldCloseOnClick: () => true,
+
         onClick: stopPropagation,
         onMouseOver: stopPropagation,
         onMouseUp: stopPropagation,
-        zIndex: undefined,
+        onAlign: noop,
+        onClose: noop,
     };
 
-    isComponentMounted: boolean;
-    clickedInside: boolean;
-    portalNode: HTMLDivElement;
+    private overlayRef = createRef<HTMLDivElement>();
+    private containerRef = createRef<HTMLSpanElement>();
+    private resizeHandler = debounce(() => this.align(), 100);
+    private portalNode: HTMLDivElement | null = null;
+    private isComponentMounted: boolean;
+    private clickedInside: boolean;
 
     constructor(props: IOverlayProps<T>) {
         super(props);
@@ -99,9 +96,6 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         this.isComponentMounted = false;
         this.clickedInside = false;
 
-        this.align = this.align.bind(this);
-        this.onMaskClick = this.onMaskClick.bind(this);
-
         bindAll(
             this,
             events.map((event) => event.handler),
@@ -110,7 +104,7 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         this.createPortalNode();
     }
 
-    public componentDidMount() {
+    public componentDidMount(): void {
         this.isComponentMounted = true;
 
         window.addEventListener("resize", this.resizeHandler);
@@ -129,7 +123,7 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         }
     }
 
-    public shouldComponentUpdate(nextProps: IOverlayProps<T>, nextState: IOverlayState) {
+    public shouldComponentUpdate(nextProps: IOverlayProps<T>, nextState: IOverlayState): boolean {
         const propsChanged = !propsEqual(this.props, nextProps);
         const positionChanged = !isEqual(this.state.alignment, nextState.alignment);
 
@@ -152,141 +146,40 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         this.removePortalNodeAfterAllTreeUnmount();
     }
 
-    private onMaskClick(e: React.MouseEvent<HTMLDivElement>) {
-        if (!this.props.closeOnOutsideClick) {
-            e.stopPropagation();
-        }
-    }
-
-    public getOverlayStyles(): any {
-        const { alignTo, positionType, zIndex } = this.props;
-        const { alignment } = this.state;
-
-        let position = positionType;
-        if (this.isSameAsTargetPosition(positionType)) {
-            position = isFixedPosition(alignTo) ? "fixed" : "absolute";
-        }
-
-        return {
-            position,
-            left: alignment.left,
-            top: alignment.top,
-            zIndex,
-        };
-    }
-
-    getOverlayClasses(): string {
-        return cx(this.props.className, this.getAlignClasses(), {
-            "overlay-wrapper": true,
-        });
-    }
-
-    /**
-     * Add CSS classes to overlay wrapper, so they can be used
-     * for position of arrows and stuff
-     */
-    private getAlignClasses(): string {
-        const align = this.state.alignment.align.split(" ");
-
-        return `target-${align[0]} self-${align[1]}`;
-    }
-
-    private createPortalNode(): void {
-        this.portalNode = document.createElement("div");
-        document.body.appendChild(this.portalNode);
-    }
-
-    private removePortalNodeAfterAllTreeUnmount(): void {
-        setTimeout(() => {
-            if (this.portalNode && document.body.contains(this.portalNode)) {
-                document.body.removeChild(this.portalNode);
-            }
-            this.portalNode = null;
-        });
-    }
-
-    private isSameAsTargetPosition = (positionType: string): boolean => {
-        return positionType === POSITION_SAME_AS_TARGET;
-    };
-
-    private resizeHandler = debounce(() => this.align(), 100);
-
-    private isEventOnParent(event: any) {
-        const node = this.containerRef.current;
-        const eventNode = (event.detail && event.detail.node) || event.target;
-        return eventNode.contains(node);
-    }
-
-    private shouldCloseOnClick(e: React.MouseEvent) {
-        if (!this.isComponentMounted) {
-            return false;
-        }
-
-        if (!this.isAligned()) {
-            return false;
-        }
-
-        // an ignored node has been clicked, always keep the overlay open
-        if (this.hasClickedOnIgnoredNode(e)) {
-            return false;
-        }
-
-        // non-ignored node clicked, give shouldCloseOnClick the chance
-        // to override closing the dialog
-        if (!this.props.shouldCloseOnClick(e)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    private hasClickedOnIgnoredNode(e: any) {
-        if (e.defaultPrevented) {
-            // Ignore event if it should be prevented (e.q. by click in child component)
-            return true;
-        }
-
-        const clickedElement = e.target;
-
-        if (this.isElementInChildOverlay(clickedElement) || this.clickedInside) {
-            return true;
-        }
-
-        const ignoredRefElements = [this.overlayRef.current, ...this.props.ignoreClicksOn];
-        const clickInsideIgnoredRefElement = ignoredRefElements.some((ref: any) => {
-            return ref && ref.contains(clickedElement);
-        });
-        if (clickInsideIgnoredRefElement) {
-            return true;
-        }
-
-        const clickInsideIgnoredClassElement = this.props.ignoreClicksOnByClass.some((selector: string) =>
-            clickedElement.closest(selector),
+    public render(): React.ReactNode {
+        // Need stop propagation of events from Portal thats new behavior of react 16
+        // https://github.com/facebook/react/issues/11387
+        return (
+            <span className="s-portal-scroll-anchor" ref={this.containerRef}>
+                <Portal node={this.portalNode}>
+                    {/* Do not prevent onScroll events - see ONE-4189 for details */}
+                    <div
+                        className={this.props.containerClassName}
+                        onClick={this.props.onClick}
+                        onMouseOver={this.props.onMouseOver}
+                        onMouseUp={this.props.onMouseUp}
+                    >
+                        {this.renderMask()}
+                        <div
+                            ref={this.overlayRef}
+                            style={this.getOverlayStyles()}
+                            className={this.getOverlayClasses()}
+                        >
+                            {this.props.children}
+                        </div>
+                    </div>
+                </Portal>
+            </span>
         );
-        if (clickInsideIgnoredClassElement) {
-            return true;
-        }
-
-        return false;
     }
 
-    private isAligned() {
-        return this.state.alignment.left !== INIT_STATE_ALIGN && this.state.alignment.top != INIT_STATE_ALIGN;
-    }
-
-    // makes assumption that overlays later in the DOM are child overlays
-    private isElementInChildOverlay(element: HTMLElement) {
-        const overlays = Array.from(document.querySelectorAll(".overlay-wrapper"));
-        const thisOverlayIndex = findIndex(overlays, (overlay) => overlay === this.overlayRef.current);
-
-        return overlays.slice(thisOverlayIndex + 1).some((overlay) => overlay.contains(element));
-    }
-
-    private align(): void {
+    public align = (): void => {
         const { alignPoints, alignTo, positionType } = this.props;
-        const overlay: any = this.overlayRef.current;
+        const overlay = this.overlayRef.current;
 
-        if (!alignPoints || !overlay) return;
+        if (!alignPoints || !overlay) {
+            return;
+        }
 
         const isSameAsTarget = this.isSameAsTargetPosition(positionType);
         const optimalAlign = getOptimalAlignment({
@@ -308,6 +201,141 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         } else {
             this.props.onAlign(optimalAlign.alignment);
         }
+    };
+
+    private onMaskClick(e: React.MouseEvent<HTMLDivElement>) {
+        if (!this.props.closeOnOutsideClick) {
+            e.stopPropagation();
+        }
+    }
+
+    protected getOverlayStyles = (): React.CSSProperties => {
+        const { alignTo, positionType, zIndex } = this.props;
+        const { alignment } = this.state;
+
+        const position = this.isSameAsTargetPosition(positionType)
+            ? isFixedPosition(alignTo)
+                ? "fixed"
+                : "absolute"
+            : positionType;
+
+        return {
+            position,
+            left: alignment.left,
+            top: alignment.top,
+            zIndex,
+        };
+    };
+
+    private getOverlayClasses = (): string => {
+        return cx(this.props.className, this.getAlignClasses(), {
+            "overlay-wrapper": true,
+        });
+    };
+
+    /**
+     * Add CSS classes to overlay wrapper, so they can be used
+     * for position of arrows and stuff
+     */
+    private getAlignClasses = (): string => {
+        const align = this.state.alignment.align.split(" ");
+
+        return `target-${align[0]} self-${align[1]}`;
+    };
+
+    private createPortalNode(): void {
+        this.portalNode = document.createElement("div");
+        document.body.appendChild(this.portalNode);
+    }
+
+    private removePortalNodeAfterAllTreeUnmount(): void {
+        setTimeout(() => {
+            if (this.portalNode && document.body.contains(this.portalNode)) {
+                document.body.removeChild(this.portalNode);
+            }
+            this.portalNode = null;
+        });
+    }
+
+    private isSameAsTargetPosition = (
+        positionType: OverlayPositionType,
+    ): positionType is SameAsTargetPosition => {
+        return positionType === POSITION_SAME_AS_TARGET;
+    };
+
+    private isEventOnParent = (event: any) => {
+        const node = this.containerRef.current;
+        const eventNode = (event.detail && event.detail.node) || event.target;
+        return eventNode.contains(node);
+    };
+
+    private shouldCloseOnClick = (e: React.MouseEvent) => {
+        if (!this.isComponentMounted) {
+            return false;
+        }
+
+        if (!this.isAligned()) {
+            return false;
+        }
+
+        // an ignored node has been clicked, always keep the overlay open
+        if (this.hasClickedOnIgnoredNode(e)) {
+            return false;
+        }
+
+        // non-ignored node clicked, give shouldCloseOnClick the chance
+        // to override closing the dialog
+        if (!this.props.shouldCloseOnClick(e)) {
+            return false;
+        }
+
+        return true;
+    };
+
+    private hasClickedOnIgnoredNode = (e: any) => {
+        if (e.defaultPrevented) {
+            // Ignore event if it should be prevented (e.q. by click in child component)
+            return true;
+        }
+
+        const clickedElement = e.target;
+
+        if (this.isElementInChildOverlay(clickedElement) || this.clickedInside) {
+            return true;
+        }
+
+        const ignoredRefElements = [this.overlayRef.current, ...this.props.ignoreClicksOn];
+        const clickInsideIgnoredRefElement = ignoredRefElements.some((ref: any) => {
+            return ref && ref.contains(clickedElement);
+        });
+        if (clickInsideIgnoredRefElement) {
+            return true;
+        }
+
+        const clickInsideIgnoredClassElement = this.props.ignoreClicksOnByClass.some((selector) =>
+            clickedElement.closest(selector),
+        );
+        if (clickInsideIgnoredClassElement) {
+            return true;
+        }
+
+        return false;
+    };
+
+    private isAligned = () => {
+        return this.state.alignment.left !== INIT_STATE_ALIGN && this.state.alignment.top != INIT_STATE_ALIGN;
+    };
+
+    // makes assumption that overlays later in the DOM are child overlays
+    private isElementInChildOverlay = (element: HTMLElement) => {
+        const overlays = Array.from(document.querySelectorAll(".overlay-wrapper"));
+        const thisOverlayIndex = findIndex(overlays, (overlay) => overlay === this.overlayRef.current);
+
+        return overlays.slice(thisOverlayIndex + 1).some((overlay) => overlay.contains(element));
+    };
+
+    public onDocumentMouseDown(e: React.MouseEvent): void {
+        this.clickedInside = (this.overlayRef.current as any).contains(e.target);
     }
 
     public closeOnParentScroll(e: React.MouseEvent): void {
@@ -320,22 +348,18 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         }
     }
 
-    public closeOnMouseDrag(): void {
+    public closeOnMouseDrag = (): void => {
         if (!this.isComponentMounted) {
             return;
         }
 
         this.props.onClose();
-    }
+    };
 
     public closeOnOutsideClick(e: React.MouseEvent): void {
         if (this.shouldCloseOnClick(e)) {
             this.props.onClose();
         }
-    }
-
-    public onDocumentMouseDown(e: React.MouseEvent): void {
-        this.clickedInside = (this.overlayRef.current as any).contains(e.target);
     }
 
     public closeOnEscape(e: React.KeyboardEvent): void {
@@ -348,7 +372,7 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
         }
     }
 
-    private updateListeners(method: string, props: IOverlayProps<T>) {
+    private updateListeners = (method: string, props: IOverlayProps<T>) => {
         events.forEach((event) => {
             if (props[event.handler] || props[event.requiredProp]) {
                 const handler = this[event.handler];
@@ -357,49 +381,21 @@ export class Overlay<T> extends React.Component<IOverlayProps<T>, IOverlayState>
                 }
             }
         });
-    }
+    };
 
-    private addListeners(props: IOverlayProps<T>): void {
+    private addListeners = (props: IOverlayProps<T>) => {
         this.updateListeners("add", props);
-    }
+    };
 
-    private removeListeners(props: IOverlayProps<T>): void {
+    private removeListeners = (props: IOverlayProps<T>) => {
         this.updateListeners("remove", props);
-    }
+    };
 
-    private renderMask(): false | JSX.Element {
+    private renderMask = (): false | JSX.Element => {
         return this.props.isModal ? (
             <div className="modalityPlugin-mask modalityPlugin-mask-visible" onClick={this.onMaskClick} />
         ) : (
             false
         );
-    }
-
-    public render(): React.ReactNode {
-        // Need stop propagation of events from Portal thats new behavior of react 16
-        // https://github.com/facebook/react/issues/11387
-        return (
-            <span className="s-portal-scroll-anchor" ref={this.containerRef}>
-                <Portal node={this.portalNode}>
-                    {/* Do not prevent onScroll events - see ONE-4189 for details */}
-                    <div
-                        className={this.props.containerClassName}
-                        onClick={this.props.onClick}
-                        onMouseOver={this.props.onMouseOver}
-                        onMouseUp={this.props.onMouseUp}
-                    >
-                        {this.renderMask()}
-
-                        <div
-                            ref={this.overlayRef}
-                            style={this.getOverlayStyles()}
-                            className={this.getOverlayClasses()}
-                        >
-                            {this.props.children}
-                        </div>
-                    </div>
-                </Portal>
-            </span>
-        );
-    }
+    };
 }

--- a/libs/sdk-ui-kit/src/Overlay/typings.ts
+++ b/libs/sdk-ui-kit/src/Overlay/typings.ts
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import { IAlignPoint } from "../typings/positioning";
-import { Alignment } from "../typings/overlay";
+import { Alignment, OverlayPositionType } from "../typings/overlay";
 
 /**
  * @internal
@@ -24,7 +24,7 @@ export interface IOverlayProps<T> {
     ignoreClicksOnByClass?: string[];
 
     isModal?: boolean;
-    onAlign?: (optiimalAlign: Alignment) => void;
+    onAlign?: (optimalAlign: Alignment) => void;
     onClose?: () => void;
     /**
      * positionType: sameAsTarget
@@ -34,7 +34,8 @@ export interface IOverlayProps<T> {
      *  - the overlay's offsets (top, left) will be calculated based on
      *    target's offsets (top, left), without scroll offsets
      */
-    positionType?: string;
+    positionType?: OverlayPositionType;
+
     shouldCloseOnClick?: (e: React.MouseEvent) => boolean;
     onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     onMouseOver?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;

--- a/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
@@ -40,7 +40,7 @@ class WrappedMeasureNumberFormat extends React.PureComponent<
     MeasureNumberFormatProps,
     IMeasureNumberFormatState
 > {
-    private toggleButtonEl?: EventTarget;
+    private toggleButtonEl?: HTMLElement;
 
     constructor(props: MeasureNumberFormatProps) {
         super(props);
@@ -116,7 +116,7 @@ class WrappedMeasureNumberFormat extends React.PureComponent<
         this.props.presets.find((preset: IFormatPreset) => preset.format === this.props.selectedFormat) ||
         this.getCustomFormatPreset();
 
-    private toggleDropdownOpened = (e: React.SyntheticEvent) => {
+    private toggleDropdownOpened = (e: React.SyntheticEvent<HTMLElement>) => {
         this.toggleButtonEl = e.currentTarget;
 
         this.setState((state) => ({

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
@@ -1,12 +1,12 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps } from "react-intl";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ISeparators } from "@gooddata/sdk-ui";
 
 import { IPositioning, SnapPoint } from "../../typings/positioning";
 import { positioningToAlignPoints } from "../../utils/positioning";
 import { Button } from "../../Button";
+import { Overlay } from "../../Overlay";
 import { IFormatTemplate } from "../typings";
 import Preview from "./previewSection/Preview";
 import FormatInput from "./FormatInput";
@@ -17,7 +17,7 @@ interface ICustomFormatDialogOwnProps {
     onCancel: () => void;
     formatString: string;
     documentationLink?: string;
-    anchorEl?: string | EventTarget;
+    anchorEl?: string | HTMLElement;
     positioning?: IPositioning[];
     separators?: ISeparators;
     locale?: string;

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
@@ -1,10 +1,10 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ISeparators } from "@gooddata/sdk-ui";
 import DropdownItem from "./DropdownItem";
 import DropdownToggleButton from "./DropdownToggleButton";
 import { IFormatTemplate } from "../../typings";
+import { Overlay } from "../../../Overlay";
 
 interface ICustomFormatTemplatesState {
     isOpened: boolean;

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
@@ -1,13 +1,13 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps } from "react-intl";
-import Overlay from "@gooddata/goodstrap/lib/core/Overlay";
 import { ISeparators } from "@gooddata/sdk-ui";
 
 import { IFormatPreset } from "../typings";
 import { PresetsDropdownItem } from "./PresetsDropdownItem";
 import { IPositioning, SnapPoint } from "../../typings/positioning";
 import { positioningToAlignPoints } from "../../utils/positioning";
+import { Overlay } from "../../Overlay";
 
 interface IMeasureNumberFormatDropdownOwnProps {
     presets: ReadonlyArray<IFormatPreset>;
@@ -16,7 +16,7 @@ interface IMeasureNumberFormatDropdownOwnProps {
     separators: ISeparators;
     onSelect: (selectedPreset: IFormatPreset) => void;
     onClose: () => void;
-    anchorEl?: string | EventTarget;
+    anchorEl?: string | HTMLElement;
     positioning?: IPositioning[];
 }
 

--- a/libs/sdk-ui-kit/src/typings.d.ts
+++ b/libs/sdk-ui-kit/src/typings.d.ts
@@ -2,7 +2,6 @@
 declare module "react-native-listener";
 declare module "fixed-data-table-2";
 declare module "@gooddata/goodstrap/lib/core/addCSS";
-declare module "@gooddata/goodstrap/lib/core/domUtilities";
 declare module "@gooddata/goodstrap/lib/core/immutable" {
     export function propsEqual(props: any, nextProps: any): boolean;
 }

--- a/libs/sdk-ui-kit/src/typings/overlay.ts
+++ b/libs/sdk-ui-kit/src/typings/overlay.ts
@@ -58,5 +58,9 @@ export interface IOptimalAlignment {
 /**
  * @internal
  */
+export type SameAsTargetPosition = "sameAsTarget";
 
-export type OverlayPositionType = "absolute" | "fixed" | "sameAsTarget";
+/**
+ * @internal
+ */
+export type OverlayPositionType = "absolute" | "fixed" | SameAsTargetPosition;

--- a/libs/sdk-ui-kit/styles/scss/overlay.scss
+++ b/libs/sdk-ui-kit/styles/scss/overlay.scss
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-@import "mixins";
+@import "./mixins.scss";
 @import "typo-mixins";
 
 .gd-dropdown.overlay {


### PR DESCRIPTION
JIRA: ONE-4786

Except charts replaces imports from GS by imports from ui-kit where possible

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
