### PR TITLE
RELATED: RAIL-2885 fix underline display in KPI

### DIFF
--- a/libs/sdk-ui-ext/styles/internal/scss/kpi.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/kpi.scss
@@ -108,7 +108,6 @@ $kpi-with-pop-min-height: $kpi-min-height + $pop-height;
 
 .kpi-value {
     position: relative;
-    overflow: hidden;
 
     $value-height: 60px;
 


### PR DESCRIPTION
Remove overflow: hidden that made the drill underline hidden in some widths.

JIRA: RAIL-2885

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
