### PR TITLE
Layouting improvements & fixes

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1196,6 +1196,7 @@ export interface ISettings {
     // (undocumented)
     [key: string]: number | boolean | string | object | undefined;
     ADMeasureValueFilterNullAsZeroOption?: string;
+    areSectionHeadersEnabled?: boolean;
     disableKpiDashboardHeadlineUnderline?: boolean;
     enableAxisNameConfiguration?: boolean;
     enableBulletChart?: boolean;

--- a/libs/sdk-backend-spi/src/common/settings.ts
+++ b/libs/sdk-backend-spi/src/common/settings.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 
 /**
  * Settings are obtained from backend and are effectively a collection of feature flags or settings with
@@ -89,6 +89,11 @@ export interface ISettings {
      * Indicates whether the user can zoom on the insights in KPI dashboards that have this feature enabled.
      */
     enableKDZooming?: boolean;
+
+    /**
+     * Indicates, whether dashboard "row headers" are enabled
+     */
+    areSectionHeadersEnabled?: boolean;
 
     [key: string]: number | boolean | string | object | undefined;
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/column.ts
@@ -13,6 +13,11 @@ import { IFluidLayoutColumnMethods, IFluidLayoutFacade, IFluidLayoutRowMethods }
  * @alpha
  */
 export class FluidLayoutColumnMethods<TContent> implements IFluidLayoutColumnMethods<TContent> {
+    private static Cache: WeakMap<IFluidLayoutColumn<any>, FluidLayoutColumnMethods<any>> = new WeakMap<
+        IFluidLayoutColumn<any>,
+        FluidLayoutColumnMethods<any>
+    >();
+
     protected constructor(
         protected _layoutFacade: IFluidLayoutFacade<TContent>,
         protected _rowFacade: IFluidLayoutRowMethods<TContent>,
@@ -26,7 +31,14 @@ export class FluidLayoutColumnMethods<TContent> implements IFluidLayoutColumnMet
         column: IFluidLayoutColumn<TContent>,
         index: number,
     ): FluidLayoutColumnMethods<TContent> {
-        return new FluidLayoutColumnMethods(layoutFacade, rowFacade, column, index);
+        if (!FluidLayoutColumnMethods.Cache.has(column)) {
+            FluidLayoutColumnMethods.Cache.set(
+                column,
+                new FluidLayoutColumnMethods(layoutFacade, rowFacade, column, index),
+            );
+        }
+
+        return FluidLayoutColumnMethods.Cache.get(column)!;
     }
 
     public raw = (): IFluidLayoutColumn<TContent> => this._column;

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/columns.ts
@@ -14,54 +14,96 @@ import { FluidLayoutColumnMethods } from "./column";
  * @alpha
  */
 export class FluidLayoutColumnsMethods<TContent> implements IFluidLayoutColumnsMethods<TContent> {
+    private static Cache: WeakMap<IFluidLayoutRowMethods<any>, FluidLayoutColumnsMethods<any>> = new WeakMap<
+        IFluidLayoutRowMethods<any>,
+        FluidLayoutColumnsMethods<any>
+    >();
+
     protected constructor(
         protected readonly _layoutFacade: IFluidLayoutFacade<TContent>,
         protected readonly _rowFacade: IFluidLayoutRowMethods<TContent>,
-        protected readonly _columns: IFluidLayoutColumnMethods<TContent>[],
         protected readonly _rawColumns: IFluidLayoutColumn<TContent>[],
     ) {}
+
+    private _columns: IFluidLayoutColumnMethods<TContent>[] | undefined = undefined;
 
     public static for<TContent>(
         layoutFacade: IFluidLayoutFacade<TContent>,
         rowFacade: IFluidLayoutRowMethods<TContent>,
+        columns: IFluidLayoutColumn<TContent>[],
     ): FluidLayoutColumnsMethods<TContent> {
-        const rawColumns = rowFacade.raw().columns;
-        const columns = rawColumns.map((column, index) =>
-            FluidLayoutColumnMethods.for(layoutFacade, rowFacade, column, index),
-        );
-        return new FluidLayoutColumnsMethods(layoutFacade, rowFacade, columns, rawColumns);
+        if (!FluidLayoutColumnsMethods.Cache.has(rowFacade)) {
+            FluidLayoutColumnsMethods.Cache.set(
+                rowFacade,
+                new FluidLayoutColumnsMethods(layoutFacade, rowFacade, columns),
+            );
+        }
+
+        return FluidLayoutColumnsMethods.Cache.get(rowFacade)!;
     }
+
+    private getColumnFacades = () => {
+        if (!this._columns) {
+            this._columns = this._rawColumns.map((column, index) =>
+                FluidLayoutColumnMethods.for(this._layoutFacade, this._rowFacade, column, index),
+            );
+        }
+
+        return this._columns;
+    };
 
     public raw = (): IFluidLayoutColumn<TContent>[] => this._rawColumns;
 
-    public column = (columnIndex: number): IFluidLayoutColumnMethods<TContent> | undefined =>
-        this._columns[columnIndex];
+    public column = (columnIndex: number): IFluidLayoutColumnMethods<TContent> | undefined => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades[columnIndex];
+    };
 
-    public map = <TReturn>(callback: (column: IFluidLayoutColumnMethods<TContent>) => TReturn): TReturn[] =>
-        this._columns.map(callback);
+    public map = <TReturn>(callback: (column: IFluidLayoutColumnMethods<TContent>) => TReturn): TReturn[] => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.map(callback);
+    };
 
     public flatMap = <TReturn>(
         callback: (column: IFluidLayoutColumnMethods<TContent>) => TReturn[],
-    ): TReturn[] => flatMap(this._columns, callback);
+    ): TReturn[] => {
+        const columnFacades = this.getColumnFacades();
+        return flatMap(columnFacades, callback);
+    };
 
     public reduce = <TReturn>(
         callback: (acc: TReturn, row: IFluidLayoutColumnMethods<TContent>) => TReturn,
         initialValue: TReturn,
-    ): TReturn => this._columns.reduce(callback, initialValue);
+    ): TReturn => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.reduce(callback, initialValue);
+    };
 
     public find = (
         pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean,
-    ): IFluidLayoutColumnMethods<TContent> | undefined => this._columns.find(pred);
+    ): IFluidLayoutColumnMethods<TContent> | undefined => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.find(pred);
+    };
 
