### PR TITLE
RELATED: RAIL-2847 convert errors in useDataView and useDataExport

### DIFF
--- a/libs/sdk-ui/src/execution/useDataExport.ts
+++ b/libs/sdk-ui/src/execution/useDataExport.ts
@@ -1,7 +1,8 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { DependencyList } from "react";
 import { IExportConfig, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import {
+    convertError,
     GoodDataSdkError,
     useCancelablePromise,
     UseCancelablePromiseCallbacks,
@@ -51,6 +52,9 @@ export function useDataExport(
                           .then((executionResult) => executionResult.export(exportConfig))
                           .then((exportResult) => {
                               return exportResult.uri;
+                          })
+                          .catch((error) => {
+                              throw convertError(error);
                           })
                 : null,
             onCancel,

--- a/libs/sdk-ui/src/execution/useDataView.ts
+++ b/libs/sdk-ui/src/execution/useDataView.ts
@@ -1,8 +1,9 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { DependencyList } from "react";
 import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { DataViewWindow } from "./withExecutionLoading";
 import {
+    convertError,
     DataViewFacade,
     GoodDataSdkError,
     useCancelablePromise,
@@ -57,6 +58,9 @@ export function useDataView(
                           )
                           .then((dataView) => {
                               return DataViewFacade.for(dataView);
+                          })
+                          .catch((error) => {
+                              throw convertError(error);
                           })
                 : null,
             onCancel,


### PR DESCRIPTION
Previously they would throw AnalyticalBackendErrors
which is not what they declare.

JIRA: RAIL-2847

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
