### PR TITLE
RELATED: RAIL-2863 remove wrong default value in InsightRenderer

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
@@ -49,7 +49,7 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
     insight,
     filters,
     filterContext,
-    drillableItems = [],
+    drillableItems,
     onDrill,
     onError,
     backend,


### PR DESCRIPTION
We need to allow undefined as value of drillableItems now.

JIRA: RAIL-2863

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