-    public every = (pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean): boolean =>
-        this._columns.every(pred);
+    public every = (pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean): boolean => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.every(pred);
+    };
 
-    public some = (pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean): boolean =>
-        this._columns.some(pred);
+    public some = (pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean): boolean => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.some(pred);
+    };
 
     public filter = (
         pred: (row: IFluidLayoutColumnMethods<TContent>) => boolean,
-    ): IFluidLayoutColumnMethods<TContent>[] => this._columns.filter(pred);
+    ): IFluidLayoutColumnMethods<TContent>[] => {
+        const columnFacades = this.getColumnFacades();
+        return columnFacades.filter(pred);
+    };
 
-    public all = (): IFluidLayoutColumnMethods<TContent>[] => this._columns;
+    public all = (): IFluidLayoutColumnMethods<TContent>[] => {
+        return this.getColumnFacades();
+    };
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/layout.ts
@@ -10,6 +10,10 @@ import { FluidLayoutRowsMethods } from "./rows";
  * @alpha
  */
 export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent> {
+    private static Cache: WeakMap<IFluidLayout<any>, FluidLayoutFacade<any>> = new WeakMap<
+        IFluidLayout<any>,
+        FluidLayoutFacade<any>
+    >();
     protected constructor(protected _layout: IFluidLayout<TContent>) {}
 
     /**
@@ -18,11 +22,15 @@ export class FluidLayoutFacade<TContent> implements IFluidLayoutFacade<TContent>
      */
     public static for<TContent>(layout: IFluidLayout<TContent>): IFluidLayoutFacade<TContent> {
         invariant(isFluidLayout(layout), "Provided data must be IFluidLayout!");
-        return new FluidLayoutFacade<TContent>(layout);
+        if (!FluidLayoutFacade.Cache.has(layout)) {
+            FluidLayoutFacade.Cache.set(layout, new FluidLayoutFacade(layout));
+        }
+
+        return FluidLayoutFacade.Cache.get(layout)!;
     }
 
     public rows = (): IFluidLayoutRowsMethods<TContent> => {
-        return FluidLayoutRowsMethods.for(this);
+        return FluidLayoutRowsMethods.for(this, this._layout.rows);
     };
 
     public raw = (): IFluidLayout<TContent> => {

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/row.ts
@@ -13,6 +13,11 @@ import { FluidLayoutColumnsMethods } from "./columns";
  * @alpha
  */
 export class FluidLayoutRowMethods<TContent> implements IFluidLayoutRowMethods<TContent> {
+    private static Cache: WeakMap<IFluidLayoutRow<any>, FluidLayoutRowMethods<any>> = new WeakMap<
+        IFluidLayoutRow<any>,
+        FluidLayoutRowMethods<any>
+    >();
+
     protected constructor(
         protected readonly _layoutFacade: IFluidLayoutFacade<TContent>,
         protected readonly _row: IFluidLayoutRow<TContent>,
@@ -24,7 +29,11 @@ export class FluidLayoutRowMethods<TContent> implements IFluidLayoutRowMethods<T
         row: IFluidLayoutRow<TContent>,
         index: number,
     ): FluidLayoutRowMethods<TContent> {
-        return new FluidLayoutRowMethods(layoutFacade, row, index);
+        if (!FluidLayoutRowMethods.Cache.has(row)) {
+            FluidLayoutRowMethods.Cache.set(row, new FluidLayoutRowMethods(layoutFacade, row, index));
+        }
+
+        return FluidLayoutRowMethods.Cache.get(row)!;
     }
 
     public raw = (): IFluidLayoutRow<TContent> => this._row;
@@ -36,7 +45,7 @@ export class FluidLayoutRowMethods<TContent> implements IFluidLayoutRowMethods<T
     public index = (): number => this._index;
 
     public columns = (): IFluidLayoutColumnsMethods<TContent> =>
-        FluidLayoutColumnsMethods.for(this._layoutFacade, this);
+        FluidLayoutColumnsMethods.for(this._layoutFacade, this, this._row.columns);
 
     public isLast = (): boolean => this.index() + 1 === this._layoutFacade.rows().raw().length;
 

--- a/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/layout/facade/rows.ts
@@ -9,51 +9,89 @@ import { FluidLayoutRowMethods } from "./row";
  * @alpha
  */
 export class FluidLayoutRowsMethods<TContent> implements IFluidLayoutRowsMethods<TContent> {
+    private static Cache: WeakMap<IFluidLayoutFacade<any>, FluidLayoutRowsMethods<any>> = new WeakMap<
+        IFluidLayoutFacade<any>,
+        FluidLayoutRowsMethods<any>
+    >();
+
+    private _rows: IFluidLayoutRowMethods<TContent>[] | undefined;
+
     protected constructor(
         protected readonly _layoutFacade: IFluidLayoutFacade<TContent>,
-        protected readonly _rows: IFluidLayoutRowMethods<TContent>[],
         protected readonly _rawRows: IFluidLayoutRow<TContent>[],
     ) {}
 
     public static for<TContent>(
         layoutFacade: IFluidLayoutFacade<TContent>,
+        rows: IFluidLayoutRow<TContent>[],
     ): FluidLayoutRowsMethods<TContent> {
-        const rawRows = layoutFacade.raw().rows;
-        const rows = layoutFacade
-            .raw()
-            .rows.map((row, index) => FluidLayoutRowMethods.for(layoutFacade, row, index));
-        return new FluidLayoutRowsMethods(layoutFacade, rows, rawRows);
+        if (!FluidLayoutRowsMethods.Cache.has(layoutFacade)) {
+            FluidLayoutRowsMethods.Cache.set(layoutFacade, new FluidLayoutRowsMethods(layoutFacade, rows));
+        }
+
+        return FluidLayoutRowsMethods.Cache.get(layoutFacade)!;
     }
+
+    private getRowFacades = () => {
+        if (!this._rows) {
+            this._rows = this._rawRows.map((row, index) =>
+                FluidLayoutRowMethods.for(this._layoutFacade, row, index),
+            );
+        }
+
+        return this._rows;
+    };
 
     public raw = (): IFluidLayoutRow<TContent>[] => this._rawRows;
 
-    public row = (rowIndex: number): IFluidLayoutRowMethods<TContent> | undefined => this._rows[rowIndex];
+    public row = (rowIndex: number): IFluidLayoutRowMethods<TContent> | undefined => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades[rowIndex];
+    };
 
-    public map = <TReturn>(callback: (row: IFluidLayoutRowMethods<TContent>) => TReturn): TReturn[] =>
-        this._rows.map(callback);
+    public map = <TReturn>(callback: (row: IFluidLayoutRowMethods<TContent>) => TReturn): TReturn[] => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.map(callback);
+    };
 
-    public flatMap = <TReturn>(
-        callback: (column: IFluidLayoutRowMethods<TContent>) => TReturn[],
-    ): TReturn[] => flatMap(this._rows, callback);
+    public flatMap = <TReturn>(callback: (row: IFluidLayoutRowMethods<TContent>) => TReturn[]): TReturn[] => {
+        const rowFacades = this.getRowFacades();
+        return flatMap(rowFacades, callback);
+    };
 
     public reduce = <TReturn>(
         callback: (acc: TReturn, row: IFluidLayoutRowMethods<TContent>) => TReturn,
         initialValue: TReturn,
-    ): TReturn => this._rows.reduce(callback, initialValue);
+    ): TReturn => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.reduce(callback, initialValue);
+    };
 
     public find = (
         pred: (row: IFluidLayoutRowMethods<TContent>) => boolean,
-    ): IFluidLayoutRowMethods<TContent> | undefined => this._rows.find(pred);
+    ): IFluidLayoutRowMethods<TContent> | undefined => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.find(pred);
+    };
 
