### PR TITLE
RELATED: RAIL-2905 - Make target of drill to dashboard optional - self drill

### DIFF
--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -2699,7 +2699,7 @@ export namespace GdcVisualizationWidget {
         drillToDashboard: {
             target: "in-place";
             from: IDrillFromMeasure;
-            toDashboard: Identifier;
+            toDashboard?: Identifier;
         };
     }
     // (undocumented)

--- a/libs/api-model-bear/src/visualizationWidget/GdcVisualizationWidget.ts
+++ b/libs/api-model-bear/src/visualizationWidget/GdcVisualizationWidget.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import isEmpty from "lodash/fp/isEmpty";
 import has from "lodash/has";
 import { GdcMetadata } from "../meta/GdcMetadata";
@@ -50,7 +50,7 @@ export namespace GdcVisualizationWidget {
         drillToDashboard: {
             target: "in-place";
             from: IDrillFromMeasure;
-            toDashboard: Identifier;
+            toDashboard?: Identifier;
         };
     }
 

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/drills.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/drills.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 import { GdcVisualizationWidget, GdcKpi } from "@gooddata/api-model-bear";
 import { uriRef, idRef, localIdRef } from "@gooddata/sdk-model";
@@ -46,7 +46,7 @@ export const convertVisualizationWidgetDrill = (
         const drillDefinition: IDrillToDashboard = {
             type: "drillToDashboard",
             origin: { type: "drillFromMeasure", measure: localIdRef(localIdentifier) },
-            target: idRef(toDashboard),
+            target: toDashboard !== undefined ? idRef(toDashboard) : undefined,
             transition: target,
         };
         return drillDefinition;

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -56,7 +56,14 @@ import {
     GdcFilterContext,
     GdcScheduledMail,
 } from "@gooddata/api-model-bear";
-import { ObjRef, isUriRef, objRefToString, isAttributeElementsByValue } from "@gooddata/sdk-model";
+import {
+    ObjRef,
+    isUriRef,
+    isAttributeElementsByValue,
+    isIdentifierRef,
+    ObjRefInScope,
+    isLocalIdRef,
+} from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import { convertUrisToReferences } from "../fromBackend/ReferenceConverter";
 import isEmpty from "lodash/isEmpty";
@@ -64,13 +71,21 @@ import omitBy from "lodash/omitBy";
 import { serializeProperties } from "../fromBackend/PropertiesConverter";
 
 const refToUri = (ref: ObjRef) => {
-    if (isUriRef(ref)) {
-        return ref.uri;
-    }
+    invariant(isUriRef(ref));
 
-    throw new UnexpectedError(
-        "Identifiers are not supported in the bear dashboard model, first sanitize your object refs!",
-    );
+    return ref.uri;
+};
+
+const refToIdentifier = (ref: ObjRef) => {
+    invariant(isIdentifierRef(ref));
+
+    return ref.identifier;
+};
+
+const refToLocalId = (ref: ObjRefInScope) => {
+    invariant(isLocalIdRef(ref));
+
+    return ref.localIdentifier;
 };
 
 export const convertResponsiveSize = (size: IFluidLayoutSize): GdcDashboardLayout.IFluidLayoutSize => {
@@ -324,7 +339,7 @@ export function convertDrill(
     } = drill;
     const drillFromMeasure = {
         drillFromMeasure: {
-            localIdentifier: objRefToString(measure),
+            localIdentifier: refToLocalId(measure),
         },
     };
 
@@ -333,7 +348,7 @@ export function convertDrill(
             drillToDashboard: {
                 from: drillFromMeasure,
                 target: "in-place",
-                toDashboard: objRefToString(drill.target),
+                toDashboard: drill.target !== undefined ? refToIdentifier(drill.target) : undefined,
             },
         };
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -574,7 +574,6 @@ export type IDimensionItemDescriptor = IMeasureGroupDescriptor | IAttributeDescr
 // @alpha
 export interface IDrill {
     origin: DrillOrigin;
-    target: IDrillTarget;
     transition: DrillTransition;
     type: DrillType;
 }
@@ -620,7 +619,7 @@ export interface IDrillToCustomUrlTarget {
 
 // @alpha
 export interface IDrillToDashboard extends IDrill {
-    target: ObjRef;
+    target?: ObjRef;
     transition: "in-place";
     type: "drillToDashboard";
 }

--- a/libs/sdk-backend-spi/src/workspace/dashboards/drills.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/drills.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 
 import { ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
@@ -122,11 +122,6 @@ export interface IDrill {
      * Drill origin
      */
     origin: DrillOrigin;
-
-    /**
-     * Drill target
-     */
-    target: IDrillTarget;
 }
 
 /**
@@ -179,9 +174,17 @@ export interface IDrillToDashboard extends IDrill {
     transition: "in-place";
 
     /**
-     * Target dashboard ref
+     * Target dashboard ref. If not specified, then this is a drill to self - activating such
+     * drill will not switch to a different dashboard but will instead set dashboard filters to
+     * 'focus' on the drilled attribute element IF a filter for that attribute is defined for
+     * the dashboard.
+     *
+     * Example: dashboard shows several for company departments. It is possible to filter the entire
+     * dashboard by department. A column chart showing cost by department has drill to dashboard set
+     * without 'target'. When user clicks a column, the dashboard's department filter will be set
+     * to the department that the clicked column represents.
      */
-    target: ObjRef;
+    target?: ObjRef;
 }
 
 /**


### PR DESCRIPTION
-  This change reflects reality;
-  Bear can accept drill to dash without target dash = drill to self (with updated filters)
-  The SPI should reflect this as well

The client code was already dancing around this and passing down drills with target undefined. It worked by chance because the sdk-model idRef(id) function does not bomb if ID is undefined :)

JIRA: RAIL-2905

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
