### PR TITLE
RELATED: RAIL-2843 fix KpiPop translation logic, prevent null reference

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiContent.tsx
@@ -48,10 +48,7 @@ class KpiContent extends Component<IKpiContentProps & WrappedComponentProps> {
         );
 
         const dateFilter = this.props.filters.find(isDateFilter); // for now we use the first date filter available for this
-        const popLabel = dateFilter
-            ? getKpiPopLabel(dateFilter, this.props.kpi.kpi.comparisonType, this.props.intl)
-            : undefined;
-
+        const popLabel = getKpiPopLabel(dateFilter, this.props.kpi.kpi.comparisonType, this.props.intl);
         const popDisabled = isDateFilterAllTime || isDateFilterNotRelevant || isDateFilterAbsolute;
         const isSdkError = isGoodDataSdkError(this.props.error);
         const isNoData = isSdkError && this.props.error.message === ErrorCodes.NO_DATA;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/utils/test/translations.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/utils/test/translations.test.ts
@@ -17,6 +17,11 @@ describe("getKpiPopLabel", () => {
     });
 
     describe("previousPeriod comparison", () => {
+        it("should return the correct popLabel for no filter", () => {
+            const actual = getKpiPopLabel(undefined, "previousPeriod", intl);
+            expect(actual).toEqual("prev. period");
+        });
+
         it("should return the correct popLabel for allTime filter", () => {
             const actual = getKpiPopLabel(allTimeFilter, "previousPeriod", intl);
             expect(actual).toEqual("prev. period");

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/utils/translations.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/utils/translations.ts
@@ -3,11 +3,11 @@ import { IntlShape } from "react-intl";
 import {
     IDateFilter,
     IRelativeDateFilter,
-    isAbsoluteDateFilter,
     isAllTimeDateFilter,
+    isRelativeDateFilter,
     relativeDateFilterValues,
 } from "@gooddata/sdk-model";
-import { DateFilterGranularity } from "@gooddata/sdk-backend-spi";
+import { DateFilterGranularity, ILegacyKpiComparisonTypeComparison } from "@gooddata/sdk-backend-spi";
 
 const granularityIntlCodes: {
     [key in DateFilterGranularity]: string;
@@ -36,8 +36,8 @@ const getRelativeFilterKpiPopLabel = (filter: IRelativeDateFilter, intl: IntlSha
 };
 
 export const getKpiPopLabel = (
-    filter: IDateFilter,
-    comparisonType: "previousPeriod" | "lastYear",
+    filter: IDateFilter | undefined,
+    comparisonType: ILegacyKpiComparisonTypeComparison,
     intl: IntlShape,
 ): string => {
     if (comparisonType === "lastYear") {
@@ -45,9 +45,9 @@ export const getKpiPopLabel = (
         return intl.formatMessage({ id: "filters.allTime.lastYear" });
     }
 
-    if (isAbsoluteDateFilter(filter) || isAllTimeDateFilter(filter)) {
-        return getGeneralKpiPopLabel(intl);
-    } else {
+    if (isRelativeDateFilter(filter) && !isAllTimeDateFilter(filter)) {
         return getRelativeFilterKpiPopLabel(filter, intl);
     }
+
+    return getGeneralKpiPopLabel(intl);
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiView/KpiExecutor.tsx
@@ -154,7 +154,11 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
 
 export const KpiExecutor = injectIntl(KpiExecutorCore);
 
-function getSeriesResult(series: IDataSeries): number | null {
+function getSeriesResult(series: IDataSeries | undefined): number | null {
+    if (!series) {
+        return null;
+    }
+
     const value = series.dataPoints()[0].rawValue;
 
     if (isNil(value)) {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
