### PR TITLE
RELATED: RAIL-2758 minor fixes to Header and ResponsiveText

### DIFF
--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -266,20 +266,22 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
             "is-open": this.state.isOverlayMenuOpen,
         });
 
-        return [
-            <div className="hamburger-wrapper" key="hamburger-wrapper">
-                <div
-                    className={iconClasses}
-                    key="hamburger-icon"
-                    onClick={() => {
-                        this.setOverlayMenu(!this.state.isOverlayMenuOpen);
-                    }}
-                >
-                    <i />
+        return (
+            <>
+                <div className="hamburger-wrapper" key="hamburger-wrapper">
+                    <div
+                        className={iconClasses}
+                        key="hamburger-icon"
+                        onClick={() => {
+                            this.setOverlayMenu(!this.state.isOverlayMenuOpen);
+                        }}
+                    >
+                        <i />
+                    </div>
                 </div>
-            </div>,
-            this.renderOverlayMenu(),
-        ];
+                {this.state.isOverlayMenuOpen && this.renderOverlayMenu()}
+            </>
+        );
     };
 
     private renderOverlayMenu = () => {
@@ -308,10 +310,6 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
     };
 
     private renderVerticalMenu = () => {
-        if (!this.state.isOverlayMenuOpen) {
-            return false;
-        }
-
         const menuItemsGroups = !this.state.isHelpMenuOpen
             ? this.addHelpItemGroup(this.props.menuItemsGroups)
             : this.getHelpMenu();

--- a/libs/sdk-ui-kit/src/ResponsiveText/ResponsiveText.tsx
+++ b/libs/sdk-ui-kit/src/ResponsiveText/ResponsiveText.tsx
@@ -34,12 +34,16 @@ export const ResponsiveText: React.FC<IResponsiveTextProps> = ({
     const containerRef = useRef<HTMLDivElement>();
 
     const adjustFontSize = () => {
+        if (!containerRef.current) {
+            return;
+        }
+
         const currentStyle = windowInstance.getComputedStyle(containerRef.current, null);
         const currentFontSize = parseFloat(currentStyle.fontSize);
 
         if (!fontSize && isNumber(currentFontSize)) {
             const { scrollWidth } = containerRef.current;
-            const width = containerRef.current ? containerRef.current.getBoundingClientRect().width : 0;
+            const width = containerRef.current.getBoundingClientRect().width;
 
             const ratio = width / scrollWidth;
             const size = Math.floor(currentFontSize * ratio);


### PR DESCRIPTION
* in Header we no longer can pass false as children to CSSTransition
* there were null references in ResponsiveText if ref was not ready for some reason

JIRA: RAIL-2758

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
