### PR TITLE
Fix handling of referencePoint in pluggable visualizations 

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -213,9 +213,9 @@ export class PluggableAreaChart extends PluggableBaseChart {
         const isAllowMoreThanOneViewByAttribute = !stacks.length && measures.length <= 1;
         const numOfAttributes = isAllowMoreThanOneViewByAttribute ? MAX_VIEW_COUNT : 1;
         let views: IBucketItem[] = removeDivergentDateItems(
-            getAllCategoriesAttributeItems(buckets).slice(0, numOfAttributes),
+            getAllCategoriesAttributeItems(buckets),
             mainDateItem,
-        );
+        ).slice(0, numOfAttributes);
         const hasDateItemInViewByBucket = views.some(isDateBucketItem);
 
         if (dateItems.length && !hasDateItemInViewByBucket) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -167,6 +167,28 @@ describe("PluggableAreaChart", () => {
             expect(extendedReferencePoint.buckets).toEqual(expectedBuckets);
         });
 
+        it("should keep two date attributes in view by bucket when coming from pivot table with date buckets with different date dimensions", async () => {
+            const areaChart = createComponent(defaultProps);
+            const mockRefPoint = cloneDeep(referencePointMocks.dateAttributesOnRowsReferencePoint);
+            const expectedBuckets: IBucketOfFun[] = [
+                {
+                    localIdentifier: "measures",
+                    items: mockRefPoint.buckets[0].items,
+                },
+                {
+                    localIdentifier: "view",
+                    items: [mockRefPoint.buckets[1].items[0], mockRefPoint.buckets[1].items[3]],
+                },
+                {
+                    localIdentifier: "stack",
+                    items: [],
+                },
+            ];
+            const extendedReferencePoint = await areaChart.getExtendedReferencePoint(mockRefPoint);
+
+            expect(extendedReferencePoint.buckets).toEqual(expectedBuckets);
+        });
+
         it("should keep only first date attribute in view by bucket when comming from pivot table with different dimensions", async () => {
             const areaChart = createComponent(defaultProps);
             const mockRefPoint = cloneDeep(referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint);

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
 import isEmpty from "lodash/isEmpty";
 import { IAnalyticalBackend, IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import {
     IReferencePoint,
     IBucketItem,
@@ -12,6 +12,9 @@ import {
 } from "../../interfaces/Visualization";
 import { OverTimeComparisonTypes } from "@gooddata/sdk-ui";
 import { ColumnWidthItem } from "@gooddata/sdk-ui-pivot";
+import { ObjRef, uriRef } from "@gooddata/sdk-model";
+
+export const dateDatasetRef: ObjRef = uriRef("data.dataset.1");
 
 export const masterMeasureItems: IBucketItem[] = [
     {
@@ -268,6 +271,9 @@ export const samePeriodPrevYearFiltersBucket: IFilters = {
                 },
             ],
             aggregation: null,
+            dateDataset: {
+                ref: dateDatasetRef,
+            },
         },
     ],
 };
@@ -489,6 +495,20 @@ export const overTimeComparisonDateItem: IBucketItem = {
     localIdentifier: "2fb4a818526f4ca18c926b1a11adc859",
     filters: [dateFilterSamePeriodPreviousYear],
     attribute: "attr.datedataset",
+    dateDataset: {
+        ref: dateDatasetRef,
+    },
+};
+
+export const dateItemWithDateDataset: IBucketItem = {
+    localIdentifier: "a1",
+    type: "date",
+    attribute: "attr.datedataset",
+    aggregation: null,
+    showInPercent: null,
+    dateDataset: {
+        ref: dateDatasetRef,
+    },
 };
 
 const defaultSortItem = {
@@ -713,7 +733,7 @@ export const samePeriodPreviousYearRefPoint: IReferencePoint = {
         },
         {
             localIdentifier: "view",
-            items: [],
+            items: [dateItemWithDateDataset],
         },
         {
             localIdentifier: "stack",
@@ -1747,6 +1767,64 @@ export const dateAttributeOnRowsAndColumnsReferencePoint: IReferencePoint = {
                     localIdentifier: "date2",
                 },
             ],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const dateAttributesOnRowsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "created",
+                        },
+                    },
+                    localIdentifier: "date1",
+                },
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "closed",
+                        },
+                    },
+                    localIdentifier: "date2",
+                },
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "snapshot",
+                        },
+                    },
+                    localIdentifier: "date3",
+                },
+                {
+                    ...dateItem,
+                    dateDataset: {
+                        ref: {
+                            uri: "created",
+                        },
+                    },
+                    localIdentifier: "date4",
+                },
+            ],
+        },
+        {
+            localIdentifier: "columns",
+            items: [],
         },
     ],
     filters: {

--- a/libs/sdk-ui-ext/src/internal/utils/bucketConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import forEach from "lodash/forEach";
 import set from "lodash/set";
 import isEmpty from "lodash/isEmpty";
@@ -15,6 +15,8 @@ import {
     getComparisonTypeFromFilters,
     keepOnlyMasterAndDerivedMeasuresOfType,
     filterOutIncompatibleArithmeticMeasures,
+    isComparisonAvailable,
+    removeAllDerivedMeasures,
 } from "./bucketHelper";
 import { isShowInPercentAllowed, isComparisonOverTimeAllowed } from "./bucketRules";
 
@@ -31,7 +33,9 @@ export function configureOverTimeComparison(
     extendedReferencePoint: IExtendedReferencePoint,
     weekFiltersEnabled: boolean,
 ): IExtendedReferencePoint {
-    const { buckets, filters, uiConfig } = extendedReferencePoint;
+    let newExtendedReferencePoint = cloneDeep(extendedReferencePoint);
+
+    const { buckets, filters, uiConfig } = newExtendedReferencePoint;
     const { supportedOverTimeComparisonTypes } = uiConfig;
 
     const appliedComparisonType = getComparisonTypeFromFilters(filters);
@@ -66,7 +70,11 @@ export function configureOverTimeComparison(
         bucket.items = newItems;
     });
 
-    return extendedReferencePoint;
+    if (!isComparisonAvailable(buckets, filters)) {
+        newExtendedReferencePoint = removeAllDerivedMeasures(newExtendedReferencePoint);
+    }
+
+    return newExtendedReferencePoint;
 }
 
 function removeShowInPercent(measure: IBucketItem) {


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
