### PR TITLE
RELATED: RAIL-2905 simplify IDashboardAttributeFilter attributeElements

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/filterContext.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/filterContext.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { GdcFilterContext } from "@gooddata/api-model-bear";
 import { uriRef } from "@gooddata/sdk-model";
 import {
@@ -59,7 +59,7 @@ export const convertFilterContextItem = (
 
         const convertedFilterContextItem: IDashboardAttributeFilter = {
             attributeFilter: {
-                attributeElements: attributeElements.map(uriRef),
+                attributeElements: { uris: attributeElements },
                 displayForm: uriRef(displayForm),
                 negativeSelection,
                 localIdentifier,

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
@@ -63,14 +63,12 @@ Object {
     "filters": Array [
       Object {
         "attributeFilter": Object {
-          "attributeElements": Array [
-            Object {
-              "uri": "/test",
-            },
-            Object {
-              "uri": "/test2",
-            },
-          ],
+          "attributeElements": Object {
+            "uris": Array [
+              "/test",
+              "/test2",
+            ],
+          },
           "displayForm": Object {
             "uri": "/displayForm",
           },
@@ -81,14 +79,12 @@ Object {
       },
       Object {
         "attributeFilter": Object {
-          "attributeElements": Array [
-            Object {
-              "uri": "/test3",
-            },
-            Object {
-              "uri": "/test4",
-            },
-          ],
+          "attributeElements": Object {
+            "uris": Array [
+              "/test3",
+              "/test4",
+            ],
+          },
           "displayForm": Object {
             "uri": "/displayForm34",
           },

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -44,6 +44,7 @@ import {
     IDashboardLayoutRow,
     ResponsiveScreenType,
     IDashboardLayout,
+    NotSupported,
 } from "@gooddata/sdk-backend-spi";
 import {
     GdcDashboardLayout,
@@ -55,7 +56,7 @@ import {
     GdcFilterContext,
     GdcScheduledMail,
 } from "@gooddata/api-model-bear";
-import { ObjRef, isUriRef, objRefToString } from "@gooddata/sdk-model";
+import { ObjRef, isUriRef, objRefToString, isAttributeElementsByValue } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import { convertUrisToReferences } from "../fromBackend/ReferenceConverter";
 import isEmpty from "lodash/isEmpty";
@@ -210,7 +211,6 @@ export const convertFilterContextItem = (
             filterElementsBy = [],
         },
     } = filterContextItem;
-    const attributeElementsUris = attributeElements.map(refToUri);
     const displayFormUri = refToUri(displayForm);
 
     const convertedAttributeFilterParents = filterElementsBy.map((filterElementsByItem) => {
@@ -222,10 +222,16 @@ export const convertFilterContextItem = (
         };
     });
 
+    if (isAttributeElementsByValue(attributeElements)) {
+        throw new NotSupported(
+            "Bear backend does not support value attribute filters in analytical dashboards",
+        );
+    }
+
     const convertedAttributeFilter: GdcFilterContext.IAttributeFilter = {
         attributeFilter: {
             negativeSelection,
-            attributeElements: attributeElementsUris,
+            attributeElements: attributeElements.uris,
             displayForm: displayFormUri,
             localIdentifier,
             filterElementsBy: convertedAttributeFilterParents,

--- a/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.fixtures.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/tests/DashboardConverter.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import {
     IDashboard,
     IDashboardLayoutColumn,
@@ -27,7 +27,7 @@ export const dashboardFilterContext: IFilterContext = {
     filters: [
         {
             attributeFilter: {
-                attributeElements: [{ identifier: "attrId", uri: "/gdc/md/attrId" }],
+                attributeElements: { uris: ["/gdc/md/attrId"] },
                 displayForm: {
                     uri: "/gdc/md/displayForm",
                 },
@@ -53,7 +53,7 @@ export const dashboardTempFilterContext: ITempFilterContext = {
     filters: [
         {
             attributeFilter: {
-                attributeElements: [{ identifier: "attrId", uri: "/gdc/md/attrId" }],
+                attributeElements: { uris: ["/gdc/md/attrId"] },
                 displayForm: {
                     uri: "/gdc/md/displayForm",
                 },

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -6,6 +6,7 @@
 
 import { DateAttributeGranularity } from '@gooddata/sdk-model';
 import { DimensionGenerator } from '@gooddata/sdk-model';
+import { IAttributeElements } from '@gooddata/sdk-model';
 import { IAttributeFilter } from '@gooddata/sdk-model';
 import { IAttributeOrMeasure } from '@gooddata/sdk-model';
 import { IBucket } from '@gooddata/sdk-model';
@@ -376,7 +377,7 @@ export interface IDashboardAttributeFilter {
     attributeFilter: {
         displayForm: ObjRef;
         negativeSelection: boolean;
-        attributeElements: ObjRef[];
+        attributeElements: IAttributeElements;
         localIdentifier?: string;
         filterElementsBy?: IDashboardAttributeFilterParent[];
     };

--- a/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
@@ -1,5 +1,5 @@
-// (C) 2019-2020 GoodData Corporation
-import { ObjRef, isObjRef } from "@gooddata/sdk-model";
+// (C) 2019-2021 GoodData Corporation
+import { ObjRef, isObjRef, IAttributeElements } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
 import { IDashboardObjectIdentity } from "./common";
 import { DateFilterGranularity, DateString } from "../dateFilterConfigs/types";
@@ -56,9 +56,9 @@ export interface IDashboardAttributeFilter {
         negativeSelection: boolean;
 
         /**
-         * Selected attribute elements object refs
+         * Selected attribute elements
          */
-        attributeElements: ObjRef[];
+        attributeElements: IAttributeElements;
 
         /**
          * Identifier of the filter which is valid in the scope of the filter context

--- a/libs/sdk-backend-spi/src/workspace/dashboards/tests/filterContext.fixtures.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/tests/filterContext.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import {
     IDashboardAttributeFilter,
     IDashboardAttributeFilterReference,
@@ -12,7 +12,7 @@ import { uriRef } from "@gooddata/sdk-model";
 
 export const dashboardAttributeFilter: IDashboardAttributeFilter = {
     attributeFilter: {
-        attributeElements: [],
+        attributeElements: { uris: [] },
         displayForm: uriRef("/displayForm"),
         negativeSelection: false,
     },

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/filters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/filters.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import {
     NotSupported,
     FilterContextItem,
@@ -10,15 +10,17 @@ import {
     isAbsoluteDateFilter,
     isRelativeDateFilter,
     isNegativeAttributeFilter,
-    isPositiveAttributeFilter,
     isAttributeElementsByRef,
-    uriRef,
+    filterAttributeElements,
+    filterObjRef,
+    isAttributeFilter,
 } from "@gooddata/sdk-model";
 import { IDashboardFilter } from "../../DashboardView/types";
 
 export const dashboardFilterToFilterContextItem = (filter: IDashboardFilter): FilterContextItem => {
-    if (isNegativeAttributeFilter(filter)) {
-        if (!isAttributeElementsByRef(filter.negativeAttributeFilter.notIn)) {
+    if (isAttributeFilter(filter)) {
+        const attributeElements = filterAttributeElements(filter);
+        if (!isAttributeElementsByRef(attributeElements)) {
             // For attributes with a lot of elements, this transformation can be very expensive.
             // Let's enforce user to provide element uris by himself.
             throw new NotSupported(
@@ -27,26 +29,9 @@ export const dashboardFilterToFilterContextItem = (filter: IDashboardFilter): Fi
         }
         const filterContextItem: IDashboardAttributeFilter = {
             attributeFilter: {
-                negativeSelection: false,
-                displayForm: filter.negativeAttributeFilter.displayForm,
-                attributeElements: filter.negativeAttributeFilter.notIn.uris.map(uriRef),
-            },
-        };
-
-        return filterContextItem;
-    } else if (isPositiveAttributeFilter(filter)) {
-        if (!isAttributeElementsByRef(filter.positiveAttributeFilter.in)) {
-            // For attributes with a lot of elements, this transformation can be very expensive.
-            // Let's enforce user to provide element uris by himself.
-            throw new NotSupported(
-                "Attribute filter with text values is not supported. Please provide element uris instead.",
-            );
-        }
-        const filterContextItem: IDashboardAttributeFilter = {
-            attributeFilter: {
-                negativeSelection: false,
-                displayForm: filter.positiveAttributeFilter.displayForm,
-                attributeElements: filter.positiveAttributeFilter.in.uris.map(uriRef),
+                negativeSelection: isNegativeAttributeFilter(filter),
+                displayForm: filterObjRef(filter),
+                attributeElements,
             },
         };
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import {
     IFilterContext,
     isDashboardAttributeFilter,
@@ -8,13 +8,9 @@ import {
 import {
     IFilter,
     newNegativeAttributeFilter,
-    isUriRef,
-    objRefToString,
     newPositiveAttributeFilter,
     newRelativeDateFilter,
     newAbsoluteDateFilter,
-    IAttributeElements,
-    ObjRef,
 } from "@gooddata/sdk-model";
 import isString from "lodash/isString";
 
@@ -38,12 +34,12 @@ export function filterContextToFiltersForWidget(
             if (filter.attributeFilter.negativeSelection) {
                 return newNegativeAttributeFilter(
                     filter.attributeFilter.displayForm,
-                    filterContextAttributeElementsToElements(filter.attributeFilter.attributeElements),
+                    filter.attributeFilter.attributeElements,
                 );
             } else {
                 return newPositiveAttributeFilter(
                     filter.attributeFilter.displayForm,
-                    filterContextAttributeElementsToElements(filter.attributeFilter.attributeElements),
+                    filter.attributeFilter.attributeElements,
                 );
             }
         } else {
@@ -67,12 +63,4 @@ export function filterContextToFiltersForWidget(
 
 function numberOrStringToNumber(input: number | string): number {
     return isString(input) ? Number.parseInt(input) : input;
-}
-
-function filterContextAttributeElementsToElements(attributeElements: ObjRef[]): IAttributeElements {
-    return attributeElements.length
-        ? isUriRef(attributeElements[0])
-            ? { uris: attributeElements.map(objRefToString) }
-            : { values: attributeElements.map(objRefToString) }
-        : { values: [] };
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/test/converters.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/test/converters.test.ts
@@ -1,7 +1,7 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { ReferenceLdm } from "@gooddata/reference-workspace";
 import { FilterContextItem, IFilterContext, IWidgetDefinition } from "@gooddata/sdk-backend-spi";
-import { idRef, uriRef } from "@gooddata/sdk-model";
+import { idRef } from "@gooddata/sdk-model";
 
 import { filterContextToFiltersForWidget } from "../converters";
 
@@ -34,7 +34,7 @@ describe("filterContextToFiltersForWidget", () => {
             getFilterContext([
                 {
                     attributeFilter: {
-                        attributeElements: [idRef("foo"), idRef("bar")],
+                        attributeElements: { values: ["foo", "bar"] },
                         displayForm: ReferenceLdm.Account.Name.attribute.displayForm,
                         negativeSelection: false,
                     },
@@ -46,7 +46,7 @@ describe("filterContextToFiltersForWidget", () => {
             getFilterContext([
                 {
                     attributeFilter: {
-                        attributeElements: [uriRef("foo"), uriRef("bar")],
+                        attributeElements: { uris: ["foo", "bar"] },
                         displayForm: ReferenceLdm.Account.Name.attribute.displayForm,
                         negativeSelection: true,
                     },


### PR DESCRIPTION
The ObjRef is misleading, IAttributeElements are more appropriate.

This is technically breaking, but the API is alpha, so we are ok.

JIRA: RAIL-2905

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
