### PR TITLE
Implement update insight function for new metadata

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -203,23 +203,32 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
     };
 
     public updateInsight = async (insight: IInsight): Promise<IInsight> => {
-        await this.authCall((sdk) =>
-            // TODO - update to PUT in new MD
-            sdk.metadata.visualizationObjectsIdPatch({
-                contentType: "application/json",
-                id: insightId(insight),
-                visualizationObjectPatchResource: {
-                    data: {
-                        id: insightId(insight),
-                        attributes: {
-                            content: convertInsight(insight),
-                            title: insightTitle(insight),
+        await this.authCall((sdk) => {
+            return sdk.workspaceModel.updateEntity(
+                {
+                    entity: "visualizationObjects",
+                    id: insightId(insight),
+                    workspaceId: this.workspace,
+                    analyticsObject: {
+                        data: {
+                            id: insightId(insight),
+                            type: "visualizationObject",
+                            attributes: {
+                                description: insightTitle(insight),
+                                content: convertInsight(insight),
+                                title: insightTitle(insight),
+                            },
                         },
                     },
-                } as any, // The OpenAPI is wrong for now, waiting for a fix on backend 3rd party dependency fix release
-            }),
-        );
-
+                },
+                {
+                    headers: {
+                        Accept: "application/vnd.gooddata.api+json",
+                        "Content-Type": "application/vnd.gooddata.api+json",
+                    },
+                },
+            );
+        });
         return insight;
     };
 


### PR DESCRIPTION
Previous PATCH was actually storing the whole insight so that
it's compatible with the update method on the new metadata (using PUT).

JIRA: RAIL-2822

--

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
