### PR TITLE
RELATED: RAIL-2755 Fix secondary KPI item title

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -8,6 +8,7 @@ import {
     IErrorProps,
     ILoadingProps,
     OnError,
+    ILocale,
 } from "@gooddata/sdk-ui";
 
 /**
@@ -62,6 +63,13 @@ export interface IDashboardViewProps {
      * it will be loaded for the dashboard.
      */
     theme?: ITheme;
+
+    /**
+     * Locale to use for localization of texts appearing in the dashboard.
+     *
+     * Note: text values coming from the data itself are not localized.
+     */
+    locale?: ILocale;
 
     /**
      * When true, disables the loading of the workspace theme and creation of a ThemeProvider (if there is none

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/useLocale.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/useLocale.ts
@@ -1,0 +1,53 @@
+// (C) 2020 GoodData Corporation
+
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import {
+    DefaultLocale,
+    GoodDataSdkError,
+    ILocale,
+    OnError,
+    useBackend,
+    useCancelablePromise,
+    UseCancelablePromiseState,
+} from "@gooddata/sdk-ui";
+import { useRef } from "react";
+
+interface IUseLocaleConfig {
+    locale?: ILocale;
+    backend?: IAnalyticalBackend;
+    onError?: OnError;
+}
+
+export const useLocale = ({
+    backend,
+    locale,
+    onError,
+}: IUseLocaleConfig): UseCancelablePromiseState<ILocale, GoodDataSdkError> => {
+    const effectiveBackend = useBackend(backend);
+
+    const cachedLocale = useRef(locale);
+
+    return useCancelablePromise(
+        {
+            promise: async () => {
+                if (cachedLocale.current) {
+                    return cachedLocale.current;
+                }
+
+                cachedLocale.current = await effectiveBackend
+                    .currentUser()
+                    .settings()
+                    .getSettings()
+                    .then((settings) => settings.locale as ILocale)
+                    .catch((error) => {
+                        cachedLocale.current = DefaultLocale;
+                        throw error;
+                    });
+
+                return cachedLocale.current;
+            },
+            onError,
+        },
+        [effectiveBackend, locale],
+    );
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiRenderer.tsx
@@ -83,22 +83,13 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
             {secondaryValue ? (
                 <div className="gd-flex-container headline-compare-section">
                     <div
-                        className={cx([
-                            "gd-flex-item",
-                            "headline-compare-section-item",
-                            "headline-secondary-item",
-                            "s-headline-secondary-item",
-                            { "is-drillable": secondaryValue.isDrillable },
-                        ])}
+                        className="gd-flex-item headline-compare-section-item headline-secondary-item s-headline-secondary-item"
+                        style={{ borderLeft: "none" }} // temporary override of the original Headline styles
                         onClick={onSecondaryValueClick}
                     >
                         <div className="headline-value-wrapper s-headline-value-wrapper">
                             <ResponsiveText>
-                                {secondaryValue.isDrillable ? (
-                                    <KpiItemAsLink value={secondaryValue} />
-                                ) : (
-                                    <KpiItemAsValue value={secondaryValue} />
-                                )}
+                                <KpiItemAsValue value={secondaryValue} />
                             </ResponsiveText>
                         </div>
                         <div
@@ -110,7 +101,6 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
                     </div>
                 </div>
             ) : null}
-            {secondaryValue && <div onClick={onSecondaryValueClick}>{secondaryValue.formattedValue}</div>}
         </div>
     );
 };

--- a/libs/sdk-ui-ext/src/internal/translations/de-DE.json
+++ b/libs/sdk-ui-ext/src/internal/translations/de-DE.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Messung",
     "dashboard.bucket.measures_subtitle.bullet": "Primär",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Ziel",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Komparativ"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Komparativ",
+    "filters.allTime.previousPeriod": "vorh. Zeitraum"
 }

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -803,5 +803,10 @@
         "value": "Comparative",
         "comment": "Comparative measures of a bullet chart",
         "limit": 0
+    },
+    "filters.allTime.previousPeriod": {
+        "value": "prev. period",
+        "comment": "",
+        "limit": 0
     }
 }

--- a/libs/sdk-ui-ext/src/internal/translations/es-ES.json
+++ b/libs/sdk-ui-ext/src/internal/translations/es-ES.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Medida",
     "dashboard.bucket.measures_subtitle.bullet": "Principal",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Destino",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativas"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativas",
+    "filters.allTime.previousPeriod": "period. prev."
 }

--- a/libs/sdk-ui-ext/src/internal/translations/fr-FR.json
+++ b/libs/sdk-ui-ext/src/internal/translations/fr-FR.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Mesure",
     "dashboard.bucket.measures_subtitle.bullet": "Principal",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Objectif",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparaison"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparaison",
+    "filters.allTime.previousPeriod": "période préc."
 }

--- a/libs/sdk-ui-ext/src/internal/translations/ja-JP.json
+++ b/libs/sdk-ui-ext/src/internal/translations/ja-JP.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "測定値",
     "dashboard.bucket.measures_subtitle.bullet": "プライマリ",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "ターゲット",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "比較"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "比較",
+    "filters.allTime.previousPeriod": "前期"
 }

--- a/libs/sdk-ui-ext/src/internal/translations/nl-NL.json
+++ b/libs/sdk-ui-ext/src/internal/translations/nl-NL.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Maat",
     "dashboard.bucket.measures_subtitle.bullet": "Primair",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Doel",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Relatief"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Relatief",
+    "filters.allTime.previousPeriod": "vorige periode"
 }

--- a/libs/sdk-ui-ext/src/internal/translations/pt-BR.json
+++ b/libs/sdk-ui-ext/src/internal/translations/pt-BR.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Medida",
     "dashboard.bucket.measures_subtitle.bullet": "Primário",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Meta",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativo"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativo",
+    "filters.allTime.previousPeriod": "vorige periode"
 }

--- a/libs/sdk-ui-ext/src/internal/translations/pt-PT.json
+++ b/libs/sdk-ui-ext/src/internal/translations/pt-PT.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "Medir",
     "dashboard.bucket.measures_subtitle.bullet": "Primário",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "Destino",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativo"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "Comparativo",
+    "filters.allTime.previousPeriod": "período ant."
 }

--- a/libs/sdk-ui-ext/src/internal/translations/zh-Hans.json
+++ b/libs/sdk-ui-ext/src/internal/translations/zh-Hans.json
@@ -159,5 +159,6 @@
     "dashboard.bucket.tertiary_measures_title.bullet": "度量",
     "dashboard.bucket.measures_subtitle.bullet": "主要",
     "dashboard.bucket.secondary_measures_subtitle.bullet": "目标",
-    "dashboard.bucket.tertiary_measures_subtitle.bullet": "比较"
+    "dashboard.bucket.tertiary_measures_subtitle.bullet": "比较",
+    "filters.allTime.previousPeriod": "前一时间段"
 }


### PR DESCRIPTION
This is a temporary solution until we have the full-fledged KPI component.
The strings were sourced from gdc-dashboards.
We also added the missing locale prop and downloading to DashboardView.
Finally, a small bug in DashboardView was fixed for dashboardLayout errors.

JIRA: RAIL-2755

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
