### PR TITLE
RELATED: RAIL-2905 - Downgrade styled-jsx to prevent example runtime errors

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -238,12 +238,6 @@ packages:
     dev: false
     resolution:
       integrity: sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==
-  /@babel/helper-module-imports/7.12.5:
-    dependencies:
-      '@babel/types': 7.12.13
-    dev: false
-    resolution:
-      integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
   /@babel/helper-module-transforms/7.12.13:
     dependencies:
       '@babel/helper-module-imports': 7.12.13
@@ -1536,9 +1530,9 @@ packages:
   /@heroku-cli/command/8.4.0:
     dependencies:
       '@heroku-cli/color': 1.1.14
-      '@oclif/errors': 1.2.2
+      '@oclif/errors': 1.3.4
       cli-ux: 4.9.3
-      debug: 4.1.1
+      debug: 4.3.1
       fs-extra: 7.0.1
       heroku-client: 3.1.0
       http-call: 5.3.0
@@ -1601,8 +1595,8 @@ packages:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
       '@heroku-cli/schema': 1.0.25
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 5.5.1
       inquirer: 7.3.3
       shell-escape: 0.2.0
@@ -1617,8 +1611,8 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 4.9.3
       date-fns: 2.16.1
     dev: false
@@ -1629,11 +1623,11 @@ packages:
   /@heroku-cli/plugin-autocomplete/7.43.0:
     dependencies:
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       chalk: 2.4.2
       cli-ux: 4.9.3
-      debug: 4.1.1
+      debug: 4.3.1
       fs-extra: 7.0.1
       lodash.flatten: 4.4.0
       tslib: 1.9.3
@@ -1647,7 +1641,7 @@ packages:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
       '@heroku/buildpack-registry': 1.0.1
-      '@oclif/config': 1.13.2
+      '@oclif/config': 1.17.0
       '@oclif/plugin-legacy': 1.1.4
       cli-ux: 4.9.3
       heroku-cli-util: 8.0.12
@@ -1675,8 +1669,8 @@ packages:
   /@heroku-cli/plugin-certs/7.43.0:
     dependencies:
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       tslib: 1.14.1
     dev: false
     engines:
@@ -1708,12 +1702,12 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       ansi-escapes: 3.2.0
       async-file: 2.0.2
       cli-ux: 4.9.3
-      debug: 4.1.1
+      debug: 4.3.1
       fs-extra: 7.0.1
       github-url-to-object: 4.0.4
       got: 9.6.0
@@ -1733,8 +1727,8 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 4.9.3
       edit-string: 1.1.6
       lodash: 4.17.20
@@ -1757,8 +1751,8 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 4.9.3
       debug: 4.1.1
     dev: false
@@ -1769,8 +1763,8 @@ packages:
   /@heroku-cli/plugin-local/7.43.0_debug@4.1.1:
     dependencies:
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       foreman: 3.0.1_debug@4.1.1
       tslib: 1.14.1
     dev: false
@@ -1806,7 +1800,7 @@ packages:
       bytes: 3.1.0
       co: 4.6.0
       co-wait: 0.0.0
-      debug: 4.1.1
+      debug: 4.3.1
       filesize: 4.2.1
       heroku-cli-util: 8.0.12
       lodash: 4.17.20
@@ -1824,8 +1818,8 @@ packages:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
       '@heroku-cli/schema': 1.0.25
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 5.5.1
       got: 9.6.0
       heroku-cli-util: 8.0.12
@@ -1851,8 +1845,8 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 4.9.3
       lodash: 4.17.20
     dev: false
@@ -1887,10 +1881,10 @@ packages:
       '@heroku-cli/command': 8.4.0
       '@heroku-cli/notifications': 1.2.2
       '@heroku/eventsource': 1.0.7
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 5.5.1
-      debug: 4.1.1
+      debug: 4.3.1
       tslib: 1.14.1
     dev: false
     engines:
@@ -1912,9 +1906,9 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
-      '@oclif/errors': 1.2.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
+      '@oclif/errors': 1.3.4
       cli-ux: 4.9.3
       date-fns: 1.30.1
       http-call: 5.3.0
@@ -1927,8 +1921,8 @@ packages:
     dependencies:
       '@heroku-cli/color': 1.1.14
       '@heroku-cli/command': 8.4.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 5.5.1
       tslib: 1.14.1
     dev: false
