### PR TITLE
RELATED: RAIL-2760 Move InternalIntlWrapper to ScheduledMailRenderer to fix translations in KD

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
@@ -12,7 +12,6 @@ import { GoodDataSdkError, LoadingComponent, ErrorComponent } from "@gooddata/sd
 import { Overlay } from "@gooddata/sdk-ui-kit";
 
 import { useCurrentUser } from "../../hooks/useCurrentUser";
-import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 import { useUserWorkspacePermissions } from "../../hooks/useUserWorkspacePermissions";
 import { useUserWorkspaceSettings } from "../../hooks/useUserWorkspaceSettings";
 import { useSaveScheduledMail } from "../../hooks/useSaveScheduledMail";
@@ -189,21 +188,19 @@ export const ScheduledMailDialog: React.FC<ScheduledMailDialogProps> = (props) =
     }
 
     return currentUser ? (
-        <InternalIntlWrapper locale={effectiveLocale}>
-            <ScheduledMailDialogRenderer
-                backend={backend}
-                workspace={workspace}
-                locale={effectiveLocale}
-                canListUsersInProject={permissions?.canListUsersInProject}
-                enableKPIDashboardScheduleRecipients={featureFlags?.enableKPIDashboardScheduleRecipients}
-                dateFormat={featureFlags?.responsiveUiDateFormat}
-                currentUser={currentUser}
-                dashboard={dashboardUriRef}
-                dashboardTitle={dashboard?.title}
-                onSubmit={handleSubmit}
-                onCancel={onCancel}
-                onError={onError}
-            />
-        </InternalIntlWrapper>
+        <ScheduledMailDialogRenderer
+            backend={backend}
+            workspace={workspace}
+            locale={effectiveLocale}
+            canListUsersInProject={permissions?.canListUsersInProject}
+            enableKPIDashboardScheduleRecipients={featureFlags?.enableKPIDashboardScheduleRecipients}
+            dateFormat={featureFlags?.responsiveUiDateFormat}
+            currentUser={currentUser}
+            dashboard={dashboardUriRef}
+            dashboardTitle={dashboard?.title}
+            onSubmit={handleSubmit}
+            onCancel={onCancel}
+            onError={onError}
+        />
     ) : null;
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
@@ -40,6 +40,7 @@ import { Input } from "./Input";
 import { DateTime } from "./DateTime";
 import { Attachment } from "./Attachment";
 import { RecipientsSelect } from "./RecipientsSelect/RecipientsSelect";
+import { InternalIntlWrapper } from "../../../utils/internalIntlProvider";
 
 const MAX_MESSAGE_LENGTH = 200;
 const MAX_SUBJECT_LENGTH = 200;
@@ -475,4 +476,10 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
     };
 }
 
-export const ScheduledMailDialogRenderer = injectIntl(ScheduledMailDialogRendererUI);
+export const ScheduledMailDialogRendererIntl = injectIntl(ScheduledMailDialogRendererUI);
+
+export const ScheduledMailDialogRenderer: React.FC<IScheduledMailDialogRendererOwnProps> = (props) => (
+    <InternalIntlWrapper locale={props.locale}>
+        <ScheduledMailDialogRendererIntl {...props} />
+    </InternalIntlWrapper>
+);


### PR DESCRIPTION
- only ScheduledMailRenderer is used in gdc-dashboards
- Move InternalIntlWrapper to ScheduledMailRenderer to ensure translations are available in KD

JIRA: RELATED: RAIL-2760 / RAIL-2831

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