-    public every = (pred: (row: IFluidLayoutRowMethods<TContent>) => boolean): boolean =>
-        this._rows.every(pred);
+    public every = (pred: (row: IFluidLayoutRowMethods<TContent>) => boolean): boolean => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.every(pred);
+    };
 
-    public some = (pred: (row: IFluidLayoutRowMethods<TContent>) => boolean): boolean =>
-        this._rows.some(pred);
+    public some = (pred: (row: IFluidLayoutRowMethods<TContent>) => boolean): boolean => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.some(pred);
+    };
 
     public filter = (
         pred: (row: IFluidLayoutRowMethods<TContent>) => boolean,
-    ): IFluidLayoutRowMethods<TContent>[] => this._rows.filter(pred);
+    ): IFluidLayoutRowMethods<TContent>[] => {
+        const rowFacades = this.getRowFacades();
+        return rowFacades.filter(pred);
+    };
 
-    public all = (): IFluidLayoutRowMethods<TContent>[] => this._rows;
+    public all = (): IFluidLayoutRowMethods<TContent>[] => {
+        return this.getRowFacades();
+    };
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayout.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayout.tsx
@@ -1,21 +1,17 @@
 // (C) 2007-2020 GoodData Corporation
-import React, { useMemo } from "react";
+import React from "react";
 import isEqual from "lodash/isEqual";
 import { setConfiguration } from "react-grid-system";
 import cx from "classnames";
-import { isWidget, isWidgetDefinition } from "@gooddata/sdk-backend-spi";
 import { FluidLayout } from "../FluidLayout";
 import { IDashboardViewLayout, IDashboardViewLayoutContent } from "./interfaces/dashboardLayout";
 import {
-    IDashboardViewLayoutColumnRenderProps,
     IDashboardViewLayoutColumnKeyGetter,
     IDashboardViewLayoutColumnRenderer,
-    IDashboardViewLayoutContentRenderProps,
     IDashboardViewLayoutRowKeyGetter,
     IDashboardViewLayoutRowRenderer,
-    IDashboardViewLayoutRowRenderProps,
     IDashboardViewLayoutRowHeaderRenderer,
-    IDashboardViewLayoutRowHeaderRenderProps,
+    IDashboardViewLayoutContentRenderer,
 } from "./interfaces/dashboardLayoutComponents";
 import { DASHBOARD_LAYOUT_GRID_CONFIGURATION } from "./constants";
 import { getResizedColumnPositions, unifyDashboardLayoutColumnHeights } from "./utils/sizing";
