### PR TITLE
FEATURE: ONE-4819 Multiple dates in PluggablePivotTable

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1107,6 +1107,7 @@ export interface ISettings {
     enableBulletChart?: boolean;
     enableCustomColorPicker?: boolean;
     enableHidingOfDataPoints?: boolean;
+    enableMultipleDates?: boolean;
     enablePushpinGeoChart?: boolean;
     enableTableColumnsAutoResizing?: boolean;
     enableTableColumnsGrowToFit?: boolean;

--- a/libs/sdk-backend-spi/src/common/settings.ts
+++ b/libs/sdk-backend-spi/src/common/settings.ts
@@ -69,6 +69,11 @@ export interface ISettings {
      */
     responsiveUiDateFormat?: string;
 
+    /**
+     * Indicates whether multiple dates can be put into buckets
+     */
+    enableMultipleDates?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -41,7 +41,6 @@ import ReactMeasure from "react-measure";
 
 import { ATTRIBUTE, DATE, METRIC } from "../../../constants/bucket";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
-import { DEFAULT_PIVOT_TABLE_UICONFIG } from "../../../constants/uiConfig";
 import {
     IBucketFilter,
     IBucketItem,
@@ -71,7 +70,10 @@ import {
     getReferencePointWithSupportedProperties,
 } from "../../../utils/propertiesHelper";
 
-import { setPivotTableUiConfig } from "../../../utils/uiConfigHelpers/pivotTableUiConfigHelper";
+import {
+    getPivotTableDefaultUiConfig,
+    setPivotTableUiConfig,
+} from "../../../utils/uiConfigHelpers/pivotTableUiConfigHelper";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 import { AbstractPluggableVisualization } from "../AbstractPluggableVisualization";
 import { PIVOT_TABLE_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
@@ -137,7 +139,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         const clonedReferencePoint = cloneDeep(referencePoint);
         const newReferencePoint: IExtendedReferencePoint = {
             ...clonedReferencePoint,
-            uiConfig: cloneDeep(DEFAULT_PIVOT_TABLE_UICONFIG),
+            uiConfig: getPivotTableDefaultUiConfig(multipleDatesEnabled(this.settings)),
         };
 
         const buckets = newReferencePoint.buckets;
@@ -448,6 +450,10 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
 function isManualResizingEnabled(settings: ISettings): boolean {
     return settings["enableTableColumnsManualResizing"] === true;
+}
+
+function multipleDatesEnabled(settings: ISettings): boolean {
+    return settings["enableMultipleDates"] === true;
 }
 
 /**

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
@@ -571,6 +571,34 @@ describe("PluggablePivotTable", () => {
                     expect(extendedReferencePoint.buckets).toEqual(expectedBuckets);
                 });
         });
+
+        it("should return a new reference point with ui config supporting mulple date dimensions when turned on", () => {
+            const pivotTable = createComponent({
+                ...defaultProps,
+                featureFlags: {
+                    enableMultipleDates: true,
+                },
+            });
+            const sourceReferencePoint = referencePointMocks.simpleStackedReferencePoint;
+            const mockReferencePointWithMultipleDatesAllowed = getMockReferencePoint(
+                sourceReferencePoint.buckets[0].items,
+                sourceReferencePoint.buckets[1].items,
+                sourceReferencePoint.buckets[2].items,
+                [],
+                [],
+                true,
+                [],
+                true,
+            );
+
+            return pivotTable
+                .getExtendedReferencePoint(sourceReferencePoint)
+                .then((extendedReferencePoint) => {
+                    expect(extendedReferencePoint.uiConfig).toEqual(
+                        mockReferencePointWithMultipleDatesAllowed.uiConfig,
+                    );
+                });
+        });
     });
 });
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/mockReferencePoint.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/mockReferencePoint.ts
@@ -16,6 +16,7 @@ export const getMockReferencePoint = (
     sortItems: ISortItem[] = [],
     measuresIsShowInPercentEnabled = false,
     columnWidths: ColumnWidthItem[] = [],
+    multipleDatesEnabled = false,
 ): IExtendedReferencePoint => ({
     buckets: [
         {
@@ -52,7 +53,11 @@ export const getMockReferencePoint = (
                 icon: "",
                 isShowInPercentEnabled: false,
                 itemsLimit: 20,
+                itemsLimitByType: {
+                    date: multipleDatesEnabled ? 20 : 1,
+                },
                 title: "Rows",
+                allowsDuplicateDates: multipleDatesEnabled,
             },
             columns: {
                 accepts: ["attribute", "date"],
@@ -63,7 +68,11 @@ export const getMockReferencePoint = (
                 icon: "",
                 isShowInPercentEnabled: false,
                 itemsLimit: 20,
+                itemsLimitByType: {
+                    date: multipleDatesEnabled ? 20 : 1,
+                },
                 title: "Columns",
+                allowsDuplicateDates: multipleDatesEnabled,
             },
             filters: {
                 accepts: ["attribute", "date"],
@@ -71,6 +80,9 @@ export const getMockReferencePoint = (
                 enabled: true,
                 isShowInPercentEnabled: false,
                 itemsLimit: 20,
+                itemsLimitByType: {
+                    date: 1,
+                },
             },
             measures: {
                 accepts: ["metric", "fact", "attribute"],

--- a/libs/sdk-ui-ext/src/internal/constants/uiConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/uiConfig.ts
@@ -25,7 +25,7 @@ export const OPEN_AS_REPORT = "openAsReport";
 export const SUPPORTED = "supported";
 export const UICONFIG_AXIS = "uiConfig.axis";
 
-const measuresBase = {
+export const measuresBase = {
     accepts: [METRIC, FACT, ATTRIBUTE],
     allowsDuplicateItems: true,
     enabled: true,
@@ -36,9 +36,12 @@ const measuresBase = {
     isShowInPercentVisible: true,
 };
 
-const viewBase = {
+export const viewBase = {
     accepts: [ATTRIBUTE, DATE],
     itemsLimit: MAX_CATEGORIES_COUNT,
+    itemsLimitByType: {
+        date: 1,
+    },
     allowsSwapping: true,
     allowsReordering: false,
     enabled: true,
@@ -54,10 +57,13 @@ const stackBase = {
     isShowInPercentEnabled: false,
 };
 
-const defaultFilters = {
+export const defaultFilters = {
     filters: {
         accepts: [ATTRIBUTE, DATE],
         itemsLimit: MAX_FILTERS_COUNT,
+        itemsLimitByType: {
+            date: 1,
+        },
         allowsReordering: false,
         enabled: true,
         isShowInPercentEnabled: false,
@@ -84,7 +90,7 @@ const enabledOpenAsReportConfig = {
     openAsReport: { supported: true },
 };
 
-const defaultRootUiConfigProperties: Partial<IUiConfig> = {
+export const defaultRootUiConfigProperties: Partial<IUiConfig> = {
     recommendations: {},
     supportedOverTimeComparisonTypes: [],
     ...disabledOpenAsReportConfig,
@@ -340,33 +346,6 @@ export const TREEMAP_UICONFIG_WITH_ONE_MEASURE: IUiConfig = {
         ...defaultFilters,
     },
     ...defaultRootUiConfigProperties,
-};
-
-export const DEFAULT_PIVOT_TABLE_UICONFIG: IUiConfig = {
-    buckets: {
-        measures: {
-            ...measuresBase,
-        },
-        attribute: {
-            ...viewBase,
-            allowsSwapping: true,
-            allowsReordering: true,
-            itemsLimit: MAX_TABLE_CATEGORIES_COUNT,
-        },
-        columns: {
-            ...viewBase,
-            allowsSwapping: true,
-            allowsReordering: true,
-            itemsLimit: MAX_TABLE_CATEGORIES_COUNT,
-        },
-        ...defaultFilters,
-    },
-    ...defaultRootUiConfigProperties,
-    ...disabledOpenAsReportConfig,
-    supportedOverTimeComparisonTypes: [
-        OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR,
-        OverTimeComparisonTypes.PREVIOUS_PERIOD,
-    ],
 };
 
 export const DEFAULT_TABLE_UICONFIG: IUiConfig = {

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -215,10 +215,17 @@ export interface IBucketUiConfig {
     subtitle?: string;
     icon?: string;
     allowsDuplicateItems?: boolean;
+    allowsDuplicateDates?: boolean;
     allowsReordering?: boolean;
     allowsSwapping?: boolean;
     enabled?: boolean;
     itemsLimit?: number;
+    itemsLimitByType?: {
+        date?: number;
+        metric?: number;
+        fact?: number;
+        attribute?: number;
+    };
     isShowInPercentEnabled?: boolean;
     isShowInPercentVisible?: boolean;
     isShowOnSecondaryAxisVisible?: boolean;

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/uiConfigMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/uiConfigMocks.ts
@@ -45,6 +45,9 @@ const secondaryMeasuresBase = {
 const viewBase = {
     accepts: [ATTRIBUTE, DATE],
     itemsLimit: MAX_CATEGORIES_COUNT,
+    itemsLimitByType: {
+        date: 1,
+    },
     allowsSwapping: true,
     allowsReordering: false,
     enabled: true,
@@ -69,6 +72,9 @@ const stackBase = {
 const filtersBase = {
     accepts: [ATTRIBUTE, DATE],
     itemsLimit: MAX_FILTERS_COUNT,
+    itemsLimitByType: {
+        date: 1,
+    },
     allowsReordering: false,
     enabled: true,
     isShowInPercentEnabled: false,
@@ -126,6 +132,9 @@ const defaultRecommendations = {
 const attributeBase = {
     accepts: [ATTRIBUTE, DATE],
     itemsLimit: MAX_TABLE_CATEGORIES_COUNT,
+    itemsLimitByType: {
+        date: 1,
+    },
     allowsReordering: true,
     allowsSwapping: false,
     enabled: true,
@@ -389,6 +398,9 @@ export const bubbleChartUiConfig: IUiConfig = {
             canAddItems: true,
             title: "View by",
             itemsLimit: 1,
+            itemsLimitByType: {
+                date: 1,
+            },
         },
         filters: {
             ...filtersBase,
@@ -1136,6 +1148,9 @@ export const defaultHeatmapUiConfig: IUiConfig = {
         filters: {
             accepts: [ATTRIBUTE, DATE],
             itemsLimit: MAX_FILTERS_COUNT,
+            itemsLimitByType: {
+                date: 1,
+            },
             allowsReordering: false,
             enabled: true,
             isShowInPercentEnabled: false,
@@ -1155,17 +1170,22 @@ export const defaultPivotTableUiConfig: IUiConfig = {
         },
         attribute: {
             ...attributeBase,
+            allowsDuplicateDates: false,
             allowsSwapping: true,
             title: "Rows",
         },
         columns: {
             ...attributeBase,
+            allowsDuplicateDates: false,
             allowsSwapping: true,
             title: "Columns",
         },
         filters: {
             accepts: [ATTRIBUTE, DATE],
             itemsLimit: MAX_FILTERS_COUNT,
+            itemsLimitByType: {
+                date: 1,
+            },
             allowsReordering: false,
             enabled: true,
             isShowInPercentEnabled: false,
@@ -1194,6 +1214,9 @@ export const fullySpecifiedXirrUiConfig: IUiConfig = {
         filters: {
             accepts: [ATTRIBUTE, DATE],
             itemsLimit: MAX_FILTERS_COUNT,
+            itemsLimitByType: {
+                date: 1,
+            },
             allowsReordering: false,
             enabled: true,
             isShowInPercentEnabled: false,
@@ -1201,6 +1224,9 @@ export const fullySpecifiedXirrUiConfig: IUiConfig = {
         attribute: {
             accepts: [DATE],
             itemsLimit: DEFAULT_XIRR_ATTRIBUTES_COUNT,
+            itemsLimitByType: {
+                date: 1,
+            },
             allowsSwapping: true,
             allowsReordering: false,
             enabled: true,
@@ -1226,6 +1252,9 @@ export const defaultGeoPushpinUiConfig: IUiConfig = {
             isShowInPercentEnabled: false,
             canAddItems: true,
             itemsLimit: 1,
+            itemsLimitByType: {
+                date: 1,
+            },
             title: "Location",
         },
         size: {
@@ -1265,6 +1294,9 @@ export const defaultGeoPushpinUiConfig: IUiConfig = {
             isShowInPercentEnabled: false,
             canAddItems: true,
             itemsLimit: 1,
+            itemsLimitByType: {
+                date: 1,
+            },
             title: "Segment by",
         },
         filters: {
@@ -1273,6 +1305,9 @@ export const defaultGeoPushpinUiConfig: IUiConfig = {
             enabled: true,
             isShowInPercentEnabled: false,
             itemsLimit: 20,
+            itemsLimitByType: {
+                date: 1,
+            },
         },
     },
     exportConfig: enabledExportConfig,

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pivotTableUiConfigHelper.ts
@@ -2,10 +2,18 @@
 import set from "lodash/set";
 import { IntlShape } from "react-intl";
 
-import { BucketNames } from "@gooddata/sdk-ui";
-import { IExtendedReferencePoint } from "../../interfaces/Visualization";
+import { BucketNames, OverTimeComparisonTypes } from "@gooddata/sdk-ui";
+import { IExtendedReferencePoint, IUiConfig } from "../../interfaces/Visualization";
 
-import { UICONFIG } from "../../constants/uiConfig";
+import {
+    UICONFIG,
+    MAX_TABLE_CATEGORIES_COUNT,
+    measuresBase,
+    viewBase,
+    defaultFilters,
+    defaultRootUiConfigProperties,
+    disabledOpenAsReportConfig,
+} from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
 
 import { setBucketTitles } from "./../bucketHelper";
@@ -27,4 +35,41 @@ export function setPivotTableUiConfig(
     set(referencePoint, [UICONFIG, BUCKETS, BucketNames.MEASURES, "icon"], tableMeasuresIcon);
     set(referencePoint, [UICONFIG, BUCKETS, BucketNames.ATTRIBUTE, "icon"], tableRowsIcon);
     set(referencePoint, [UICONFIG, BUCKETS, BucketNames.COLUMNS, "icon"], tableColumnsIcon);
+}
+
+export function getPivotTableDefaultUiConfig(multipleDatesEnabled: boolean): IUiConfig {
+    return {
+        buckets: {
+            measures: {
+                ...measuresBase,
+            },
+            attribute: {
+                ...viewBase,
+                allowsSwapping: true,
+                allowsReordering: true,
+                itemsLimit: MAX_TABLE_CATEGORIES_COUNT,
+                allowsDuplicateDates: multipleDatesEnabled,
+                itemsLimitByType: {
+                    date: multipleDatesEnabled ? MAX_TABLE_CATEGORIES_COUNT : 1,
+                },
+            },
+            columns: {
+                ...viewBase,
+                allowsSwapping: true,
+                allowsReordering: true,
+                itemsLimit: MAX_TABLE_CATEGORIES_COUNT,
+                allowsDuplicateDates: multipleDatesEnabled,
+                itemsLimitByType: {
+                    date: multipleDatesEnabled ? MAX_TABLE_CATEGORIES_COUNT : 1,
+                },
+            },
+            ...defaultFilters,
+        },
+        ...defaultRootUiConfigProperties,
+        ...disabledOpenAsReportConfig,
+        supportedOverTimeComparisonTypes: [
+            OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR,
+            OverTimeComparisonTypes.PREVIOUS_PERIOD,
+        ],
+    };
 }

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/__snapshots__/bulletChartUiConfigHelper.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/__snapshots__/bulletChartUiConfigHelper.test.ts.snap
@@ -69,6 +69,9 @@ Object {
         "enabled": true,
         "isShowInPercentEnabled": false,
         "itemsLimit": 20,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
       },
       "measures": Object {
         "accepts": Array [
@@ -139,6 +142,9 @@ Object {
         "icon": "",
         "isShowInPercentEnabled": false,
         "itemsLimit": 2,
+        "itemsLimitByType": Object {
+          "date": 1,
+        },
         "title": "View by",
       },
     },


### PR DESCRIPTION
JIRA: ONE-4819
Introduces new FF enableMultipleDates for turning on the functionality
New bucket ui configs to allow multiple date items and to control its count limit

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
