### PR TITLE
RELATED: RAIL-2841 add implicit All time filter in InsightRenderer

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
@@ -7,7 +7,7 @@ import {
     IWidget,
     ISeparators,
 } from "@gooddata/sdk-backend-spi";
-import { IFilter, newAllTimeFilter } from "@gooddata/sdk-model";
+import { IFilter } from "@gooddata/sdk-model";
 import {
     IDrillableItem,
     IErrorProps,
@@ -22,7 +22,7 @@ import {
 import { InsightView } from "../../../insightView";
 import { widgetDrillsToDrillPredicates } from "./convertors";
 import { filterContextToFiltersForWidget } from "../converters";
-import { hasDateFilterForDateDataset } from "./utils";
+import { addImplicitAllTimeFilter } from "./utils";
 
 interface IInsightRendererProps {
     insightWidget: IWidget;
@@ -67,17 +67,7 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
                     .dashboards()
                     .getResolvedFiltersForWidget(insightWidget, inputFilters);
 
-                // if the widget is connected to a dateDataset and has no date filters for it in the context,
-                // add an implicit All time filter for that dimension - this will cause the InsightView to ignore
-                // any date filters on that dimension - this is how KPI dashboards behave
-                if (
-                    insightWidget.dateDataSet &&
-                    !hasDateFilterForDateDataset(resolvedFilters, insightWidget.dateDataSet)
-                ) {
-                    resolvedFilters.push(newAllTimeFilter(insightWidget.dateDataSet));
-                }
-
-                return resolvedFilters;
+                return addImplicitAllTimeFilter(insightWidget, resolvedFilters);
             },
             onError,
         },

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/test/utils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/test/utils.test.ts
@@ -1,0 +1,25 @@
+// (C) 2020 GoodData Corporation
+import { IFilter, newRelativeDateFilter, ObjRef } from "@gooddata/sdk-model";
+import { ReferenceLdm } from "@gooddata/reference-workspace";
+import { hasDateFilterForDateDataset } from "../utils";
+
+describe("hasDateFilterForDateDataset", () => {
+    type Scenario = [boolean, string, IFilter[], ObjRef];
+
+    const dateDimension = ReferenceLdm.DateDatasets.Created.ref;
+    const otherDateDimension = ReferenceLdm.DateDatasets.Timeline.ref;
+
+    const matchingFilter = newRelativeDateFilter(dateDimension, "GDC.time.date", -5, 5);
+    const notMatchingFilter = newRelativeDateFilter(otherDateDimension, "GDC.time.date", -5, 5);
+
+    const scenarios: Scenario[] = [
+        [false, "empty filters", [], dateDimension],
+        [false, "undefined date dimension", [matchingFilter], undefined],
+        [false, "not matching date dimension", [notMatchingFilter], dateDimension],
+        [true, "matching date dimension and filter", [matchingFilter], dateDimension],
+    ];
+
+    it.each(scenarios)("should return %p for %s", (expected, _, filters, dateDimension) => {
+        expect(hasDateFilterForDateDataset(filters, dateDimension)).toEqual(expected);
+    });
+});

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/test/utils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/test/utils.test.ts
@@ -1,7 +1,8 @@
 // (C) 2020 GoodData Corporation
-import { IFilter, newRelativeDateFilter, ObjRef } from "@gooddata/sdk-model";
+import { IFilter, newAllTimeFilter, newRelativeDateFilter, ObjRef } from "@gooddata/sdk-model";
 import { ReferenceLdm } from "@gooddata/reference-workspace";
-import { hasDateFilterForDateDataset } from "../utils";
+import { hasDateFilterForDateDataset, addImplicitAllTimeFilter } from "../utils";
+import { IWidgetDefinition } from "@gooddata/sdk-backend-spi";
 
 describe("hasDateFilterForDateDataset", () => {
     type Scenario = [boolean, string, IFilter[], ObjRef];
@@ -21,5 +22,59 @@ describe("hasDateFilterForDateDataset", () => {
 
     it.each(scenarios)("should return %p for %s", (expected, _, filters, dateDimension) => {
         expect(hasDateFilterForDateDataset(filters, dateDimension)).toEqual(expected);
+    });
+});
+
+describe("addImplicitAllTimeFilter", () => {
+    type Scenario = [string, IWidgetDefinition, IFilter[], IFilter[]];
+
+    const dateDimension = ReferenceLdm.DateDatasets.Created.ref;
+    const otherDateDimension = ReferenceLdm.DateDatasets.Timeline.ref;
+
+    const matchingFilter = newRelativeDateFilter(dateDimension, "GDC.time.date", -5, 5);
+    const notMatchingFilter = newRelativeDateFilter(otherDateDimension, "GDC.time.date", -5, 5);
+
+    const widgetWithNoDateDataset: IWidgetDefinition = {
+        description: "",
+        drills: [],
+        ignoreDashboardFilters: [],
+        title: "Foo",
+        type: "insight",
+        dateDataSet: undefined,
+    };
+
+    const widgetWithMatchingDateDataset: IWidgetDefinition = {
+        ...widgetWithNoDateDataset,
+        dateDataSet: dateDimension,
+    };
+
+    const widgetWithNotMatchingDateDataset: IWidgetDefinition = {
+        ...widgetWithNoDateDataset,
+        dateDataSet: otherDateDimension,
+    };
+
+    const expectedFilter = newAllTimeFilter(dateDimension);
+    const expectedNotMatchingFilter = newAllTimeFilter(otherDateDimension);
+
+    const scenarios: Scenario[] = [
+        ["empty filters with no date dataset", widgetWithNoDateDataset, [], []],
+        ["empty filters with matching date dataset", widgetWithMatchingDateDataset, [], [expectedFilter]],
+        [
+            "empty filters with not matching date dataset",
+            widgetWithNotMatchingDateDataset,
+            [],
+            [expectedNotMatchingFilter],
+        ],
+        ["filters with matching filter", widgetWithMatchingDateDataset, [matchingFilter], [matchingFilter]],
+        [
+            "filters with not matching filter",
+            widgetWithMatchingDateDataset,
+            [notMatchingFilter],
+            [notMatchingFilter, expectedFilter],
+        ],
+    ];
+
+    it.each(scenarios)("should handle %s properly", (_, widget, filters, expected) => {
+        expect(addImplicitAllTimeFilter(widget, filters)).toEqual(expected);
     });
 });

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/utils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/utils.ts
@@ -1,0 +1,12 @@
+// (C) 2020 GoodData Corporation
+import { areObjRefsEqual, filterObjRef, IFilter, isDateFilter, ObjRef } from "@gooddata/sdk-model";
+
+export function hasDateFilterForDateDataset(filters: IFilter[], dateDataset: ObjRef): boolean {
+    return filters.some((filter) => {
+        if (!isDateFilter(filter)) {
+            return false;
+        }
+
+        return areObjRefsEqual(filterObjRef(filter), dateDataset);
+    });
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/utils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/utils.ts
@@ -1,5 +1,13 @@
 // (C) 2020 GoodData Corporation
-import { areObjRefsEqual, filterObjRef, IFilter, isDateFilter, ObjRef } from "@gooddata/sdk-model";
+import { IWidgetDefinition } from "@gooddata/sdk-backend-spi";
+import {
+    areObjRefsEqual,
+    filterObjRef,
+    IFilter,
+    isDateFilter,
+    newAllTimeFilter,
+    ObjRef,
+} from "@gooddata/sdk-model";
 
 export function hasDateFilterForDateDataset(filters: IFilter[], dateDataset: ObjRef): boolean {
     return filters.some((filter) => {
@@ -9,4 +17,14 @@ export function hasDateFilterForDateDataset(filters: IFilter[], dateDataset: Obj
 
         return areObjRefsEqual(filterObjRef(filter), dateDataset);
     });
+}
+
+export function addImplicitAllTimeFilter(widget: IWidgetDefinition, resolvedFilters: IFilter[]): IFilter[] {
+    // if the widget is connected to a dateDataset and has no date filters for it in the context,
+    // add an implicit All time filter for that dimension - this will cause the InsightView to ignore
+    // any date filters on that dimension - this is how KPI dashboards behave
+    if (widget.dateDataSet && !hasDateFilterForDateDataset(resolvedFilters, widget.dateDataSet)) {
+        return [...resolvedFilters, newAllTimeFilter(widget.dateDataSet)];
+    }
+    return resolvedFilters;
 }


### PR DESCRIPTION
This mimics the KPI dashboards behavior, that allows users to "remove"
date filters from insights connected to date dimension by using
the All time filter there.

JIRA: RAIL-2841

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
