### PR TITLE
RELATED: RAIL-2859 fix drilling in DashboardView with PivotTable

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
@@ -1,5 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { useCallback, useMemo, useState } from "react";
+import isEqual from "lodash/isEqual";
 import merge from "lodash/merge";
 import { IAnalyticalBackend, IFilterContext, ITempFilterContext, IWidget } from "@gooddata/sdk-backend-spi";
 import { IFilter, IInsight, insightProperties, insightSetProperties } from "@gooddata/sdk-model";
@@ -160,7 +161,15 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
 
     const handlePushData = useCallback((data: IPushData): void => {
         if (data.availableDrillTargets?.attributes) {
-            setPossibleDrills(data.availableDrillTargets.attributes);
+            setPossibleDrills((prevValue) => {
+                // only set possible drills if really different to prevent other hooks firing unnecessarily
+                if (!isEqual(prevValue, data.availableDrillTargets.attributes)) {
+                    return data.availableDrillTargets.attributes;
+                }
+
+                // returning prevValue effectively skips the setState
+                return prevValue;
+            });
         }
     }, []);
 


### PR DESCRIPTION
PivotTable fired pushData multiple times with the same items
however, not referentially the same. This led to infinite re-rendering.

Now, we deeply compare the results of pushData and set the state only
when there are actual changes.

Also, the logic around drilling was simplified.

JIRA: RAIL-2859

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