@@ -2440,12 +2434,12 @@ packages:
       integrity: sha512-KKd3W7eNwfNF061tr663oUNdt8EMnfuyf5Xv55SGWA1a0rjhWqS/32P7OeB7CbXcJUBdfVrPyR//1afaW12AWw==
   /@oclif/command/1.5.18:
     dependencies:
-      '@oclif/config': 1.13.2
-      '@oclif/errors': 1.2.2
+      '@oclif/config': 1.17.0
+      '@oclif/errors': 1.3.4
       '@oclif/parser': 3.8.5
       '@oclif/plugin-help': 2.2.0
-      debug: 4.1.1
-      semver: 5.6.0
+      debug: 4.3.1
+      semver: 5.7.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -2457,17 +2451,32 @@ packages:
       '@oclif/errors': 1.3.4
       '@oclif/parser': 3.8.5
       '@oclif/plugin-help': 3.2.1
-      debug: 4.1.1
+      debug: 4.3.1
       semver: 7.3.4
     dev: false
     engines:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
+  /@oclif/command/1.8.0_supports-color@7.2.0:
+    dependencies:
+      '@oclif/config': 1.17.0_supports-color@7.2.0
+      '@oclif/errors': 1.3.4
+      '@oclif/parser': 3.8.5
+      '@oclif/plugin-help': 3.2.1_supports-color@7.2.0
+      debug: 4.3.1_supports-color@7.2.0
+      semver: 7.3.4
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      supports-color: '*'
+    resolution:
+      integrity: sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
   /@oclif/config/1.13.2:
     dependencies:
       '@oclif/parser': 3.8.5
-      debug: 4.1.1
+      debug: 4.3.1
       tslib: 1.14.1
     dev: false
     engines:
@@ -2478,13 +2487,28 @@ packages:
     dependencies:
       '@oclif/errors': 1.3.4
       '@oclif/parser': 3.8.5
-      debug: 4.1.1
+      debug: 4.3.1
       globby: 11.0.2
       is-wsl: 2.2.0
       tslib: 2.1.0
     dev: false
     engines:
       node: '>=8.0.0'
+    resolution:
+      integrity: sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
+  /@oclif/config/1.17.0_supports-color@7.2.0:
+    dependencies:
+      '@oclif/errors': 1.3.4
+      '@oclif/parser': 3.8.5
+      debug: 4.3.1_supports-color@7.2.0
+      globby: 11.0.2
+      is-wsl: 2.2.0
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      supports-color: '*'
     resolution:
       integrity: sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
   /@oclif/errors/1.2.2:
@@ -2517,7 +2541,7 @@ packages:
       integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
   /@oclif/parser/3.8.5:
     dependencies:
-      '@oclif/errors': 1.2.2
+      '@oclif/errors': 1.3.4
       '@oclif/linewrap': 1.0.0
       chalk: 2.4.2
       tslib: 1.14.1
@@ -2528,8 +2552,8 @@ packages:
       integrity: sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
   /@oclif/plugin-commands/1.3.0:
     dependencies:
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 5.5.1
       lodash: 4.17.20
     dev: false
@@ -2539,7 +2563,7 @@ packages:
       integrity: sha512-Qx9gJ7/aPBgo+Q/DHmGcWyxn2/0bjqmCwt/nO0lWuTZQIH3ZTqclTm68TMZLS4QnQyDGeeYK0GqZ5qJlrXD+SQ==
   /@oclif/plugin-help/2.2.0:
     dependencies:
-      '@oclif/command': 1.5.18
+      '@oclif/command': 1.8.0
       chalk: 2.4.2
       indent-string: 3.2.0
       lodash.template: 4.5.0
@@ -2569,14 +2593,33 @@ packages:
       node: '>=8.0.0'
     resolution:
       integrity: sha512-vq7rn16TrQmjX3Al/k1Z5iBZWZ3HE8fDXs52OmDJmmTqryPSNvURH9WCAsqr0PODYCSR17Hy1VTzS0x7vVVLEQ==
