### PR TITLE
Tiger: Load the date dataset (attribute) in catalog

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -443,69 +443,69 @@ export interface AttributeAttributesAllOf {
 // @public
 export enum AttributeAttributesAllOfGranularityEnum {
     // (undocumented)
-    DAY = "DAY",
+    DAY = "day",
     // (undocumented)
-    DAYOFMONTH = "DAY_OF_MONTH",
+    DAYOFMONTH = "dayOfMonth",
     // (undocumented)
-    DAYOFWEEK = "DAY_OF_WEEK",
+    DAYOFWEEK = "dayOfWeek",
     // (undocumented)
-    DAYOFYEAR = "DAY_OF_YEAR",
+    DAYOFYEAR = "dayOfYear",
     // (undocumented)
-    HOUR = "HOUR",
+    HOUR = "hour",
     // (undocumented)
-    HOUROFDAY = "HOUR_OF_DAY",
+    HOUROFDAY = "hourOfDay",
     // (undocumented)
-    MINUTE = "MINUTE",
+    MINUTE = "minute",
     // (undocumented)
-    MINUTEOFHOUR = "MINUTE_OF_HOUR",
+    MINUTEOFHOUR = "minuteOfHour",
     // (undocumented)
-    MONTH = "MONTH",
+    MONTH = "month",
     // (undocumented)
-    MONTHOFYEAR = "MONTH_OF_YEAR",
+    MONTHOFYEAR = "monthOfYear",
     // (undocumented)
-    QUARTER = "QUARTER",
+    QUARTER = "quarter",
     // (undocumented)
-    QUARTEROFYEAR = "QUARTER_OF_YEAR",
+    QUARTEROFYEAR = "quarterOfYear",
     // (undocumented)
-    WEEK = "WEEK",
+    WEEK = "week",
     // (undocumented)
-    WEEKOFYEAR = "WEEK_OF_YEAR",
+    WEEKOFYEAR = "weekOfYear",
     // (undocumented)
-    YEAR = "YEAR"
+    YEAR = "year"
 }
 
 // @public
 export enum AttributeAttributesGranularityEnum {
     // (undocumented)
-    DAY = "DAY",
+    DAY = "day",
     // (undocumented)
-    DAYOFMONTH = "DAY_OF_MONTH",
+    DAYOFMONTH = "dayOfMonth",
     // (undocumented)
-    DAYOFWEEK = "DAY_OF_WEEK",
+    DAYOFWEEK = "dayOfWeek",
     // (undocumented)
-    DAYOFYEAR = "DAY_OF_YEAR",
+    DAYOFYEAR = "dayOfYear",
     // (undocumented)
-    HOUR = "HOUR",
+    HOUR = "hour",
     // (undocumented)
-    HOUROFDAY = "HOUR_OF_DAY",
+    HOUROFDAY = "hourOfDay",
     // (undocumented)
-    MINUTE = "MINUTE",
+    MINUTE = "minute",
     // (undocumented)
-    MINUTEOFHOUR = "MINUTE_OF_HOUR",
+    MINUTEOFHOUR = "minuteOfHour",
     // (undocumented)
-    MONTH = "MONTH",
+    MONTH = "month",
     // (undocumented)
-    MONTHOFYEAR = "MONTH_OF_YEAR",
+    MONTHOFYEAR = "monthOfYear",
     // (undocumented)
-    QUARTER = "QUARTER",
+    QUARTER = "quarter",
     // (undocumented)
-    QUARTEROFYEAR = "QUARTER_OF_YEAR",
+    QUARTEROFYEAR = "quarterOfYear",
     // (undocumented)
-    WEEK = "WEEK",
+    WEEK = "week",
     // (undocumented)
-    WEEKOFYEAR = "WEEK_OF_YEAR",
+    WEEKOFYEAR = "weekOfYear",
     // (undocumented)
-    YEAR = "YEAR"
+    YEAR = "year"
 }
 
 // @public

--- a/libs/api-client-tiger/src/generated/metadata-new-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-new-json-api/api.ts
@@ -387,21 +387,21 @@ export interface AttributeAttributes {
  * @enum {string}
  */
 export enum AttributeAttributesGranularityEnum {
-    MINUTE = "MINUTE",
-    HOUR = "HOUR",
-    DAY = "DAY",
-    WEEK = "WEEK",
-    MONTH = "MONTH",
-    QUARTER = "QUARTER",
-    YEAR = "YEAR",
-    MINUTEOFHOUR = "MINUTE_OF_HOUR",
-    HOUROFDAY = "HOUR_OF_DAY",
-    DAYOFWEEK = "DAY_OF_WEEK",
-    DAYOFMONTH = "DAY_OF_MONTH",
-    DAYOFYEAR = "DAY_OF_YEAR",
-    WEEKOFYEAR = "WEEK_OF_YEAR",
-    MONTHOFYEAR = "MONTH_OF_YEAR",
-    QUARTEROFYEAR = "QUARTER_OF_YEAR",
+    MINUTE = "minute",
+    HOUR = "hour",
+    DAY = "day",
+    WEEK = "week",
+    MONTH = "month",
+    QUARTER = "quarter",
+    YEAR = "year",
+    MINUTEOFHOUR = "minuteOfHour",
+    HOUROFDAY = "hourOfDay",
+    DAYOFWEEK = "dayOfWeek",
+    DAYOFMONTH = "dayOfMonth",
+    DAYOFYEAR = "dayOfYear",
+    WEEKOFYEAR = "weekOfYear",
+    MONTHOFYEAR = "monthOfYear",
+    QUARTEROFYEAR = "quarterOfYear",
 }
 
 /**
@@ -423,21 +423,21 @@ export interface AttributeAttributesAllOf {
  * @enum {string}
  */
 export enum AttributeAttributesAllOfGranularityEnum {
-    MINUTE = "MINUTE",
-    HOUR = "HOUR",
-    DAY = "DAY",
-    WEEK = "WEEK",
-    MONTH = "MONTH",
-    QUARTER = "QUARTER",
-    YEAR = "YEAR",
-    MINUTEOFHOUR = "MINUTE_OF_HOUR",
-    HOUROFDAY = "HOUR_OF_DAY",
-    DAYOFWEEK = "DAY_OF_WEEK",
-    DAYOFMONTH = "DAY_OF_MONTH",
-    DAYOFYEAR = "DAY_OF_YEAR",
-    WEEKOFYEAR = "WEEK_OF_YEAR",
-    MONTHOFYEAR = "MONTH_OF_YEAR",
-    QUARTEROFYEAR = "QUARTER_OF_YEAR",
+    MINUTE = "minute",
+    HOUR = "hour",
+    DAY = "day",
+    WEEK = "week",
+    MONTH = "month",
+    QUARTER = "quarter",
+    YEAR = "year",
+    MINUTEOFHOUR = "minuteOfHour",
+    HOUROFDAY = "hourOfDay",
+    DAYOFWEEK = "dayOfWeek",
+    DAYOFMONTH = "dayOfMonth",
+    DAYOFYEAR = "dayOfYear",
+    WEEKOFYEAR = "weekOfYear",
+    MONTHOFYEAR = "monthOfYear",
+    QUARTEROFYEAR = "quarterOfYear",
 }
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -131,6 +131,8 @@ export async function loadAttributesAndDateDatasets(
             headers: { Accept: "application/vnd.gooddata.api+json" },
             query: {
                 include: "labels,datasets",
+                // TODO - update after paging is fixed in MDC-354
+                size: "500",
                 tags: includeTags.join(","),
             },
         },

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -120,7 +120,8 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     // Groups are collected from all catalog entities.
     // There is no separate endpoint for the tags anymore.
     private extractGroups(catalogItems: CatalogItem[]): ICatalogGroup[] {
-        const allTags = flatMap(catalogItems, (item): ICatalogGroup[] => {
+        const groupableItems = catalogItems.filter((item) => item.type !== "dateDataset");
+        const allTags = flatMap(groupableItems, (item): ICatalogGroup[] => {
             return (item as IGroupableCatalogItemBase).groups.map((tag) => ({
                 title: (tag as IdentifierRef).identifier,
                 tag: tag,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
@@ -127,9 +127,9 @@ export const convertDateDataset = (
             .dataSet(idRef(dataset.id, "dataSet"), (m) => {
                 return m
                     .id(dataset.id)
-                    .uri(dataset.links!.self)
                     .title(dataset.attributes?.title || "")
                     .description(dataset.attributes?.description || "")
+                    .uri("") // we don't have links in included entities
                     .production(true)
                     .unlisted(false);
             })

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/result.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/result.test.ts.snap
@@ -27,13 +27,13 @@ Object {
       Array [
         Object {
           "attributeHeaderItem": Object {
-            "name": "1906-4",
+            "name": "Q4/1906",
             "uri": "/obj/0/elements?id=1906-4",
           },
         },
         Object {
           "attributeHeaderItem": Object {
-            "name": "1910-1",
+            "name": "Q1/1910",
             "uri": "/obj/0/elements?id=1910-1",
           },
         },

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -222,7 +222,7 @@ Object {
       },
     },
     "from": 20,
-    "granularity": "DAY",
+    "granularity": "day",
     "to": 30,
   },
 }
@@ -300,7 +300,7 @@ Object {
       },
     },
     "from": -11,
-    "granularity": "DAY",
+    "granularity": "day",
     "to": 0,
   },
 }
@@ -316,7 +316,7 @@ Object {
       },
     },
     "from": 5,
-    "granularity": "DAY",
+    "granularity": "day",
     "to": NaN,
   },
 }
@@ -334,7 +334,7 @@ Object {
       },
     },
     "from": -3,
-    "granularity": "MONTH",
+    "granularity": "month",
     "to": 9,
   },
 }
@@ -350,7 +350,7 @@ Object {
       },
     },
     "from": 25,
-    "granularity": "QUARTER",
+    "granularity": "quarter",
     "to": -2,
   },
 }
@@ -366,7 +366,7 @@ Object {
       },
     },
     "from": 50,
-    "granularity": "WEEK",
+    "granularity": "week",
     "to": 100,
   },
 }
@@ -382,7 +382,7 @@ Object {
       },
     },
     "from": 2,
-    "granularity": "YEAR",
+    "granularity": "year",
     "to": 7,
   },
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/MeasureConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/MeasureConverter.test.ts.snap
@@ -284,7 +284,7 @@ Object {
               },
             },
             "from": 5,
-            "granularity": "DAY",
+            "granularity": "day",
             "to": 22,
           },
         },


### PR DESCRIPTION
There is a bug in loading attributes from backend (see MDC-354)
which is possible to workaround by providing bigger size limit.

Overall paging does not work well (yet).

Besides that the Date is not a groupable item in the catalog so it has to be
filtered out in grouping function.

JIRA: RAIL-2822

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
