### PR TITLE
Handle Date bucket items when switching viz. types

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -43,7 +43,7 @@ import {
     getFilteredMeasuresForStackedCharts,
     getMeasureItems,
     getStackItems,
-    isDateBucketItem,
+    isNotDateBucketItem,
     sanitizeFilters,
 } from "../../../utils/bucketHelper";
 import { getValidProperties } from "../../../utils/colors";
@@ -198,7 +198,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         if (masterMeasures.length <= 1 && allAttributes.length > 1) {
             // first attribute is taken, find next available non-date attribute
             const attributesWithoutFirst = tail(allAttributes);
-            const nonDate = attributesWithoutFirst.filter((attribute) => !isDateBucketItem(attribute));
+            const nonDate = attributesWithoutFirst.filter(isNotDateBucketItem);
             stacks = nonDate.slice(0, 1);
         }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/bucketHelper.ts
@@ -4,9 +4,12 @@ import { BucketNames } from "@gooddata/sdk-ui";
 import { IBucketOfFun } from "../../../interfaces/Visualization";
 import {
     getAllAttributeItems,
+    getDateItems,
+    removeDivergentDateItems,
     IMeasureBucketItemsLimit,
     limitNumberOfMeasuresInBuckets,
     transformMeasureBuckets,
+    getMainDateItem,
 } from "../../../utils/bucketHelper";
 
 const measureBucketItemsLimit: IMeasureBucketItemsLimit[] = [
@@ -29,9 +32,12 @@ export const transformBuckets = (buckets: IBucketOfFun[]): IBucketOfFun[] => {
 
     const measureBuckets = transformMeasureBuckets(measureBucketItemsLimit, bucketsWithLimitedMeasures);
 
+    const dateItems = getDateItems(buckets);
+    const mainDateItem = getMainDateItem(dateItems);
+
     const viewByBucket = {
         localIdentifier: BucketNames.VIEW,
-        items: getAllAttributeItems(buckets).slice(0, 2),
+        items: removeDivergentDateItems(getAllAttributeItems(buckets), mainDateItem).slice(0, 2),
     };
 
     return [...measureBuckets, viewByBucket];

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -1,5 +1,6 @@
 // (C) 2020 GoodData Corporation
 import noop from "lodash/noop";
+import cloneDeep from "lodash/cloneDeep";
 import { PluggableBulletChart } from "../PluggableBulletChart";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
 import { IBucketOfFun, IFilters, IReferencePoint, IVisConstruct } from "../../../../interfaces/Visualization";
@@ -228,6 +229,74 @@ describe("PluggableBulletChart", () => {
             filters: expectedFilters,
             uiConfig: expectedUiConfig,
             properties: {},
+        });
+    });
+
+    describe("handling date items", () => {
+        it("should keep Date items with the same dimension", async () => {
+            const expectedBuckets: IBucketOfFun[] = [
+                {
+                    localIdentifier: "measures",
+                    items: [
+                        ...referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint.buckets[0].items,
+                    ],
+                },
+                {
+                    localIdentifier: "secondary_measures",
+                    items: [],
+                },
+                {
+                    localIdentifier: "tertiary_measures",
+                    items: [],
+                },
+                {
+                    localIdentifier: "view",
+                    items: [
+                        ...referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint.buckets[1].items,
+                        ...referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint.buckets[2].items,
+                    ],
+                },
+            ];
+
+            const extendedReferencePoint = await bulletChart.getExtendedReferencePoint(
+                referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint,
+            );
+
+            expect(extendedReferencePoint).toMatchObject({
+                buckets: expectedBuckets,
+            });
+        });
+
+        it("should keep first Date item when items have different dimensions", async () => {
+            const mockRefPoint = cloneDeep(referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint);
+            mockRefPoint.buckets[2].items[0].dateDataset.ref = {
+                uri: "closed",
+            };
+
+            const expectedBuckets: IBucketOfFun[] = [
+                {
+                    localIdentifier: "measures",
+                    items: [...mockRefPoint.buckets[0].items],
+                },
+                {
+                    localIdentifier: "secondary_measures",
+                    items: [],
+                },
+                {
+                    localIdentifier: "tertiary_measures",
+                    items: [],
+                },
+                {
+                    localIdentifier: "view",
+                    items: [...mockRefPoint.buckets[1].items],
+                },
+            ];
+
+            const extendedReferencePoint = await bulletChart.getExtendedReferencePoint(mockRefPoint);
+
+            expect(extendedReferencePoint).toMatchObject({
+                buckets: expectedBuckets,
+            });
         });
     });
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
@@ -434,7 +434,7 @@ describe("PluggableLineChart", () => {
 
     it("should allow only one date attribute", async () => {
         const lineChart = createComponent();
-        const referencePoint = referencePointMocks.dateAttributeOnRowAndColumnReferencePoint;
+        const referencePoint = referencePointMocks.dateAttributeOnViewAndStackReferencePoint;
 
         const expectedBuckets: IBucketOfFun[] = [
             {
@@ -452,7 +452,7 @@ describe("PluggableLineChart", () => {
         ];
 
         const extendedReferencePoint = await lineChart.getExtendedReferencePoint(
-            referencePointMocks.dateAttributeOnRowAndColumnReferencePoint,
+            referencePointMocks.dateAttributeOnViewAndStackReferencePoint,
         );
 
         expect(extendedReferencePoint.buckets).toEqual(expectedBuckets);

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -182,6 +182,9 @@ export interface IBucketItem {
 
     dfRef?: ObjRef;
     locationDisplayFormRef?: ObjRef;
+    dateDataset?: {
+        ref: ObjRef;
+    };
 }
 
 export interface IFiltersBucketItem extends IBucketItem {

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -1683,7 +1683,7 @@ export const dateAttributeOnStackBucketReferencePoint: IReferencePoint = {
     },
 };
 
-export const dateAttributeOnRowAndColumnReferencePoint: IReferencePoint = {
+export const dateAttributeOnViewAndStackReferencePoint: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
@@ -1703,6 +1703,47 @@ export const dateAttributeOnRowAndColumnReferencePoint: IReferencePoint = {
             items: [
                 {
                     ...dateItem,
+                    localIdentifier: "date2",
+                },
+            ],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const dateAttributeOnRowsAndColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "created",
+                        },
+                    },
+                    localIdentifier: "date1",
+                },
+            ],
+        },
+        {
+            localIdentifier: "columns",
+            items: [
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "created",
+                        },
+                    },
                     localIdentifier: "date2",
                 },
             ],

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
@@ -6,7 +6,6 @@ import { BucketNames, DefaultLocale, OverTimeComparisonTypes, VisualizationTypes
 import { ATTRIBUTE, METRIC } from "../../constants/bucket";
 import { DEFAULT_BASE_CHART_UICONFIG } from "../../constants/uiConfig";
 import {
-    DATE_DATASET_ATTRIBUTE,
     IBucketItem,
     IBucketOfFun,
     IExtendedReferencePoint,
@@ -364,7 +363,7 @@ describe("isDateBucketItem", () => {
     it("should return true if the attribute prop matches date id", () => {
         const bucketItem: IBucketItem = {
             localIdentifier: "",
-            attribute: DATE_DATASET_ATTRIBUTE,
+            type: "date",
         };
         expect(isDateBucketItem(bucketItem)).toBe(true);
     });
@@ -372,13 +371,17 @@ describe("isDateBucketItem", () => {
     it("should return false if the attribute prop does not match date id", () => {
         const bucketItem: IBucketItem = {
             localIdentifier: "",
-            attribute: "something",
+            type: "metric",
         };
         expect(isDateBucketItem(bucketItem)).toBe(false);
     });
 });
 
 describe("getDateFilter", () => {
+    it("should handle empty filter bucket", () => {
+        expect(getDateFilter(undefined)).toBeNull();
+    });
+
     it("should get date filter from filter bucket", () => {
         const filterBucket: IFilters = {
             localIdentifier: "filters",


### PR DESCRIPTION
JIRA: ONE-4820

Few viz. types accept multiple Date items when switching from table, but they need to have the same dateDataset (dimension). Otherwise only first item is kept.


---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