+  /@oclif/plugin-help/3.2.1_supports-color@7.2.0:
+    dependencies:
+      '@oclif/command': 1.8.0_supports-color@7.2.0
+      '@oclif/config': 1.17.0_supports-color@7.2.0
+      '@oclif/errors': 1.3.4
+      chalk: 2.4.2
+      indent-string: 4.0.0
+      lodash.template: 4.5.0
+      string-width: 4.2.0
+      strip-ansi: 6.0.0
+      widest-line: 3.1.0
+      wrap-ansi: 4.0.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    peerDependencies:
+      supports-color: '*'
+    resolution:
+      integrity: sha512-vq7rn16TrQmjX3Al/k1Z5iBZWZ3HE8fDXs52OmDJmmTqryPSNvURH9WCAsqr0PODYCSR17Hy1VTzS0x7vVVLEQ==
   /@oclif/plugin-legacy/1.1.4:
     dependencies:
       '@heroku-cli/command': 8.4.0
       '@oclif/color': 0.0.0
-      '@oclif/command': 1.5.18
+      '@oclif/command': 1.8.0
       ansi-escapes: 3.2.0
-      debug: 4.1.1
-      semver: 5.6.0
+      debug: 4.3.1
+      semver: 5.7.1
       tslib: 1.14.1
     dev: false
     engines:
@@ -2586,7 +2629,7 @@ packages:
   /@oclif/plugin-not-found/1.2.2:
     dependencies:
       '@oclif/color': 0.0.0
-      '@oclif/command': 1.5.18
+      '@oclif/command': 1.8.0
       cli-ux: 4.9.3
       fast-levenshtein: 2.0.6
       lodash: 4.17.20
@@ -2598,15 +2641,15 @@ packages:
   /@oclif/plugin-plugins/1.7.9:
     dependencies:
       '@oclif/color': 0.0.0
-      '@oclif/command': 1.5.18
+      '@oclif/command': 1.8.0
       chalk: 2.4.2
       cli-ux: 5.5.1
-      debug: 4.1.1
+      debug: 4.3.1
       fs-extra: 7.0.1
       http-call: 5.3.0
       load-json-file: 5.3.0
       npm-run-path: 3.1.0
-      semver: 5.6.0
+      semver: 5.7.1
       tslib: 1.14.1
       yarn: 1.22.10
     dev: false
@@ -2617,19 +2660,19 @@ packages:
   /@oclif/plugin-update/1.3.9:
     dependencies:
       '@oclif/color': 0.0.0
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
-      '@oclif/errors': 1.2.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
+      '@oclif/errors': 1.3.4
       '@types/semver': 5.5.0
       cli-ux: 4.9.3
       cross-spawn: 6.0.5
-      debug: 4.1.1
+      debug: 4.3.1
       filesize: 3.6.1
       fs-extra: 7.0.1
       http-call: 5.3.0
       lodash: 4.17.20
       log-chopper: 1.0.2
-      semver: 5.6.0
+      semver: 5.7.1
       tar-fs: 1.16.3
     dev: false
     engines:
@@ -2638,15 +2681,15 @@ packages:
       integrity: sha512-rEMsKT7VlCNnfAF7gxHcY9FtQw+w3ZMvxzoRqafMRCz6+Lt94r3PRulBI4M7IkIQwE+dqW/GPUlkDj86Os9Njg==
   /@oclif/plugin-warn-if-update-available/1.7.0:
     dependencies:
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
-      '@oclif/errors': 1.2.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
+      '@oclif/errors': 1.3.4
       chalk: 2.4.2
-      debug: 4.1.1
+      debug: 4.3.1
       fs-extra: 7.0.1
       http-call: 5.3.0
       lodash.template: 4.5.0
-      semver: 5.6.0
+      semver: 5.7.1
     dev: false
     engines:
       node: '>=8.0.0'
@@ -2654,8 +2697,8 @@ packages:
       integrity: sha512-Nwyz3BJ8RhsfQ+OmFSsJSPIfn5YJqMrCzPh72Zgo2jqIjKIBWD8N9vTTe4kZlpeUUn77SyXFfwlBQbNCL5OEuQ==
   /@oclif/plugin-which/1.0.3:
     dependencies:
-      '@oclif/command': 1.5.18
-      '@oclif/config': 1.13.2
+      '@oclif/command': 1.8.0
+      '@oclif/config': 1.17.0
       cli-ux: 4.9.3
       tslib: 1.14.1
     dev: false
@@ -6131,7 +6174,7 @@ packages:
       integrity: sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
   /cli-ux/4.9.3:
     dependencies:
-      '@oclif/errors': 1.2.2
+      '@oclif/errors': 1.3.4
       '@oclif/linewrap': 1.0.0
       '@oclif/screen': 1.0.4
       ansi-escapes: 3.2.0
