### PR TITLE
RELATED: RAIL-2884 prevent DashboardView reloads

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithEmails.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithEmails.tsx
@@ -1,0 +1,33 @@
+// (C) 2007-2018 GoodData Corporation
+import React, { useState } from "react";
+import { DashboardView } from "@gooddata/sdk-ui-ext/esm/internal";
+import { idRef } from "@gooddata/sdk-model";
+import { MAPBOX_TOKEN } from "../../constants/fixtures";
+
+const dashboardRef = idRef("aeO5PVgShc0T");
+const config = { mapboxToken: MAPBOX_TOKEN };
+
+const DashboardViewWithEmails: React.FC = () => {
+    const [isEmailDialogOpen, setIsEmailDialogOpen] = useState(false);
+    return (
+        <>
+            <button onClick={() => setIsEmailDialogOpen(true)}>Open Schedule Email Dialog</button>
+            <DashboardView
+                dashboard={dashboardRef}
+                config={config}
+                isScheduledMailDialogVisible={isEmailDialogOpen}
+                onScheduledMailDialogCancel={() => setIsEmailDialogOpen(false)}
+                onScheduledMailSubmitSuccess={() => {
+                    alert("Scheduled email scheduled successfully");
+                    setIsEmailDialogOpen(true);
+                }}
+                onScheduledMailSubmitError={() => {
+                    alert("Scheduled email error");
+                    setIsEmailDialogOpen(true);
+                }}
+            />
+        </>
+    );
+};
+
+export default DashboardViewWithEmails;

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
@@ -16,6 +16,10 @@ import DashboardViewWithDrilling from "./DashboardViewWithDrilling";
 import DashboardViewWithDrillingSRC from "!raw-loader!./DashboardViewWithDrilling";
 import DashboardViewWithDrillingSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithDrilling";
 
+import DashboardViewWithEmails from "./DashboardViewWithEmails";
+import DashboardViewWithEmailsSRC from "!raw-loader!./DashboardViewWithEmails";
+import DashboardViewWithEmailsSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithEmails";
+
 export const DashboardView = (): JSX.Element => (
     <div>
         <h1>DashboardView</h1>
@@ -53,6 +57,16 @@ export const DashboardView = (): JSX.Element => (
             for={DashboardViewWithDrilling}
             source={DashboardViewWithDrillingSRC}
             sourceJS={DashboardViewWithDrillingSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <p>Example of how to embed a Dashboard into your application with the option to schedule emails.</p>
+
+        <ExampleWithSource
+            for={DashboardViewWithEmails}
+            source={DashboardViewWithEmailsSRC}
+            sourceJS={DashboardViewWithEmailsSRCJS}
         />
     </div>
 );

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContent.tsx
@@ -8,7 +8,7 @@ interface IDashboardItemContentProps {
 }
 
 export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemContentProps>(
-    ({ children, className }, ref) => {
+    function DashboardItemContent({ children, className }, ref) {
         return (
             <div className={cx("dash-item-content", className)} ref={ref}>
                 {children}
@@ -16,5 +16,3 @@ export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemCon
         );
     },
 );
-
-DashboardItemContent.displayName = "DashboardItemContent";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -1,5 +1,5 @@
 // (C) 2020 GoodData Corporation
-import React, { useCallback } from "react";
+import React, { memo, useCallback } from "react";
 import {
     IAnalyticalBackend,
     IFilterContext,
@@ -36,7 +36,7 @@ interface IDashboardRendererProps {
     className?: string;
 }
 
-export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
+export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(function DashboardRenderer({
     dashboardViewLayout,
     alerts,
     filters,
@@ -49,7 +49,7 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
     onError,
     LoadingComponent,
     className,
-}) => {
+}) {
     const isThemeLoading = useThemeIsLoading();
 
     const contentWithProps = useCallback(
@@ -115,4 +115,4 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = ({
             className={className}
         />
     );
-};
+});

--- a/libs/sdk-ui-kit/src/Overlay/tests/Overlay.test.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/tests/Overlay.test.tsx
@@ -45,16 +45,16 @@ class FixedComponent extends Component<FixedComponentProps> {
     }
 }
 
-const ComposedOverlay = forwardRef((props: any, ref) => (
-    <div>
-        <FixedComponent {...props.fixed} />
-        <Overlay {...props.overlay} ref={ref}>
-            <FixedComponent {...props.content} />
-        </Overlay>
-    </div>
-));
-
-ComposedOverlay.displayName = "ComposedOverlay";
+const ComposedOverlay = forwardRef(function ComposedOverlay(props: any, ref) {
+    return (
+        <div>
+            <FixedComponent {...props.fixed} />
+            <Overlay {...props.overlay} ref={ref}>
+                <FixedComponent {...props.content} />
+            </Overlay>
+        </div>
+    );
+});
 
 function createEvent(options = {}) {
     return {


### PR DESCRIPTION
This makes sure that DashboardView is not reloaded unnecessarily
when only the isScheduledMailDialogVisible prop changes.

The DashboardRenderer was converted from arrow function to normal function
so that its displayName is set automatically (arrow functions do not do that).
This change was adopted in other existing components to reduce redundancy.

Also, an example of email scheduling for DashboardView was added.

JIRA: RAIL-2884

<!--

Description of changes.

-->

---

Supported PR commands:

| Command         | Description            |
| --------------- | ---------------------- |
| `ok to test`    | Re-run standard checks |
| `extended test` | BackstopJS tests       |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