@@ -36,7 +32,7 @@ export interface IDashboardViewLayoutProps<TCustomContent> {
     rowHeaderRenderer?: IDashboardViewLayoutRowHeaderRenderer<TCustomContent>;
     columnKeyGetter?: IDashboardViewLayoutColumnKeyGetter<TCustomContent>;
     columnRenderer?: IDashboardViewLayoutColumnRenderer<TCustomContent>;
-    contentRenderer?: React.ComponentType<IDashboardViewLayoutContentRenderProps<TCustomContent>>;
+    contentRenderer?: IDashboardViewLayoutContentRenderer<TCustomContent>;
     debug?: boolean;
     className?: string;
     onMouseLeave?: (e: React.MouseEvent<HTMLDivElement>) => void;
@@ -50,89 +46,20 @@ export function DashboardLayout<TCustomContent = IDashboardViewLayoutContent>(
 ): JSX.Element {
     const {
         layout,
-        rowRenderer: RowRenderer,
-        rowHeaderRenderer: RowHeaderRenderer,
+        rowRenderer = DashboardLayoutRowRenderer,
+        rowHeaderRenderer,
         rowKeyGetter,
-        columnRenderer: ColumnRenderer,
+        columnRenderer = DashboardLayoutColumnRenderer,
         columnKeyGetter,
-        contentRenderer: ContentRenderer,
+        contentRenderer = DashboardLayoutContentRenderer,
         debug,
         className,
         onMouseLeave,
         layoutSizingStrategy = unifyDashboardLayoutColumnHeights,
     } = props;
 
-    const resizedLayout = useMemo(() => layoutSizingStrategy(layout), [layout]);
-
-    const rowRenderer = React.useCallback(
-        (renderProps: IDashboardViewLayoutRowRenderProps<TCustomContent>) => {
-            return RowRenderer ? (
-                <RowRenderer {...renderProps} DefaultRenderer={DashboardLayoutRowRenderer} debug={debug} />
-            ) : (
-                <DashboardLayoutRowRenderer {...renderProps} />
-            );
-        },
-        [RowRenderer, debug],
-    );
-
-    const rowHeaderRenderer = React.useCallback(
-        (renderProps: IDashboardViewLayoutRowHeaderRenderProps<TCustomContent>) => {
-            return RowHeaderRenderer ? (
-                <RowHeaderRenderer
-                    {...renderProps}
-                    DefaultRenderer={DashboardLayoutRowHeaderRenderer}
-                    debug={debug}
-                />
-            ) : (
-                <DashboardLayoutRowHeaderRenderer {...renderProps} debug={debug} />
-            );
-        },
-        [RowHeaderRenderer, debug],
-    );
-
-    const columnRenderer = React.useCallback(
-        (renderProps: IDashboardViewLayoutColumnRenderProps<TCustomContent>) => {
-            return ColumnRenderer ? (
-                <ColumnRenderer
-                    {...renderProps}
-                    DefaultRenderer={DashboardLayoutColumnRenderer}
-                    debug={debug}
-                />
-            ) : (
-                <DashboardLayoutColumnRenderer {...renderProps} debug={debug} />
-            );
-        },
-        [ColumnRenderer, debug],
-    );
-
-    const contentRenderer = React.useCallback(
-        (renderProps: IDashboardViewLayoutColumnRenderProps<TCustomContent>) => {
-            const content = renderProps.column.content();
-            let isResizedByLayoutSizingStrategy: boolean;
-            if (isWidget(content) || isWidgetDefinition(content)) {
-                const resizedColumnPosition = getResizedColumnPositions(layout, resizedLayout);
-                isResizedByLayoutSizingStrategy = resizedColumnPosition.some((position) =>
-                    isEqual(position, [renderProps.column.row().index(), renderProps.column.index()]),
-                );
-            }
-
-            return ContentRenderer ? (
-                <ContentRenderer
-                    {...renderProps}
-                    debug={debug}
-                    isResizedByLayoutSizingStrategy={isResizedByLayoutSizingStrategy}
-                    DefaultRenderer={DashboardLayoutContentRenderer}
-                />
-            ) : (
-                <DashboardLayoutContentRenderer
-                    {...renderProps}
-                    debug={debug}
-                    isResizedByLayoutSizingStrategy={isResizedByLayoutSizingStrategy}
-                />
-            );
-        },
-        [ContentRenderer, debug, layout, resizedLayout],
-    );
+    const resizedLayout = layoutSizingStrategy(layout);
+    const resizedColumnPosition = getResizedColumnPositions(layout, resizedLayout);
 
     return (
         <FluidLayout
@@ -140,11 +67,36 @@ export function DashboardLayout<TCustomContent = IDashboardViewLayoutContent>(
             containerClassName="gd-fluidlayout-layout s-fluid-layout"
             layout={resizedLayout}
             rowKeyGetter={rowKeyGetter}
-            rowRenderer={rowRenderer}
-            rowHeaderRenderer={rowHeaderRenderer}
+            rowRenderer={(renderProps) =>
+                rowRenderer({ ...renderProps, debug, DefaultRowRenderer: DashboardLayoutRowRenderer })
+            }
+            rowHeaderRenderer={(renderProps) =>
+                rowHeaderRenderer({
+                    ...renderProps,
+                    debug,
+                    DefaultRowHeaderRenderer: DashboardLayoutRowHeaderRenderer,
+                })
+            }
             columnKeyGetter={columnKeyGetter}
-            columnRenderer={columnRenderer}
-            contentRenderer={contentRenderer}
+            columnRenderer={(renderProps) =>
+                columnRenderer({
+                    ...renderProps,
+                    debug,
+                    DefaultColumnRenderer: DashboardLayoutColumnRenderer,
+                })
+            }
+            contentRenderer={(renderProps) => {
+                const isResizedByLayoutSizingStrategy = resizedColumnPosition.some((position) =>
+                    isEqual(position, [renderProps.column.row().index(), renderProps.column.index()]),
+                );
+
+                return contentRenderer({
+                    ...renderProps,
+                    debug,
+                    DefaultContentRenderer: DashboardLayoutContentRenderer,
+                    isResizedByLayoutSizingStrategy: isResizedByLayoutSizingStrategy,
+                });
+            }}
             onMouseLeave={onMouseLeave}
         />
     );

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayoutRowHeaderRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayoutRowHeaderRenderer.tsx
@@ -4,7 +4,7 @@ import { IFluidLayoutColumnMethods } from "@gooddata/sdk-backend-spi";
 import { DashboardLayoutColumnRenderer } from "./DashboardLayoutColumnRenderer";
 import { DashboardLayoutRowHeader } from "./DashboardLayoutRowHeader";
 import { IDashboardViewLayoutRowHeaderRenderProps } from "./interfaces/dashboardLayoutComponents";
-import { FluidLayoutColumnRenderer } from "../FluidLayout/FluidLayoutColumnRenderer";
+import { FluidLayoutColumnRenderer } from "../FluidLayout";
 
 const emptyColumnFacadeWithFullSize: IFluidLayoutColumnMethods<any> = {
     index: () => 0,
@@ -25,7 +25,7 @@ export function DashboardLayoutRowHeaderRenderer<TCustomContent>(
 
     return rowHeader ? (
         <DashboardLayoutColumnRenderer
-            DefaultRenderer={FluidLayoutColumnRenderer}
+            DefaultColumnRenderer={FluidLayoutColumnRenderer}
             column={emptyColumnFacadeWithFullSize}
             screen={screen}
         >

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/interfaces/dashboardLayoutComponents.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/interfaces/dashboardLayoutComponents.ts
@@ -54,7 +54,7 @@ export type IDashboardViewLayoutRowHeaderRenderProps<
         /**
          * Default row header renderer - can be used as a fallback for custom rowHeaderRenderer.
          */
-        DefaultRenderer: IDashboardViewLayoutRowHeaderRenderer<TCustomContent>;
+        DefaultRowHeaderRenderer: IDashboardViewLayoutRowHeaderRenderer<TCustomContent>;
     };
 
 /**
@@ -131,7 +131,7 @@ export type IDashboardViewLayoutContentRenderProps<
         /**
          * Default content renderer - can be used as a fallback for custom contentRenderer.
          */
-        DefaultRenderer: IDashboardViewLayoutContentRenderer<TCustomContent>;
+        DefaultContentRenderer: IDashboardViewLayoutContentRenderer<TCustomContent>;
     };
 
 /**

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutColumnRenderer.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutColumnRenderer.test.tsx
@@ -37,10 +37,12 @@ describe("DashboardLayoutColumnRenderer", () => {
     it("should set minHeight:0 to override default grid style", () => {
         const wrapper = shallow(
             <DashboardLayoutColumnRenderer
-                DefaultRenderer={FluidLayoutColumnRenderer}
+                DefaultColumnRenderer={FluidLayoutColumnRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
-            />,
+            >
+                Test
+            </DashboardLayoutColumnRenderer>,
         );
 
         expect(wrapper.find(FluidLayoutColumnRenderer)).toHaveProp("minHeight", 0);
@@ -49,11 +51,13 @@ describe("DashboardLayoutColumnRenderer", () => {
     it("should set custom minHeight, when provided", () => {
         const wrapper = shallow(
             <DashboardLayoutColumnRenderer
-                DefaultRenderer={FluidLayoutColumnRenderer}
+                DefaultColumnRenderer={FluidLayoutColumnRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 minHeight={100}
-            />,
+            >
+                Test
+            </DashboardLayoutColumnRenderer>,
         );
 
         expect(wrapper.find(FluidLayoutColumnRenderer)).toHaveProp("minHeight", 100);
@@ -64,10 +68,12 @@ describe("DashboardLayoutColumnRenderer", () => {
         (screen, width, ratio) => {
             const wrapper = shallow(
                 <DashboardLayoutColumnRenderer
-                    DefaultRenderer={FluidLayoutColumnRenderer}
+                    DefaultColumnRenderer={FluidLayoutColumnRenderer}
                     column={dashboardLayoutWithSizingFacade.rows().row(0).columns().column(0)}
                     screen={screen}
-                />,
+                >
+                    Test
+                </DashboardLayoutColumnRenderer>,
             );
 
             expect(wrapper.find(FluidLayoutColumnRenderer)).toHaveClassName(
@@ -85,10 +91,12 @@ describe("DashboardLayoutColumnRenderer", () => {
     it("should not set ratio class for column without ratio", () => {
         const wrapper = shallow(
             <DashboardLayoutColumnRenderer
-                DefaultRenderer={FluidLayoutColumnRenderer}
+                DefaultColumnRenderer={FluidLayoutColumnRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
-            />,
+            >
+                Test
+            </DashboardLayoutColumnRenderer>,
         );
 
         expect(wrapper.find(FluidLayoutColumnRenderer).props().className).not.toMatch(
@@ -100,11 +108,13 @@ describe("DashboardLayoutColumnRenderer", () => {
         const className = "test";
         const wrapper = shallow(
             <DashboardLayoutColumnRenderer
-                DefaultRenderer={FluidLayoutColumnRenderer}
+                DefaultColumnRenderer={FluidLayoutColumnRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 className={className}
-            />,
+            >
+                Test
+            </DashboardLayoutColumnRenderer>,
         );
 
         expect(wrapper.find(FluidLayoutColumnRenderer)).toHaveClassName(className);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutContentRenderer.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutContentRenderer.test.tsx
@@ -13,7 +13,7 @@ describe("DashboardLayoutContentRenderer", () => {
 
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 debug
@@ -37,7 +37,7 @@ describe("DashboardLayoutContentRenderer", () => {
 
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 debug
@@ -61,7 +61,7 @@ describe("DashboardLayoutContentRenderer", () => {
 
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 isResizedByLayoutSizingStrategy
@@ -79,7 +79,7 @@ describe("DashboardLayoutContentRenderer", () => {
 
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 isResizedByLayoutSizingStrategy
                 allowOverflow
@@ -98,7 +98,7 @@ describe("DashboardLayoutContentRenderer", () => {
         const className = "test";
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 isResizedByLayoutSizingStrategy
                 screen="xl"
@@ -116,7 +116,7 @@ describe("DashboardLayoutContentRenderer", () => {
         const minHeight = 100;
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 minHeight={minHeight}
@@ -140,7 +140,7 @@ describe("DashboardLayoutContentRenderer", () => {
         const height = 100;
         const wrapper = shallow(
             <DashboardLayoutContentRenderer
-                DefaultRenderer={DashboardLayoutContentRenderer}
+                DefaultContentRenderer={DashboardLayoutContentRenderer}
                 column={dashboardLayoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
                 height={height}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutRowRenderer.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/test/DashboardLayoutRowRenderer.test.tsx
@@ -14,7 +14,7 @@ describe("DashboardLayoutRowRenderer", () => {
     it("should add debug css class in debug mode", () => {
         const wrapper = shallow(
             <DashboardLayoutRowRenderer
-                DefaultRenderer={FluidLayoutRowRenderer}
+                DefaultRowRenderer={FluidLayoutRowRenderer}
                 row={dashboardLayoutFacade.rows().row(0)}
                 screen="xl"
                 debug

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardContentRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardContentRenderer.tsx
@@ -15,10 +15,10 @@ export const DashboardContentRenderer: React.FC<IDashboardContentRenderProps> = 
         className,
         debug,
         contentRef,
-        DefaultRenderer,
+        DefaultContentRenderer,
         isResizedByLayoutSizingStrategy,
         widgetClass,
-        widgetRenderer: WidgetRenderer,
+        widgetRenderer,
         insight,
         ErrorComponent,
         LoadingComponent,
@@ -38,48 +38,55 @@ export const DashboardContentRenderer: React.FC<IDashboardContentRenderProps> = 
         throw new UnexpectedError("Custom dashboard view content is not yet supported.");
     }
 
-    // TODO: RAIL-2869
     const currentSize = column.size()[screen];
-    const minHeight = getDashboardLayoutMinimumWidgetHeight(widgetClass);
-    const height = currentSize && getDashboardLayoutContentHeightForRatioAndScreen(currentSize, screen);
+    const minHeight = !currentSize.heightAsRatio
+        ? getDashboardLayoutMinimumWidgetHeight(widgetClass)
+        : undefined;
+    const height = currentSize?.heightAsRatio
+        ? getDashboardLayoutContentHeightForRatioAndScreen(currentSize, screen)
+        : undefined;
 
-    return WidgetRenderer ? (
-        <WidgetRenderer
-            column={column}
-            ErrorComponent={ErrorComponent}
-            LoadingComponent={LoadingComponent}
-            alerts={alerts}
-            filterContext={filterContext}
-            screen={screen}
-            widget={content}
-            backend={backend}
-            drillableItems={drillableItems}
-            filters={filters}
-            insight={insight}
-            onDrill={onDrill}
-            onError={onError}
-            widgetClass={widgetClass}
-            workspace={workspace}
-            DefaultRenderer={WidgetRenderer}
-            // TODO: RAIL-2869 Unify props for DefaultRenderer & WidgetRenderer
-            minHeight={minHeight}
-            height={height}
-        />
+    return widgetRenderer ? (
+        widgetRenderer({
+            column,
+            ErrorComponent,
+            LoadingComponent,
+            alerts,
+            filterContext,
+            screen,
+            backend,
+            drillableItems,
+            filters,
+            insight,
+            onDrill,
+            onError,
+            widgetClass,
+            workspace,
+            minHeight,
+            height,
+            widget: content,
+            DefaultWidgetRenderer: DashboardWidgetRenderer,
+        })
     ) : (
-        <DefaultRenderer
-            DefaultRenderer={DefaultRenderer}
-            column={column}
-            screen={screen}
-            className={className}
-            contentRef={contentRef}
-            debug={debug}
-            // TODO: RAIL-2869 how to solve it inside DashboardViewLayoutContentRenderer?
-            height={currentSize.heightAsRatio ? height : undefined}
-            minHeight={!currentSize.heightAsRatio ? minHeight : undefined}
-            allowOverflow={!!currentSize.heightAsRatio}
-            isResizedByLayoutSizingStrategy={isResizedByLayoutSizingStrategy}
+        <DefaultContentRenderer
+            {...{
+                DefaultContentRenderer,
+                column,
+                screen,
+                className,
+                contentRef,
+                debug,
+                height,
+                minHeight,
+                isResizedByLayoutSizingStrategy,
+                allowOverflow: !!currentSize.heightAsRatio,
+            }}
         >
-            <DashboardWidgetRenderer {...props} DefaultRenderer={DashboardWidgetRenderer} widget={content} />
-        </DefaultRenderer>
+            <DashboardWidgetRenderer
+                {...props}
+                DefaultWidgetRenderer={DashboardWidgetRenderer}
+                widget={content}
+            />
+        </DefaultContentRenderer>
     );
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -41,6 +41,7 @@ interface IDashboardRendererProps {
     getDashboardViewLayoutWidgetClass: (widget: IWidget) => DashboardViewLayoutWidgetClass;
     getInsightByRef: (insightRef: ObjRef) => IInsight | undefined;
     widgetRenderer: IDashboardWidgetRenderer;
+    areSectionHeadersEnabled?: boolean;
 }
 
 export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(function DashboardRenderer({
@@ -59,6 +60,7 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
     getDashboardViewLayoutWidgetClass,
     getInsightByRef,
     widgetRenderer,
+    areSectionHeadersEnabled,
 }) {
     const isThemeLoading = useThemeIsLoading();
 
@@ -118,6 +120,9 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
             layout={dashboardViewLayout}
             contentRenderer={contentWithProps}
             className={className}
+            // When section headers are enabled, use default DashboardLayout rowHeaderRenderer.
+            // When turned off, render nothing.
+            rowHeaderRenderer={areSectionHeadersEnabled ? undefined : () => null}
         />
     );
 });

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
@@ -178,7 +178,6 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                             onError={onError}
                             isVisible={isScheduledMailDialogVisible}
                         />
-
                         {isFluidLayoutEmpty(dashboardData.layout) ? (
                             <EmptyDashboardError ErrorComponent={ErrorComponent} />
                         ) : (
@@ -199,6 +198,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                                 }
                                 getInsightByRef={dashboardViewLayoutResult.getInsightByRef}
                                 widgetRenderer={widgetRenderer}
+                                areSectionHeadersEnabled={userWorkspaceSettings?.areSectionHeadersEnabled}
                             />
                         )}
                     </AttributesWithDrillDownProvider>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -264,7 +264,7 @@ export type IDashboardWidgetRenderProps = {
     widgetClass?: DashboardViewLayoutWidgetClass;
     insight?: IInsight;
     widget: IWidget;
-    DefaultRenderer: IDashboardWidgetRenderer;
+    DefaultWidgetRenderer: IDashboardWidgetRenderer;
     screen: ResponsiveScreenType;
     column: IFluidLayoutColumnMethods<IDashboardLayoutContent>;
 
@@ -282,4 +282,4 @@ export type IDashboardWidgetRenderProps = {
 /**
  * Component used for the widget rendering.
  */
-export type IDashboardWidgetRenderer = React.ComponentType<IDashboardWidgetRenderProps>;
+export type IDashboardWidgetRenderer = (renderProps: IDashboardWidgetRenderProps) => JSX.Element;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayout.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayout.tsx
@@ -41,14 +41,14 @@ export function FluidLayout<TContent>(props: IFluidLayoutProps<TContent>): JSX.E
                     render={(screen: ResponsiveScreenType) =>
                         screen ? (
                             <Container fluid={true} className={containerClassName}>
-                                {layoutFacade.rows().map((rowFacade) => {
+                                {layoutFacade.rows().map((row) => {
                                     return (
                                         <FluidLayoutRow
                                             key={rowKeyGetter({
-                                                row: rowFacade,
+                                                row,
                                                 screen,
                                             })}
-                                            row={rowFacade}
+                                            row={row}
                                             rowRenderer={rowRenderer}
                                             rowHeaderRenderer={rowHeaderRenderer}
                                             columnKeyGetter={columnKeyGetter}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumn.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumn.tsx
@@ -1,8 +1,8 @@
 // (C) 2007-2020 GoodData Corporation
-import React from "react";
+
+import { FluidLayoutColumnRenderer } from "./FluidLayoutColumnRenderer";
 import { ResponsiveScreenType, IFluidLayoutColumnMethods } from "@gooddata/sdk-backend-spi";
 import { IFluidLayoutColumnRenderer, IFluidLayoutContentRenderer } from "./interfaces";
-import { FluidLayoutColumnRenderer } from "./FluidLayoutColumnRenderer";
 
 /**
  * @alpha
@@ -15,18 +15,12 @@ export interface IFluidLayoutColumnProps<TContent> {
 }
 
 export function FluidLayoutColumn<TContent>(props: IFluidLayoutColumnProps<TContent>): JSX.Element {
-    const {
-        column,
-        columnRenderer: ColumnRenderer = FluidLayoutColumnRenderer,
-        contentRenderer: ContentRenderer,
-        screen,
-    } = props;
-
+    const { column, columnRenderer = FluidLayoutColumnRenderer, contentRenderer, screen } = props;
     const renderProps = { column, screen };
 
-    return (
-        <ColumnRenderer {...renderProps} DefaultRenderer={FluidLayoutColumnRenderer}>
-            <ContentRenderer {...renderProps} />
-        </ColumnRenderer>
-    );
+    return columnRenderer({
+        ...renderProps,
+        DefaultColumnRenderer: FluidLayoutColumnRenderer,
+        children: contentRenderer(renderProps),
+    });
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumnRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutColumnRenderer.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import React, { useMemo } from "react";
-import { Col } from "react-grid-system";
 import { IFluidLayoutColumnRenderer } from "./interfaces";
+import { Col } from "react-grid-system";
 
 export const FluidLayoutColumnRenderer: IFluidLayoutColumnRenderer<any> = (props) => {
     const { column, children, className, minHeight } = props;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRow.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRow.tsx
@@ -29,8 +29,8 @@ export interface IFluidLayoutRowProps<TContent> {
 export function FluidLayoutRow<TContent>(props: IFluidLayoutRowProps<TContent>): JSX.Element {
     const {
         row,
-        rowRenderer: RowRenderer = FluidLayoutRowRenderer,
-        rowHeaderRenderer: RowHeaderRenderer,
+        rowRenderer = FluidLayoutRowRenderer,
+        rowHeaderRenderer,
         columnKeyGetter = ({ column }) => column.index(),
         columnRenderer,
         contentRenderer,
@@ -38,11 +38,11 @@ export function FluidLayoutRow<TContent>(props: IFluidLayoutRowProps<TContent>):
     } = props;
     const renderProps = { row, screen };
 
-    const columns = row.columns().map((column) => {
+    const columns = row.columns().map((columnFacade) => {
         return (
             <FluidLayoutColumn
-                key={columnKeyGetter({ column, screen })}
-                column={column}
+                key={columnKeyGetter({ column: columnFacade, screen })}
+                column={columnFacade}
                 columnRenderer={columnRenderer}
                 contentRenderer={contentRenderer}
                 screen={screen}
@@ -50,10 +50,14 @@ export function FluidLayoutRow<TContent>(props: IFluidLayoutRowProps<TContent>):
         );
     });
 
-    return (
-        <RowRenderer {...renderProps} DefaultRenderer={FluidLayoutRowRenderer}>
-            {RowHeaderRenderer && <RowHeaderRenderer row={row} screen={screen} />}
-            {columns}
-        </RowRenderer>
-    );
+    return rowRenderer({
+        ...renderProps,
+        DefaultRowRenderer: FluidLayoutRowRenderer,
+        children: (
+            <>
+                {rowHeaderRenderer && rowHeaderRenderer({ row, screen })}
+                {columns}
+            </>
+        ),
+    });
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRowRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/FluidLayoutRowRenderer.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
-import { Row } from "react-grid-system";
 import { IFluidLayoutRowRenderer } from "./interfaces";
+import { Row } from "react-grid-system";
 
 export const FluidLayoutRowRenderer: IFluidLayoutRowRenderer<any> = (props) => {
     const { children, className } = props;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/interfaces.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/interfaces.ts
@@ -53,12 +53,12 @@ export type IFluidLayoutRowRenderProps<TContent> = {
     /**
      * Default renderer of the row - can be used as a fallback for custom rowRenderer.
      */
-    DefaultRenderer: IFluidLayoutRowRenderer<TContent>;
+    DefaultRowRenderer: IFluidLayoutRowRenderer<TContent>;
 
     /**
      * Columns rendered by columnRenderer.
      */
-    children?: React.ReactNode;
+    children: React.ReactNode;
 
     /**
      * Additional row css class name.
@@ -72,9 +72,9 @@ export type IFluidLayoutRowRenderProps<TContent> = {
  *
  * @alpha
  */
-export type IFluidLayoutRowRenderer<TContent, TCustomProps = object> = React.ComponentType<
-    IFluidLayoutRowRenderProps<TContent> & TCustomProps
->;
+export type IFluidLayoutRowRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutRowRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Default props provided to {@link IFluidLayoutRowHeaderRenderer}.
@@ -99,9 +99,9 @@ export type IFluidLayoutRowHeaderRenderProps<TContent> = {
  *
  * @alpha
  */
-export type IFluidLayoutRowHeaderRenderer<TContent, TCustomProps = object> = React.ComponentType<
-    IFluidLayoutRowHeaderRenderProps<TContent> & TCustomProps
->;
+export type IFluidLayoutRowHeaderRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutRowHeaderRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Default props provided to {@link IFluidLayoutColumnKeyGetter}
@@ -152,7 +152,7 @@ export type IFluidLayoutColumnRenderProps<TContent> = {
     /**
      * Default renderer of the column - can be used as a fallback for custom columnRenderer.
      */
-    DefaultRenderer: IFluidLayoutColumnRenderer<TContent>;
+    DefaultColumnRenderer: IFluidLayoutColumnRenderer<TContent>;
 
     /**
      * Additional column css class name.
@@ -167,7 +167,7 @@ export type IFluidLayoutColumnRenderProps<TContent> = {
     /**
      * Column content rendered by contentRenderer.
      */
-    children?: React.ReactNode;
+    children: React.ReactNode;
 };
 
 /**
@@ -176,9 +176,9 @@ export type IFluidLayoutColumnRenderProps<TContent> = {
  *
  * @alpha
  */
-export type IFluidLayoutColumnRenderer<TContent, TCustomProps = object> = React.ComponentType<
-    IFluidLayoutColumnRenderProps<TContent> & TCustomProps
->;
+export type IFluidLayoutColumnRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutColumnRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Default props provided to {@link IFluidLayoutContentRenderer}
@@ -203,9 +203,9 @@ export type IFluidLayoutContentRenderProps<TContent> = {
  *
  * @alpha
  */
-export type IFluidLayoutContentRenderer<TContent, TCustomProps = object> = React.ComponentType<
-    IFluidLayoutContentRenderProps<TContent> & TCustomProps
->;
+export type IFluidLayoutContentRenderer<TContent, TCustomProps = object> = (
+    renderProps: IFluidLayoutContentRenderProps<TContent> & TCustomProps,
+) => JSX.Element;
 
 /**
  * Fluid layout renderer.

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutColumn.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutColumn.test.tsx
@@ -2,49 +2,56 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { FluidLayoutFacade } from "@gooddata/sdk-backend-spi";
+import { Col } from "react-grid-system";
 import { FluidLayoutColumn } from "../FluidLayoutColumn";
-import { FluidLayoutColumnRenderer } from "../FluidLayoutColumnRenderer";
 import { fluidLayoutWithOneColumn, TextLayoutColumnRenderer, TextLayoutContentRenderer } from "./fixtures";
 
-const CustomColumnRenderer: TextLayoutColumnRenderer = ({ children }) => <div>{children}</div>;
-const CustomContentRenderer: TextLayoutContentRenderer = ({ column }) => <div>{column.content()}</div>;
+const customColumnRendererClass = "s-column-renderer";
+const customContentRendererClass = "s-column-renderer";
+
+const customColumnRenderer: TextLayoutColumnRenderer = ({ children }) => (
+    <div className={customColumnRendererClass}>{children}</div>
+);
+const customContentRenderer: TextLayoutContentRenderer = ({ column }) => (
+    <div className={customContentRendererClass}>{column.content()}</div>
+);
 
 const layoutFacade = FluidLayoutFacade.for(fluidLayoutWithOneColumn);
 
 describe("FluidLayoutColumn", () => {
-    it("should render default column renderer, when columnRenderer prop is not provided", () => {
+    it("should use default column renderer, when columnRenderer prop is not provided", () => {
         const wrapper = shallow(
             <FluidLayoutColumn
                 screen="xl"
                 column={layoutFacade.rows().row(0).columns().column(0)}
-                contentRenderer={CustomContentRenderer}
+                contentRenderer={customContentRenderer}
             />,
         );
-        expect(wrapper.find(FluidLayoutColumnRenderer)).toExist();
+        expect(wrapper.find(Col)).toExist();
     });
 
-    it("should render provided column renderer, when columnRenderer prop is provided", () => {
+    it("should use provided column renderer, when columnRenderer prop is provided", () => {
         const wrapper = shallow(
             <FluidLayoutColumn
                 screen="xl"
                 column={layoutFacade.rows().row(0).columns().column(0)}
-                columnRenderer={CustomColumnRenderer}
-                contentRenderer={CustomContentRenderer}
+                columnRenderer={customColumnRenderer}
+                contentRenderer={customContentRenderer}
             />,
         );
 
-        expect(wrapper.find(CustomColumnRenderer)).toExist();
+        expect(wrapper.find(`.${customColumnRendererClass}`)).toExist();
     });
 
-    it("should render provided content renderer", () => {
+    it("should use provided content renderer", () => {
         const wrapper = shallow(
             <FluidLayoutColumn
                 screen="xl"
                 column={layoutFacade.rows().row(0).columns().column(0)}
-                contentRenderer={CustomContentRenderer}
+                contentRenderer={customContentRenderer}
             />,
         );
 
-        expect(wrapper.find(CustomContentRenderer)).toExist();
+        expect(wrapper.find(`.${customContentRendererClass}`)).toExist();
     });
 });

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutColumnRenderer.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutColumnRenderer.test.tsx
@@ -33,10 +33,12 @@ describe("FluidLayoutColumnRenderer", () => {
     it("should propagate responsive widths to Col component", () => {
         const wrapper = shallow(
             <FluidLayoutColumnRenderer
-                DefaultRenderer={FluidLayoutColumnRenderer}
+                DefaultColumnRenderer={FluidLayoutColumnRenderer}
                 column={layoutFacade.rows().row(0).columns().column(0)}
                 screen="xl"
-            />,
+            >
+                Test
+            </FluidLayoutColumnRenderer>,
         );
         expect(wrapper.find(Col)).toHaveProp("xl", 12);
         expect(wrapper.find(Col)).toHaveProp("lg", 10);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutRow.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutRow.test.tsx
@@ -2,9 +2,9 @@
 import React from "react";
 import { shallow } from "enzyme";
 import { FluidLayoutFacade } from "@gooddata/sdk-backend-spi";
+import { Row } from "react-grid-system";
 import { FluidLayoutRow } from "../FluidLayoutRow";
 import { FluidLayoutColumn } from "../FluidLayoutColumn";
-import { FluidLayoutRowRenderer } from "../FluidLayoutRowRenderer";
 import {
     createArrayWithSize,
     fluidLayoutWithOneColumn,
@@ -12,7 +12,10 @@ import {
     createFluidLayoutMock,
 } from "./fixtures";
 
-const CustomRowRenderer: TextLayoutRowRenderer = ({ children }) => <div>{children}</div>;
+const customRowRendererClass = "s-row-renderer";
+const customRowRenderer: TextLayoutRowRenderer = ({ children }) => (
+    <div className={customRowRendererClass}>{children}</div>
+);
 
 const layoutFacade = FluidLayoutFacade.for(fluidLayoutWithOneColumn);
 
@@ -25,14 +28,14 @@ describe("FluidLayoutRow", () => {
 
     it("should use default row renderer, when rowRenderer prop is not provided", () => {
         const wrapper = shallow(<FluidLayoutRow row={layoutFacade.rows().row(0)} screen="xl" />);
-        expect(wrapper.find(FluidLayoutRowRenderer)).toExist();
+        expect(wrapper.find(Row)).toExist();
     });
 
     it("should use provided row renderer, when rowRenderer prop is provided", () => {
         const wrapper = shallow(
-            <FluidLayoutRow row={layoutFacade.rows().row(0)} screen="xl" rowRenderer={CustomRowRenderer} />,
+            <FluidLayoutRow row={layoutFacade.rows().row(0)} screen="xl" rowRenderer={customRowRenderer} />,
         );
 
-        expect(wrapper.find(CustomRowRenderer)).toExist();
+        expect(wrapper.find(`.${customRowRendererClass}`)).toExist();
     });
 });

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutRowRenderer.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/FluidLayout/test/FluidLayoutRowRenderer.test.tsx
@@ -16,7 +16,7 @@ describe("FluidLayoutRowRenderer", () => {
                 row={layoutFacade.rows().row(0)}
                 screen="xl"
                 className={className}
-                DefaultRenderer={FluidLayoutRowRenderer}
+                DefaultRowRenderer={FluidLayoutRowRenderer}
             >
                 Test
             </FluidLayoutRowRenderer>,


### PR DESCRIPTION
- Change FluidLayout renderers from React components to pure render props callbacks for better composability, and to avoid component remounting when injecting custom props (without usage of context)
- Optimize FluidLayoutFacade performance by adding WeakMap cache, make it more "lazy"
- Update naming for default renderers for better understandability & readability
- Minor fixes

JIRA: RAIL-2869

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