@@ -6146,7 +6189,7 @@ packages:
       is-wsl: 1.1.0
       lodash: 4.17.20
       password-prompt: 1.1.2
-      semver: 5.6.0
+      semver: 5.7.1
       strip-ansi: 5.2.0
       supports-color: 5.5.0
       supports-hyperlinks: 1.0.1
@@ -6159,8 +6202,8 @@ packages:
       integrity: sha512-/1owvF0SZ5Gn54cgrikJ0QskgTzeg30HGjkmjFoaHDJzAqFpuX1DBpFR8aLvsE1J5s9MgeYRENQK4BFwOag5VA==
   /cli-ux/5.5.1:
     dependencies:
-      '@oclif/command': 1.8.0
-      '@oclif/errors': 1.2.2
+      '@oclif/command': 1.8.0_supports-color@7.2.0
+      '@oclif/errors': 1.3.4
       '@oclif/linewrap': 1.0.0
       '@oclif/screen': 1.0.4
       ansi-escapes: 4.3.1
@@ -7074,6 +7117,20 @@ packages:
         optional: true
     resolution:
       integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  /debug/4.3.1_supports-color@7.2.0:
+    dependencies:
+      ms: 2.1.2
+      supports-color: 7.2.0
+    dev: false
+    engines:
+      node: '>=6.0'
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    resolution:
+      integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   /decamelize-keys/1.1.0:
     dependencies:
       decamelize: 1.2.0
@@ -7484,7 +7541,7 @@ packages:
     dependencies:
       domelementtype: 2.1.0
       domhandler: 4.0.0
-      entities: 2.1.0
+      entities: 2.2.0
     dev: false
     resolution:
       integrity: sha512-n6kZFH/KlCrqs/1GHMOd5i2fd/beQHuehKdWvNNffbGHTr/almdhuVvTVFb3V7fglz+nC50fFusu3lY33h12pA==
@@ -8935,6 +8992,19 @@ packages:
         optional: true
     resolution:
       integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
+  /follow-redirects/1.13.2_debug@4.3.1:
+    dependencies:
+      debug: 4.3.1_supports-color@6.1.0
+    dev: false
+    engines:
+      node: '>=4.0'
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    resolution:
+      integrity: sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==
   /for-each/0.3.3:
     dependencies:
       is-callable: 1.2.3
@@ -10096,7 +10166,7 @@ packages:
       domelementtype: 2.1.0
       domhandler: 4.0.0
       domutils: 2.4.4
-      entities: 2.1.0
+      entities: 2.2.0
     dev: false
     resolution:
       integrity: sha512-numTQtDZMoh78zJpaNdJ9MXb2cv5G3jwUoe3dMQODubZvLoGvTE/Ofp6sHvH8OGKcN/8A47pGLi/k58xHP/Tfw==
@@ -10111,7 +10181,7 @@ packages:
   /http-call/5.3.0:
     dependencies:
       content-type: 1.0.4
-      debug: 4.1.1
+      debug: 4.3.1
       is-retry-allowed: 1.2.0
       is-stream: 2.0.0
       parse-json: 4.0.0
@@ -10192,7 +10262,7 @@ packages:
   /http-proxy/1.18.1_debug@4.3.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.13.2
+      follow-redirects: 1.13.2_debug@4.3.1
       requires-port: 1.0.0
     dev: false
     engines:
@@ -13434,7 +13504,7 @@ packages:
     dependencies:
       growly: 1.3.0
       is-wsl: 1.1.0
-      semver: 5.6.0
+      semver: 5.7.1
       shellwords: 0.1.1
       which: 1.3.1
     dev: false
@@ -17211,7 +17281,7 @@ packages:
   /ssh2-streams/0.1.20:
     dependencies:
       asn1: 0.2.4
-      semver: 5.6.0
+      semver: 5.7.1
       streamsearch: 0.1.2
     dev: false
     engines:
@@ -17221,7 +17291,7 @@ packages:
   /ssh2-streams/0.2.1:
     dependencies:
       asn1: 0.2.4
-      semver: 5.6.0
+      semver: 5.7.1
       streamsearch: 0.1.2
     dev: false
     engines:
@@ -17667,9 +17737,8 @@ packages:
     dev: false
     resolution:
       integrity: sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=
-  /styled-jsx/3.4.1_react@16.14.0:
+  /styled-jsx/3.2.5_react@16.14.0:
     dependencies:
