### PR TITLE
RELATED: RAIL-2863 Fix drilling configuration in DashboardView

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -88,7 +88,7 @@ export interface IDashboardViewProps {
 
     /**
      * Configure drillability; e.g. which parts of the visualization can be interacted with.
-     * These are applied to all the widgets in the dashboard.
+     * These are applied to all the widgets in the dashboard. If specified, these override any drills specified in the dashboards.
      *
      * TODO: do we need more sophisticated logic to specify drillability?
      */


### PR DESCRIPTION
This makes the logic more in line with KPI Dashboards.

1. if user provided drillableItems, use only them
   (analogous to KPI Dashboards and drilling specified in post message).
2. use the forceDisableDrillOnAxes setting the same way KPI Dashboards do

JIRA: RAIL-2863

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
