### PR TITLE
Make widget rendering customization more convenient

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardEmbedding/CustomDashboardView.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/CustomDashboardView.tsx
@@ -1,0 +1,254 @@
+// (C) 2007-2018 GoodData Corporation
+import React from "react";
+import { FilterContextItem, isKpiWidget } from "@gooddata/sdk-backend-spi";
+import { DashboardView, useDashboardWidgetExecution } from "@gooddata/sdk-ui-ext/esm/internal";
+import { idRef, newPositiveAttributeFilter, ObjRef } from "@gooddata/sdk-model";
+import { useDataView, IErrorProps, ILoadingProps } from "@gooddata/sdk-ui";
+import { MAPBOX_TOKEN } from "../../constants/fixtures";
+import { Ldm } from "../../ldm";
+
+const dashboardRef = idRef("aeO5PVgShc0T");
+const config = { mapboxToken: MAPBOX_TOKEN };
+interface CustomWidgetProps {
+    widgetRef: ObjRef;
+    filters?: FilterContextItem[];
+    ErrorComponent: React.ComponentType<IErrorProps>;
+    LoadingComponent: React.ComponentType<ILoadingProps>;
+}
+
+const customWidgetContainerStyle: React.CSSProperties = {
+    padding: 5,
+    height: "100%",
+    width: "100%",
+};
+
+const CustomWidgetContainer: React.FC = ({ children }) => (
+    <div style={customWidgetContainerStyle}>{children}</div>
+);
+
+const customTableHeaderStyle: React.CSSProperties = {
+    textAlign: "center",
+};
+const customTableThStyle: React.CSSProperties = {
+    textAlign: "left",
+    padding: "10px 20px",
+};
+const customTableTdStyle: React.CSSProperties = {
+    padding: "10px 20px",
+};
+const CustomTable: React.FC<CustomWidgetProps & { title: string }> = ({
+    title: widgetTitle,
+    widgetRef,
+    filters,
+    ErrorComponent,
+    LoadingComponent,
+}) => {
+    const { result: execution, status: executionStatus, error: executionError } = useDashboardWidgetExecution(
+        {
+            dashboard: dashboardRef,
+            widget: widgetRef,
+            filters,
+        },
+    );
+    const { result: dataView, status: dataViewStatus, error: dataViewError } = useDataView({ execution }, [
+        execution?.fingerprint(),
+    ]);
+
+    const error = executionError ?? dataViewError;
+    const statuses = [executionStatus, dataViewStatus];
+
+    if (error) {
+        return <ErrorComponent message={error.message} />;
+    }
+    if (statuses.some((status) => status === "loading")) {
+        return <LoadingComponent />;
+    }
+
+    const measureDescriptors = dataView?.meta().measureDescriptors();
+    const attributeDescriptors = dataView?.meta().attributeDescriptors();
+
+    const slices = dataView?.data().slices().toArray();
+
+    return (
+        <CustomWidgetContainer>
+            <h2 style={customTableHeaderStyle}>{widgetTitle}</h2>
+            <table style={{ width: "100%" }}>
+                <thead>
+                    <tr>
+                        {attributeDescriptors?.map((attrDesc) => (
+                            <th key={attrDesc.attributeHeader.localIdentifier} style={customTableThStyle}>
+                                {attrDesc.attributeHeader.name}
+                            </th>
+                        ))}
+                        {measureDescriptors?.map((measureDesc) => (
+                            <th
+                                key={measureDesc.measureHeaderItem.localIdentifier}
+                                style={customTableThStyle}
+                            >
+                                {measureDesc.measureHeaderItem.name}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {slices?.map((slice) => (
+                        <tr key={slice.id}>
+                            {slice.sliceTitles().map((title, i) => (
+                                <td key={i} style={customTableTdStyle}>
+                                    {title}
+                                </td>
+                            ))}
+                            {slice.dataPoints().map((dataPoint, i) => (
+                                <td key={i} style={customTableTdStyle}>
+                                    {dataPoint.formattedValue()}
+                                </td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </CustomWidgetContainer>
+    );
+};
+
+const customKpiContainerStyle: React.CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "space-between",
+    height: "100%",
+    fontSize: 17,
+    textAlign: "center",
+    borderRadius: 15,
+    overflow: "hidden",
+    backgroundColor: "black",
+    color: "white",
+    width: "100%",
+};
+const customKpiHeaderStyle: React.CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "20px 10px",
+    width: "100%",
+};
+const customKpiHeaderTextStyle: React.CSSProperties = {
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+};
+const customKpiValueStyle: React.CSSProperties = {
+    fontSize: 24,
+    fontWeight: "bold",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    height: "100%",
+    width: "100%",
+    backgroundColor: "#333",
+};
+
+const CustomKpi: React.FC<CustomWidgetProps> = ({ widgetRef, filters, ErrorComponent, LoadingComponent }) => {
+    const { result: execution, status: executionStatus, error: executionError } = useDashboardWidgetExecution(
+        {
+            dashboard: dashboardRef,
+            widget: widgetRef,
+            filters,
+        },
+    );
+    const { result: dataView, status: dataViewStatus, error: dataViewError } = useDataView({ execution }, [
+        execution?.fingerprint(),
+    ]);
+
+    const error = executionError ?? dataViewError;
+    const statuses = [executionStatus, dataViewStatus];
+    const isLoading = statuses.some((s) => s === "loading");
+
+    if (error) {
+        return <ErrorComponent message={error.message} />;
+    }
+    if (isLoading) {
+        return <LoadingComponent />;
+    }
+
+    const kpiMeasure = dataView?.meta().measureDescriptors()[0];
+
+    return (
+        <CustomWidgetContainer>
+            <div style={customKpiContainerStyle}>
+                <div style={customKpiHeaderStyle}>
+                    <div style={customKpiHeaderTextStyle}>
+                        {kpiMeasure &&
+                            dataView &&
+                            dataView
+                                ?.data()
+                                .series()
+                                .firstForMeasure(kpiMeasure.measureHeaderItem.localIdentifier)
+                                .measureTitle()}
+                    </div>
+                </div>
+                <div style={customKpiValueStyle}>
+                    {kpiMeasure &&
+                        dataView &&
+                        dataView
+                            .data()
+                            .series()
+                            .firstForMeasure(kpiMeasure.measureHeaderItem.localIdentifier)
+                            .dataPoints()[0]
+                            .formattedValue()}
+                </div>
+            </div>
+        </CustomWidgetContainer>
+    );
+};
+
+const dashboardFilters = [
+    newPositiveAttributeFilter(Ldm.LocationState, {
+        uris: ["/gdc/md/xms7ga4tf3g3nzucd8380o2bev8oeknp/obj/2210/elements?id=6340116"],
+    }),
+];
+const CustomDashboardView: React.FC = () => {
+    return (
+        <DashboardView
+            dashboard={dashboardRef}
+            config={config}
+            filters={dashboardFilters}
+            widgetRenderer={({
+                renderedWidget,
+                predicates,
+                widget,
+                filters,
+                ErrorComponent,
+                LoadingComponent,
+            }) => {
+                if (isKpiWidget(widget)) {
+                    // Render all Kpi components with custom kpi component
+                    return (
+                        <CustomKpi
+                            filters={filters}
+                            widgetRef={widget.ref}
+                            ErrorComponent={ErrorComponent}
+                            LoadingComponent={LoadingComponent}
+                        />
+                    );
+                } else if (predicates.isWidgetWithInsightType("table")) {
+                    // Render all "table" insights with custom table component
+                    return (
+                        <CustomTable
+                            title={widget.title}
+                            widgetRef={widget.ref}
+                            filters={filters}
+                            ErrorComponent={ErrorComponent}
+                            LoadingComponent={LoadingComponent}
+                        />
+                    );
+                }
+
+                // Render all other widgets in a common way, just wrap them with some component
+                return <CustomWidgetContainer>{renderedWidget}</CustomWidgetContainer>;
+            }}
+        />
+    );
+};
+
+export default CustomDashboardView;

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/index.tsx
@@ -24,6 +24,10 @@ import DashboardViewWithEmails from "./DashboardViewWithEmails";
 import DashboardViewWithEmailsSRC from "!raw-loader!./DashboardViewWithEmails";
 import DashboardViewWithEmailsSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/DashboardViewWithEmails";
 
+import CustomDashboardView from "./CustomDashboardView";
+import CustomDashboardViewSRC from "!raw-loader!./CustomDashboardView";
+import CustomDashboardViewSRCJS from "!raw-loader!../../../examplesJS/dashboardEmbedding/CustomDashboardView";
+
 export const DashboardView = (): JSX.Element => (
     <div>
         <h1>DashboardView</h1>
@@ -90,6 +94,16 @@ export const DashboardView = (): JSX.Element => (
             for={DashboardViewWithEmails}
             source={DashboardViewWithEmailsSRC}
             sourceJS={DashboardViewWithEmailsSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <p>Example of how to customize rendering of the dashboard widgets.</p>
+
+        <ExampleWithSource
+            for={CustomDashboardView}
+            source={CustomDashboardViewSRC}
+            sourceJS={CustomDashboardViewSRCJS}
         />
     </div>
 );

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
@@ -1,18 +1,56 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import cx from "classnames";
-import { areObjRefsEqual } from "@gooddata/sdk-model";
-import { isWidget, isDashboardLayoutContent, UnexpectedError } from "@gooddata/sdk-backend-spi";
+import { IInsight, ObjRef } from "@gooddata/sdk-model";
+import {
+    isWidget,
+    isDashboardLayoutContent,
+    UnexpectedError,
+    IWidgetAlert,
+    IAnalyticalBackend,
+    IFilterContext,
+    ITempFilterContext,
+    ResponsiveScreenType,
+    IWidget,
+    FilterContextItem,
+} from "@gooddata/sdk-backend-spi";
+import {
+    IDrillableItem,
+    IHeaderPredicate,
+    OnFiredDrillEvent,
+    IErrorProps,
+    ILoadingProps,
+    OnError,
+} from "@gooddata/sdk-ui";
 import { KpiView } from "./KpiView";
 import { InsightRenderer } from "./InsightRenderer";
 import { DashboardItemHeadline } from "../DashboardItem/DashboardItemHeadline";
 import { DashboardItemVisualization } from "../DashboardItem/DashboardItemVisualization";
 import { DashboardItem } from "../DashboardItem/DashboardItem";
 import { getVisTypeCssClass } from "./utils";
-import { IDashboardWidgetRenderProps } from "./types";
-import { useAlerts } from "./DashboardAlertsContext";
+import { DashboardViewLayoutWidgetClass } from "../DashboardLayout";
+import { IDashboardFilter } from "../types";
 
-export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (props) => {
+export type IDashboardWidgetRendererProps = {
+    backend?: IAnalyticalBackend;
+    workspace?: string;
+    filters?: FilterContextItem[];
+    filterContext: IFilterContext | ITempFilterContext;
+    drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
+    onDrill?: OnFiredDrillEvent;
+    ErrorComponent: React.ComponentType<IErrorProps>;
+    LoadingComponent: React.ComponentType<ILoadingProps>;
+    onError?: OnError;
+    widgetClass?: DashboardViewLayoutWidgetClass;
+    insight?: IInsight;
+    widget?: IWidget;
+    screen: ResponsiveScreenType;
+    dashboardRef: ObjRef;
+    alert?: IWidgetAlert;
+    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+};
+
+export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRendererProps> = (props) => {
     const {
         ErrorComponent,
         LoadingComponent,
@@ -24,10 +62,11 @@ export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (p
         onDrill,
         onError,
         workspace,
-        screen,
         widgetClass,
         insight,
+        screen,
         widget,
+        alert,
         dashboardRef,
     } = props;
 
@@ -36,7 +75,6 @@ export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (p
             "Cannot render custom widget with DefaultWidgetRenderer! Please handle custom widget rendering in your widgetRenderer.",
         );
     }
-    const { alerts } = useAlerts();
 
     if (isWidget(widget)) {
         if (widget.type === "insight") {
@@ -72,15 +110,13 @@ export const DashboardWidgetRenderer: React.FC<IDashboardWidgetRenderProps> = (p
             );
         }
 
-        const relevantAlert = alerts?.find((alert) => areObjRefsEqual(alert.widget, widget.ref));
-
         return (
             <DashboardItem className="type-kpi" screen={screen}>
                 <KpiView
                     dashboardRef={dashboardRef}
                     kpiWidget={widget}
                     filterContext={filterContext}
-                    alert={relevantAlert}
+                    alert={alert}
                     backend={backend}
                     workspace={workspace}
                     filters={filters}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardInsightExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardInsightExecution.ts
@@ -1,0 +1,87 @@
+// (C) 2020-2021 GoodData Corporation
+import {
+    IAnalyticalBackend,
+    IPreparedExecution,
+    IInsightWidget,
+    IFilterContext,
+    ITempFilterContext,
+    FilterContextItem,
+} from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useBackend,
+    UseCancelablePromiseCallbacks,
+    useWorkspace,
+    OnError,
+    UseCancelablePromiseState,
+    useCancelablePromise,
+} from "@gooddata/sdk-ui";
+import { IInsight } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+import { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "../converters";
+import { IDashboardFilter } from "../types";
+
+/**
+ * @beta
+ */
+export interface IUseInsightExecutionConfig
+    extends UseCancelablePromiseCallbacks<IPreparedExecution | undefined, GoodDataSdkError> {
+    insightWidget?: IInsightWidget;
+    insight?: IInsight;
+    filters?: FilterContextItem[];
+    filterContext?: IFilterContext | ITempFilterContext;
+    backend?: IAnalyticalBackend;
+    workspace?: string;
+    onError?: OnError;
+}
+
+/**
+ * Hook allowing to get execution for particular insight widget.
+ * @param config - configuration of the hook
+ * @beta
+ */
+export function useInsightExecution(
+    config: IUseInsightExecutionConfig,
+): UseCancelablePromiseState<IPreparedExecution, GoodDataSdkError> {
+    const { backend, workspace, insightWidget, insight, filters, filterContext } = config;
+    const effectiveBackend = useBackend(backend);
+    const effectiveWorkspace = useWorkspace(workspace);
+
+    invariant(
+        effectiveBackend,
+        "The backend in useInsightExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useInsightExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const promise =
+        insight && insightWidget
+            ? async () => {
+                  const inputFilters = filters
+                      ? filterContextItemsToFiltersForWidget(filters, insightWidget)
+                      : filterContextToFiltersForWidget(filterContext, insightWidget);
+
+                  const relevantFilters = (await effectiveBackend
+                      .workspace(effectiveWorkspace)
+                      .dashboards()
+                      .getResolvedFiltersForWidget(insightWidget, inputFilters)) as IDashboardFilter[]; // all the inputs are IDashboardFilter, so the result must be too
+
+                  return effectiveBackend
+                      .workspace(effectiveWorkspace)
+                      .execution()
+                      .forInsight(insight, relevantFilters);
+              }
+            : null;
+
+    return useCancelablePromise({ promise }, [
+        effectiveBackend,
+        effectiveWorkspace,
+        insight,
+        insightWidget,
+        filters,
+        filterContext,
+    ]);
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardKpiExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardKpiExecution.ts
@@ -1,0 +1,82 @@
+// (C) 2020-2021 GoodData Corporation
+import {
+    IAnalyticalBackend,
+    IPreparedExecution,
+    IKpiWidget,
+    IFilterContext,
+    ITempFilterContext,
+    UnexpectedError,
+    FilterContextItem,
+} from "@gooddata/sdk-backend-spi";
+import {
+    GoodDataSdkError,
+    useBackend,
+    UseCancelablePromiseCallbacks,
+    useWorkspace,
+    OnError,
+    useExecution,
+    UseCancelablePromiseState,
+} from "@gooddata/sdk-ui";
+import invariant from "ts-invariant";
+import compact from "lodash/compact";
+import { useKpiData } from "../DashboardView/KpiView/utils";
+
+/**
+ * @beta
+ */
+export interface IUseKpiExecutionConfig
+    extends UseCancelablePromiseCallbacks<IPreparedExecution | undefined, GoodDataSdkError> {
+    kpiWidget?: IKpiWidget;
+    filters?: FilterContextItem[];
+    filterContext?: IFilterContext | ITempFilterContext;
+    backend?: IAnalyticalBackend;
+    workspace?: string;
+    onError?: OnError;
+}
+
+/**
+ * Hook allowing to get execution for particular kpi widget.
+ * @param config - configuration of the hook
+ * @beta
+ */
+export function useKpiExecution(
+    config: IUseKpiExecutionConfig,
+): UseCancelablePromiseState<IPreparedExecution, GoodDataSdkError> {
+    const { backend, workspace } = config;
+    const effectiveBackend = useBackend(backend);
+    const effectiveWorkspace = useWorkspace(workspace);
+
+    invariant(
+        effectiveBackend,
+        "The backend in useKpiExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useKpiExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const { result, status, error } = useKpiData(config);
+    const execution = useExecution({
+        seriesBy: compact([result?.primaryMeasure, result?.secondaryMeasure]),
+        filters: result?.filters,
+        backend: effectiveBackend,
+        workspace: effectiveWorkspace,
+    });
+
+    switch (status) {
+        case "pending":
+        case "loading": {
+            return { status, result: undefined, error: undefined };
+        }
+        case "error":
+            return { status, result: undefined, error };
+        case "success": {
+            return { status, result: execution, error: undefined };
+        }
+        default: {
+            const unhandledStatus: never = status;
+            throw new UnexpectedError(`Unhandled status: ${unhandledStatus}`);
+        }
+    }
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardWidgetExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardWidgetExecution.ts
@@ -1,0 +1,162 @@
+// (C) 2020-2021 GoodData Corporation
+import {
+    IAnalyticalBackend,
+    IPreparedExecution,
+    isWidget,
+    widgetId,
+    widgetUri,
+    layoutWidgets,
+    FilterContextItem,
+} from "@gooddata/sdk-backend-spi";
+import {
+    useBackend,
+    useWorkspace,
+    GoodDataSdkError,
+    UseCancelablePromiseState,
+    UnexpectedSdkError,
+} from "@gooddata/sdk-ui";
+import { ObjRef, areObjRefsEqual, objRefToString } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+import { useDashboard } from "./useDashboard";
+import { useKpiExecution } from "./useDashboardKpiExecution";
+import { useInsightExecution } from "./useDashboardInsightExecution";
+import { useDashboardViewLayout } from "./useDashboardViewLayout";
+
+/**
+ * @alpha
+ */
+export interface IUseDashboardWidgetExecutionConfig {
+    /**
+     * Reference to the dashboard that contains target widget.
+     */
+    dashboard: ObjRef;
+
+    /**
+     * Reference to the widget to get.
+     */
+    widget: ObjRef;
+
+    /**
+     * Optionally specify filters to merge into the execution.
+     */
+    filters?: FilterContextItem[];
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the hook MUST be called within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where the insight exists.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the hook MUST be called within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * Hook allowing to get execution for particular dashboard widget.
+ * @param config - configuration of the hook
+ * @beta
+ */
+export function useDashboardWidgetExecution({
+    dashboard,
+    widget: widgetRef,
+    filters,
+    backend,
+    workspace,
+}: IUseDashboardWidgetExecutionConfig): UseCancelablePromiseState<IPreparedExecution, GoodDataSdkError> {
+    const effectiveBackend = useBackend(backend);
+    const effectiveWorkspace = useWorkspace(workspace);
+
+    invariant(
+        effectiveBackend,
+        "The backend in useWidgetExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
+    );
+
+    invariant(
+        effectiveWorkspace,
+        "The workspace in useWidgetExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
+    );
+
+    const { result: dashboardResult, status: dashboardStatus, error: dashboardError } = useDashboard({
+        dashboard,
+        backend: effectiveBackend,
+        workspace: effectiveWorkspace,
+    });
+    const {
+        result: dashboardViewLayoutResult,
+        status: dashboardViewLayoutStatus,
+        error: dashboardViewLayoutError,
+    } = useDashboardViewLayout({
+        dashboardLayout: dashboardResult?.layout,
+        backend: effectiveBackend,
+        workspace: effectiveWorkspace,
+    });
+
+    const widget =
+        dashboardResult?.layout &&
+        layoutWidgets(dashboardResult.layout)
+            .filter(isWidget)
+            .find((w) => {
+                return areObjRefsEqual(widgetRef, {
+                    uri: widgetUri(w),
+                    identifier: widgetId(w),
+                });
+            });
+
+    if (dashboardResult?.layout && !widget) {
+        throw new UnexpectedSdkError(
+            `Widget with ObjRef ${objRefToString(widget)} not found on the referenced dashboard.`,
+        );
+    }
+
+    const kpiWidget = widget?.type === "kpi" ? widget : undefined;
+    const insightWidget = widget?.type === "insight" ? widget : undefined;
+
+    const kpiExecution = useKpiExecution({
+        kpiWidget,
+        filterContext: dashboardResult?.filterContext,
+        filters,
+        backend: effectiveBackend,
+        workspace: effectiveWorkspace,
+    });
+
+    const insightExecution = useInsightExecution({
+        insightWidget,
+        insight: dashboardViewLayoutResult?.getInsightByRef(insightWidget?.insight),
+        filters,
+        filterContext: dashboardResult?.filterContext,
+        backend: effectiveBackend,
+        workspace: effectiveWorkspace,
+    });
+
+    const { result: executionResult, status: executionStatus, error: executionError } =
+        widget?.type === "kpi" ? kpiExecution : insightExecution;
+
+    const statuses = [dashboardStatus, dashboardViewLayoutStatus, executionStatus];
+    const error = dashboardError ?? dashboardViewLayoutError ?? executionError;
+
+    if (error) {
+        return {
+            error,
+            result: undefined,
+            status: "error",
+        };
+    } else if (statuses.some((s) => s === "loading")) {
+        return {
+            error: undefined,
+            result: undefined,
+            status: "loading",
+        };
+    }
+    return {
+        error: undefined,
+        result: executionResult,
+        status: "success",
+    };
+}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./DashboardView";
 export { mergeFiltersWithDashboard } from "./mergeFiltersWithDashboard";
 export { isDateFilterIrrelevant } from "./utils/filters";
+export { useDashboardWidgetExecution } from "./hooks/useDashboardWidgetExecution";
 
 // TODO: RAIL-2869 Migrate to Responsive context
 export {

--- a/libs/sdk-ui/src/execution/index.ts
+++ b/libs/sdk-ui/src/execution/index.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 
 export { withExecution, IWithExecution } from "./withExecution";
 export {
@@ -12,4 +12,4 @@ export { RawExecute, IRawExecuteProps } from "./RawExecute";
 export { Execute, IExecuteProps } from "./Execute";
 export { useDataExport } from "./useDataExport";
 export { useDataView } from "./useDataView";
-export { useExecution } from "./useExecution";
+export { useExecution, IUseExecutionConfig } from "./useExecution";

--- a/libs/sdk-ui/src/execution/useExecution.ts
+++ b/libs/sdk-ui/src/execution/useExecution.ts
@@ -1,16 +1,10 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { IAttributeOrMeasure, IAttribute, ITotal, INullableFilter, ISortItem } from "@gooddata/sdk-model";
 import { useBackend, useWorkspace } from "../base";
 import { createExecution } from "./createExecution";
 
-/**
- * This hook provides a simplified interface for creating executions.
- * It builds the execution on top of the backend passed to the BackendProvider, and workspace passed to the WorkspaceProvider.
- *
- * @beta
- */
-export function useExecution(options: {
+export interface IUseExecutionConfig {
     /**
      * Data series will be built using the provided measures that are optionally further scoped for
      * elements of the specified attributes.
@@ -61,12 +55,20 @@ export function useExecution(options: {
      * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
      */
     workspace?: string;
-}): IPreparedExecution {
-    const backend = useBackend(options.backend);
-    const workspace = useWorkspace(options.workspace);
+}
+
+/**
+ * This hook provides a simplified interface for creating executions.
+ * It builds the execution on top of the backend passed to the BackendProvider, and workspace passed to the WorkspaceProvider.
+ *
+ * @beta
+ */
+export function useExecution(config: IUseExecutionConfig): IPreparedExecution {
+    const backend = useBackend(config.backend);
+    const workspace = useWorkspace(config.workspace);
 
     const execution = createExecution({
-        ...options,
+        ...config,
         backend,
         workspace,
     });


### PR DESCRIPTION
- Introduce useDashboardWidgetExecution hook, to get same execution definition as the widget on the dashboard
- Add predicates to test widgets for common conditions
- Improve IDashboardWidgetRenderer interface, make it more limited, but still flexible
- Hide sizing logic and other sizing implementation details from the widget (sizing should be solved on the layout level until we support custom widget heights)
- Minor fixes
- Add custom widget rendering example

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