-      '@babel/helper-module-imports': 7.12.5
       '@babel/types': 7.8.3
       babel-plugin-syntax-jsx: 6.18.0
       convert-source-map: 1.7.0
@@ -17681,9 +17750,9 @@ packages:
       stylis-rule-sheet: 0.0.10_stylis@3.5.4
     dev: false
     peerDependencies:
-      react: 15.x.x || 16.x.x || 17.x.x
+      react: 15.x.x || 16.x.x
     resolution:
-      integrity: sha512-Jl1pcQVTnHdsfePHxZ0GgxxgU3+KgiDKj9QTp2vZ0eifg2cgNV5RFdgfxcXvJyspsynUhF32opNZ4jmM1EIROA==
+      integrity: sha512-prEahkYwQHomUljJzXzrFnBmQrSMtWOBbXn8QeEkpfFkqMZQGshxzzp4H8ebBIsbVlHF/3+GSXMnmK/fp7qVYQ==
   /stylelint-checkstyle-formatter/0.1.2:
     dependencies:
       lodash: 4.17.20
@@ -19651,7 +19720,7 @@ packages:
       integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   /wide-align/1.1.3:
     dependencies:
-      string-width: 1.0.2
+      string-width: 2.1.1
     dev: false
     resolution:
       integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
@@ -20014,7 +20083,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-JDMTs7IOMSBJiUHvoo6+sSvCk8h0h2MOpHRLj/AvP5bHJrXmSPnWuJbkWesbIAbFm1EABQ1eTukQeeJ18p3BiA==
+      integrity: sha512-D6IbJN+FVRjdxGqZ5ojwXs/aK3ImfRCx3SqCoovMQnNQ/AfC7vpkwO9r+feGLAgijRoLyEK7wBMOs2ZnqQuLgQ==
       tarball: 'file:projects/api-client-bear.tgz'
     version: 0.0.0
   'file:projects/api-client-tiger.tgz_ts-node@8.10.2':
@@ -20625,7 +20694,7 @@ packages:
       source-map-loader: 1.1.3_webpack@4.46.0
       stats-webpack-plugin: 0.7.0_webpack@4.46.0
       style-loader: 1.3.0_webpack@4.46.0
-      styled-jsx: 3.4.1_react@16.14.0
+      styled-jsx: 3.2.5_react@16.14.0
       supertest: 4.0.2
       testcafe: 1.10.1
       ts-invariant: 0.6.0
@@ -20641,7 +20710,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-zZYwdhyRfuvqLuxaS7uOFEUMZS2uRjBIirXsZ/heCh9bynwmYttdQO8CKOSSnZy69pIc7vpTaK65tux5xljr9w==
+      integrity: sha512-imbTY5lgFsQ/BFnGlylHfKrq4lQlnJPOiiJ+O9xVLTXgcyZhdZhEeqsnw9qdCMssXYG+mMkBCa7KmNUKet88gA==
       tarball: 'file:projects/sdk-examples.tgz'
     version: 0.0.0
   'file:projects/sdk-model.tgz_ts-node@8.10.2':
@@ -21483,6 +21552,7 @@ packages:
       integrity: sha512-nvCV4VQ2N9w3oq2t5D7fDG1Rlu72aaxhdpsEw8vrLEeWPr3A83uX0TWBgkQsf31UtGPK6aK1mJKCQHXDgNwVhw==
       tarball: 'file:projects/util.tgz'
     version: 0.0.0
+registry: ''
 specifiers:
   '@gooddata/frontend-npm-scripts': 1.2.0
   '@microsoft/api-documenter': ^7.3.16

--- a/examples/sdk-examples/package.json
+++ b/examples/sdk-examples/package.json
@@ -73,7 +73,7 @@
         "source-map-loader": "^1.1.1",
         "stats-webpack-plugin": "^0.7.0",
         "style-loader": "^1.2.1",
-        "styled-jsx": "^3.2.5",
+        "styled-jsx": "~3.2.5",
         "supertest": "^4.0.2",
         "testcafe": "^1.8.4",
         "typescript": "4.0.2",


### PR DESCRIPTION
-  Some bad interplay between styled-jsx & babel,
-  Errors appear. Similar to this: https://github.com/vercel/styled-jsx/issues/560
-  Not critical to be on latest version so downgrading

JIRA: RAIL-2905

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
