### PR TITLE
RELATED: RAIL-2844 split InsightView, fix DashboardRenderer

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -40,20 +40,13 @@ export interface IInsightRendererProps extends Omit<IInsightViewProps, "insight"
     onError?: (error: GoodDataSdkError | undefined) => void;
 }
 
-interface IInsightRendererState {
-    isLoading: boolean;
-}
-
 const getElementId = () => `gd-vis-${uuid.v4()}`;
 
 const visualizationUriRootStyle = {
     height: "100%",
 };
 
-class InsightRendererCore extends React.Component<
-    IInsightRendererProps & WrappedComponentProps,
-    IInsightRendererState
-> {
+class InsightRendererCore extends React.Component<IInsightRendererProps & WrappedComponentProps> {
     private elementId = getElementId();
     private visualization: IVisualization | undefined;
     private containerRef = React.createRef<HTMLDivElement>();
@@ -65,10 +58,6 @@ class InsightRendererCore extends React.Component<
         LoadingComponent,
         pushData: noop,
         locale: DefaultLocale,
-    };
-
-    state: IInsightRendererState = {
-        isLoading: false,
     };
 
     private unmountVisualization = () => {
@@ -127,12 +116,10 @@ class InsightRendererCore extends React.Component<
             backend: this.props.backend,
             callbacks: {
                 onError: (error) => {
-                    this.setState({ isLoading: false });
                     this.props.onError?.(error);
                     this.props.onLoadingChanged?.({ isLoading: false });
                 },
                 onLoadingChanged: ({ isLoading }) => {
-                    this.setState({ isLoading });
                     this.props.onLoadingChanged?.({ isLoading });
                 },
                 pushData: this.props.pushData,
@@ -222,15 +209,12 @@ class InsightRendererCore extends React.Component<
 
     public render(): React.ReactNode {
         return (
-            <>
-                {this.state.isLoading && <this.props.LoadingComponent />}
-                <div
-                    className="visualization-uri-root"
-                    id={this.elementId}
-                    ref={this.containerRef}
-                    style={visualizationUriRootStyle}
-                />
-            </>
+            <div
+                className="visualization-uri-root"
+                id={this.elementId}
+                ref={this.containerRef}
+                style={visualizationUriRootStyle}
+            />
         );
     }
 }

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -1,0 +1,253 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import uuid from "uuid";
+import { render } from "react-dom";
+import noop from "lodash/noop";
+import isEqual from "lodash/isEqual";
+import { injectIntl, WrappedComponentProps } from "react-intl";
+import { IExecutionFactory, IExportResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import { IInsightDefinition, insightProperties, IColorPalette, insightTitle } from "@gooddata/sdk-model";
+
+import { IVisualization, IVisProps } from "../internal/interfaces/Visualization";
+import { FullVisualizationCatalog } from "../internal/components/VisualizationCatalog";
+import {
+    GoodDataSdkError,
+    fillMissingTitles,
+    ignoreTitlesForSimpleMeasures,
+    ILocale,
+    withContexts,
+    DefaultLocale,
+    LoadingComponent,
+    ErrorComponent,
+    IExportFunction,
+    IExtendedExportConfig,
+    IntlWrapper,
+} from "@gooddata/sdk-ui";
+import {
+    ExecutionFactoryUpgradingToExecByReference,
+    ExecutionFactoryWithFixedFilters,
+} from "@gooddata/sdk-backend-base";
+import { IInsightViewProps } from "./types";
+
+/**
+ * @internal
+ */
+export interface IInsightRendererProps extends Omit<IInsightViewProps, "insight"> {
+    insight: IInsightDefinition | undefined;
+    locale: ILocale;
+    settings: IUserWorkspaceSettings | undefined;
+    colorPalette: IColorPalette | undefined;
+    onError?: (error: GoodDataSdkError | undefined) => void;
+}
+
+interface IInsightRendererState {
+    isLoading: boolean;
+}
+
+const getElementId = () => `gd-vis-${uuid.v4()}`;
+
+const visualizationUriRootStyle = {
+    height: "100%",
+};
+
+class InsightRendererCore extends React.Component<
+    IInsightRendererProps & WrappedComponentProps,
+    IInsightRendererState
+> {
+    private elementId = getElementId();
+    private visualization: IVisualization | undefined;
+    private containerRef = React.createRef<HTMLDivElement>();
+
+    public static defaultProps: Partial<IInsightRendererProps & WrappedComponentProps> = {
+        ErrorComponent,
+        filters: [],
+        drillableItems: [],
+        LoadingComponent,
+        pushData: noop,
+        locale: DefaultLocale,
+    };
+
+    state: IInsightRendererState = {
+        isLoading: false,
+    };
+
+    private unmountVisualization = () => {
+        if (this.visualization) {
+            this.visualization.unmount();
+        }
+        this.visualization = undefined;
+    };
+
+    private updateVisualization = () => {
+        // if the container no longer exists, update was called after unmount -> do nothing
+        if (!this.visualization || !this.containerRef.current) {
+            return;
+        }
+
+        const { config = {} } = this.props;
+        const { responsiveUiDateFormat } = this.props.settings ?? {};
+
+        const visProps: IVisProps = {
+            locale: this.props.locale,
+            dateFormat: responsiveUiDateFormat,
+            custom: {
+                drillableItems: this.props.drillableItems,
+            },
+            config: {
+                separators: config.separators,
+                colorPalette: this.props.colorPalette,
+                mapboxToken: config.mapboxToken,
+                forceDisableDrillOnAxes: config.forceDisableDrillOnAxes,
+                isInEditMode: false,
+            },
+            customVisualizationConfig: config,
+        };
+
+        this.visualization.update(
+            visProps,
+            ignoreTitlesForSimpleMeasures(fillMissingTitles(this.props.insight, this.props.locale)),
+            {},
+            this.getExecutionFactory(),
+        );
+    };
+
+    private setupVisualization = async () => {
+        if (!this.props.insight) {
+            return;
+        }
+
+        this.props.onLoadingChanged?.({ isLoading: true });
+
+        // the visualization we may have from earlier is no longer valid -> get rid of it
+        this.unmountVisualization();
+
+        const visualizationFactory = FullVisualizationCatalog.forInsight(this.props.insight);
+
+        this.visualization = visualizationFactory({
+            backend: this.props.backend,
+            callbacks: {
+                onError: (error) => {
+                    this.setState({ isLoading: false });
+                    this.props.onError?.(error);
+                    this.props.onLoadingChanged?.({ isLoading: false });
+                },
+                onLoadingChanged: ({ isLoading }) => {
+                    this.setState({ isLoading });
+                    this.props.onLoadingChanged?.({ isLoading });
+                },
+                pushData: this.props.pushData,
+                onDrill: this.props.onDrill,
+                onExportReady: this.onExportReadyDecorator,
+            },
+            configPanelElement: ".gd-configuration-panel-content", // this is apparently a well-know constant (see BaseVisualization)
+            element: `#${this.elementId}`,
+            environment: "dashboards", // TODO get rid of this
+            locale: this.props.locale,
+            projectId: this.props.workspace,
+            visualizationProperties: insightProperties(this.props.insight),
+            featureFlags: this.props.settings,
+            renderFun: render,
+        });
+    };
+
+    private onExportReadyDecorator = (exportFunction: IExportFunction): void => {
+        if (!this.props.onExportReady) {
+            return;
+        }
+
+        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
+            if (exportConfig.title || !this.props.insight) {
+                return exportFunction(exportConfig);
+            }
+
+            return exportFunction({
+                ...exportConfig,
+                title: insightTitle(this.props.insight),
+            });
+        };
+
+        this.props.onExportReady(decorator);
+    };
+
+    private getExecutionFactory = (): IExecutionFactory => {
+        const factory = this.props.backend.workspace(this.props.workspace).execution();
+
+        if (this.props.executeByReference) {
+            /*
+             * When executing by reference, decorate the original execution factory so that it
+             * transparently routes `forInsight` to `forInsightByRef` AND adds the filters
+             * from InsightView props.
+             *
+             * Code will pass this factory over to the pluggable visualizations - they will do execution
+             * `forInsight` and under the covers things will be routed and done differently without the
+             * plug viz knowing.
+             */
+            return new ExecutionFactoryUpgradingToExecByReference(
+                new ExecutionFactoryWithFixedFilters(factory, this.props.filters),
+            );
+        }
+
+        return factory;
+    };
+
+    private componentDidMountInner = async () => {
+        await this.setupVisualization();
+        return this.updateVisualization();
+    };
+
+    public componentDidMount(): void {
+        this.componentDidMountInner();
+    }
+
+    private componentDidUpdateInner = async (prevProps: IInsightRendererProps) => {
+        const needsNewSetup =
+            !isEqual(this.props.insight, prevProps.insight) ||
+            !isEqual(this.props.filters, prevProps.filters) ||
+            this.props.workspace !== prevProps.workspace;
+
+        if (needsNewSetup) {
+            await this.setupVisualization();
+        }
+
+        return this.updateVisualization();
+    };
+
+    public componentDidUpdate(prevProps: IInsightRendererProps & WrappedComponentProps): void {
+        this.componentDidUpdateInner(prevProps);
+    }
+
+    public componentWillUnmount() {
+        this.unmountVisualization();
+    }
+
+    public render(): React.ReactNode {
+        return (
+            <>
+                {this.state.isLoading && <this.props.LoadingComponent />}
+                <div
+                    className="visualization-uri-root"
+                    id={this.elementId}
+                    ref={this.containerRef}
+                    style={visualizationUriRootStyle}
+                />
+            </>
+        );
+    }
+}
+
+export const IntlInsightRenderer = withContexts(injectIntl(InsightRendererCore));
+
+/**
+ * Renders insight passed as a parameter.
+ *
+ * @internal
+ */
+export class InsightRenderer extends React.Component<IInsightRendererProps> {
+    public render(): React.ReactNode {
+        return (
+            <IntlWrapper locale={this.props.locale}>
+                <IntlInsightRenderer {...this.props} />
+            </IntlWrapper>
+        );
+    }
+}

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -1,165 +1,39 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
-import uuid from "uuid";
-import { render } from "react-dom";
-import noop from "lodash/noop";
+import compact from "lodash/compact";
 import isEqual from "lodash/isEqual";
+import noop from "lodash/noop";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import {
-    IAnalyticalBackend,
-    IExecutionFactory,
-    IExportResult,
-    IUserWorkspaceSettings,
-} from "@gooddata/sdk-backend-spi";
-import {
-    IInsight,
-    IFilter,
-    insightProperties,
-    IColorPalette,
-    ObjRef,
-    idRef,
-    insightTitle,
-} from "@gooddata/sdk-model";
+import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import { IInsight, IColorPalette, idRef } from "@gooddata/sdk-model";
 
-import { IVisualization, IVisCallbacks, IVisProps } from "../internal/interfaces/Visualization";
-import { FullVisualizationCatalog } from "../internal/components/VisualizationCatalog";
 import {
     GoodDataSdkError,
-    fillMissingTitles,
-    ignoreTitlesForSimpleMeasures,
     ILocale,
     withContexts,
     DefaultLocale,
     LoadingComponent,
-    ILoadingProps,
     ErrorComponent,
-    IErrorProps,
-    IDrillableItem,
-    IExportFunction,
-    IExtendedExportConfig,
     IErrorDescriptors,
     IntlWrapper,
     newErrorMapping,
     isGoodDataSdkError,
     UnexpectedSdkError,
-    IHeaderPredicate,
 } from "@gooddata/sdk-ui";
-import { IChartConfig } from "@gooddata/sdk-ui-charts";
-import { IGeoConfig } from "@gooddata/sdk-ui-geo";
-import { IPivotTableConfig } from "@gooddata/sdk-ui-pivot";
 import { IInsightViewDataLoader, getInsightViewDataLoader } from "./dataLoaders";
-import {
-    ExecutionFactoryUpgradingToExecByReference,
-    ExecutionFactoryWithFixedFilters,
-} from "@gooddata/sdk-backend-base";
-
-/**
- * @public
- */
-export interface IInsightViewProps extends Partial<IVisCallbacks> {
-    /**
-     * Backend to work with.
-     *
-     * Note: the backend must come either from this property or from BackendContext. If you do not specify
-     * backend here, then the executor MUST be rendered within an existing BackendContext.
-     */
-    backend?: IAnalyticalBackend;
-
-    /**
-     * Workspace where the insight exists.
-     *
-     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
-     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
-     */
-    workspace?: string;
-
-    /**
-     * Reference to the insight to render. This can be specified by either object reference using URI or using identifier.
-     *
-     * For convenience it is also possible to specify just the identifier of the insight.
-     */
-    insight: ObjRef | string;
-
-    /**
-     * Additional filters to apply on top of the insight.
-     */
-    filters?: IFilter[];
-
-    /**
-     * Configure chart drillability; e.g. which parts of the charts can be clicked.
-     */
-    drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
-
-    /**
-     * Configure color palette to use for the chart. If you do not specify this, then the palette will be
-     * obtained from style settings stored on the backend.
-     */
-    colorPalette?: IColorPalette;
-
-    /**
-     * When embedding insight rendered by a chart, you can specify extra options to merge with existing
-     * options saved for the insight.
-     */
-    config?: IChartConfig | IGeoConfig | IPivotTableConfig | any;
-
-    /**
-     * Locale to use for localization of texts appearing in the chart.
-     *
-     * Note: text values coming from the data itself are not localized.
-     */
-    locale?: ILocale;
-
-    /**
-     * Indicates that the execution to obtain the data for the insight should be an 'execution by reference'.
-     *
-     * Execution by reference means that the InsightView will ask analytical backend to compute results for an insight
-     * which is stored on the backend by specifying link to the insight, additional filters and description how
-     * to organize the data.
-     *
-     * Otherwise, a freeform execution is done, in which the InsightView will send to backend the full execution
-     * definition of what to compute.
-     *
-     * This distinction is in place because some backends MAY want to prohibit users from doing freeform executions
-     * and only allow computing data for set of insights created by admins.
-     *
-     * Note: the need for execute by reference is rare. You will typically be notified by the solution admin to use
-     * this mode.
-     */
-    executeByReference?: boolean;
-
-    /**
-     * Component to render if embedding fails.
-     */
-    ErrorComponent?: React.ComponentType<IErrorProps>;
-
-    /**
-     * Component to render while the insight is loading.
-     */
-    LoadingComponent?: React.ComponentType<ILoadingProps>;
-}
+import { IInsightViewProps } from "./types";
+import { InsightRenderer } from "./InsightRenderer";
 
 interface IInsightViewState {
     isLoading: boolean;
     error: GoodDataSdkError | undefined;
+    insight: IInsight | undefined;
+    locale: ILocale | undefined;
+    colorPalette: IColorPalette | undefined;
+    settings: IUserWorkspaceSettings | undefined;
 }
 
-const getElementId = () => `gd-vis-${uuid.v4()}`;
-
-const visualizationUriRootStyle = {
-    height: "100%",
-};
-
-class RenderInsightView extends React.Component<
-    IInsightViewProps & WrappedComponentProps,
-    IInsightViewState
-> {
-    private elementId = getElementId();
-    private visualization: IVisualization | undefined;
-    private insight: IInsight | undefined;
-    private colorPalette: IColorPalette | undefined;
-    private settings: IUserWorkspaceSettings | undefined;
-    private containerRef = React.createRef<HTMLDivElement>();
-    private locale: string | undefined;
+class InsightViewCore extends React.Component<IInsightViewProps & WrappedComponentProps, IInsightViewState> {
     private errorMap: IErrorDescriptors;
 
     public static defaultProps: Partial<IInsightViewProps & WrappedComponentProps> = {
@@ -178,6 +52,10 @@ class RenderInsightView extends React.Component<
         this.state = {
             isLoading: false,
             error: undefined,
+            insight: undefined,
+            locale: DefaultLocale,
+            colorPalette: undefined,
+            settings: undefined,
         };
     }
 
@@ -200,122 +78,6 @@ class RenderInsightView extends React.Component<
         if (this.state.error !== error) {
             this.setState({ error });
         }
-    };
-
-    private unmountVisualization = () => {
-        if (this.visualization) {
-            this.visualization.unmount();
-        }
-        this.visualization = undefined;
-    };
-
-    private updateVisualization = () => {
-        // if the container no longer exists, update was called after unmount -> do nothing
-        if (!this.visualization || !this.containerRef.current) {
-            return;
-        }
-
-        const { config = {} } = this.props;
-        const { responsiveUiDateFormat } = this.settings || {};
-
-        const visProps: IVisProps = {
-            locale: this.getLocale(),
-            dateFormat: responsiveUiDateFormat,
-            custom: {
-                drillableItems: this.props.drillableItems,
-            },
-            config: {
-                separators: config.separators,
-                colorPalette: this.colorPalette,
-                mapboxToken: config.mapboxToken,
-                forceDisableDrillOnAxes: config.forceDisableDrillOnAxes,
-                isInEditMode: false,
-            },
-            customVisualizationConfig: config,
-        };
-
-        this.visualization.update(
-            visProps,
-            ignoreTitlesForSimpleMeasures(fillMissingTitles(this.insight, this.getLocale())),
-            {},
-            this.getExecutionFactory(),
-        );
-    };
-
-    private setupVisualization = async () => {
-        this.startLoading();
-
-        // the visualization we may have from earlier is no longer valid -> get rid of it
-        this.unmountVisualization();
-
-        this.insight = await this.getInsight();
-        this.locale = await this.getUserProfileLocale();
-
-        [this.insight, this.locale] = await Promise.all([this.getInsight(), this.getUserProfileLocale()]);
-
-        if (!this.insight) {
-            return;
-        }
-
-        const visualizationFactory = FullVisualizationCatalog.forInsight(this.insight);
-
-        this.visualization = visualizationFactory({
-            backend: this.props.backend,
-            callbacks: {
-                onError: (error) => {
-                    this.setError(error);
-                    this.setIsLoading(false);
-                    if (this.props.onError) {
-                        this.props.onError(error);
-                    }
-                },
-                onLoadingChanged: ({ isLoading }) => {
-                    if (isLoading) {
-                        this.startLoading();
-                    } else {
-                        this.stopLoading();
-                    }
-
-                    if (this.props.onLoadingChanged) {
-                        this.props.onLoadingChanged({ isLoading });
-                    }
-                },
-                pushData: this.props.pushData,
-                onDrill: this.props.onDrill,
-                onExportReady: this.onExportReadyDecorator,
-            },
-            configPanelElement: ".gd-configuration-panel-content", // this is apparently a well-know constant (see BaseVisualization)
-            element: `#${this.elementId}`,
-            environment: "dashboards", // TODO get rid of this
-            locale: this.getLocale(),
-            projectId: this.props.workspace,
-            visualizationProperties: insightProperties(this.insight),
-            featureFlags: this.settings,
-            renderFun: render,
-        });
-    };
-
-    private getLocale = () => {
-        return (this.props.locale || this.locale || DefaultLocale) as ILocale;
-    };
-
-    private onExportReadyDecorator = (exportFunction: IExportFunction): void => {
-        if (!this.props.onExportReady) {
-            return;
-        }
-
-        const decorator = (exportConfig: IExtendedExportConfig): Promise<IExportResult> => {
-            if (exportConfig.title || !this.insight) {
-                return exportFunction(exportConfig);
-            }
-
-            return exportFunction({
-                ...exportConfig,
-                title: insightTitle(this.insight),
-            });
-        };
-
-        this.props.onExportReady(decorator);
     };
 
     private getRemoteResource = async <T extends any>(
@@ -369,51 +131,67 @@ class RenderInsightView extends React.Component<
         return this.getRemoteResource((loader) => loader.getUserWorkspaceSettings(this.props.backend));
     };
 
-    private getUserProfileLocale = (): Promise<string> => {
-        return this.getRemoteResource((loader) => loader.getLocale(this.props.backend));
+    private getUserProfileLocale = (): Promise<ILocale> => {
+        return this.getRemoteResource((loader) => loader.getLocale(this.props.backend)) as Promise<ILocale>;
     };
 
     private updateUserWorkspaceSettings = async () => {
-        this.settings = await this.getUserWorkspaceSettings();
+        const settings = await this.getUserWorkspaceSettings();
+
+        if (!settings || isEqual(settings, this.state.settings)) {
+            return;
+        }
+
+        this.setState({ settings });
     };
 
     private updateColorPalette = async () => {
         if (this.props.colorPalette) {
-            this.colorPalette = this.props.colorPalette;
-
             return;
         }
 
-        this.colorPalette = await this.getColorPalette();
-    };
+        const colorPalette = await this.getColorPalette();
 
-    private getExecutionFactory = (): IExecutionFactory => {
-        const factory = this.props.backend.workspace(this.props.workspace).execution();
-
-        if (this.props.executeByReference) {
-            /*
-             * When executing by reference, decorate the original execution factory so that it
-             * transparently routes `forInsight` to `forInsightByRef` AND adds the filters
-             * from InsightView props.
-             *
-             * Code will pass this factory over to the pluggable visualizations - they will do execution
-             * `forInsight` and under the covers things will be routed and done differently without the
-             * plug viz knowing.
-             */
-            return new ExecutionFactoryUpgradingToExecByReference(
-                new ExecutionFactoryWithFixedFilters(factory, this.props.filters),
-            );
+        if (!colorPalette || isEqual(colorPalette, this.state.colorPalette)) {
+            return;
         }
 
-        return factory;
+        this.setState({ colorPalette });
+    };
+
+    private updateInsight = async () => {
+        const insight = await this.getInsight();
+
+        if (!insight || isEqual(insight, this.state.insight)) {
+            return;
+        }
+
+        this.setState({ insight });
+    };
+
+    private updateLocale = async () => {
+        if (this.props.locale) {
+            return;
+        }
+
+        const locale = await this.getUserProfileLocale();
+
+        if (!locale || locale === this.state.locale) {
+            return;
+        }
+
+        this.setState({ locale });
     };
 
     private componentDidMountInner = async () => {
-        await this.updateColorPalette();
-        await this.updateUserWorkspaceSettings();
-        await this.setupVisualization();
-
-        return this.updateVisualization();
+        this.startLoading();
+        await Promise.all([
+            this.updateColorPalette(),
+            this.updateUserWorkspaceSettings(),
+            this.updateInsight(),
+            this.updateLocale(),
+        ]);
+        this.stopLoading();
     };
 
     public componentDidMount(): void {
@@ -426,16 +204,19 @@ class RenderInsightView extends React.Component<
             !isEqual(this.props.filters, prevProps.filters) ||
             this.props.workspace !== prevProps.workspace;
 
-        if (needsNewSetup) {
-            await this.setupVisualization();
-        }
-
         const needsNewColorPalette = this.props.workspace !== prevProps.workspace;
-        if (needsNewColorPalette) {
-            await this.updateColorPalette();
-        }
 
-        return this.updateVisualization();
+        if (needsNewSetup || needsNewColorPalette) {
+            this.startLoading();
+            await Promise.all(
+                compact([
+                    needsNewSetup && this.updateInsight(),
+                    needsNewSetup && this.updateLocale(),
+                    needsNewColorPalette && this.updateColorPalette(),
+                ]),
+            );
+            this.stopLoading();
+        }
     };
 
     public componentDidUpdate(prevProps: IInsightViewProps & WrappedComponentProps): void {
@@ -446,10 +227,6 @@ class RenderInsightView extends React.Component<
         if (!isEqual(prevProps.intl, intl)) {
             this.errorMap = newErrorMapping(intl);
         }
-    }
-
-    public componentWillUnmount() {
-        this.unmountVisualization();
     }
 
     public render(): React.ReactNode {
@@ -463,18 +240,19 @@ class RenderInsightView extends React.Component<
             <>
                 {isLoading && <LoadingComponent />}
                 {error && !isLoading && <ErrorComponent {...errorProps} />}
-                <div
-                    className="visualization-uri-root"
-                    id={this.elementId}
-                    ref={this.containerRef}
-                    style={visualizationUriRootStyle}
+                <InsightRenderer
+                    {...this.props}
+                    colorPalette={this.props.colorPalette ?? this.state.colorPalette}
+                    insight={this.state.insight}
+                    locale={this.props.locale || this.state.locale || DefaultLocale}
+                    settings={this.state.settings}
                 />
             </>
         );
     }
 }
 
-export const IntlInsightView = withContexts(injectIntl(RenderInsightView));
+export const IntlInsightView = withContexts(injectIntl(InsightViewCore));
 
 /**
  * Renders insight which was previously created and saved in the Analytical Designer.

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -29,7 +29,6 @@ interface IInsightViewState {
     isVisualizationLoading: boolean;
     error: GoodDataSdkError | undefined;
     insight: IInsight | undefined;
-    locale: ILocale | undefined;
     colorPalette: IColorPalette | undefined;
     settings: IUserWorkspaceSettings | undefined;
 }
@@ -55,7 +54,6 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
             isVisualizationLoading: false,
             error: undefined,
             insight: undefined,
-            locale: DefaultLocale,
             colorPalette: undefined,
             settings: undefined,
         };
@@ -133,10 +131,6 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         return this.getRemoteResource((loader) => loader.getUserWorkspaceSettings(this.props.backend));
     };
 
-    private getUserProfileLocale = (): Promise<ILocale> => {
-        return this.getRemoteResource((loader) => loader.getLocale(this.props.backend)) as Promise<ILocale>;
-    };
-
     private updateUserWorkspaceSettings = async () => {
         const settings = await this.getUserWorkspaceSettings();
 
@@ -171,27 +165,12 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         this.setState({ insight });
     };
 
-    private updateLocale = async () => {
-        if (this.props.locale) {
-            return;
-        }
-
-        const locale = await this.getUserProfileLocale();
-
-        if (!locale || locale === this.state.locale) {
-            return;
-        }
-
-        this.setState({ locale });
-    };
-
     private componentDidMountInner = async () => {
         this.startDataLoading();
         await Promise.all([
             this.updateColorPalette(),
             this.updateUserWorkspaceSettings(),
             this.updateInsight(),
-            this.updateLocale(),
         ]);
         this.stopDataLoading();
     };
@@ -213,7 +192,7 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
             await Promise.all(
                 compact([
                     needsNewSetup && this.updateInsight(),
-                    needsNewSetup && this.updateLocale(),
+                    needsNewSetup && this.updateUserWorkspaceSettings(),
                     needsNewColorPalette && this.updateColorPalette(),
                 ]),
             );
@@ -251,7 +230,7 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
                     {...this.props}
                     colorPalette={this.props.colorPalette ?? this.state.colorPalette}
                     insight={this.state.insight}
-                    locale={this.props.locale || this.state.locale || DefaultLocale}
+                    locale={this.props.locale || (this.state.settings?.locale as ILocale) || DefaultLocale}
                     settings={this.state.settings}
                     onLoadingChanged={this.handleLoadingChanged}
                 />

--- a/libs/sdk-ui-ext/src/insightView/dataLoaders.ts
+++ b/libs/sdk-ui-ext/src/insightView/dataLoaders.ts
@@ -35,11 +35,6 @@ export interface IInsightViewDataLoader {
      * @param backend - the {@link IAnalyticalBackend} instance to use to communicate with the backend
      */
     getUserWorkspaceSettings(backend: IAnalyticalBackend): Promise<IUserWorkspaceSettings>;
-    /**
-     * Obtains the locale that is set in user's account
-     * @param backend - the {@link IAnalyticalBackend} instance to use to communicate with the backend
-     */
-    getLocale(backend: IAnalyticalBackend): Promise<string>;
 }
 
 /**
@@ -50,7 +45,6 @@ export interface IInsightViewDataLoader {
 export class InsightViewDataLoader implements IInsightViewDataLoader {
     private cachedColorPalette: Promise<IColorPalette> | undefined;
     private cachedUserWorkspaceSettings: Promise<IUserWorkspaceSettings> | undefined;
-    private cachedLocale: Promise<string> | undefined;
     private insightCache: LRUCache<string, Promise<IInsight>> = new LRUCache({ max: INSIGHT_CACHE_SIZE });
 
     constructor(protected readonly workspace: string) {}
@@ -103,21 +97,6 @@ export class InsightViewDataLoader implements IInsightViewDataLoader {
         }
 
         return this.cachedUserWorkspaceSettings;
-    }
-
-    public getLocale(backend: IAnalyticalBackend): Promise<string> {
-        if (!this.cachedLocale) {
-            this.cachedLocale = backend
-                .currentUser()
-                .settings()
-                .getSettings()
-                .then((settings) => settings.locale)
-                .catch((error) => {
-                    this.cachedLocale = undefined;
-                    throw error;
-                });
-        }
-        return this.cachedLocale;
     }
 }
 

--- a/libs/sdk-ui-ext/src/insightView/index.ts
+++ b/libs/sdk-ui-ext/src/insightView/index.ts
@@ -1,4 +1,5 @@
 // (C) 2020 GoodData Corporation
 
-export { InsightView, IInsightViewProps } from "./InsightView";
+export { InsightView } from "./InsightView";
+export { IInsightViewProps } from "./types";
 export { clearInsightViewCaches } from "./dataLoaders";

--- a/libs/sdk-ui-ext/src/insightView/types.ts
+++ b/libs/sdk-ui-ext/src/insightView/types.ts
@@ -1,0 +1,95 @@
+// (C) 2019-2020 GoodData Corporation
+import React from "react";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IFilter, IColorPalette, ObjRef } from "@gooddata/sdk-model";
+
+import { IVisCallbacks } from "../internal/interfaces/Visualization";
+import { ILocale, ILoadingProps, IErrorProps, IDrillableItem, IHeaderPredicate } from "@gooddata/sdk-ui";
+import { IChartConfig } from "@gooddata/sdk-ui-charts";
+import { IGeoConfig } from "@gooddata/sdk-ui-geo";
+import { IPivotTableConfig } from "@gooddata/sdk-ui-pivot";
+
+/**
+ * @public
+ */
+export interface IInsightViewProps extends Partial<IVisCallbacks> {
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+
+    /**
+     * Reference to the insight to render. This can be specified by either object reference using URI or using identifier.
+     *
+     * For convenience it is also possible to specify just the identifier of the insight.
+     */
+    insight: ObjRef | string;
+
+    /**
+     * Additional filters to apply on top of the insight.
+     */
+    filters?: IFilter[];
+
+    /**
+     * Configure chart drillability; e.g. which parts of the charts can be clicked.
+     */
+    drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
+
+    /**
+     * Configure color palette to use for the chart. If you do not specify this, then the palette will be
+     * obtained from style settings stored on the backend.
+     */
+    colorPalette?: IColorPalette;
+
+    /**
+     * When embedding insight rendered by a chart, you can specify extra options to merge with existing
+     * options saved for the insight.
+     */
+    config?: IChartConfig | IGeoConfig | IPivotTableConfig | any;
+
+    /**
+     * Locale to use for localization of texts appearing in the chart.
+     *
+     * Note: text values coming from the data itself are not localized.
+     */
+    locale?: ILocale;
+
+    /**
+     * Indicates that the execution to obtain the data for the insight should be an 'execution by reference'.
+     *
+     * Execution by reference means that the InsightView will ask analytical backend to compute results for an insight
+     * which is stored on the backend by specifying link to the insight, additional filters and description how
+     * to organize the data.
+     *
+     * Otherwise, a freeform execution is done, in which the InsightView will send to backend the full execution
+     * definition of what to compute.
+     *
+     * This distinction is in place because some backends MAY want to prohibit users from doing freeform executions
+     * and only allow computing data for set of insights created by admins.
+     *
+     * Note: the need for execute by reference is rare. You will typically be notified by the solution admin to use
+     * this mode.
+     */
+    executeByReference?: boolean;
+
+    /**
+     * Component to render if embedding fails.
+     */
+    ErrorComponent?: React.ComponentType<IErrorProps>;
+
+    /**
+     * Component to render while the insight is loading.
+     */
+    LoadingComponent?: React.ComponentType<ILoadingProps>;
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -49,10 +49,6 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
     LoadingComponent,
 }) => {
     const isThemeLoading = useThemeIsLoading();
-    if (isThemeLoading) {
-        // do not render the dashboard until you have the theme to avoid flash of un-styled content
-        return <LoadingComponent />;
-    }
 
     const contentWithProps = useCallback(
         (props: IDashboardViewLayoutColumnRenderProps) => {
@@ -86,6 +82,11 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
             workspace,
         ],
     );
+
+    if (isThemeLoading) {
+        // do not render the dashboard until you have the theme to avoid flash of un-styled content
+        return <LoadingComponent />;
+    }
 
     return (
         <DashboardLayout


### PR DESCRIPTION
Split InsightView into two parts

1. InsightRenderer which receives IInsightDefinition instance and renders it using PluggableVisualization
1. the original InsightView, that loads all the necessary data and passes them to InsightRenderer

This will allow us to use the InsightRenderer in DashboardView, where we will load the insight data differently (all at once for the whole dashboard).

Also, the InsightView data loading logic was cleaned up and better parallelized where possible.

The InsightView API was not changed in any way and neither was sdk-ui-ext API.

Finally, a minor bug in DashboardRenderer was fixed along the way.

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
