### PR TITLE
RELATED: SD-1292 Bubble trigger should cover children

### DIFF
--- a/libs/sdk-ui-kit/src/Header/HeaderDataMenu.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderDataMenu.tsx
@@ -42,7 +42,7 @@ export const CoreHeaderDataMenu: React.FC<IHeaderDataMenuProps> = ({
             return (
                 <li key={key}>
                     <BubbleHoverTrigger
-                        tagName="abbr"
+                        tagName="div"
                         hideDelay={100}
                         showDelay={100}
                         className="gd-bubble-trigger-data-menu"
@@ -55,12 +55,7 @@ export const CoreHeaderDataMenu: React.FC<IHeaderDataMenuProps> = ({
                         />
                         {tooltipText && isDisable && (
                             <Bubble
-                                alignPoints={[
-                                    { align: "bc tc" },
-                                    { align: "tc bc" },
-                                    { align: "bl tl" },
-                                    { align: "br tr" },
-                                ]}
+                                alignPoints={[{ align: "bc tc" }, { align: "bc tl" }, { align: "bc tr" }]}
                             >
                                 {tooltipText}
                             </Bubble>

--- a/libs/sdk-ui-kit/styles/scss/header.scss
+++ b/libs/sdk-ui-kit/styles/scss/header.scss
@@ -635,10 +635,16 @@ $button-normal-active-shadow: transparentize($button-normal-active-border-color,
 
         &::before {
             top: 11px;
-            color: #6d7680;
+            color: #b0beca;
         }
 
-        &:hover {
+        &:hover.disabled {
+            color: #b0beca;
+            border-color: $gd-color-highlight;
+        }
+
+        &:hover:not(.disabled) {
+            color: #464e56;
             border-color: $gd-color-highlight;
         }
     }
@@ -696,5 +702,19 @@ $button-normal-active-shadow: transparentize($button-normal-active-border-color,
     li {
         display: block;
         list-style: none;
+    }
+}
+
+button.gd-button-primary {
+    &.icon-cloud-upload.s-load.gd-button,
+    &.icon-sources.s-sources.gd-button {
+        > span {
+            margin-left: 23px;
+        }
+    }
+    &.icon-model.s-model.gd-button {
+        > span {
+            margin-left: 22px;
+        }
     }
 }


### PR DESCRIPTION
We change tag name of bubble hover triger to make it cover the button. It didnt change logic code and css ( we dont have any css related to this class abbr)  and so on just change div to cover the children ( this case is button)
It's just change the css style of new component and dont need code owner to review it 

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
