### PR TITLE
RELATED: RAIL-2847 Add broken alert filters support

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithDrilling.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithDrilling.tsx
@@ -13,7 +13,7 @@ const DashboardViewWithDrilling: React.FC = () => {
         <DashboardView
             dashboard={dashboardRef}
             config={config}
-            drillableItems={[HeaderPredicates.attributeItemNameMatch("Aventura")]}
+            drillableItems={[HeaderPredicates.attributeItemNameMatch("Daly City")]}
             onDrill={(e) => {
                 // eslint-disable-next-line no-console
                 console.log("Drill event in DashboardView: ", e);

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithFilters.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithFilters.tsx
@@ -6,7 +6,11 @@ import { Ldm } from "../../ldm";
 import { MAPBOX_TOKEN } from "../../constants/fixtures";
 
 const dashboardRef = idRef("aeO5PVgShc0T");
-const filters = [newPositiveAttributeFilter(Ldm.LocationState, { values: ["California"] })];
+const filters = [
+    newPositiveAttributeFilter(Ldm.LocationState, {
+        uris: ["/gdc/md/xms7ga4tf3g3nzucd8380o2bev8oeknp/obj/2210/elements?id=6340116"],
+    }),
+];
 const config = { mapboxToken: MAPBOX_TOKEN };
 
 const DashboardViewWithFilters: React.FC = () => {

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithMergedFilters.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithMergedFilters.tsx
@@ -1,0 +1,34 @@
+// (C) 2007-2018 GoodData Corporation
+import React, { useMemo, useState } from "react";
+import { DashboardView, mergeFiltersWithDashboard } from "@gooddata/sdk-ui-ext/esm/internal";
+import { idRef, newPositiveAttributeFilter } from "@gooddata/sdk-model";
+import { IDashboard } from "@gooddata/sdk-backend-spi";
+import { Ldm } from "../../ldm";
+import { MAPBOX_TOKEN } from "../../constants/fixtures";
+
+const dashboardRef = idRef("aeO5PVgShc0T");
+const filters = [
+    newPositiveAttributeFilter(Ldm.LocationState, {
+        uris: ["/gdc/md/xms7ga4tf3g3nzucd8380o2bev8oeknp/obj/2210/elements?id=6340116"],
+    }),
+];
+const config = { mapboxToken: MAPBOX_TOKEN };
+
+const DashboardViewWithMergedFilters: React.FC = () => {
+    const [dashboard, setDashboard] = useState<IDashboard | undefined>();
+
+    const mergedFilters = useMemo(() => {
+        return mergeFiltersWithDashboard(dashboard, filters);
+    }, [dashboard]);
+
+    return (
+        <DashboardView
+            dashboard={dashboardRef}
+            filters={mergedFilters}
+            config={config}
+            onDashboardLoaded={({ dashboard }) => setDashboard(dashboard)}
+        />
+    );
+};
+
+export default DashboardViewWithMergedFilters;

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
@@ -12,6 +12,10 @@ import DashboardViewWithFilters from "./DashboardViewWithFilters";
 import DashboardViewWithFiltersSRC from "!raw-loader!./DashboardViewWithFilters";
 import DashboardViewWithFiltersSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithFilters";
 
+import DashboardViewWithMergedFilters from "./DashboardViewWithMergedFilters";
+import DashboardViewWithMergedFiltersSRC from "!raw-loader!./DashboardViewWithMergedFilters";
+import DashboardViewWithMergedFiltersSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithMergedFilters";
+
 import DashboardViewWithDrilling from "./DashboardViewWithDrilling";
 import DashboardViewWithDrillingSRC from "!raw-loader!./DashboardViewWithDrilling";
 import DashboardViewWithDrillingSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithDrilling";
@@ -24,7 +28,10 @@ export const DashboardView = (): JSX.Element => (
     <div>
         <h1>DashboardView</h1>
 
-        <p>Simple example of how to embed a Dashboard into your application</p>
+        <p>
+            Simple example of how to embed a Dashboard into your application. There is a filter set on this
+            Dashboard itself to show only <em>Fine Dining</em> restaurants.
+        </p>
 
         <ExampleWithSource
             for={SimpleDashboardView}
@@ -35,8 +42,9 @@ export const DashboardView = (): JSX.Element => (
         <hr className="separator" />
 
         <p>
-            Example of how to embed a Dashboard into your application with added filters – the same Dashboard
-            as in the previous example filtered only to California
+            Example of how to embed a Dashboard into your application with custom filters – the same Dashboard
+            as in the previous example filtered only to California (disregarding any filters set on the
+            Dashboard itself, if you do not want that, see the next example).
         </p>
 
         <ExampleWithSource
@@ -48,8 +56,23 @@ export const DashboardView = (): JSX.Element => (
         <hr className="separator" />
 
         <p>
+            Example of how to embed a Dashboard into your application with custom filters combined with the
+            filters already specified on the dashboard itself – the same Dashboard as in the first example
+            with added filter only to California (this also respects the filters set on the Dashboard itself,
+            if you do not want that, see the previous example).
+        </p>
+
+        <ExampleWithSource
+            for={DashboardViewWithMergedFilters}
+            source={DashboardViewWithMergedFiltersSRC}
+            sourceJS={DashboardViewWithMergedFiltersSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <p>
             Example of how to embed a Dashboard into your application with added drilling – the same Dashboard
-            as in the previous examples wit Aventura with enabled drilling (check the console logs for
+            as in the previous examples with Daly City with enabled drilling (check the console logs for
             results).
         </p>
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -9,7 +9,7 @@ import {
     IDashboardLayoutContent,
     UnexpectedError,
 } from "@gooddata/sdk-backend-spi";
-import { IFilter, ObjRef, IInsight } from "@gooddata/sdk-model";
+import { ObjRef, IInsight } from "@gooddata/sdk-model";
 import {
     IDrillableItem,
     IErrorProps,
@@ -27,6 +27,7 @@ import {
 } from "../DashboardLayout";
 import { IDashboardViewLayout } from "../DashboardLayout/interfaces/dashboardLayout";
 import { IDashboardWidgetRenderer, IDashboardWidgetRenderProps } from "./types";
+import { IDashboardFilter } from "../types";
 import { DashboardWidgetRenderer } from "./DashboardWidgetRenderer";
 
 interface IDashboardRendererProps {
@@ -34,7 +35,8 @@ interface IDashboardRendererProps {
     dashboardViewLayout: IDashboardViewLayout<IDashboardLayoutContent>;
     backend?: IAnalyticalBackend;
     workspace?: string;
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
     filterContext?: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     onDrill?: OnFiredDrillEvent;
@@ -51,6 +53,7 @@ interface IDashboardRendererProps {
 export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(function DashboardRenderer({
     dashboardViewLayout,
     filters,
+    onFiltersChange,
     filterContext,
     backend,
     workspace,
@@ -117,6 +120,7 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
                     LoadingComponent,
                     drillableItems,
                     filters,
+                    onFiltersChange,
                     filterContext,
                     onDrill,
                     onError,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -1,6 +1,7 @@
 // (C) 2020 GoodData Corporation
 import React, { memo } from "react";
 import {
+    FilterContextItem,
     IAnalyticalBackend,
     IFilterContext,
     ITempFilterContext,
@@ -35,7 +36,7 @@ interface IDashboardRendererProps {
     dashboardViewLayout: IDashboardViewLayout<IDashboardLayoutContent>;
     backend?: IAnalyticalBackend;
     workspace?: string;
-    filters?: IDashboardFilter[];
+    filters?: FilterContextItem[];
     onFiltersChange?: (filters: IDashboardFilter[]) => void;
     filterContext?: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
@@ -20,6 +20,7 @@ import { useDashboardViewLayout } from "../hooks/useDashboardViewLayout";
 import { DashboardRenderer } from "./DashboardRenderer";
 import { EmptyDashboardError } from "./EmptyDashboardError";
 import { DashboardAlertsProvider } from "./DashboardAlertsContext";
+import { filterArrayToFilterContextItems } from "../utils/filters";
 
 export const DashboardView: React.FC<IDashboardViewProps> = ({
     dashboard,
@@ -145,6 +146,10 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
         };
     }, [config, userWorkspaceSettings]);
 
+    const sanitizedFilters = useMemo(() => {
+        return filters ? filterArrayToFilterContextItems(filters) : undefined;
+    }, [filters]);
+
     const statuses = [
         dashboardStatus,
         alertsStatus,
@@ -173,7 +178,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                                 workspace={workspace}
                                 locale={effectiveLocale}
                                 dashboard={dashboard}
-                                filters={applyFiltersToScheduledMail ? filters : undefined}
+                                filters={applyFiltersToScheduledMail ? sanitizedFilters : undefined}
                                 onSubmit={onScheduledMailDialogSubmit}
                                 onSubmitSuccess={onScheduledMailSubmitSuccess}
                                 onSubmitError={onScheduledMailSubmitError}
@@ -189,7 +194,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                                     workspace={workspace}
                                     dashboardRef={dashboard}
                                     dashboardViewLayout={dashboardData?.layout}
-                                    filters={filters}
+                                    filters={sanitizedFilters}
                                     onFiltersChange={onFiltersChange}
                                     filterContext={dashboardData.filterContext}
                                     onDrill={onDrill}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
@@ -24,6 +24,7 @@ import { DashboardAlertsProvider } from "./DashboardAlertsContext";
 export const DashboardView: React.FC<IDashboardViewProps> = ({
     dashboard,
     filters,
+    onFiltersChange,
     theme,
     disableThemeLoading = false,
     themeModifier = defaultThemeModifier,
@@ -189,6 +190,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                                     dashboardRef={dashboard}
                                     dashboardViewLayout={dashboardData?.layout}
                                     filters={filters}
+                                    onFiltersChange={onFiltersChange}
                                     filterContext={dashboardData.filterContext}
                                     onDrill={onDrill}
                                     drillableItems={drillableItems}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
@@ -19,6 +19,7 @@ export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (p
         backend,
         drillableItems,
         filters,
+        onFiltersChange,
         filterContext,
         onDrill,
         onError,
@@ -83,6 +84,7 @@ export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (p
                     backend={backend}
                     workspace={workspace}
                     filters={filters}
+                    onFiltersChange={onFiltersChange}
                     drillableItems={drillableItems}
                     onDrill={onDrill}
                     onError={onError}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -41,7 +41,7 @@ import {
     useExecution,
 } from "@gooddata/sdk-ui";
 
-import { filterContextToFiltersForWidget } from "../../converters";
+import { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "../../converters";
 import { DashboardItemHeadline } from "../../DashboardItem/DashboardItemHeadline";
 import { useCurrentUser } from "../../hooks/useCurrentUser";
 import { useUserWorkspacePermissions } from "../../hooks/useUserWorkspacePermissions";
@@ -54,7 +54,7 @@ import {
 } from "../../KpiAlerts";
 import { useBrokenAlertFiltersMeta } from "../../KpiAlerts/useBrokenAlertFiltersMeta";
 import { IDashboardFilter, IKpiAlertResult, IKpiResult } from "../../types";
-import { dashboardFilterToFilterContextItem, filterContextItemToDashboardFilter } from "../../utils/filters";
+import { dashboardFilterToFilterContextItem } from "../../utils/filters";
 import { useUserWorkspaceSettings } from "../UserWorkspaceSettingsContext";
 
 import {
@@ -293,8 +293,10 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                         onFiltersChange
                             ? () =>
                                   onFiltersChange(
-                                      alert.filterContext?.filters?.map(filterContextItemToDashboardFilter) ??
-                                          [],
+                                      filterContextItemsToFiltersForWidget(
+                                          alert.filterContext?.filters ?? [],
+                                          kpiWidget,
+                                      ),
                                   )
                             : undefined
                     }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -1,12 +1,18 @@
 // (C) 2020 GoodData Corporation
 import React, { useCallback, useMemo, useState } from "react";
+import { injectIntl, IntlShape, WrappedComponentProps } from "react-intl";
+import compact from "lodash/compact";
+import isNil from "lodash/isNil";
+import isNumber from "lodash/isNumber";
+import noop from "lodash/noop";
+import round from "lodash/round";
 import {
     IAnalyticalBackend,
-    IWidgetAlert,
-    ISeparators,
-    IWidgetAlertDefinition,
     IKpiWidget,
     IKpiWidgetDefinition,
+    ISeparators,
+    IWidgetAlert,
+    IWidgetAlertDefinition,
 } from "@gooddata/sdk-backend-spi";
 import {
     IFilter,
@@ -17,50 +23,48 @@ import {
     ObjRef,
 } from "@gooddata/sdk-model";
 import {
-    useExecution,
-    useDataView,
-    IErrorProps,
-    ILoadingProps,
-    ErrorComponent as DefaultError,
-    LoadingComponent as DefaultLoading,
-    IDrillableItem,
-    IHeaderPredicate,
-    OnFiredDrillEvent,
-    IDrillEventContext,
     convertDrillableItemsToPredicates,
-    isSomeHeaderPredicateMatched,
-    OnError,
     createNumberJsFormatter,
-    IDataSeries,
-    NoDataSdkError,
-    isNoDataSdkError,
     DataViewFacade,
+    ErrorComponent as DefaultError,
+    IDataSeries,
+    IDrillableItem,
+    IDrillEventContext,
+    IErrorProps,
+    IHeaderPredicate,
+    ILoadingProps,
+    isNoDataSdkError,
+    isSomeHeaderPredicateMatched,
+    LoadingComponent as DefaultLoading,
+    NoDataSdkError,
+    OnError,
+    OnFiredDrillEvent,
+    useDataView,
+    useExecution,
 } from "@gooddata/sdk-ui";
-import compact from "lodash/compact";
-import isNil from "lodash/isNil";
-import isNumber from "lodash/isNumber";
-import noop from "lodash/noop";
-import round from "lodash/round";
-import { KpiRenderer } from "./KpiRenderer";
-import { injectIntl, IntlShape, WrappedComponentProps } from "react-intl";
-import { IKpiResult, IKpiAlertResult } from "../../types";
-import { DashboardItemWithKpiAlert } from "../../KpiAlerts/DashboardItemWithKpiAlert";
-import { DashboardItemHeadline } from "../../DashboardItem/DashboardItemHeadline";
-import { useUserWorkspaceSettings } from "../UserWorkspaceSettingsContext";
+
 import { filterContextToFiltersForWidget } from "../../converters";
-import {
-    enrichBrokenAlertsInfo,
-    getBrokenAlertFiltersBasicInfo,
-} from "../../KpiAlerts/utils/brokenFilterUtils";
-import KpiAlertDialog from "../../KpiAlerts/KpiAlertDialog/KpiAlertDialog";
-import { useAlertDeleteHandler } from "./alertManipulationHooks/useAlertDeleteHandler";
-import { useAlertSaveOrUpdateHandler } from "./alertManipulationHooks/useAlertSaveOrUpdateHandler";
-import { evaluateTriggered } from "../../KpiAlerts/utils/alertThresholdUtils";
-import { dashboardFilterToFilterContextItem } from "../../utils/filters";
-import { IUseAlertManipulationHandlerConfig } from "./alertManipulationHooks/types";
+import { DashboardItemHeadline } from "../../DashboardItem/DashboardItemHeadline";
 import { useCurrentUser } from "../../hooks/useCurrentUser";
 import { useUserWorkspacePermissions } from "../../hooks/useUserWorkspacePermissions";
-import { useBrokenAlertFiltersMeta } from "./useBrokenAlertFiltersMeta";
+import {
+    DashboardItemWithKpiAlert,
+    enrichBrokenAlertsInfo,
+    evaluateAlertTriggered,
+    getBrokenAlertFiltersBasicInfo,
+    KpiAlertDialog,
+} from "../../KpiAlerts";
+import { useBrokenAlertFiltersMeta } from "../../KpiAlerts/useBrokenAlertFiltersMeta";
+import { IKpiAlertResult, IKpiResult } from "../../types";
+import { dashboardFilterToFilterContextItem } from "../../utils/filters";
+import { useUserWorkspaceSettings } from "../UserWorkspaceSettingsContext";
+
+import {
+    IUseAlertManipulationHandlerConfig,
+    useAlertDeleteHandler,
+    useAlertSaveOrUpdateHandler,
+} from "./alertManipulationHooks";
+import { KpiRenderer } from "./KpiRenderer";
 
 interface IKpiExecutorProps {
     dashboardRef: ObjRef;
@@ -243,7 +247,7 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                                   ...alert,
                                   threshold,
                                   whenTriggered,
-                                  isTriggered: evaluateTriggered(
+                                  isTriggered: evaluateAlertTriggered(
                                       kpiAlertResult.measureResult,
                                       threshold,
                                       whenTriggered,
@@ -254,7 +258,7 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                                   widget: kpiWidget.ref,
                                   threshold,
                                   whenTriggered,
-                                  isTriggered: evaluateTriggered(
+                                  isTriggered: evaluateAlertTriggered(
                                       kpiResult?.measureResult ?? 0,
                                       threshold,
                                       whenTriggered,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -15,7 +15,6 @@ import {
     IWidgetAlertDefinition,
 } from "@gooddata/sdk-backend-spi";
 import {
-    IFilter,
     IMeasure,
     IPoPMeasureDefinition,
     IPreviousPeriodMeasureDefinition,
@@ -55,8 +54,8 @@ import {
     KpiAlertDialog,
 } from "../../KpiAlerts";
 import { useBrokenAlertFiltersMeta } from "../../KpiAlerts/useBrokenAlertFiltersMeta";
-import { IKpiAlertResult, IKpiResult } from "../../types";
-import { dashboardFilterToFilterContextItem } from "../../utils/filters";
+import { IDashboardFilter, IKpiAlertResult, IKpiResult } from "../../types";
+import { dashboardFilterToFilterContextItem, filterContextItemToDashboardFilter } from "../../utils/filters";
 import { useUserWorkspaceSettings } from "../UserWorkspaceSettingsContext";
 
 import {
@@ -72,7 +71,8 @@ interface IKpiExecutorProps {
     primaryMeasure: IMeasure;
     secondaryMeasure?: IMeasure<IPoPMeasureDefinition> | IMeasure<IPreviousPeriodMeasureDefinition>;
     alert?: IWidgetAlert;
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     onDrill?: OnFiredDrillEvent;
     onError?: OnError;
@@ -95,6 +95,7 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
     secondaryMeasure,
     alert,
     filters,
+    onFiltersChange,
     drillableItems,
     onDrill,
     onError,
@@ -274,7 +275,11 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                         saveOrUpdateAlert(toSave);
                     }}
                     onAlertDialogUpdateClick={noop as any} // TODO implement
-                    onApplyAlertFiltersClick={noop as any} // TODO implement
+                    onApplyAlertFiltersClick={() =>
+                        onFiltersChange(
+                            alert.filterContext?.filters?.map(filterContextItemToDashboardFilter) ?? [],
+                        )
+                    }
                     isAlertLoading={alertStatus === "loading"}
                     alertDeletingStatus={alertDeletingStatus}
                     alertSavingStatus={alertSavingStatus}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -275,10 +275,14 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                         saveOrUpdateAlert(toSave);
                     }}
                     onAlertDialogUpdateClick={noop as any} // TODO implement
-                    onApplyAlertFiltersClick={() =>
-                        onFiltersChange(
-                            alert.filterContext?.filters?.map(filterContextItemToDashboardFilter) ?? [],
-                        )
+                    onApplyAlertFiltersClick={
+                        onFiltersChange
+                            ? () =>
+                                  onFiltersChange(
+                                      alert.filterContext?.filters?.map(filterContextItemToDashboardFilter) ??
+                                          [],
+                                  )
+                            : undefined
                     }
                     isAlertLoading={alertStatus === "loading"}
                     alertDeletingStatus={alertDeletingStatus}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/alertManipulationHooks/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/alertManipulationHooks/index.ts
@@ -1,0 +1,4 @@
+// (C) 2021 GoodData Corporation
+export * from "./types";
+export { useAlertDeleteHandler } from "./useAlertDeleteHandler";
+export { useAlertSaveOrUpdateHandler } from "./useAlertSaveOrUpdateHandler";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo } from "react";
 import compact from "lodash/compact";
 import {
+    FilterContextItem,
     IAnalyticalBackend,
     IFilterContext,
     ITempFilterContext,
@@ -45,7 +46,7 @@ export interface IKpiViewProps {
     /**
      * Optionally, specify filters to be applied to the KPI.
      */
-    filters?: IDashboardFilter[];
+    filters?: FilterContextItem[];
 
     /**
      * Optionally, specify a callback that will be triggered when the filters should be changed.

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
@@ -8,7 +8,7 @@ import {
     IKpiWidget,
     IWidgetAlert,
 } from "@gooddata/sdk-backend-spi";
-import { IFilter, ObjRef } from "@gooddata/sdk-model";
+import { ObjRef } from "@gooddata/sdk-model";
 import {
     IErrorProps,
     ILoadingProps,
@@ -24,6 +24,7 @@ import invariant from "ts-invariant";
 import { useKpiData } from "./utils";
 import { KpiExecutor } from "./KpiExecutor";
 import { useDashboardViewConfig } from "../DashboardViewConfigContext";
+import { IDashboardFilter } from "../../types";
 
 export interface IKpiViewProps {
     /**
@@ -44,7 +45,13 @@ export interface IKpiViewProps {
     /**
      * Optionally, specify filters to be applied to the KPI.
      */
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
+
+    /**
+     * Optionally, specify a callback that will be triggered when the filters should be changed.
+     * (e.g. to apply filters of a KPI alert to the whole dashboard)
+     */
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
 
     /**
      * The filter context used in the parent dashboard.
@@ -102,6 +109,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
     kpiWidget,
     alert,
     filters,
+    onFiltersChange,
     filterContext,
     drillableItems = [],
     onDrill,
@@ -146,6 +154,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
             secondaryMeasure={result.secondaryMeasure}
             alert={alert}
             filters={result.filters}
+            onFiltersChange={onFiltersChange}
             onDrill={onDrill}
             onError={onError}
             drillableItems={effectiveDrillableItems}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/useBrokenAlertFiltersMeta.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/useBrokenAlertFiltersMeta.ts
@@ -1,0 +1,148 @@
+// (C) 2021 GoodData Corporation
+import invariant from "ts-invariant";
+import {
+    AnalyticalBackendError,
+    IAnalyticalBackend,
+    IDataSetMetadataObject,
+    NotSupported,
+} from "@gooddata/sdk-backend-spi";
+import {
+    useBackend,
+    useCancelablePromise,
+    UseCancelablePromiseCallbacks,
+    UseCancelablePromiseState,
+    useWorkspace,
+} from "@gooddata/sdk-ui";
+import { isAttributeElementsByRef, objRefToString } from "@gooddata/sdk-model";
+
+import {
+    IAttributeFilterMetaCollection,
+    IBrokenAlertFilterBasicInfo,
+    isBrokenAlertAttributeFilterInfo,
+} from "../../KpiAlerts/utils/brokenFilterUtils";
+import { dateDatasetsDataLoaderFactory } from "../../hooks/dataLoaders";
+
+export interface IBrokenAlertFiltersMeta {
+    attributeFiltersMeta: IAttributeFilterMetaCollection;
+    dateDatasets: IDataSetMetadataObject[];
+}
+
+/**
+ * @internal
+ */
+export interface IUseEnrichedBrokenAlertsConfig
+    extends UseCancelablePromiseCallbacks<IBrokenAlertFiltersMeta, AnalyticalBackendError> {
+    /**
+     * Broken filters to get meta data for.
+     */
+    brokenAlertFilters: IBrokenAlertFilterBasicInfo[];
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the hook MUST be called within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the hook MUST be called within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+const DEFAULT_ATTRIBUTE_ELEMENT_COUNT = 20;
+
+export function useBrokenAlertFiltersMeta({
+    backend,
+    brokenAlertFilters,
+    workspace,
+    onCancel,
+    onError,
+    onLoading,
+    onPending,
+    onSuccess,
+}: IUseEnrichedBrokenAlertsConfig): UseCancelablePromiseState<
+    IBrokenAlertFiltersMeta,
+    AnalyticalBackendError
+> {
+    const effectiveBackend = useBackend(backend);
+    const effectiveWorkspace = useWorkspace(workspace);
+
+    invariant(
+        effectiveBackend,
+        "The backend in useBrokenAlertFiltersMeta must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useBrokenAlertFiltersMeta must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const promise = brokenAlertFilters
+        ? async (): Promise<IBrokenAlertFiltersMeta> => {
+              const filtersToLoad = brokenAlertFilters.filter(isBrokenAlertAttributeFilterInfo);
+
+              const dateDatasetLoader = dateDatasetsDataLoaderFactory.forWorkspace(effectiveWorkspace);
+              const dateDatasetsPromise = dateDatasetLoader.getDateDatasets(effectiveBackend);
+
+              const filterDataPromise = Promise.all(
+                  filtersToLoad.map(async (filter) => {
+                      if (!isAttributeElementsByRef(filter.alertFilter.attributeFilter.attributeElements)) {
+                          throw new NotSupported(
+                              "Only URI attribute filters are supported in useBrokenAlertFiltersMeta",
+                          );
+                      }
+
+                      const displayForm = filter.alertFilter.attributeFilter.displayForm;
+
+                      const attributesService = effectiveBackend.workspace(effectiveWorkspace).attributes();
+
+                      const [elements, displayFormData] = await Promise.all([
+                          attributesService
+                              .elements()
+                              .forDisplayForm(displayForm)
+                              .withLimit(DEFAULT_ATTRIBUTE_ELEMENT_COUNT)
+                              .withOptions({
+                                  uris: filter.alertFilter.attributeFilter.attributeElements.uris,
+                                  includeTotalCountWithoutFilters: true,
+                              })
+                              .query(),
+                          attributesService.getAttributeDisplayForm(displayForm), // TODO: we might load all displayForms at once
+                      ]);
+
+                      return {
+                          elements,
+                          displayForm,
+                          title: displayFormData.title,
+                      };
+                  }),
+              );
+
+              const [filterData, dateDatasets] = await Promise.all([filterDataPromise, dateDatasetsPromise]);
+
+              const attributeFiltersMeta = filterData.reduce((acc: IAttributeFilterMetaCollection, curr) => {
+                  acc[objRefToString(curr.displayForm)] = {
+                      title: curr.title,
+                      totalElementsCount: curr.elements.totalCount,
+                      validElements: curr.elements.items,
+                  };
+                  return acc;
+              }, {});
+
+              return {
+                  attributeFiltersMeta,
+                  dateDatasets: dateDatasets.map((ds) => ds.dataSet),
+              };
+          }
+        : null;
+
+    return useCancelablePromise({ promise, onCancel, onError, onLoading, onPending, onSuccess }, [
+        effectiveBackend,
+        effectiveWorkspace,
+        brokenAlertFilters,
+    ]);
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/utils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/utils.ts
@@ -1,5 +1,6 @@
 // (C) 2020-2021 GoodData Corporation
 import {
+    FilterContextItem,
     IAnalyticalBackend,
     IFilterContext,
     ITempFilterContext,
@@ -26,13 +27,13 @@ import {
     useWorkspace,
 } from "@gooddata/sdk-ui";
 import invariant from "ts-invariant";
-import { filterContextToFiltersForWidget } from "../../converters";
+import { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "../../converters";
 import { IDashboardFilter } from "../../types";
 
 interface IUseKpiDataConfig {
     kpiWidget: IKpiWidget;
     filterContext?: IFilterContext | ITempFilterContext;
-    filters?: IDashboardFilter[];
+    filters?: FilterContextItem[];
     backend?: IAnalyticalBackend;
     workspace?: string;
     onError?: OnError;
@@ -57,8 +58,9 @@ export function useKpiData({
     const promise = async () => {
         invariant(kpiWidget.kpi, "The provided widget is not a KPI widget.");
 
-        const filtersFromFilterContext = filterContextToFiltersForWidget(filterContext, kpiWidget);
-        const inputFilters = [...filtersFromFilterContext, ...(filters ?? [])];
+        const inputFilters = filters
+            ? filterContextItemsToFiltersForWidget(filters, kpiWidget)
+            : filterContextToFiltersForWidget(filterContext, kpiWidget);
 
         const relevantFilters = (await effectiveBackend
             .workspace(effectiveWorkspace)

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/utils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/utils.ts
@@ -6,7 +6,6 @@ import {
     IKpiWidget,
 } from "@gooddata/sdk-backend-spi";
 import {
-    IFilter,
     IMeasure,
     IPoPMeasureDefinition,
     IPreviousPeriodMeasureDefinition,
@@ -28,11 +27,12 @@ import {
 } from "@gooddata/sdk-ui";
 import invariant from "ts-invariant";
 import { filterContextToFiltersForWidget } from "../../converters";
+import { IDashboardFilter } from "../../types";
 
 interface IUseKpiDataConfig {
     kpiWidget: IKpiWidget;
     filterContext?: IFilterContext | ITempFilterContext;
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
     backend?: IAnalyticalBackend;
     workspace?: string;
     onError?: OnError;
@@ -41,7 +41,7 @@ interface IUseKpiDataConfig {
 interface IUseKpiDataResult {
     primaryMeasure: IMeasure;
     secondaryMeasure?: IMeasure<IPoPMeasureDefinition> | IMeasure<IPreviousPeriodMeasureDefinition>;
-    filters: IFilter[];
+    filters: IDashboardFilter[];
 }
 
 export function useKpiData({
@@ -58,13 +58,12 @@ export function useKpiData({
         invariant(kpiWidget.kpi, "The provided widget is not a KPI widget.");
 
         const filtersFromFilterContext = filterContextToFiltersForWidget(filterContext, kpiWidget);
-
         const inputFilters = [...filtersFromFilterContext, ...(filters ?? [])];
 
-        const relevantFilters = await effectiveBackend
+        const relevantFilters = (await effectiveBackend
             .workspace(effectiveWorkspace)
             .dashboards()
-            .getResolvedFiltersForWidget(kpiWidget, inputFilters);
+            .getResolvedFiltersForWidget(kpiWidget, inputFilters)) as IDashboardFilter[]; // all the inputs are IDashboardFilter, so the result must be too
 
         const primaryMeasure = newMeasure(kpiWidget.kpi.metric);
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/index.ts
@@ -1,6 +1,6 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { DashboardViewErrorBoundary } from "./DashboardViewErrorBoundary";
 export { DashboardViewErrorBoundary as DashboardView };
-export { IDashboardViewProps, IDashboardFilter } from "./types";
+export { IDashboardViewProps } from "./types";
 export { KpiView, IKpiViewProps } from "./KpiView";
 export { defaultThemeModifier } from "./defaultThemeModifier";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -15,15 +15,7 @@ import {
     ResponsiveScreenType,
     IFluidLayoutColumnMethods,
 } from "@gooddata/sdk-backend-spi";
-import {
-    ObjRef,
-    IAbsoluteDateFilter,
-    IRelativeDateFilter,
-    IPositiveAttributeFilter,
-    INegativeAttributeFilter,
-    IInsight,
-    IFilter,
-} from "@gooddata/sdk-model";
+import { ObjRef, IInsight } from "@gooddata/sdk-model";
 import {
     IDrillableItem,
     IHeaderPredicate,
@@ -34,16 +26,7 @@ import {
     ILocale,
 } from "@gooddata/sdk-ui";
 import { IDashboardViewLayoutContentRenderProps, DashboardViewLayoutWidgetClass } from "../DashboardLayout";
-
-/**
- * Supported dashboard filter type.
- * @alpha
- */
-export type IDashboardFilter =
-    | IAbsoluteDateFilter
-    | IRelativeDateFilter
-    | IPositiveAttributeFilter
-    | INegativeAttributeFilter;
+import { IDashboardFilter } from "../types";
 
 /**
  * @beta
@@ -95,6 +78,12 @@ export interface IDashboardViewProps {
      * (and then the attached dashboard will use the original filters stored on the dashboard)
      */
     filters?: IDashboardFilter[];
+
+    /**
+     * Optionally, specify a callback that will be triggered when the filters should be changed.
+     * (e.g. to apply filters of a KPI alert to the whole dashboard)
+     */
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
 
     /**
      * Configure drillability; e.g. which parts of the visualization can be interacted with.
@@ -233,7 +222,7 @@ export type IDashboardContentRenderProps = IDashboardViewLayoutContentRenderProp
     backend?: IAnalyticalBackend;
     workspace?: string;
     dashboardRef: ObjRef;
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
     filterContext: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     onDrill?: OnFiredDrillEvent;
@@ -254,7 +243,8 @@ export type IDashboardWidgetRenderProps = {
     backend?: IAnalyticalBackend;
     workspace?: string;
     dashboardRef: ObjRef;
-    filters?: IFilter[];
+    filters?: IDashboardFilter[];
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
     filterContext: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     onDrill?: OnFiredDrillEvent;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -14,6 +14,7 @@ import {
     IWidget,
     ResponsiveScreenType,
     IFluidLayoutColumnMethods,
+    FilterContextItem,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef, IInsight } from "@gooddata/sdk-model";
 import {
@@ -69,15 +70,17 @@ export interface IDashboardViewProps {
     dashboard: ObjRef;
 
     /**
-     * Optionally, specify filters to be applied to all the widgets in the dashboard
-     * on top of any filters the dashboard already has saved within.
+     * Optionally, specify filters to be applied to all the widgets in the dashboard.
+     * If you specify this and want to merge your filters with the filters from the dashboard,
+     * you need to use the data from the {@link onDashboardLoaded} callback.
+     * To make the merging of the filters easier, you can use the {@link mergeFiltersWithDashboard} function.
      *
      * Note: These filters are also applied to created scheduled e-mails.
      * (the attached dashboard will use the filters that are set at the time we schedule it)
      * To suppress this behavior, set applyFiltersToScheduledMail property to false.
      * (and then the attached dashboard will use the original filters stored on the dashboard)
      */
-    filters?: IDashboardFilter[];
+    filters?: Array<IDashboardFilter | FilterContextItem>;
 
     /**
      * Optionally, specify a callback that will be triggered when the filters should be changed.
@@ -243,7 +246,7 @@ export type IDashboardWidgetRenderProps = {
     backend?: IAnalyticalBackend;
     workspace?: string;
     dashboardRef: ObjRef;
-    filters?: IDashboardFilter[];
+    filters?: FilterContextItem[];
     onFiltersChange?: (filters: IDashboardFilter[]) => void;
     filterContext: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
@@ -41,14 +41,34 @@ export interface IKpiAlertDialogProps {
     filters?: IFilter[];
     dateFormat: string;
 
-    // Callbacks
+    /**
+     * Triggered when either the "Close" button or the "Cancel" button is clicked.
+     */
     onAlertDialogCloseClick: () => void;
+
+    /**
+     * Triggered when a new alert creation or an update of the settings of an existing alert is triggered.
+     * The function is called with the current values of the alert dialog inputs.
+     */
     onAlertDialogSaveClick: (
         threshold: number,
         whenTriggered: IWidgetAlertDefinition["whenTriggered"],
     ) => void;
+
+    /**
+     * Triggered when the "Delete" button is clicked.
+     */
     onAlertDialogDeleteClick: () => void;
+
+    /**
+     * Triggered when the "Update filters" button in broken alert state is clicked.
+     * This should make sure the alert is updated with the filters currently used by its KPI (and therefore fix the alert).
+     */
     onAlertDialogUpdateClick: () => void;
+
+    /**
+     * Triggered when user clicks the "Apply alert filters to dashboard" button in case the dashboard has different filters than the alert
+     */
     onApplyAlertFiltersClick: () => void;
 }
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
@@ -67,9 +67,10 @@ export interface IKpiAlertDialogProps {
     onAlertDialogUpdateClick: () => void;
 
     /**
-     * Triggered when user clicks the "Apply alert filters to dashboard" button in case the dashboard has different filters than the alert
+     * Triggered when user clicks the "Apply alert filters to dashboard" button in case the dashboard has different filters than the alert.
+     * If not specified, the corresponding button will not be rendered.
      */
-    onApplyAlertFiltersClick: () => void;
+    onApplyAlertFiltersClick?: () => void;
 }
 
 interface IKpiAlertDialogState {
@@ -383,10 +384,15 @@ export class KpiAlertDialog extends Component<
         const shouldShowFiltersDifferMessage = !!this.props.alert && filtersDiffer;
         return shouldShowFiltersDifferMessage ? (
             <ReactMessage type="warning">
-                <FormattedHTMLMessage id="kpiAlertDialog.filtersDiffer" />{" "}
-                <a className="s-apply-alert-filters" onClick={this.applyAlertFilterSetting}>
-                    <FormattedHTMLMessage id="kpiAlertDialog.filtersApply" />
-                </a>
+                <FormattedHTMLMessage id="kpiAlertDialog.filtersDiffer" />
+                {!!this.props.onApplyAlertFiltersClick && (
+                    <>
+                        {" "}
+                        <a className="s-apply-alert-filters" onClick={this.applyAlertFilterSetting}>
+                            <FormattedHTMLMessage id="kpiAlertDialog.filtersApply" />
+                        </a>
+                    </>
+                )}
             </ReactMessage>
         ) : (
             false

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/index.ts
@@ -8,6 +8,7 @@ import {
     enrichBrokenAlertsInfo,
     getBrokenAlertFiltersBasicInfo,
 } from "./utils/brokenFilterUtils";
+import { evaluateAlertTriggered } from "./utils/alertThresholdUtils";
 
 export {
     DashboardItemWithKpiAlert,
@@ -16,4 +17,5 @@ export {
     IBrokenAlertFilterBasicInfo,
     enrichBrokenAlertsInfo,
     getBrokenAlertFiltersBasicInfo,
+    evaluateAlertTriggered,
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/useBrokenAlertFiltersMeta.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/useBrokenAlertFiltersMeta.ts
@@ -115,7 +115,7 @@ export function useBrokenAlertFiltersMeta({
                                   includeTotalCountWithoutFilters: true,
                               })
                               .query(),
-                          attributesService.getAttributeDisplayForm(displayForm), // TODO: we might load all displayForms at once
+                          attributesService.getAttributeDisplayForm(displayForm),
                       ]);
 
                       return {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/useBrokenAlertFiltersMeta.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/useBrokenAlertFiltersMeta.ts
@@ -15,12 +15,13 @@ import {
 } from "@gooddata/sdk-ui";
 import { isAttributeElementsByRef, objRefToString } from "@gooddata/sdk-model";
 
+import { dateDatasetsDataLoaderFactory } from "../hooks/dataLoaders";
+
 import {
     IAttributeFilterMetaCollection,
     IBrokenAlertFilterBasicInfo,
     isBrokenAlertAttributeFilterInfo,
-} from "../../KpiAlerts/utils/brokenFilterUtils";
-import { dateDatasetsDataLoaderFactory } from "../../hooks/dataLoaders";
+} from "./utils/brokenFilterUtils";
 
 export interface IBrokenAlertFiltersMeta {
     attributeFiltersMeta: IAttributeFilterMetaCollection;
@@ -56,6 +57,9 @@ export interface IUseEnrichedBrokenAlertsConfig
 
 const DEFAULT_ATTRIBUTE_ELEMENT_COUNT = 20;
 
+/**
+ * @internal
+ */
 export function useBrokenAlertFiltersMeta({
     backend,
     brokenAlertFilters,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/alertThresholdUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/alertThresholdUtils.ts
@@ -49,7 +49,7 @@ function sanitizeValue(value: number) {
     return isNaN(value) ? 0 : value; // eslint-disable-line no-restricted-globals
 }
 
-export function evaluateTriggered(
+export function evaluateAlertTriggered(
     kpiMeasureResult: number,
     threshold: number,
     when: IWidgetAlertBase["whenTriggered"],

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
@@ -41,13 +41,13 @@ export interface IBrokenAlertFilterBasicInfo<TFilter extends FilterContextItem =
     brokenType: BrokenAlertType;
 }
 
-function isBrokenAlertDateFilterInfo(
+export function isBrokenAlertDateFilterInfo(
     item: IBrokenAlertFilterBasicInfo,
 ): item is IBrokenAlertFilterBasicInfo<IDashboardDateFilter> {
     return isDashboardDateFilter(item.alertFilter);
 }
 
-function isBrokenAlertAttributeFilterInfo(
+export function isBrokenAlertAttributeFilterInfo(
     item: IBrokenAlertFilterBasicInfo,
 ): item is IBrokenAlertFilterBasicInfo<IDashboardAttributeFilter> {
     return isDashboardAttributeFilter(item.alertFilter);
@@ -196,7 +196,9 @@ function enrichBrokenDateFilter(
         type: "date",
         brokenType: brokenType,
         dateFilterTitle,
-        title: matchingDateDataset?.title ?? intl.formatMessage({ id: "configurationPanel.date" }), // TODO: migrate this default to SDK with a more appropriate name
+        title:
+            matchingDateDataset?.title ??
+            intl.formatMessage({ id: "kpiAlertDialog.brokenAlertDefaultDateLabel" }),
     };
 }
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/alertThresholdUtils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/alertThresholdUtils.test.ts
@@ -2,7 +2,7 @@
 import { IWidgetAlertBase } from "@gooddata/sdk-backend-spi";
 
 import {
-    evaluateTriggered,
+    evaluateAlertTriggered,
     thresholdFromDecimalToPercent,
     thresholdFromPercentToDecimal,
 } from "../alertThresholdUtils";
@@ -29,7 +29,7 @@ describe("thresholdFromPercentToDecimal", () => {
     });
 });
 
-describe("evaluateTriggered", () => {
+describe("evaluateAlertTriggered", () => {
     type Scenario = [boolean, number, number, IWidgetAlertBase["whenTriggered"]];
     const scenarios: Scenario[] = [
         [false, 5, 10, "aboveThreshold"],
@@ -55,7 +55,7 @@ describe("evaluateTriggered", () => {
     it.each(scenarios)(
         "should return %p when kpi result is %p, threshold is %p and type is %s",
         (expected, kpiResult, threshold, whenTriggered) => {
-            expect(evaluateTriggered(kpiResult, threshold, whenTriggered)).toEqual(expected);
+            expect(evaluateAlertTriggered(kpiResult, threshold, whenTriggered)).toEqual(expected);
         },
     );
 });

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/brokenFilterUtils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/brokenFilterUtils.test.ts
@@ -226,7 +226,7 @@ describe("getBrokenAlertFiltersBasicInfo", () => {
 
 describe("enrichBrokenAlertsInfo", () => {
     const DEFAULT_DATE_TITLE = "Date";
-    const intl = createIntlMock({ "configurationPanel.date": DEFAULT_DATE_TITLE });
+    const intl = createIntlMock({ "kpiAlertDialog.brokenAlertDefaultDateLabel": DEFAULT_DATE_TITLE });
     const dateFormat = "yyyy/MM/dd";
     const dateDataSets: IDataSetMetadataObject[] = [
         {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
@@ -19,7 +19,7 @@ import { useDashboard } from "../../hooks/useDashboard";
 
 import { ScheduledMailDialogRenderer } from "./ScheduledMailDialogRenderer";
 import { uriRef } from "@gooddata/sdk-model";
-import { IDashboardFilter } from "../../DashboardView/types";
+import { IDashboardFilter } from "../../types";
 import { dashboardFilterToFilterContextItem } from "../../utils/filters";
 
 export type ScheduledMailDialogProps = {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
@@ -6,6 +6,7 @@ import {
     IScheduledMail,
     IAnalyticalBackend,
     IFilterContextDefinition,
+    FilterContextItem,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError, LoadingComponent, ErrorComponent } from "@gooddata/sdk-ui";
@@ -19,8 +20,6 @@ import { useDashboard } from "../../hooks/useDashboard";
 
 import { ScheduledMailDialogRenderer } from "./ScheduledMailDialogRenderer";
 import { uriRef } from "@gooddata/sdk-model";
-import { IDashboardFilter } from "../../types";
-import { dashboardFilterToFilterContextItem } from "../../utils/filters";
 
 export type ScheduledMailDialogProps = {
     /**
@@ -39,7 +38,7 @@ export type ScheduledMailDialogProps = {
      * Note: By default, exported dashboard in the scheduled mail will use the original stored dashboard filter context,
      * with this prop, you can override it.
      */
-    filters?: IDashboardFilter[];
+    filters?: FilterContextItem[];
 
     /**
      * Backend to work with.
@@ -131,7 +130,7 @@ export const ScheduledMailDialog: React.FC<ScheduledMailDialogProps> = (props) =
             const filterContext: IFilterContextDefinition = {
                 title: "filterContext",
                 description: "",
-                filters: filters.map(dashboardFilterToFilterContextItem),
+                filters,
             };
 
             return filterContext;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
@@ -1,5 +1,6 @@
 // (C) 2020-2021 GoodData Corporation
 import {
+    FilterContextItem,
     IFilterContext,
     isDashboardAttributeFilter,
     ITempFilterContext,
@@ -29,7 +30,21 @@ export function filterContextToFiltersForWidget(
         return [];
     }
 
-    return filterContext.filters.map((filter) => {
+    return filterContextItemsToFiltersForWidget(filterContext.filters, widget);
+}
+
+/**
+ * Gets {@link IDashboardFilter} items for filters specified as {@link FilterContextItem} instances.
+ *
+ * @param filterContextItems - filter context items to get filters for
+ * @param widget - widget to use to get dateDataSet for date filters
+ * @internal
+ */
+export function filterContextItemsToFiltersForWidget(
+    filterContextItems: FilterContextItem[],
+    widget: IWidgetDefinition,
+): IDashboardFilter[] {
+    return filterContextItems.map((filter) => {
         if (isDashboardAttributeFilter(filter)) {
             if (filter.attributeFilter.negativeSelection) {
                 return newNegativeAttributeFilter(

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/converters.ts
@@ -6,16 +6,16 @@ import {
     IWidgetDefinition,
 } from "@gooddata/sdk-backend-spi";
 import {
-    IFilter,
     newNegativeAttributeFilter,
     newPositiveAttributeFilter,
     newRelativeDateFilter,
     newAbsoluteDateFilter,
 } from "@gooddata/sdk-model";
 import isString from "lodash/isString";
+import { IDashboardFilter } from "./types";
 
 /**
- * Gets {@link IFilter} items for filters specified in given filterContext in relation to the given widget.
+ * Gets {@link IDashboardFilter} items for filters specified in given filterContext in relation to the given widget.
  *
  * @param filterContext - filter context to get filters for
  * @param widget - widget to use to get dateDataSet for date filters
@@ -24,7 +24,7 @@ import isString from "lodash/isString";
 export function filterContextToFiltersForWidget(
     filterContext: IFilterContext | ITempFilterContext | undefined,
     widget: IWidgetDefinition,
-): IFilter[] {
+): IDashboardFilter[] {
     if (!filterContext) {
         return [];
     }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/dataLoaders/DateDatasetsDataLoader.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/dataLoaders/DateDatasetsDataLoader.ts
@@ -1,0 +1,44 @@
+// (C) 2021 GoodData Corporation
+import { IAnalyticalBackend, ICatalogDateDataset } from "@gooddata/sdk-backend-spi";
+import { dataLoaderAbstractFactory } from "../../../../dataLoaders/DataLoaderAbstractFactory";
+
+/**
+ * @internal
+ */
+export interface IDateDatasetsDataLoader {
+    /**
+     * Obtains all catalog attributes with a drill down specified.
+     * @param backend - the {@link IAnalyticalBackend} instance to use to communicate with the backend
+     */
+    getDateDatasets(backend: IAnalyticalBackend): Promise<ICatalogDateDataset[]>;
+}
+
+class DateDatasetsDataLoader implements IDateDatasetsDataLoader {
+    private cachedDateDatasets: Promise<ICatalogDateDataset[]> | undefined;
+
+    constructor(protected readonly workspace: string) {}
+
+    public getDateDatasets(backend: IAnalyticalBackend): Promise<ICatalogDateDataset[]> {
+        if (!this.cachedDateDatasets) {
+            this.cachedDateDatasets = backend
+                .workspace(this.workspace)
+                .catalog()
+                .forTypes(["dateDataset"])
+                .load()
+                .then((catalog) => catalog.dateDatasets())
+                .catch((error) => {
+                    this.cachedDateDatasets = undefined;
+                    throw error;
+                });
+        }
+
+        return this.cachedDateDatasets;
+    }
+}
+
+/**
+ * @internal
+ */
+export const dateDatasetsDataLoaderFactory = dataLoaderAbstractFactory<IDateDatasetsDataLoader>(
+    (workspace) => new DateDatasetsDataLoader(workspace),
+);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/dataLoaders/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/dataLoaders/index.ts
@@ -1,7 +1,8 @@
 // (C) 2021 GoodData Corporation
 import { attributesWithDrillDownDataLoaderFactory } from "./AttributesWithDrillDownDataLoader";
-import { dashboardDataLoaderFactory } from "./DashboardDataLoader";
 import { dashboardAlertsDataLoaderFactory } from "./DashboardAlertsDataLoader";
+import { dashboardDataLoaderFactory } from "./DashboardDataLoader";
+import { dateDatasetsDataLoaderFactory } from "./DateDatasetsDataLoader";
 import { userWorkspacePermissionsDataLoaderFactory } from "./UserWorkspacePermissionsDataLoader";
 import {
     colorPaletteDataLoaderFactory,
@@ -13,9 +14,10 @@ import { IDataLoaderFactory } from "../../../../dataLoaders/types";
 export function clearDashboardViewCaches(): void {
     const relevantFactories: IDataLoaderFactory<unknown>[] = [
         attributesWithDrillDownDataLoaderFactory,
-        dashboardDataLoaderFactory,
-        dashboardAlertsDataLoaderFactory,
         colorPaletteDataLoaderFactory,
+        dashboardAlertsDataLoaderFactory,
+        dashboardDataLoaderFactory,
+        dateDatasetsDataLoaderFactory,
         insightDataLoaderFactory,
         userWorkspacePermissionsDataLoaderFactory,
         userWorkspaceSettingsDataLoaderFactory,
@@ -25,7 +27,8 @@ export function clearDashboardViewCaches(): void {
 
 export {
     attributesWithDrillDownDataLoaderFactory,
-    dashboardDataLoaderFactory,
     dashboardAlertsDataLoaderFactory,
+    dashboardDataLoaderFactory,
+    dateDatasetsDataLoaderFactory,
     userWorkspacePermissionsDataLoaderFactory,
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
@@ -14,6 +14,7 @@ export {
     KpiView,
     defaultThemeModifier,
 } from "./DashboardView";
+export { mergeFiltersWithDashboard } from "./mergeFiltersWithDashboard";
 
 // TODO: RAIL-2869 Migrate to Responsive context
 export {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/mergeFiltersWithDashboard.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/mergeFiltersWithDashboard.ts
@@ -1,0 +1,19 @@
+// (C) 2020-2021 GoodData Corporation
+import { IDashboard, FilterContextItem } from "@gooddata/sdk-backend-spi";
+import { IDashboardFilter } from "./types";
+import { filterArrayToFilterContextItems } from "./utils/filters";
+
+/**
+ * Gets filters merged with the filters provided by the specified dashboard.
+ *
+ * @param dashboard - dashboard to get the filters from
+ * @param additionalFilters - filters to apply on top of the filters from the dashboard
+ * @alpha
+ */
+export function mergeFiltersWithDashboard(
+    dashboard: IDashboard,
+    additionalFilters: Array<IDashboardFilter | FilterContextItem>,
+): FilterContextItem[] {
+    const sanitizedAdditionalFilters = filterArrayToFilterContextItems(additionalFilters);
+    return [...dashboard.filterContext?.filters, ...sanitizedAdditionalFilters];
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/mergeFiltersWithDashboard.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/mergeFiltersWithDashboard.ts
@@ -11,9 +11,9 @@ import { filterArrayToFilterContextItems } from "./utils/filters";
  * @alpha
  */
 export function mergeFiltersWithDashboard(
-    dashboard: IDashboard,
+    dashboard: IDashboard | undefined,
     additionalFilters: Array<IDashboardFilter | FilterContextItem>,
 ): FilterContextItem[] {
-    const sanitizedAdditionalFilters = filterArrayToFilterContextItems(additionalFilters);
-    return [...dashboard.filterContext?.filters, ...sanitizedAdditionalFilters];
+    const sanitizedAdditionalFilters = filterArrayToFilterContextItems(additionalFilters ?? []);
+    return [...(dashboard?.filterContext?.filters ?? []), ...sanitizedAdditionalFilters];
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/types.ts
@@ -1,5 +1,11 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
+import {
+    IAbsoluteDateFilter,
+    IRelativeDateFilter,
+    IPositiveAttributeFilter,
+    INegativeAttributeFilter,
+} from "@gooddata/sdk-model";
 
 export interface IKpiResult {
     measureFormat: string;
@@ -14,3 +20,13 @@ export interface IKpiAlertResult {
 }
 
 export type KpiAlertOperationStatus = "idle" | "inProgress" | "error";
+
+/**
+ * Supported dashboard filter type.
+ * @alpha
+ */
+export type IDashboardFilter =
+    | IAbsoluteDateFilter
+    | IRelativeDateFilter
+    | IPositiveAttributeFilter
+    | INegativeAttributeFilter;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/utils/filters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/utils/filters.ts
@@ -6,6 +6,7 @@ import {
     IDashboardAttributeFilter,
     isDateFilterGranularity,
     isDashboardAttributeFilter,
+    isDashboardDateFilter,
 } from "@gooddata/sdk-backend-spi";
 import {
     isAbsoluteDateFilter,
@@ -15,13 +16,13 @@ import {
     filterAttributeElements,
     filterObjRef,
     isAttributeFilter,
-    newNegativeAttributeFilter,
-    newPositiveAttributeFilter,
-    newAbsoluteDateFilter,
-    newRelativeDateFilter,
 } from "@gooddata/sdk-model";
 import { IDashboardFilter } from "../types";
 
+/**
+ * Converts a {@link IDashboardFilter} to a {@link FilterContextItem}.
+ * @param filter - filter to convert
+ */
 export function dashboardFilterToFilterContextItem(filter: IDashboardFilter): FilterContextItem {
     if (isAttributeFilter(filter)) {
         const attributeElements = filterAttributeElements(filter);
@@ -76,29 +77,14 @@ export function dashboardFilterToFilterContextItem(filter: IDashboardFilter): Fi
     throw new NotSupported("Unsupported filter type! Please provide valid dashboard filter.");
 }
 
-export function filterContextItemToDashboardFilter(filter: FilterContextItem): IDashboardFilter {
-    if (isDashboardAttributeFilter(filter)) {
-        const { attributeFilter } = filter;
-        if (attributeFilter.negativeSelection) {
-            return newNegativeAttributeFilter(attributeFilter.displayForm, attributeFilter.attributeElements);
+export function filterArrayToFilterContextItems(
+    filters: Array<IDashboardFilter | FilterContextItem>,
+): FilterContextItem[] {
+    return filters.map((filter) => {
+        if (isDashboardDateFilter(filter) || isDashboardAttributeFilter(filter)) {
+            return filter;
         } else {
-            return newPositiveAttributeFilter(attributeFilter.displayForm, attributeFilter.attributeElements);
+            return dashboardFilterToFilterContextItem(filter);
         }
-    } else {
-        const { dateFilter } = filter;
-        if (dateFilter.type === "absolute") {
-            return newAbsoluteDateFilter(
-                dateFilter.dataSet,
-                dateFilter.from?.toString(),
-                dateFilter.to?.toString(),
-            );
-        } else {
-            return newRelativeDateFilter(
-                dateFilter.dataSet,
-                dateFilter.granularity,
-                Number.parseInt(filter.dateFilter.from?.toString() ?? "0", 10),
-                Number.parseInt(filter.dateFilter.to?.toString() ?? "0", 10),
-            );
-        }
-    }
+    });
 }

--- a/libs/sdk-ui-ext/src/internal/translations/de-DE.json
+++ b/libs/sdk-ui-ext/src/internal/translations/de-DE.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Löschen des Alarms fehlgeschlagen. Bitte versuchen Sie es noch einmal.",
     "kpiAlertDialog.brokenAlert": "Gebrochene Warnmeldung",
     "kpiAlertDialog.brokenAlertAppeal": "Um den richtigen KPI-Wert anzuzeigen, aktivieren Sie die Filter in dieser Warnmeldung. Sie können die Warnmeldung auch entfernen.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Datum",
     "kpiAlertDialog.removedFilters": "Die Filter wurden aus dem Dashboard entfernt",
     "kpiAlertDialog.ignoredFilters": "Unbekannte Filter für diesen KPI",
     "kpiAlertDialog.updateTitle": "Aktualisieren",

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -1099,6 +1099,11 @@
         "comment": "",
         "limit": 0
     },
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": {
+        "value": "Date",
+        "comment": "Label used in broken alert dialog in case no other date label is found.",
+        "limit": 0
+    },
     "kpiAlertDialog.removedFilters": {
         "value": "Filters removed from dashboard",
         "comment": "",

--- a/libs/sdk-ui-ext/src/internal/translations/es-ES.json
+++ b/libs/sdk-ui-ext/src/internal/translations/es-ES.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Error al eliminar la alerta. Vuelva a intentarlo más tarde.",
     "kpiAlertDialog.brokenAlert": "Alerta rota",
     "kpiAlertDialog.brokenAlertAppeal": "Para ver el valor KPI correcto, actualice los filtros de esta alerta. También puede quitar la alerta.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Fecha",
     "kpiAlertDialog.removedFilters": "Filtros quitados del panel",
     "kpiAlertDialog.ignoredFilters": "Filtros omitidos para este kpi",
     "kpiAlertDialog.updateTitle": "Actualizar",

--- a/libs/sdk-ui-ext/src/internal/translations/fr-FR.json
+++ b/libs/sdk-ui-ext/src/internal/translations/fr-FR.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Échec de suppression de l'alerte. Réessayez.",
     "kpiAlertDialog.brokenAlert": "Alerte interrompue",
     "kpiAlertDialog.brokenAlertAppeal": "Pour voir la valeur correcte de KPI, mettez à jour les filtres dans cette alerte. Vous pouvez également supprimer l'alerte.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Date",
     "kpiAlertDialog.removedFilters": "Filtres supprimés du tableau de bord",
     "kpiAlertDialog.ignoredFilters": "Filtres ignorés pour ce KPI",
     "kpiAlertDialog.updateTitle": "Mettre à jour",

--- a/libs/sdk-ui-ext/src/internal/translations/ja-JP.json
+++ b/libs/sdk-ui-ext/src/internal/translations/ja-JP.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "通知を消去できませんでした。もう一度やり直してください。",
     "kpiAlertDialog.brokenAlert": "通知が壊れています",
     "kpiAlertDialog.brokenAlertAppeal": "正しい KPI の値を確認するには、この通知のフィルターを更新します。通知を削除することもできます。",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "日付",
     "kpiAlertDialog.removedFilters": "フィルターをダッシュボードから削除しました",
     "kpiAlertDialog.ignoredFilters": "この kpi に対してフィルターが無視されました",
     "kpiAlertDialog.updateTitle": "更新",

--- a/libs/sdk-ui-ext/src/internal/translations/nl-NL.json
+++ b/libs/sdk-ui-ext/src/internal/translations/nl-NL.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Het alarm kon niet worden verwijderd. Probeer het opnieuw.",
     "kpiAlertDialog.brokenAlert": "Niet-nagekomen waarschuwing",
     "kpiAlertDialog.brokenAlertAppeal": "Om de juist KPI-waarde te zien moet u de filters in deze waarschuwing bijwerken. U kunt de waarschuwing ook verwijderen.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Datum",
     "kpiAlertDialog.removedFilters": "Filters verwijderd uit dashboard",
     "kpiAlertDialog.ignoredFilters": "Geen rekening gehouden met de filters voor deze kpi",
     "kpiAlertDialog.updateTitle": "Update",

--- a/libs/sdk-ui-ext/src/internal/translations/pt-BR.json
+++ b/libs/sdk-ui-ext/src/internal/translations/pt-BR.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Falha ao excluir alerta. Tente novamente.",
     "kpiAlertDialog.brokenAlert": "Alerta interrompido",
     "kpiAlertDialog.brokenAlertAppeal": "Para ver o valor KPI correcto, atualize os filtros nesta alerta. Você também poderá remover o alerta.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Data",
     "kpiAlertDialog.removedFilters": "Filtros removidos do painel",
     "kpiAlertDialog.ignoredFilters": "Filtros ignorados por este KPI",
     "kpiAlertDialog.updateTitle": "Atualizar",

--- a/libs/sdk-ui-ext/src/internal/translations/pt-PT.json
+++ b/libs/sdk-ui-ext/src/internal/translations/pt-PT.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "Eliminar o alerta falhou. Tente de novo.",
     "kpiAlertDialog.brokenAlert": "Alerta infringido",
     "kpiAlertDialog.brokenAlertAppeal": "Para ver o valor KPI correto, atualize os filtros neste alerta. Pode também remover o alerta.",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "Data",
     "kpiAlertDialog.removedFilters": "Filtros removidos do dashboard",
     "kpiAlertDialog.ignoredFilters": "Filtros ignorados para este kpi",
     "kpiAlertDialog.updateTitle": "Atualizar",

--- a/libs/sdk-ui-ext/src/internal/translations/zh-Hans.json
+++ b/libs/sdk-ui-ext/src/internal/translations/zh-Hans.json
@@ -219,6 +219,7 @@
     "kpiAlertDialog.deleteingFailed": "删除警报失败。请重试。",
     "kpiAlertDialog.brokenAlert": "损坏的警报",
     "kpiAlertDialog.brokenAlertAppeal": "要查看正确的 KPI 值，请更新此警报中的筛选器。您也可以删除此警报。",
+    "kpiAlertDialog.brokenAlertDefaultDateLabel": "日期",
     "kpiAlertDialog.removedFilters": "从控制面板删除的筛选器",
     "kpiAlertDialog.ignoredFilters": "忽略此 KPI 的筛选器",
     "kpiAlertDialog.updateTitle": "更新",


### PR DESCRIPTION
Makes the KpiAlertDialog feature complete with KPI Dashboards:

* broken alert filters data is obtained and shown properly
* if the alert has different filters than the dashboard, user can set them to the filter from the alert

To implement the second feature mentioned, the `filters` prop of `DashboardView` was changed to allow full override of the dashboard filters. A convenience method was provided to enable users to still use the filter merging if they want to.

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
