### PR TITLE
Propagate title in typography component, remove empty row headers in dashboard converter

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -136,15 +136,21 @@ const convertLayoutRow = (row: IDashboardLayoutRow): GdcDashboardLayout.IFluidLa
         columns: row.columns.map((column) => convertLayoutColumn(column)),
     };
     if (row.header) {
-        const header = {} as GdcDashboardLayout.ISectionHeader;
-        if (row.header?.title) {
-            header.title = row.header.title;
+        // Ignore empty strings in header
+        const headerWithoutEmptyStrings = omitBy(row.header, (x) => !x);
+        const isEmptyHeader = isEmpty(headerWithoutEmptyStrings);
+        if (!isEmptyHeader) {
+            const header = {} as GdcDashboardLayout.ISectionHeader;
+            if (row.header?.title) {
+                header.title = row.header.title;
+            }
+            if (row.header?.description) {
+                header.description = row.header.description;
+            }
+            convertedRow.header = header;
         }
-        if (row.header?.description) {
-            header.description = row.header.description;
-        }
-        convertedRow.header = header;
     }
+
     if (row.style) {
         convertedRow.style = row.style;
     }

--- a/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.fixtures.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.fixtures.ts
@@ -1,5 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
-import { IDashboard, IFilterContext, ITempFilterContext, IWidget } from "@gooddata/sdk-backend-spi";
+import {
+    IDashboard,
+    IDashboardLayoutColumn,
+    IFilterContext,
+    ITempFilterContext,
+    IWidget,
+} from "@gooddata/sdk-backend-spi";
 
 const createObjectMeta = (id: string) => {
     const uri = `/gdc/md/obj/${id}`;
@@ -123,38 +129,71 @@ export const widgetKpi: IWidget = {
     drills: [],
 };
 
-export const dashboardWithLayout: IDashboard = {
+const columns: IDashboardLayoutColumn[] = [
+    {
+        size: {
+            xl: {
+                widthAsGridColumnsCount: 12,
+            },
+        },
+        content: widgetHeadline,
+    },
+    {
+        size: {
+            xl: {
+                widthAsGridColumnsCount: 6,
+            },
+        },
+        content: widgetKpi,
+    },
+    {
+        size: {
+            xl: {
+                widthAsGridColumnsCount: 2,
+            },
+        },
+        content: widgetBarChart,
+    },
+];
+
+export const dashboardWithLayoutAndRowHeaders: IDashboard = {
     ...emptyDashboard,
     layout: {
         type: "fluidLayout",
         rows: [
             {
-                columns: [
-                    {
-                        size: {
-                            xl: {
-                                widthAsGridColumnsCount: 12,
-                            },
-                        },
-                        content: widgetHeadline,
-                    },
-                    {
-                        size: {
-                            xl: {
-                                widthAsGridColumnsCount: 6,
-                            },
-                        },
-                        content: widgetKpi,
-                    },
-                    {
-                        size: {
-                            xl: {
-                                widthAsGridColumnsCount: 2,
-                            },
-                        },
-                        content: widgetBarChart,
-                    },
-                ],
+                header: {
+                    title: "Row 1",
+                },
+                columns,
+            },
+            {
+                header: {
+                    description: "Row 2 description",
+                },
+                columns: [],
+            },
+        ],
+    },
+};
+
+export const dashboardWithLayoutAndEmptyRowHeaders: IDashboard = {
+    ...emptyDashboard,
+    layout: {
+        type: "fluidLayout",
+        rows: [
+            {
+                // Test, that empty headers are removed (or it throws error on the backend)
+                header: {
+                    title: "",
+                    description: "",
+                },
+                columns,
+            },
+            {
+                // Test, that empty headers are removed (or it throws error on the backend)
+                header: {},
+                columns: [],
             },
         ],
     },

--- a/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.test.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.test.ts
@@ -4,7 +4,8 @@ import { convertDashboard, convertFilterContext, convertWidget } from "../Dashbo
 import {
     emptyDashboard,
     dashboardWithFilterContext,
-    dashboardWithLayout,
+    dashboardWithLayoutAndRowHeaders,
+    dashboardWithLayoutAndEmptyRowHeaders,
     dashboardWithExtendedDateFilterConfig,
     dashboardWithTempFilterContext,
     dashboardFilterContext,
@@ -31,7 +32,12 @@ describe("dashboard converter", () => {
         });
 
         it("should convert dashboard with layout", () => {
-            const convertedDashboard = convertDashboard(dashboardWithLayout);
+            const convertedDashboard = convertDashboard(dashboardWithLayoutAndRowHeaders);
+            expect(convertedDashboard).toMatchSnapshot();
+        });
+
+        it("should convert dashboard with layout with empty row headers", () => {
+            const convertedDashboard = convertDashboard(dashboardWithLayoutAndEmptyRowHeaders);
             expect(convertedDashboard).toMatchSnapshot();
         });
 

--- a/libs/sdk-backend-bear/src/convertors/toBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
@@ -129,6 +129,92 @@ Object {
                   },
                 },
               ],
+              "header": Object {
+                "title": "Row 1",
+              },
+            },
+            Object {
+              "columns": Array [],
+              "header": Object {
+                "description": "Row 2 description",
+              },
+            },
+          ],
+        },
+      },
+      "widgets": Array [
+        "/gdc/md/obj/widgetHeadline",
+        "/gdc/md/obj/widgetKpi",
+        "/gdc/md/obj/widgetBarChart",
+      ],
+    },
+    "meta": Object {
+      "identifier": "emptyDashboard",
+      "locked": undefined,
+      "summary": "",
+      "title": "emptyDashboard",
+      "uri": "/gdc/md/obj/emptyDashboard",
+    },
+  },
+}
+`;
+
+exports[`dashboard converter convert dashboard should convert dashboard with layout with empty row headers 1`] = `
+Object {
+  "analyticalDashboard": Object {
+    "content": Object {
+      "filterContext": undefined,
+      "layout": Object {
+        "fluidLayout": Object {
+          "rows": Array [
+            Object {
+              "columns": Array [
+                Object {
+                  "content": Object {
+                    "widget": Object {
+                      "qualifier": Object {
+                        "uri": "/gdc/md/obj/widgetHeadline",
+                      },
+                    },
+                  },
+                  "size": Object {
+                    "xl": Object {
+                      "width": 12,
+                    },
+                  },
+                },
+                Object {
+                  "content": Object {
+                    "widget": Object {
+                      "qualifier": Object {
+                        "uri": "/gdc/md/obj/widgetKpi",
+                      },
+                    },
+                  },
+                  "size": Object {
+                    "xl": Object {
+                      "width": 6,
+                    },
+                  },
+                },
+                Object {
+                  "content": Object {
+                    "widget": Object {
+                      "qualifier": Object {
+                        "uri": "/gdc/md/obj/widgetBarChart",
+                      },
+                    },
+                  },
+                  "size": Object {
+                    "xl": Object {
+                      "width": 2,
+                    },
+                  },
+                },
+              ],
+            },
+            Object {
+              "columns": Array [],
             },
           ],
         },

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -1648,6 +1648,8 @@ export interface ITypographyProps {
     onClick?: (e: React_2.MouseEvent) => void;
     // (undocumented)
     tagName: "h1" | "h2" | "h3" | "p";
+    // (undocumented)
+    title?: string;
 }
 
 // @internal @deprecated (undocumented)

--- a/libs/sdk-ui-kit/src/Typography/Typography.tsx
+++ b/libs/sdk-ui-kit/src/Typography/Typography.tsx
@@ -10,16 +10,21 @@ export interface ITypographyProps {
     children: React.ReactNode;
     className?: string;
     onClick?: (e: React.MouseEvent) => void;
+    title?: string;
 }
 
 /**
  * @internal
  */
 export const Typography: React.FC<ITypographyProps> = (props) => {
-    const { tagName: Tag, children, className, onClick } = props;
+    const { tagName: Tag, children, className, title, onClick } = props;
 
     return (
-        <Tag className={cx("gd-typography", `gd-typography--${Tag}`, className)} onClick={onClick}>
+        <Tag
+            className={cx("gd-typography", `gd-typography--${Tag}`, className)}
+            onClick={onClick}
+            title={title}
+        >
             {children}
         </Tag>
     );


### PR DESCRIPTION
- Propagate title in typography component
- Remove empty row headers in dashboard converter, when converting dashboard to api-bear-model (or backend throws error)

JIRA: RAIL-2838, RAIL-2834

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
