### PR TITLE
Add support for getting current user info to sdk-backend-spi

### DIFF
--- a/libs/sdk-backend-bear/src/backend/user/index.ts
+++ b/libs/sdk-backend-bear/src/backend/user/index.ts
@@ -1,12 +1,20 @@
 // (C) 2020 GoodData Corporation
-import { IUserService, IUserSettingsService } from "@gooddata/sdk-backend-spi";
+import { IUser, IUserService, IUserSettingsService } from "@gooddata/sdk-backend-spi";
 import { BearUserSettingsService } from "./settings";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
+import { convertUser } from "../../convertors/fromBackend/UsersConverter";
 
 export class BearUserService implements IUserService {
     constructor(private readonly authCall: BearAuthenticatedCallGuard) {}
 
     public settings(): IUserSettingsService {
         return new BearUserSettingsService(this.authCall);
+    }
+
+    public getUser(): Promise<IUser> {
+        return this.authCall(async (sdk) => {
+            const accountSettings = await sdk.user.getCurrentProfile();
+            return convertUser(accountSettings);
+        });
     }
 }

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/UsersConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/UsersConverter.ts
@@ -1,7 +1,18 @@
 // (C) 2019-2020 GoodData Corporation
-import { IWorkspaceUser } from "@gooddata/sdk-backend-spi";
+import { IWorkspaceUser, IUser } from "@gooddata/sdk-backend-spi";
 import { GdcUser } from "@gooddata/api-model-bear";
 import { uriRef } from "@gooddata/sdk-model";
+
+export const convertUser = (user: GdcUser.IAccountSetting): IUser => {
+    const { email, login, firstName, lastName, links } = user;
+    return {
+        ref: uriRef(links!.self!),
+        email: email!,
+        login: login!,
+        firstName,
+        lastName,
+    };
+};
 
 export const convertWorkspaceUser = (user: GdcUser.IUserListItem): IWorkspaceUser => {
     const { email, login, uri, firstName, lastName } = user;

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -185,6 +185,9 @@ function recordedWorkspace(
 // returns the same settings as the global ones
 function recordedUserService(implConfig: RecordedBackendConfig): IUserService {
     return {
+        getUser() {
+            throw new NotSupported("not supported");
+        },
         settings(): IUserSettingsService {
             return {
                 getSettings: async () => ({

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1365,8 +1365,18 @@ export interface ITotalDescriptor {
     };
 }
 
+// @alpha
+export interface IUser {
+    email?: string;
+    firstName?: string;
+    lastName?: string;
+    login: string;
+    ref: ObjRef;
+}
+
 // @public
 export interface IUserService {
+    getUser(): Promise<IUser>;
     settings(): IUserSettingsService;
 }
 

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -18,7 +18,7 @@ export {
     ISeparators,
 } from "./common/settings";
 
-export { IUserService } from "./user";
+export { IUserService, IUser } from "./user";
 export { IUserSettingsService } from "./user/settings";
 
 export { IExecutionFactory, IPreparedExecution, IExecutionResult, IDataView } from "./workspace/execution";

--- a/libs/sdk-backend-spi/src/user/index.ts
+++ b/libs/sdk-backend-spi/src/user/index.ts
@@ -1,5 +1,38 @@
 // (C) 2020 GoodData Corporation
+import { ObjRef } from "@gooddata/sdk-model";
 import { IUserSettingsService } from "./settings";
+
+/**
+ * Represents platform user
+ *
+ * @alpha
+ */
+export interface IUser {
+    /**
+     * Stored user reference
+     */
+    ref: ObjRef;
+
+    /**
+     * Login - unique user ID for logging into the platform
+     */
+    login: string;
+
+    /**
+     * Contact email of the user
+     */
+    email?: string;
+
+    /**
+     * First name
+     */
+    firstName?: string;
+
+    /**
+     * Last name
+     */
+    lastName?: string;
+}
 
 /**
  * Represents a user. It is an entry point to various services that can be used to inspect and modify the user.
@@ -13,4 +46,9 @@ export interface IUserService {
      * @returns user settings service
      */
     settings(): IUserSettingsService;
+
+    /**
+     * Returns currently authenticated user
+     */
+    getUser(): Promise<IUser>;
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/scheduledMail.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/scheduledMail.ts
@@ -45,7 +45,7 @@ export interface IScheduledMailBase {
     };
 
     /**
-     * Recipients email addresses
+     * Recipients unique login identifiers - should be equal to login property in {@link IWorkspaceUser} / {@link IUser}
      */
     to: string[];
 

--- a/libs/sdk-backend-spi/src/workspace/users/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/users/index.ts
@@ -15,12 +15,14 @@ export interface IWorkspaceUser {
      * User uri
      */
     uri: string;
+
     /**
-     * Login
+     * Login - unique user ID for logging into the platform
      */
     login: string;
+
     /**
-     * Email
+     * Contact email of the user
      */
     email: string;
     /**

--- a/libs/sdk-backend-tiger/src/backend/user/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/user/index.ts
@@ -1,5 +1,5 @@
 // (C) 2020 GoodData Corporation
-import { IUserService, IUserSettingsService } from "@gooddata/sdk-backend-spi";
+import { IUser, IUserService, IUserSettingsService, NotSupported } from "@gooddata/sdk-backend-spi";
 import { TigerUserSettingsService } from "./settings";
 import { TigerAuthenticatedCallGuard } from "../../types";
 
@@ -8,5 +8,9 @@ export class TigerUserService implements IUserService {
 
     public settings(): IUserSettingsService {
         return new TigerUserSettingsService(this.authCall);
+    }
+
+    public async getUser(): Promise<IUser> {
+        throw new NotSupported("not supported");
     }
 }


### PR DESCRIPTION
- Add support for getting current user info to sdk-backend-spi
- This is necessary to move scheduled emails feature to gooddata-ui-sdk

JIRA: RAIL-2760
<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
