### PR TITLE
RELATED: RAIL-2867 fix alert deleting for deleted widgets

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/index.ts
@@ -346,7 +346,11 @@ export class BearWorkspaceDashboards implements IWorkspaceDashboardsService {
 
     private getBearWidgetAlertsForWidget = async (widget: IWidget): Promise<ObjRef[]> => {
         const objectLinks = await this.authCall((sdk) =>
-            sdk.md.getObjectUsedBy(this.workspace, widget.uri, { types: ["kpiAlert"], nearest: false }),
+            sdk.md.getObjectUsedBy(this.workspace, widget.uri, {
+                types: ["kpiAlert"],
+                // limit ourselves to nearest only, otherwise, other alerts on the dashboard would be deleted, too
+                nearest: true,
+            }),
         );
 
         return objectLinks.map((link) => uriRef(link.link));


### PR DESCRIPTION
Previously, all alerts of the dashboard were deleted unexpectedly.

Port of 0ec4248

JIRA: RAIL-2867

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
