### PR TITLE
Tiger: Update OAPI and fix granularities

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -412,13 +412,17 @@ export enum DeclarativeDateDatasetGranularitiesEnum {
     // (undocumented)
     DAY = "DAY",
     // (undocumented)
+    DAYOFEUWEEK = "DAY_OF_EUWEEK",
+    // (undocumented)
     DAYOFMONTH = "DAY_OF_MONTH",
     // (undocumented)
     DAYOFWEEK = "DAY_OF_WEEK",
     // (undocumented)
-    DAYOFWEEKEU = "DAY_OF_WEEK_EU",
-    // (undocumented)
     DAYOFYEAR = "DAY_OF_YEAR",
+    // (undocumented)
+    EUWEEK = "EUWEEK",
+    // (undocumented)
+    EUWEEKOFYEAR = "EUWEEK_OF_YEAR",
     // (undocumented)
     HOUR = "HOUR",
     // (undocumented)
@@ -438,11 +442,7 @@ export enum DeclarativeDateDatasetGranularitiesEnum {
     // (undocumented)
     WEEK = "WEEK",
     // (undocumented)
-    WEEKEU = "WEEK_EU",
-    // (undocumented)
     WEEKOFYEAR = "WEEK_OF_YEAR",
-    // (undocumented)
-    WEEKOFYEAREU = "WEEK_OF_YEAR_EU",
     // (undocumented)
     YEAR = "YEAR"
 }
@@ -984,7 +984,7 @@ export interface ITigerClient {
     // (undocumented)
     validObjects: ReturnType<typeof tigerValidObjectsClientFactory>;
     // (undocumented)
-    workspaceModel: ReturnType<typeof tigerWorkspaceModelClientFactory>;
+    workspaceObjects: ReturnType<typeof tigerWorkspaceObjectsClientFactory>;
 }
 
 // @public (undocumented)
@@ -4089,7 +4089,7 @@ export const tigerOrganizationObjectsClientFactory: (axios: AxiosInstance) => Or
 export const tigerValidObjectsClientFactory: (axios: AxiosInstance) => ValidObjectsControllerApiInterface;
 
 // @public (undocumented)
-export const tigerWorkspaceModelClientFactory: (axios: AxiosInstance) => WorkspaceModelControllerApiInterface;
+export const tigerWorkspaceObjectsClientFactory: (axios: AxiosInstance) => WorkspaceObjectControllerApiInterface;
 
 // @public
 export class UserModelControllerApi extends MetadataBaseApi implements UserModelControllerApiInterface {
@@ -4388,1473 +4388,9 @@ export enum WorkspaceIdentifierTypeEnum {
 }
 
 // @public
-export class WorkspaceModelControllerApi extends MetadataBaseApi implements WorkspaceModelControllerApiInterface {
-    // (undocumented)
-    createEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityFilterContexts(params: {
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    createEntityMetrics(params: {
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    createEntityVisualizationObjects(params: {
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    getEntitiesAnalyticalDashboards(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
-    // (undocumented)
-    getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDatasets(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
-    // (undocumented)
-    getEntitiesFacts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
-    // (undocumented)
-    getEntitiesFilterContexts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
-    // (undocumented)
-    getEntitiesLabels(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
-    // (undocumented)
-    getEntitiesMetrics(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
-    // (undocumented)
-    getEntitiesSources(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
-    // (undocumented)
-    getEntitiesTables(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
-    // (undocumented)
-    getEntitiesVisualizationObjects(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
-    // (undocumented)
-    getEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    getEntityAttributes(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDatasets(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
-    // (undocumented)
-    getEntityFacts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
-    // (undocumented)
-    getEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    getEntityLabels(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
-    // (undocumented)
-    getEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    getEntitySources(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
-    // (undocumented)
-    getEntityTables(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
-    // (undocumented)
-    getEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    // (undocumented)
-    updateEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    updateEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    updateEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-}
-
-// @public
-export const WorkspaceModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
-    createEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    createEntityFilterContexts(params: {
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    createEntityMetrics(params: {
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    createEntityVisualizationObjects(params: {
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesAnalyticalDashboards(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesDatasets(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesFacts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesFilterContexts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesLabels(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesMetrics(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesSources(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesTables(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesVisualizationObjects(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityAttributes(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityDatasets(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityFacts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityLabels(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitySources(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityTables(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-};
-
-// @public
-export const WorkspaceModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
-    createEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityFilterContexts(params: {
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    createEntityMetrics(params: {
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    createEntityVisualizationObjects(params: {
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    deleteEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    deleteEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    deleteEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    getEntitiesAnalyticalDashboards(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
-    getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDatasets(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
-    getEntitiesFacts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
-    getEntitiesFilterContexts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
-    getEntitiesLabels(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
-    getEntitiesMetrics(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
-    getEntitiesSources(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
-    getEntitiesTables(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
-    getEntitiesVisualizationObjects(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
-    getEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    getEntityAttributes(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDatasets(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
-    getEntityFacts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
-    getEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    getEntityLabels(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
-    getEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    getEntitySources(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
-    getEntityTables(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
-    getEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    updateEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    updateEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    updateEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-};
-
-// @public
-export const WorkspaceModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
-    createEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityFilterContexts(params: {
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    createEntityMetrics(params: {
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    createEntityVisualizationObjects(params: {
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    getEntitiesAnalyticalDashboards(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardList>;
-    getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDatasets(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetList>;
-    getEntitiesFacts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactList>;
-    getEntitiesFilterContexts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextList>;
-    getEntitiesLabels(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelList>;
-    getEntitiesMetrics(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricList>;
-    getEntitiesSources(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesList>;
-    getEntitiesTables(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableList>;
-    getEntitiesVisualizationObjects(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectList>;
-    getEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    getEntityAttributes(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDatasets(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetDocument>;
-    getEntityFacts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactDocument>;
-    getEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    getEntityLabels(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelDocument>;
-    getEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    getEntitySources(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesDocument>;
-    getEntityTables(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableDocument>;
-    getEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    updateEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    updateEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    updateEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-};
-
-// @public
-export interface WorkspaceModelControllerApiInterface {
-    // (undocumented)
-    createEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityFilterContexts(params: {
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    createEntityMetrics(params: {
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    createEntityVisualizationObjects(params: {
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    deleteEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-    }, options?: any): AxiosPromise<void>;
-    // (undocumented)
-    getEntitiesAnalyticalDashboards(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
-    // (undocumented)
-    getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDatasets(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
-    // (undocumented)
-    getEntitiesFacts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
-    // (undocumented)
-    getEntitiesFilterContexts(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
-    // (undocumented)
-    getEntitiesLabels(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
-    // (undocumented)
-    getEntitiesMetrics(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
-    // (undocumented)
-    getEntitiesSources(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
-    // (undocumented)
-    getEntitiesTables(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
-    // (undocumented)
-    getEntitiesVisualizationObjects(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
-    // (undocumented)
-    getEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    getEntityAttributes(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDatasets(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
-    // (undocumented)
-    getEntityFacts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
-    // (undocumented)
-    getEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    getEntityLabels(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
-    // (undocumented)
-    getEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    getEntitySources(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
-    // (undocumented)
-    getEntityTables(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
-    // (undocumented)
-    getEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    // (undocumented)
-    updateEntityAnalyticalDashboards(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityFilterContexts(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    // (undocumented)
-    updateEntityMetrics(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    // (undocumented)
-    updateEntityVisualizationObjects(params: {
-        id: string;
-        workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-}
-
-// @public
 export class WorkspaceObjectControllerApi extends MetadataBaseApi implements WorkspaceObjectControllerApiInterface {
     // (undocumented)
-    createEntityAnalyticalDashboards1(params: {
+    createEntityAnalyticalDashboards(params: {
         workspaceId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
@@ -5863,7 +4399,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    createEntityFilterContexts1(params: {
+    createEntityFilterContexts(params: {
         workspaceId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
         variableParam?: {
@@ -5872,7 +4408,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    createEntityMetrics1(params: {
+    createEntityMetrics(params: {
         workspaceId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
         variableParam?: {
@@ -5881,7 +4417,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    createEntityVisualizationObjects1(params: {
+    createEntityVisualizationObjects(params: {
         workspaceId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
         variableParam?: {
@@ -5890,7 +4426,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards1(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5898,7 +4434,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityFilterContexts1(params: {
+    deleteEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5906,7 +4442,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityMetrics1(params: {
+    deleteEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5914,7 +4450,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityVisualizationObjects1(params: {
+    deleteEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5922,7 +4458,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    getEntitiesAnalyticalDashboards1(params: {
+    getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5933,7 +4469,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
     // (undocumented)
-    getEntitiesAttributes1(params: {
+    getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5944,7 +4480,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiAttributeList>;
     // (undocumented)
-    getEntitiesDatasets1(params: {
+    getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5955,7 +4491,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiDatasetList>;
     // (undocumented)
-    getEntitiesFacts1(params: {
+    getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5966,7 +4502,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiFactList>;
     // (undocumented)
-    getEntitiesFilterContexts1(params: {
+    getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5977,7 +4513,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiFilterContextList>;
     // (undocumented)
-    getEntitiesLabels1(params: {
+    getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5988,7 +4524,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiLabelList>;
     // (undocumented)
-    getEntitiesMetrics1(params: {
+    getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5999,7 +4535,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiMetricList>;
     // (undocumented)
-    getEntitiesSources1(params: {
+    getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6010,7 +4546,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
     // (undocumented)
-    getEntitiesTables1(params: {
+    getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6021,7 +4557,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiSourceTableList>;
     // (undocumented)
-    getEntitiesVisualizationObjects1(params: {
+    getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6032,7 +4568,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
     // (undocumented)
-    getEntityAnalyticalDashboards1(params: {
+    getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6041,7 +4577,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    getEntityAttributes1(params: {
+    getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6050,7 +4586,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
     // (undocumented)
-    getEntityDatasets1(params: {
+    getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6059,7 +4595,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
     // (undocumented)
-    getEntityFacts1(params: {
+    getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6068,7 +4604,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFactDocument>;
     // (undocumented)
-    getEntityFilterContexts1(params: {
+    getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6077,7 +4613,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    getEntityLabels1(params: {
+    getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6086,7 +4622,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiLabelDocument>;
     // (undocumented)
-    getEntityMetrics1(params: {
+    getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6095,7 +4631,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    getEntitySources1(params: {
+    getEntitySources(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6104,7 +4640,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
     // (undocumented)
-    getEntityTables1(params: {
+    getEntityTables(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6113,7 +4649,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
     // (undocumented)
-    getEntityVisualizationObjects1(params: {
+    getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6122,7 +4658,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
     // (undocumented)
-    updateEntityAnalyticalDashboards1(params: {
+    updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -6132,7 +4668,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    updateEntityFilterContexts1(params: {
+    updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -6142,7 +4678,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    updateEntityMetrics1(params: {
+    updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
@@ -6152,7 +4688,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    updateEntityVisualizationObjects1(params: {
+    updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -6165,7 +4701,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
 
 // @public
 export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
-    createEntityAnalyticalDashboards1(params: {
+    createEntityAnalyticalDashboards(params: {
         workspaceId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
@@ -6173,7 +4709,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    createEntityFilterContexts1(params: {
+    createEntityFilterContexts(params: {
         workspaceId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
         variableParam?: {
@@ -6181,7 +4717,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    createEntityMetrics1(params: {
+    createEntityMetrics(params: {
         workspaceId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
         variableParam?: {
@@ -6189,7 +4725,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    createEntityVisualizationObjects1(params: {
+    createEntityVisualizationObjects(params: {
         workspaceId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
         variableParam?: {
@@ -6197,35 +4733,35 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    deleteEntityAnalyticalDashboards1(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
-    deleteEntityFilterContexts1(params: {
+    deleteEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
-    deleteEntityMetrics1(params: {
+    deleteEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
-    deleteEntityVisualizationObjects1(params: {
+    deleteEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesAnalyticalDashboards1(params: {
+    getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6235,7 +4771,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesAttributes1(params: {
+    getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6245,7 +4781,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesDatasets1(params: {
+    getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6255,7 +4791,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesFacts1(params: {
+    getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6265,7 +4801,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesFilterContexts1(params: {
+    getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6275,7 +4811,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesLabels1(params: {
+    getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6285,7 +4821,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesMetrics1(params: {
+    getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6295,7 +4831,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesSources1(params: {
+    getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6305,7 +4841,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesTables1(params: {
+    getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6315,7 +4851,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitiesVisualizationObjects1(params: {
+    getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6325,7 +4861,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityAnalyticalDashboards1(params: {
+    getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6333,7 +4869,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityAttributes1(params: {
+    getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6341,7 +4877,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityDatasets1(params: {
+    getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6349,7 +4885,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityFacts1(params: {
+    getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6357,7 +4893,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityFilterContexts1(params: {
+    getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6365,7 +4901,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityLabels1(params: {
+    getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6373,7 +4909,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityMetrics1(params: {
+    getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6381,7 +4917,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntitySources1(params: {
+    getEntitySources(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6389,7 +4925,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityTables1(params: {
+    getEntityTables(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6397,7 +4933,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityVisualizationObjects1(params: {
+    getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6405,7 +4941,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityAnalyticalDashboards1(params: {
+    updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -6414,7 +4950,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityFilterContexts1(params: {
+    updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -6423,7 +4959,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityMetrics1(params: {
+    updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
@@ -6432,7 +4968,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityVisualizationObjects1(params: {
+    updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -6445,7 +4981,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
 
 // @public
 export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
-    createEntityAnalyticalDashboards1(params: {
+    createEntityAnalyticalDashboards(params: {
         workspaceId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
@@ -6453,7 +4989,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityFilterContexts1(params: {
+    createEntityFilterContexts(params: {
         workspaceId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
         variableParam?: {
@@ -6461,7 +4997,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    createEntityMetrics1(params: {
+    createEntityMetrics(params: {
         workspaceId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
         variableParam?: {
@@ -6469,7 +5005,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    createEntityVisualizationObjects1(params: {
+    createEntityVisualizationObjects(params: {
         workspaceId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
         variableParam?: {
@@ -6477,35 +5013,35 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards1(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
-    deleteEntityFilterContexts1(params: {
+    deleteEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
-    deleteEntityMetrics1(params: {
+    deleteEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
-    deleteEntityVisualizationObjects1(params: {
+    deleteEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
-    getEntitiesAnalyticalDashboards1(params: {
+    getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6515,7 +5051,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
-    getEntitiesAttributes1(params: {
+    getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6525,7 +5061,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDatasets1(params: {
+    getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6535,7 +5071,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiDatasetList>;
-    getEntitiesFacts1(params: {
+    getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6545,7 +5081,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiFactList>;
-    getEntitiesFilterContexts1(params: {
+    getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6555,7 +5091,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiFilterContextList>;
-    getEntitiesLabels1(params: {
+    getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6565,7 +5101,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiLabelList>;
-    getEntitiesMetrics1(params: {
+    getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6575,7 +5111,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiMetricList>;
-    getEntitiesSources1(params: {
+    getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6585,7 +5121,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
-    getEntitiesTables1(params: {
+    getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6595,7 +5131,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiSourceTableList>;
-    getEntitiesVisualizationObjects1(params: {
+    getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6605,7 +5141,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
-    getEntityAnalyticalDashboards1(params: {
+    getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6613,7 +5149,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    getEntityAttributes1(params: {
+    getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6621,7 +5157,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDatasets1(params: {
+    getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6629,7 +5165,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
-    getEntityFacts1(params: {
+    getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6637,7 +5173,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiFactDocument>;
-    getEntityFilterContexts1(params: {
+    getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6645,7 +5181,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    getEntityLabels1(params: {
+    getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6653,7 +5189,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiLabelDocument>;
-    getEntityMetrics1(params: {
+    getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6661,7 +5197,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    getEntitySources1(params: {
+    getEntitySources(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6669,7 +5205,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
-    getEntityTables1(params: {
+    getEntityTables(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6677,7 +5213,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
-    getEntityVisualizationObjects1(params: {
+    getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6685,7 +5221,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    updateEntityAnalyticalDashboards1(params: {
+    updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -6694,7 +5230,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityFilterContexts1(params: {
+    updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -6703,7 +5239,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
-    updateEntityMetrics1(params: {
+    updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
@@ -6712,7 +5248,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         } | undefined;
         include?: object | undefined;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
-    updateEntityVisualizationObjects1(params: {
+    updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -6725,7 +5261,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
 
 // @public
 export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
-    createEntityAnalyticalDashboards1(params: {
+    createEntityAnalyticalDashboards(params: {
         workspaceId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
@@ -6733,7 +5269,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityFilterContexts1(params: {
+    createEntityFilterContexts(params: {
         workspaceId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
         variableParam?: {
@@ -6741,7 +5277,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    createEntityMetrics1(params: {
+    createEntityMetrics(params: {
         workspaceId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
         variableParam?: {
@@ -6749,7 +5285,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    createEntityVisualizationObjects1(params: {
+    createEntityVisualizationObjects(params: {
         workspaceId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
         variableParam?: {
@@ -6757,35 +5293,35 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards1(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityFilterContexts1(params: {
+    deleteEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityMetrics1(params: {
+    deleteEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityVisualizationObjects1(params: {
+    deleteEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    getEntitiesAnalyticalDashboards1(params: {
+    getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6795,7 +5331,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardList>;
-    getEntitiesAttributes1(params: {
+    getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6805,7 +5341,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDatasets1(params: {
+    getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6815,7 +5351,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetList>;
-    getEntitiesFacts1(params: {
+    getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6825,7 +5361,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactList>;
-    getEntitiesFilterContexts1(params: {
+    getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6835,7 +5371,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextList>;
-    getEntitiesLabels1(params: {
+    getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6845,7 +5381,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelList>;
-    getEntitiesMetrics1(params: {
+    getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6855,7 +5391,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricList>;
-    getEntitiesSources1(params: {
+    getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6865,7 +5401,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesList>;
-    getEntitiesTables1(params: {
+    getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6875,7 +5411,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableList>;
-    getEntitiesVisualizationObjects1(params: {
+    getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -6885,7 +5421,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectList>;
-    getEntityAnalyticalDashboards1(params: {
+    getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6893,7 +5429,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    getEntityAttributes1(params: {
+    getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6901,7 +5437,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDatasets1(params: {
+    getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6909,7 +5445,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetDocument>;
-    getEntityFacts1(params: {
+    getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6917,7 +5453,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactDocument>;
-    getEntityFilterContexts1(params: {
+    getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6925,7 +5461,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    getEntityLabels1(params: {
+    getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6933,7 +5469,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelDocument>;
-    getEntityMetrics1(params: {
+    getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6941,7 +5477,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    getEntitySources1(params: {
+    getEntitySources(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6949,7 +5485,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesDocument>;
-    getEntityTables1(params: {
+    getEntityTables(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6957,7 +5493,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableDocument>;
-    getEntityVisualizationObjects1(params: {
+    getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6965,7 +5501,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    updateEntityAnalyticalDashboards1(params: {
+    updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -6974,7 +5510,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityFilterContexts1(params: {
+    updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -6983,7 +5519,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
-    updateEntityMetrics1(params: {
+    updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
@@ -6992,7 +5528,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         } | undefined;
         include?: object | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
-    updateEntityVisualizationObjects1(params: {
+    updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -7006,7 +5542,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
 // @public
 export interface WorkspaceObjectControllerApiInterface {
     // (undocumented)
-    createEntityAnalyticalDashboards1(params: {
+    createEntityAnalyticalDashboards(params: {
         workspaceId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
@@ -7015,7 +5551,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    createEntityFilterContexts1(params: {
+    createEntityFilterContexts(params: {
         workspaceId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
         variableParam?: {
@@ -7024,7 +5560,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    createEntityMetrics1(params: {
+    createEntityMetrics(params: {
         workspaceId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
         variableParam?: {
@@ -7033,7 +5569,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    createEntityVisualizationObjects1(params: {
+    createEntityVisualizationObjects(params: {
         workspaceId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
         variableParam?: {
@@ -7042,7 +5578,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards1(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7050,7 +5586,7 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityFilterContexts1(params: {
+    deleteEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7058,7 +5594,7 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityMetrics1(params: {
+    deleteEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7066,7 +5602,7 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    deleteEntityVisualizationObjects1(params: {
+    deleteEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7074,7 +5610,7 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
-    getEntitiesAnalyticalDashboards1(params: {
+    getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7085,7 +5621,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
     // (undocumented)
-    getEntitiesAttributes1(params: {
+    getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7096,7 +5632,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiAttributeList>;
     // (undocumented)
-    getEntitiesDatasets1(params: {
+    getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7107,7 +5643,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiDatasetList>;
     // (undocumented)
-    getEntitiesFacts1(params: {
+    getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7118,7 +5654,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiFactList>;
     // (undocumented)
-    getEntitiesFilterContexts1(params: {
+    getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7129,7 +5665,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiFilterContextList>;
     // (undocumented)
-    getEntitiesLabels1(params: {
+    getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7140,7 +5676,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiLabelList>;
     // (undocumented)
-    getEntitiesMetrics1(params: {
+    getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7151,7 +5687,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiMetricList>;
     // (undocumented)
-    getEntitiesSources1(params: {
+    getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7162,7 +5698,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
     // (undocumented)
-    getEntitiesTables1(params: {
+    getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7173,7 +5709,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiSourceTableList>;
     // (undocumented)
-    getEntitiesVisualizationObjects1(params: {
+    getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -7184,7 +5720,7 @@ export interface WorkspaceObjectControllerApiInterface {
         sort?: Array<string>;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
     // (undocumented)
-    getEntityAnalyticalDashboards1(params: {
+    getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7193,7 +5729,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    getEntityAttributes1(params: {
+    getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7202,7 +5738,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
     // (undocumented)
-    getEntityDatasets1(params: {
+    getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7211,7 +5747,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
     // (undocumented)
-    getEntityFacts1(params: {
+    getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7220,7 +5756,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFactDocument>;
     // (undocumented)
-    getEntityFilterContexts1(params: {
+    getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7229,7 +5765,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    getEntityLabels1(params: {
+    getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7238,7 +5774,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiLabelDocument>;
     // (undocumented)
-    getEntityMetrics1(params: {
+    getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7247,7 +5783,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    getEntitySources1(params: {
+    getEntitySources(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7256,7 +5792,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
     // (undocumented)
-    getEntityTables1(params: {
+    getEntityTables(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7265,7 +5801,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
     // (undocumented)
-    getEntityVisualizationObjects1(params: {
+    getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -7274,7 +5810,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
     // (undocumented)
-    updateEntityAnalyticalDashboards1(params: {
+    updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -7284,7 +5820,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
     // (undocumented)
-    updateEntityFilterContexts1(params: {
+    updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
         jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -7294,7 +5830,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
     // (undocumented)
-    updateEntityMetrics1(params: {
+    updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
         jsonApiMetricDocument: JsonApiMetricDocument;
@@ -7304,7 +5840,7 @@ export interface WorkspaceObjectControllerApiInterface {
         include?: object;
     }, options?: any): AxiosPromise<JsonApiMetricDocument>;
     // (undocumented)
-    updateEntityVisualizationObjects1(params: {
+    updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
         jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -7318,7 +5854,7 @@ export interface WorkspaceObjectControllerApiInterface {
 // @public
 export class WorkspaceRootModelControllerApi extends MetadataBaseApi implements WorkspaceRootModelControllerApiInterface {
     // (undocumented)
-    getRootJsonApi11(params: {
+    getRootJsonApi(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<RepresentationModelObject>;
     // (undocumented)
@@ -7329,7 +5865,7 @@ export class WorkspaceRootModelControllerApi extends MetadataBaseApi implements 
 
 // @public
 export const WorkspaceRootModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
-    getRootJsonApi11(params: {
+    getRootJsonApi(params: {
         workspaceId: string;
     }, options?: any): MetadataRequestArgs;
     getRootJsonApi2(params: {
@@ -7339,7 +5875,7 @@ export const WorkspaceRootModelControllerApiAxiosParamCreator: (configuration?: 
 
 // @public
 export const WorkspaceRootModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
-    getRootJsonApi11(params: {
+    getRootJsonApi(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<RepresentationModelObject>;
     getRootJsonApi2(params: {
@@ -7349,7 +5885,7 @@ export const WorkspaceRootModelControllerApiFactory: (configuration?: MetadataCo
 
 // @public
 export const WorkspaceRootModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
-    getRootJsonApi11(params: {
+    getRootJsonApi(params: {
         workspaceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<RepresentationModelObject>;
     getRootJsonApi2(params: {
@@ -7360,7 +5896,7 @@ export const WorkspaceRootModelControllerApiFp: (configuration?: MetadataConfigu
 // @public
 export interface WorkspaceRootModelControllerApiInterface {
     // (undocumented)
-    getRootJsonApi11(params: {
+    getRootJsonApi(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<RepresentationModelObject>;
     // (undocumented)

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -318,18 +318,18 @@ export enum DeclarativeDateDatasetGranularitiesEnum {
     HOUR = "HOUR",
     DAY = "DAY",
     WEEK = "WEEK",
-    WEEKEU = "WEEK_EU",
+    EUWEEK = "EUWEEK",
     MONTH = "MONTH",
     QUARTER = "QUARTER",
     YEAR = "YEAR",
     MINUTEOFHOUR = "MINUTE_OF_HOUR",
     HOUROFDAY = "HOUR_OF_DAY",
     DAYOFWEEK = "DAY_OF_WEEK",
-    DAYOFWEEKEU = "DAY_OF_WEEK_EU",
+    DAYOFEUWEEK = "DAY_OF_EUWEEK",
     DAYOFMONTH = "DAY_OF_MONTH",
     DAYOFYEAR = "DAY_OF_YEAR",
     WEEKOFYEAR = "WEEK_OF_YEAR",
-    WEEKOFYEAREU = "WEEK_OF_YEAR_EU",
+    EUWEEKOFYEAR = "EUWEEK_OF_YEAR",
     MONTHOFYEAR = "MONTH_OF_YEAR",
     QUARTEROFYEAR = "QUARTER_OF_YEAR",
 }
@@ -13192,10 +13192,10 @@ export class UserModelControllerApi extends BaseAPI implements UserModelControll
 }
 
 /**
- * WorkspaceModelControllerApi - axios parameter creator
+ * WorkspaceObjectControllerApi - axios parameter creator
  * @export
  */
-export const WorkspaceModelControllerApiAxiosParamCreator = function (configuration?: Configuration) {
+export const WorkspaceObjectControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
         /**
          *
@@ -13233,7 +13233,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling createEntityAnalyticalDashboards.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/analyticalDashboards`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13317,7 +13317,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter jsonApiFilterContextDocument was null or undefined when calling createEntityFilterContexts.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/filterContexts`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13399,7 +13399,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter jsonApiMetricDocument was null or undefined when calling createEntityMetrics.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/metrics`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13482,7 +13482,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling createEntityVisualizationObjects.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/visualizationObjects`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13535,28 +13535,21 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         deleteEntityAnalyticalDashboards(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling deleteEntityAnalyticalDashboards.",
-                );
-            }
+            const { workspaceId, objectId, variableParam } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -13564,9 +13557,16 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling deleteEntityAnalyticalDashboards.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/analyticalDashboards/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityAnalyticalDashboards.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -13596,28 +13596,21 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         deleteEntityFilterContexts(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling deleteEntityFilterContexts.",
-                );
-            }
+            const { workspaceId, objectId, variableParam } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -13625,9 +13618,16 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling deleteEntityFilterContexts.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/filterContexts/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityFilterContexts.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -13657,28 +13657,21 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         deleteEntityMetrics(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling deleteEntityMetrics.",
-                );
-            }
+            const { workspaceId, objectId, variableParam } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -13686,9 +13679,16 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling deleteEntityMetrics.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/metrics/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityMetrics.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -13718,28 +13718,21 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         deleteEntityVisualizationObjects(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling deleteEntityVisualizationObjects.",
-                );
-            }
+            const { workspaceId, objectId, variableParam } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -13747,9 +13740,16 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling deleteEntityVisualizationObjects.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/visualizationObjects/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityVisualizationObjects.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -13807,7 +13807,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesAnalyticalDashboards.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/analyticalDashboards`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13896,7 +13896,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesAttributes.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/attributes`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/attributes`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -13985,7 +13985,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesDatasets.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/datasets`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/datasets`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14074,7 +14074,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesFacts.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/facts`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/facts`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14163,7 +14163,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesFilterContexts.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/filterContexts`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14252,7 +14252,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesLabels.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/labels`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/labels`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14341,7 +14341,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesMetrics.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/metrics`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14430,7 +14430,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesSources.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/sources`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/sources`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14519,7 +14519,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesTables.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/tables`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/tables`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14608,7 +14608,7 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntitiesVisualizationObjects.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/visualizationObjects`.replace(
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -14669,8 +14669,8 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -14678,21 +14678,14 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
          */
         getEntityAnalyticalDashboards(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityAnalyticalDashboards.",
-                );
-            }
+            const { workspaceId, objectId, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -14700,9 +14693,16 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntityAnalyticalDashboards.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/analyticalDashboards/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling getEntityAnalyticalDashboards.",
+                );
+            }
+            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
             let baseOptions;
             if (configuration) {
@@ -14740,8 +14740,8 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
         },
         /**
          *
-         * @param {string} id
          * @param {string} workspaceId
+         * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -14749,21 +14749,14 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
          */
         getEntityAttributes(
             params: {
-                id: string;
                 workspaceId: string;
+                objectId: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityAttributes.",
-                );
-            }
+            const { workspaceId, objectId, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -14771,5862 +14764,11 @@ export const WorkspaceModelControllerApiAxiosParamCreator = function (configurat
                     "Required parameter workspaceId was null or undefined when calling getEntityAttributes.",
                 );
             }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/attributes/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDatasets(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityDatasets.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityDatasets.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/datasets/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFacts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityFacts.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityFacts.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/facts/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityFilterContexts.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityFilterContexts.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/filterContexts/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityLabels(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityLabels.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityLabels.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/labels/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityMetrics.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityMetrics.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/metrics/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitySources(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntitySources.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitySources.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/sources/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityTables(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityTables.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityTables.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/tables/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityVisualizationObjects.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityVisualizationObjects.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/visualizationObjects/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, jsonApiAnalyticalDashboardDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityAnalyticalDashboards.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityAnalyticalDashboards.",
-                );
-            }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
-            if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
-            ) {
-                throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/analyticalDashboards/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
-                          : {},
-                  )
-                : jsonApiAnalyticalDashboardDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, jsonApiFilterContextDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityFilterContexts.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityFilterContexts.",
-                );
-            }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling updateEntityFilterContexts.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/filterContexts/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
-                  )
-                : jsonApiFilterContextDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, jsonApiMetricDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityMetrics.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityMetrics.",
-                );
-            }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling updateEntityMetrics.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/metrics/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, workspaceId, jsonApiVisualizationObjectDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityVisualizationObjects.",
-                );
-            }
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityVisualizationObjects.",
-                );
-            }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
-            if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
-            ) {
-                throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling updateEntityVisualizationObjects.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/model/visualizationObjects/{id}`
-                .replace(`{${"id"}}`, encodeURIComponent(String(id)))
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
-                          : {},
-                  )
-                : jsonApiVisualizationObjectDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    };
-};
-
-/**
- * WorkspaceModelControllerApi - functional programming interface
- * @export
- */
-export const WorkspaceModelControllerApiFp = function (configuration?: Configuration) {
-    return {
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityAnalyticalDashboards(
-            params: {
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityFilterContexts(
-            params: {
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityFilterContexts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityMetrics(
-            params: {
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityMetrics(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityVisualizationObjects(
-            params: {
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityVisualizationObjects(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityFilterContexts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityMetrics(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityVisualizationObjects(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAnalyticalDashboards(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAttributes(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDatasets(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesDatasets(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFacts(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesFacts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFilterContexts(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesFilterContexts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesLabels(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesLabels(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesMetrics(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesMetrics(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesSources(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesSources(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesTables(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesTables(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesVisualizationObjects(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectList> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesVisualizationObjects(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAttributes(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDatasets(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityDatasets(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFacts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityFacts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityFilterContexts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityLabels(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityLabels(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityMetrics(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitySources(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitySources(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityTables(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityTables(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityVisualizationObjects(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityFilterContexts(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityMetrics(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
-            const localVarAxiosArgs = WorkspaceModelControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityVisualizationObjects(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-    };
-};
-
-/**
- * WorkspaceModelControllerApi - factory interface
- * @export
- */
-export const WorkspaceModelControllerApiFactory = function (
-    configuration?: Configuration,
-    basePath?: string,
-    axios?: AxiosInstance,
-) {
-    return {
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityAnalyticalDashboards(
-            params: {
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceModelControllerApiFp(configuration).createEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityFilterContexts(
-            params: {
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceModelControllerApiFp(configuration).createEntityFilterContexts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityMetrics(
-            params: {
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceModelControllerApiFp(configuration).createEntityMetrics(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityVisualizationObjects(
-            params: {
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceModelControllerApiFp(configuration).createEntityVisualizationObjects(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceModelControllerApiFp(configuration).deleteEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceModelControllerApiFp(configuration).deleteEntityFilterContexts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceModelControllerApiFp(configuration).deleteEntityMetrics(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceModelControllerApiFp(configuration).deleteEntityVisualizationObjects(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAnalyticalDashboards(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAttributes(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAttributeList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesAttributes(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDatasets(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDatasetList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesDatasets(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFacts(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFactList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesFacts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFilterContexts(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFilterContextList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesFilterContexts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesLabels(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiLabelList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesLabels(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesMetrics(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiMetricList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesMetrics(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesSources(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiSourceTablesList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesSources(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesTables(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiSourceTableList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesTables(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesVisualizationObjects(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectList> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitiesVisualizationObjects(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAttributes(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAttributeDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityAttributes(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDatasets(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDatasetDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityDatasets(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFacts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFactDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityFacts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityFilterContexts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityLabels(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiLabelDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityLabels(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityMetrics(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitySources(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiSourceTablesDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntitySources(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityTables(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiSourceTableDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityTables(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceModelControllerApiFp(configuration).getEntityVisualizationObjects(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAnalyticalDashboards(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceModelControllerApiFp(configuration).updateEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityFilterContexts(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceModelControllerApiFp(configuration).updateEntityFilterContexts(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityMetrics(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceModelControllerApiFp(configuration).updateEntityMetrics(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityVisualizationObjects(
-            params: {
-                id: string;
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceModelControllerApiFp(configuration).updateEntityVisualizationObjects(
-                params,
-                options,
-            )(axios, basePath);
-        },
-    };
-};
-
-/**
- * WorkspaceModelControllerApi - interface
- * @export
- * @interface WorkspaceModelControllerApi
- */
-export interface WorkspaceModelControllerApiInterface {
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    createEntityAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    createEntityFilterContexts(
-        params: {
-            workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    createEntityMetrics(
-        params: {
-            workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    createEntityVisualizationObjects(
-        params: {
-            workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    deleteEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    deleteEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    deleteEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    deleteEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesAttributes(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAttributeList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesDatasets(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDatasetList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesFacts(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFactList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesFilterContexts(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFilterContextList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesLabels(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiLabelList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesMetrics(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiMetricList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesSources(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiSourceTablesList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesTables(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiSourceTableList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitiesVisualizationObjects(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectList>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityAttributes(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAttributeDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityDatasets(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDatasetDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityFacts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFactDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityLabels(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiLabelDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntitySources(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiSourceTablesDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityTables(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiSourceTableDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    getEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    updateEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    updateEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    updateEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApiInterface
-     */
-    updateEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
-}
-
-/**
- * WorkspaceModelControllerApi - object-oriented interface
- * @export
- * @class WorkspaceModelControllerApi
- * @extends {BaseAPI}
- */
-export class WorkspaceModelControllerApi extends BaseAPI implements WorkspaceModelControllerApiInterface {
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public createEntityAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).createEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public createEntityFilterContexts(
-        params: {
-            workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).createEntityFilterContexts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public createEntityMetrics(
-        params: {
-            workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).createEntityMetrics(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public createEntityVisualizationObjects(
-        params: {
-            workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).createEntityVisualizationObjects(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public deleteEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).deleteEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public deleteEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).deleteEntityFilterContexts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public deleteEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).deleteEntityMetrics(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public deleteEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).deleteEntityVisualizationObjects(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesAttributes(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesAttributes(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesDatasets(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesDatasets(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesFacts(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesFacts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesFilterContexts(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesFilterContexts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesLabels(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesLabels(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesMetrics(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesMetrics(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesSources(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesSources(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesTables(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesTables(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitiesVisualizationObjects(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitiesVisualizationObjects(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityAttributes(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityAttributes(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityDatasets(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityDatasets(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityFacts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityFacts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityFilterContexts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityLabels(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityLabels(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityMetrics(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntitySources(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntitySources(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityTables(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityTables(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public getEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).getEntityVisualizationObjects(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public updateEntityAnalyticalDashboards(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).updateEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public updateEntityFilterContexts(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).updateEntityFilterContexts(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public updateEntityMetrics(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).updateEntityMetrics(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceModelControllerApi
-     */
-    public updateEntityVisualizationObjects(
-        params: {
-            id: string;
-            workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceModelControllerApiFp(this.configuration).updateEntityVisualizationObjects(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-}
-
-/**
- * WorkspaceObjectControllerApi - axios parameter creator
- * @export
- */
-export const WorkspaceObjectControllerApiAxiosParamCreator = function (configuration?: Configuration) {
-    return {
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityAnalyticalDashboards1(
-            params: {
-                workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiAnalyticalDashboardDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityAnalyticalDashboards1.",
-                );
-            }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
-            if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
-            ) {
-                throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling createEntityAnalyticalDashboards1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
-                          : {},
-                  )
-                : jsonApiAnalyticalDashboardDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityFilterContexts1(
-            params: {
-                workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiFilterContextDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityFilterContexts1.",
-                );
-            }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling createEntityFilterContexts1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
-                  )
-                : jsonApiFilterContextDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityMetrics1(
-            params: {
-                workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiMetricDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityMetrics1.",
-                );
-            }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling createEntityMetrics1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityVisualizationObjects1(
-            params: {
-                workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiVisualizationObjectDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityVisualizationObjects1.",
-                );
-            }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
-            if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
-            ) {
-                throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling createEntityVisualizationObjects1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
-                          : {},
-                  )
-                : jsonApiVisualizationObjectDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityAnalyticalDashboards1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityAnalyticalDashboards1.",
-                );
-            }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityAnalyticalDashboards1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityFilterContexts1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityFilterContexts1.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityFilterContexts1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityMetrics1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityMetrics1.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityMetrics1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityVisualizationObjects1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityVisualizationObjects1.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityVisualizationObjects1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAnalyticalDashboards1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesAnalyticalDashboards1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesAttributes1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesAttributes1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/attributes`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDatasets1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesDatasets1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/datasets`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFacts1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesFacts1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/facts`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesFilterContexts1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesFilterContexts1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesLabels1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesLabels1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/labels`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesMetrics1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesMetrics1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesSources1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesSources1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/sources`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesTables1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesTables1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/tables`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesVisualizationObjects1(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesVisualizationObjects1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAnalyticalDashboards1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityAnalyticalDashboards1.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityAnalyticalDashboards1.",
-                );
-            }
-            const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityAttributes1(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityAttributes1.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityAttributes1.",
+                    "Required parameter objectId was null or undefined when calling getEntityAttributes.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/attributes/{objectId}`
@@ -20676,7 +14818,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDatasets1(
+        getEntityDatasets(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -20690,14 +14832,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityDatasets1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityDatasets.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityDatasets1.",
+                    "Required parameter objectId was null or undefined when calling getEntityDatasets.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/datasets/{objectId}`
@@ -20747,7 +14889,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFacts1(
+        getEntityFacts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -20761,14 +14903,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityFacts1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityFacts.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityFacts1.",
+                    "Required parameter objectId was null or undefined when calling getEntityFacts.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/facts/{objectId}`
@@ -20818,7 +14960,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFilterContexts1(
+        getEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -20832,14 +14974,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityFilterContexts1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityFilterContexts.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityFilterContexts1.",
+                    "Required parameter objectId was null or undefined when calling getEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts/{objectId}`
@@ -20889,7 +15031,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityLabels1(
+        getEntityLabels(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -20903,14 +15045,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityLabels1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityLabels.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityLabels1.",
+                    "Required parameter objectId was null or undefined when calling getEntityLabels.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/labels/{objectId}`
@@ -20960,7 +15102,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityMetrics1(
+        getEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -20974,14 +15116,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityMetrics1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityMetrics.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityMetrics1.",
+                    "Required parameter objectId was null or undefined when calling getEntityMetrics.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics/{objectId}`
@@ -21031,7 +15173,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitySources1(
+        getEntitySources(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21045,14 +15187,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitySources1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntitySources.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntitySources1.",
+                    "Required parameter objectId was null or undefined when calling getEntitySources.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/sources/{objectId}`
@@ -21102,7 +15244,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityTables1(
+        getEntityTables(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21116,14 +15258,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityTables1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityTables.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityTables1.",
+                    "Required parameter objectId was null or undefined when calling getEntityTables.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/tables/{objectId}`
@@ -21173,7 +15315,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityVisualizationObjects1(
+        getEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21187,14 +15329,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityVisualizationObjects1.",
+                    "Required parameter workspaceId was null or undefined when calling getEntityVisualizationObjects.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityVisualizationObjects1.",
+                    "Required parameter objectId was null or undefined when calling getEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects/{objectId}`
@@ -21245,7 +15387,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityAnalyticalDashboards1(
+        updateEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21266,14 +15408,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityAnalyticalDashboards1.",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityAnalyticalDashboards1.",
+                    "Required parameter objectId was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
             // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
@@ -21283,7 +15425,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             ) {
                 throw new RequiredError(
                     "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling updateEntityAnalyticalDashboards1.",
+                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}`
@@ -21346,7 +15488,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityFilterContexts1(
+        updateEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21361,21 +15503,21 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityFilterContexts1.",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityFilterContexts1.",
+                    "Required parameter objectId was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
             // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
             if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
                 throw new RequiredError(
                     "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling updateEntityFilterContexts1.",
+                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/filterContexts/{objectId}`
@@ -21436,7 +15578,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityMetrics1(
+        updateEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21451,21 +15593,21 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityMetrics1.",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityMetrics.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityMetrics1.",
+                    "Required parameter objectId was null or undefined when calling updateEntityMetrics.",
                 );
             }
             // verify required parameter 'jsonApiMetricDocument' is not null or undefined
             if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
                 throw new RequiredError(
                     "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling updateEntityMetrics1.",
+                    "Required parameter jsonApiMetricDocument was null or undefined when calling updateEntityMetrics.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/metrics/{objectId}`
@@ -21524,7 +15666,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityVisualizationObjects1(
+        updateEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21545,14 +15687,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityVisualizationObjects1.",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
             // verify required parameter 'objectId' is not null or undefined
             if (objectId === null || objectId === undefined) {
                 throw new RequiredError(
                     "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityVisualizationObjects1.",
+                    "Required parameter objectId was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
             // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
@@ -21562,7 +15704,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             ) {
                 throw new RequiredError(
                     "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling updateEntityVisualizationObjects1.",
+                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects/visualizationObjects/{objectId}`
@@ -21633,7 +15775,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityAnalyticalDashboards1(
+        createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -21644,7 +15786,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).createEntityAnalyticalDashboards1(params, options);
+            ).createEntityAnalyticalDashboards(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21662,7 +15804,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityFilterContexts1(
+        createEntityFilterContexts(
             params: {
                 workspaceId: string;
                 jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -21673,7 +15815,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).createEntityFilterContexts1(params, options);
+            ).createEntityFilterContexts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21691,7 +15833,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityMetrics1(
+        createEntityMetrics(
             params: {
                 workspaceId: string;
                 jsonApiMetricDocument: JsonApiMetricDocument;
@@ -21702,7 +15844,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).createEntityMetrics1(params, options);
+            ).createEntityMetrics(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21720,7 +15862,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityVisualizationObjects1(
+        createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -21731,7 +15873,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).createEntityVisualizationObjects1(params, options);
+            ).createEntityVisualizationObjects(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21748,7 +15890,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityAnalyticalDashboards1(
+        deleteEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21758,7 +15900,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).deleteEntityAnalyticalDashboards1(params, options);
+            ).deleteEntityAnalyticalDashboards(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21775,7 +15917,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityFilterContexts1(
+        deleteEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21785,7 +15927,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).deleteEntityFilterContexts1(params, options);
+            ).deleteEntityFilterContexts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21802,7 +15944,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityMetrics1(
+        deleteEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21812,7 +15954,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).deleteEntityMetrics1(params, options);
+            ).deleteEntityMetrics(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21829,7 +15971,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityVisualizationObjects1(
+        deleteEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -21839,7 +15981,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).deleteEntityVisualizationObjects1(params, options);
+            ).deleteEntityVisualizationObjects(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21859,7 +16001,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesAnalyticalDashboards1(
+        getEntitiesAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -21872,7 +16014,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesAnalyticalDashboards1(params, options);
+            ).getEntitiesAnalyticalDashboards(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21892,7 +16034,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesAttributes1(
+        getEntitiesAttributes(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -21905,7 +16047,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesAttributes1(params, options);
+            ).getEntitiesAttributes(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21925,7 +16067,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesDatasets1(
+        getEntitiesDatasets(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -21938,7 +16080,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesDatasets1(params, options);
+            ).getEntitiesDatasets(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21958,7 +16100,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesFacts1(
+        getEntitiesFacts(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -21971,7 +16113,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesFacts1(params, options);
+            ).getEntitiesFacts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -21991,7 +16133,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesFilterContexts1(
+        getEntitiesFilterContexts(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22004,7 +16146,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesFilterContexts1(params, options);
+            ).getEntitiesFilterContexts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22024,7 +16166,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesLabels1(
+        getEntitiesLabels(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22037,7 +16179,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesLabels1(params, options);
+            ).getEntitiesLabels(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22057,7 +16199,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesMetrics1(
+        getEntitiesMetrics(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22070,7 +16212,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesMetrics1(params, options);
+            ).getEntitiesMetrics(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22090,7 +16232,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesSources1(
+        getEntitiesSources(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22103,7 +16245,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesSources1(params, options);
+            ).getEntitiesSources(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22123,7 +16265,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesTables1(
+        getEntitiesTables(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22136,7 +16278,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesTables1(params, options);
+            ).getEntitiesTables(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22156,7 +16298,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesVisualizationObjects1(
+        getEntitiesVisualizationObjects(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22169,7 +16311,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitiesVisualizationObjects1(params, options);
+            ).getEntitiesVisualizationObjects(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22187,7 +16329,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAnalyticalDashboards1(
+        getEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22198,7 +16340,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityAnalyticalDashboards1(params, options);
+            ).getEntityAnalyticalDashboards(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22216,7 +16358,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAttributes1(
+        getEntityAttributes(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22227,7 +16369,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityAttributes1(params, options);
+            ).getEntityAttributes(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22245,7 +16387,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDatasets1(
+        getEntityDatasets(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22256,7 +16398,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityDatasets1(params, options);
+            ).getEntityDatasets(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22274,7 +16416,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFacts1(
+        getEntityFacts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22285,7 +16427,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityFacts1(params, options);
+            ).getEntityFacts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22303,7 +16445,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFilterContexts1(
+        getEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22314,7 +16456,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityFilterContexts1(params, options);
+            ).getEntityFilterContexts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22332,7 +16474,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityLabels1(
+        getEntityLabels(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22343,7 +16485,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityLabels1(params, options);
+            ).getEntityLabels(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22361,7 +16503,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityMetrics1(
+        getEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22372,7 +16514,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityMetrics1(params, options);
+            ).getEntityMetrics(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22390,7 +16532,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitySources1(
+        getEntitySources(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22401,7 +16543,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntitySources1(params, options);
+            ).getEntitySources(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22419,7 +16561,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityTables1(
+        getEntityTables(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22430,7 +16572,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityTables1(params, options);
+            ).getEntityTables(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22448,7 +16590,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityVisualizationObjects1(
+        getEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22459,7 +16601,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityVisualizationObjects1(params, options);
+            ).getEntityVisualizationObjects(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22478,7 +16620,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityAnalyticalDashboards1(
+        updateEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22490,7 +16632,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityAnalyticalDashboards1(params, options);
+            ).updateEntityAnalyticalDashboards(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22509,7 +16651,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityFilterContexts1(
+        updateEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22521,7 +16663,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityFilterContexts1(params, options);
+            ).updateEntityFilterContexts(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22540,7 +16682,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityMetrics1(
+        updateEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22552,7 +16694,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityMetrics1(params, options);
+            ).updateEntityMetrics(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22571,7 +16713,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityVisualizationObjects1(
+        updateEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22583,7 +16725,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityVisualizationObjects1(params, options);
+            ).updateEntityVisualizationObjects(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -22614,7 +16756,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityAnalyticalDashboards1(
+        createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -22623,7 +16765,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityAnalyticalDashboards1(
+            return WorkspaceObjectControllerApiFp(configuration).createEntityAnalyticalDashboards(
                 params,
                 options,
             )(axios, basePath);
@@ -22637,7 +16779,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityFilterContexts1(
+        createEntityFilterContexts(
             params: {
                 workspaceId: string;
                 jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -22646,7 +16788,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityFilterContexts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).createEntityFilterContexts(params, options)(
                 axios,
                 basePath,
             );
@@ -22660,7 +16802,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityMetrics1(
+        createEntityMetrics(
             params: {
                 workspaceId: string;
                 jsonApiMetricDocument: JsonApiMetricDocument;
@@ -22669,7 +16811,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityMetrics1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).createEntityMetrics(params, options)(
                 axios,
                 basePath,
             );
@@ -22683,7 +16825,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        createEntityVisualizationObjects1(
+        createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -22692,7 +16834,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityVisualizationObjects1(
+            return WorkspaceObjectControllerApiFp(configuration).createEntityVisualizationObjects(
                 params,
                 options,
             )(axios, basePath);
@@ -22705,7 +16847,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityAnalyticalDashboards1(
+        deleteEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22713,7 +16855,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityAnalyticalDashboards1(
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityAnalyticalDashboards(
                 params,
                 options,
             )(axios, basePath);
@@ -22726,7 +16868,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityFilterContexts1(
+        deleteEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22734,7 +16876,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityFilterContexts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityFilterContexts(params, options)(
                 axios,
                 basePath,
             );
@@ -22747,7 +16889,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityMetrics1(
+        deleteEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22755,7 +16897,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityMetrics1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityMetrics(params, options)(
                 axios,
                 basePath,
             );
@@ -22768,7 +16910,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        deleteEntityVisualizationObjects1(
+        deleteEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -22776,7 +16918,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityVisualizationObjects1(
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityVisualizationObjects(
                 params,
                 options,
             )(axios, basePath);
@@ -22792,7 +16934,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesAnalyticalDashboards1(
+        getEntitiesAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22803,7 +16945,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAnalyticalDashboardList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesAnalyticalDashboards1(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesAnalyticalDashboards(
                 params,
                 options,
             )(axios, basePath);
@@ -22819,7 +16961,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesAttributes1(
+        getEntitiesAttributes(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22830,7 +16972,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAttributeList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesAttributes1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesAttributes(params, options)(
                 axios,
                 basePath,
             );
@@ -22846,7 +16988,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesDatasets1(
+        getEntitiesDatasets(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22857,7 +16999,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiDatasetList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesDatasets1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesDatasets(params, options)(
                 axios,
                 basePath,
             );
@@ -22873,7 +17015,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesFacts1(
+        getEntitiesFacts(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22884,7 +17026,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFactList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesFacts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesFacts(params, options)(
                 axios,
                 basePath,
             );
@@ -22900,7 +17042,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesFilterContexts1(
+        getEntitiesFilterContexts(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22911,7 +17053,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFilterContextList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesFilterContexts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesFilterContexts(params, options)(
                 axios,
                 basePath,
             );
@@ -22927,7 +17069,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesLabels1(
+        getEntitiesLabels(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22938,7 +17080,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiLabelList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesLabels1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesLabels(params, options)(
                 axios,
                 basePath,
             );
@@ -22954,7 +17096,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesMetrics1(
+        getEntitiesMetrics(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22965,7 +17107,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiMetricList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesMetrics1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesMetrics(params, options)(
                 axios,
                 basePath,
             );
@@ -22981,7 +17123,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesSources1(
+        getEntitiesSources(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -22992,7 +17134,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiSourceTablesList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesSources1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesSources(params, options)(
                 axios,
                 basePath,
             );
@@ -23008,7 +17150,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesTables1(
+        getEntitiesTables(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -23019,7 +17161,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiSourceTableList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesTables1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesTables(params, options)(
                 axios,
                 basePath,
             );
@@ -23035,7 +17177,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitiesVisualizationObjects1(
+        getEntitiesVisualizationObjects(
             params: {
                 workspaceId: string;
                 variableParam?: { [key: string]: object };
@@ -23046,7 +17188,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiVisualizationObjectList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesVisualizationObjects1(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesVisualizationObjects(
                 params,
                 options,
             )(axios, basePath);
@@ -23060,7 +17202,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAnalyticalDashboards1(
+        getEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23069,7 +17211,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityAnalyticalDashboards1(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityAnalyticalDashboards(
                 params,
                 options,
             )(axios, basePath);
@@ -23083,7 +17225,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAttributes1(
+        getEntityAttributes(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23092,7 +17234,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAttributeDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityAttributes1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityAttributes(params, options)(
                 axios,
                 basePath,
             );
@@ -23106,7 +17248,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDatasets1(
+        getEntityDatasets(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23115,7 +17257,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiDatasetDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityDatasets1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityDatasets(params, options)(
                 axios,
                 basePath,
             );
@@ -23129,7 +17271,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFacts1(
+        getEntityFacts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23138,7 +17280,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFactDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityFacts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityFacts(params, options)(
                 axios,
                 basePath,
             );
@@ -23152,7 +17294,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityFilterContexts1(
+        getEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23161,7 +17303,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityFilterContexts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityFilterContexts(params, options)(
                 axios,
                 basePath,
             );
@@ -23175,7 +17317,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityLabels1(
+        getEntityLabels(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23184,7 +17326,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiLabelDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityLabels1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityLabels(params, options)(
                 axios,
                 basePath,
             );
@@ -23198,7 +17340,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityMetrics1(
+        getEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23207,7 +17349,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityMetrics1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityMetrics(params, options)(
                 axios,
                 basePath,
             );
@@ -23221,7 +17363,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntitySources1(
+        getEntitySources(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23230,7 +17372,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiSourceTablesDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitySources1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntitySources(params, options)(
                 axios,
                 basePath,
             );
@@ -23244,7 +17386,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityTables1(
+        getEntityTables(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23253,7 +17395,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiSourceTableDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityTables1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityTables(params, options)(
                 axios,
                 basePath,
             );
@@ -23267,7 +17409,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityVisualizationObjects1(
+        getEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23276,7 +17418,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityVisualizationObjects1(
+            return WorkspaceObjectControllerApiFp(configuration).getEntityVisualizationObjects(
                 params,
                 options,
             )(axios, basePath);
@@ -23291,7 +17433,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityAnalyticalDashboards1(
+        updateEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23301,7 +17443,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityAnalyticalDashboards1(
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityAnalyticalDashboards(
                 params,
                 options,
             )(axios, basePath);
@@ -23316,7 +17458,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityFilterContexts1(
+        updateEntityFilterContexts(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23326,7 +17468,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiFilterContextDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityFilterContexts1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityFilterContexts(params, options)(
                 axios,
                 basePath,
             );
@@ -23341,7 +17483,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityMetrics1(
+        updateEntityMetrics(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23351,7 +17493,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiMetricDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityMetrics1(params, options)(
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityMetrics(params, options)(
                 axios,
                 basePath,
             );
@@ -23366,7 +17508,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityVisualizationObjects1(
+        updateEntityVisualizationObjects(
             params: {
                 workspaceId: string;
                 objectId: string;
@@ -23376,7 +17518,7 @@ export const WorkspaceObjectControllerApiFactory = function (
             },
             options?: any,
         ): AxiosPromise<JsonApiVisualizationObjectDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityVisualizationObjects1(
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityVisualizationObjects(
                 params,
                 options,
             )(axios, basePath);
@@ -23400,7 +17542,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    createEntityAnalyticalDashboards1(
+    createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -23420,7 +17562,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    createEntityFilterContexts1(
+    createEntityFilterContexts(
         params: {
             workspaceId: string;
             jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -23440,7 +17582,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    createEntityMetrics1(
+    createEntityMetrics(
         params: {
             workspaceId: string;
             jsonApiMetricDocument: JsonApiMetricDocument;
@@ -23460,7 +17602,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    createEntityVisualizationObjects1(
+    createEntityVisualizationObjects(
         params: {
             workspaceId: string;
             jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -23479,7 +17621,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    deleteEntityAnalyticalDashboards1(
+    deleteEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23497,7 +17639,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    deleteEntityFilterContexts1(
+    deleteEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23515,7 +17657,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    deleteEntityMetrics1(
+    deleteEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23533,7 +17675,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    deleteEntityVisualizationObjects1(
+    deleteEntityVisualizationObjects(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23554,7 +17696,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesAnalyticalDashboards1(
+    getEntitiesAnalyticalDashboards(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23578,7 +17720,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesAttributes1(
+    getEntitiesAttributes(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23602,7 +17744,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesDatasets1(
+    getEntitiesDatasets(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23626,7 +17768,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesFacts1(
+    getEntitiesFacts(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23650,7 +17792,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesFilterContexts1(
+    getEntitiesFilterContexts(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23674,7 +17816,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesLabels1(
+    getEntitiesLabels(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23698,7 +17840,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesMetrics1(
+    getEntitiesMetrics(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23722,7 +17864,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesSources1(
+    getEntitiesSources(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23746,7 +17888,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesTables1(
+    getEntitiesTables(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23770,7 +17912,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitiesVisualizationObjects1(
+    getEntitiesVisualizationObjects(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -23792,7 +17934,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityAnalyticalDashboards1(
+    getEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23812,7 +17954,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityAttributes1(
+    getEntityAttributes(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23832,7 +17974,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityDatasets1(
+    getEntityDatasets(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23852,7 +17994,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityFacts1(
+    getEntityFacts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23872,7 +18014,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityFilterContexts1(
+    getEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23892,7 +18034,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityLabels1(
+    getEntityLabels(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23912,7 +18054,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityMetrics1(
+    getEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23932,7 +18074,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntitySources1(
+    getEntitySources(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23952,7 +18094,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityTables1(
+    getEntityTables(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23972,7 +18114,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    getEntityVisualizationObjects1(
+    getEntityVisualizationObjects(
         params: {
             workspaceId: string;
             objectId: string;
@@ -23993,7 +18135,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    updateEntityAnalyticalDashboards1(
+    updateEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24015,7 +18157,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    updateEntityFilterContexts1(
+    updateEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24037,7 +18179,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    updateEntityMetrics1(
+    updateEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24059,7 +18201,7 @@ export interface WorkspaceObjectControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApiInterface
      */
-    updateEntityVisualizationObjects1(
+    updateEntityVisualizationObjects(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24088,7 +18230,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public createEntityAnalyticalDashboards1(
+    public createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
@@ -24097,7 +18239,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityAnalyticalDashboards1(
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityAnalyticalDashboards(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24113,7 +18255,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public createEntityFilterContexts1(
+    public createEntityFilterContexts(
         params: {
             workspaceId: string;
             jsonApiFilterContextDocument: JsonApiFilterContextDocument;
@@ -24122,10 +18264,10 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityFilterContexts1(
-            params,
-            options,
-        )(this.axios, this.basePath);
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityFilterContexts(params, options)(
+            this.axios,
+            this.basePath,
+        );
     }
 
     /**
@@ -24138,7 +18280,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public createEntityMetrics1(
+    public createEntityMetrics(
         params: {
             workspaceId: string;
             jsonApiMetricDocument: JsonApiMetricDocument;
@@ -24147,7 +18289,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityMetrics1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityMetrics(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24163,7 +18305,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public createEntityVisualizationObjects1(
+    public createEntityVisualizationObjects(
         params: {
             workspaceId: string;
             jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
@@ -24172,7 +18314,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityVisualizationObjects1(
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityVisualizationObjects(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24187,7 +18329,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public deleteEntityAnalyticalDashboards1(
+    public deleteEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24195,7 +18337,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityAnalyticalDashboards1(
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityAnalyticalDashboards(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24210,7 +18352,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public deleteEntityFilterContexts1(
+    public deleteEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24218,30 +18360,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityFilterContexts1(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public deleteEntityMetrics1(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityMetrics1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityFilterContexts(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24256,7 +18375,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public deleteEntityVisualizationObjects1(
+    public deleteEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24264,36 +18383,30 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityVisualizationObjects1(
-            params,
-            options,
-        )(this.axios, this.basePath);
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityMetrics(params, options)(
+            this.axios,
+            this.basePath,
+        );
     }
 
     /**
      *
      * @param {string} workspaceId
+     * @param {string} objectId
      * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesAnalyticalDashboards1(
+    public deleteEntityVisualizationObjects(
         params: {
             workspaceId: string;
+            objectId: string;
             variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesAnalyticalDashboards1(
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityVisualizationObjects(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24311,7 +18424,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesAttributes1(
+    public getEntitiesAnalyticalDashboards(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24322,7 +18435,36 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesAttributes1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesAnalyticalDashboards(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntitiesAttributes(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesAttributes(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24340,7 +18482,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesDatasets1(
+    public getEntitiesDatasets(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24351,7 +18493,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesDatasets1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesDatasets(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24369,7 +18511,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesFacts1(
+    public getEntitiesFacts(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24380,7 +18522,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesFacts1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesFacts(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24398,7 +18540,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesFilterContexts1(
+    public getEntitiesFilterContexts(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24409,7 +18551,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesFilterContexts1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesFilterContexts(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24427,7 +18569,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesLabels1(
+    public getEntitiesLabels(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24438,7 +18580,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesLabels1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesLabels(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24456,7 +18598,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesMetrics1(
+    public getEntitiesMetrics(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24467,7 +18609,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesMetrics1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesMetrics(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24485,7 +18627,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesSources1(
+    public getEntitiesSources(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24496,7 +18638,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesSources1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesSources(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24514,7 +18656,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesTables1(
+    public getEntitiesTables(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24525,7 +18667,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesTables1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesTables(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24543,7 +18685,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitiesVisualizationObjects1(
+    public getEntitiesVisualizationObjects(
         params: {
             workspaceId: string;
             variableParam?: { [key: string]: object };
@@ -24554,7 +18696,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesVisualizationObjects1(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesVisualizationObjects(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24570,7 +18712,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityAnalyticalDashboards1(
+    public getEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24579,7 +18721,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityAnalyticalDashboards1(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityAnalyticalDashboards(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24595,7 +18737,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityAttributes1(
+    public getEntityAttributes(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24604,7 +18746,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityAttributes1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityAttributes(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24620,7 +18762,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityDatasets1(
+    public getEntityDatasets(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24629,7 +18771,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityDatasets1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityDatasets(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24645,7 +18787,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityFacts1(
+    public getEntityFacts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24654,7 +18796,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityFacts1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityFacts(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24670,7 +18812,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityFilterContexts1(
+    public getEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24679,7 +18821,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityFilterContexts1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityFilterContexts(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24695,7 +18837,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityLabels1(
+    public getEntityLabels(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24704,7 +18846,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityLabels1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityLabels(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24720,7 +18862,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityMetrics1(
+    public getEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24729,7 +18871,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityMetrics1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityMetrics(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24745,7 +18887,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntitySources1(
+    public getEntitySources(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24754,7 +18896,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitySources1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitySources(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24770,7 +18912,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityTables1(
+    public getEntityTables(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24779,7 +18921,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityTables1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityTables(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24795,7 +18937,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public getEntityVisualizationObjects1(
+    public getEntityVisualizationObjects(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24804,7 +18946,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityVisualizationObjects1(
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityVisualizationObjects(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24821,7 +18963,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public updateEntityAnalyticalDashboards1(
+    public updateEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24831,7 +18973,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityAnalyticalDashboards1(
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityAnalyticalDashboards(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24848,7 +18990,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public updateEntityFilterContexts1(
+    public updateEntityFilterContexts(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24858,10 +19000,10 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityFilterContexts1(
-            params,
-            options,
-        )(this.axios, this.basePath);
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityFilterContexts(params, options)(
+            this.axios,
+            this.basePath,
+        );
     }
 
     /**
@@ -24875,7 +19017,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public updateEntityMetrics1(
+    public updateEntityMetrics(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24885,7 +19027,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityMetrics1(params, options)(
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityMetrics(params, options)(
             this.axios,
             this.basePath,
         );
@@ -24902,7 +19044,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      * @throws {RequiredError}
      * @memberof WorkspaceObjectControllerApi
      */
-    public updateEntityVisualizationObjects1(
+    public updateEntityVisualizationObjects(
         params: {
             workspaceId: string;
             objectId: string;
@@ -24912,7 +19054,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         },
         options?: any,
     ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityVisualizationObjects1(
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityVisualizationObjects(
             params,
             options,
         )(this.axios, this.basePath);
@@ -24931,7 +19073,7 @@ export const WorkspaceRootModelControllerApiAxiosParamCreator = function (config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getRootJsonApi11(
+        getRootJsonApi(
             params: {
                 workspaceId: string;
             },
@@ -24942,7 +19084,7 @@ export const WorkspaceRootModelControllerApiAxiosParamCreator = function (config
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
                     "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getRootJsonApi11.",
+                    "Required parameter workspaceId was null or undefined when calling getRootJsonApi.",
                 );
             }
             const localVarPath = `/api/workspaces/{workspaceId}/objects`.replace(
@@ -25026,7 +19168,7 @@ export const WorkspaceRootModelControllerApiFp = function (configuration?: Confi
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getRootJsonApi11(
+        getRootJsonApi(
             params: {
                 workspaceId: string;
             },
@@ -25034,7 +19176,7 @@ export const WorkspaceRootModelControllerApiFp = function (configuration?: Confi
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<RepresentationModelObject> {
             const localVarAxiosArgs = WorkspaceRootModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getRootJsonApi11(params, options);
+            ).getRootJsonApi(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -25085,13 +19227,13 @@ export const WorkspaceRootModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getRootJsonApi11(
+        getRootJsonApi(
             params: {
                 workspaceId: string;
             },
             options?: any,
         ): AxiosPromise<RepresentationModelObject> {
-            return WorkspaceRootModelControllerApiFp(configuration).getRootJsonApi11(params, options)(
+            return WorkspaceRootModelControllerApiFp(configuration).getRootJsonApi(params, options)(
                 axios,
                 basePath,
             );
@@ -25129,7 +19271,7 @@ export interface WorkspaceRootModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof WorkspaceRootModelControllerApiInterface
      */
-    getRootJsonApi11(
+    getRootJsonApi(
         params: {
             workspaceId: string;
         },
@@ -25166,13 +19308,13 @@ export class WorkspaceRootModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof WorkspaceRootModelControllerApi
      */
-    public getRootJsonApi11(
+    public getRootJsonApi(
         params: {
             workspaceId: string;
         },
         options?: any,
     ) {
-        return WorkspaceRootModelControllerApiFp(this.configuration).getRootJsonApi11(params, options)(
+        return WorkspaceRootModelControllerApiFp(this.configuration).getRootJsonApi(params, options)(
             this.axios,
             this.basePath,
         );

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -424,7 +424,7 @@
         "/api/workspaces/{workspaceId}/objects": {
             "get": {
                 "tags": ["workspace-root-model-controller"],
-                "operationId": "getRootJsonApi_1_1",
+                "operationId": "getRootJsonApi",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -2617,9 +2617,9 @@
                 }
             }
         },
-        "/api/workspaces/{workspaceId}/model/analyticalDashboards": {
+        "/api/workspaces/{workspaceId}/objects/analyticalDashboards": {
             "get": {
-                "tags": ["workspace-model-controller"],
+                "tags": ["workspace-object-controller"],
                 "operationId": "getEntities@AnalyticalDashboards",
                 "parameters": [
                     {
@@ -2690,1864 +2690,8 @@
                 }
             },
             "post": {
-                "tags": ["workspace-model-controller"],
+                "tags": ["workspace-object-controller"],
                 "operationId": "createEntity@AnalyticalDashboards",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/analyticalDashboards/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@AnalyticalDashboards",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "updateEntity@AnalyticalDashboards",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "deleteEntity@AnalyticalDashboards",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/attributes": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Attributes",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/attributes/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Attributes",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/datasets": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Datasets",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/datasets/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Datasets",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/facts": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Facts",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/facts/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Facts",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/filterContexts": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@FilterContexts",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "createEntity@FilterContexts",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/filterContexts/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@FilterContexts",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "updateEntity@FilterContexts",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "deleteEntity@FilterContexts",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/labels": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Labels",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/labels/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Labels",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/metrics": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Metrics",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "createEntity@Metrics",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/metrics/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Metrics",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "updateEntity@Metrics",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "deleteEntity@Metrics",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/sources": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Sources",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/sources/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Sources",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/tables": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@Tables",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableList"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/tables/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@Tables",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/visualizationObjects": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntities@VisualizationObjects",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "createEntity@VisualizationObjects",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "201": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/model/visualizationObjects/{id}": {
-            "get": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "getEntity@VisualizationObjects",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "updateEntity@VisualizationObjects",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "delete": {
-                "tags": ["workspace-model-controller"],
-                "operationId": "deleteEntity@VisualizationObjects",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
-                    }
-                }
-            }
-        },
-        "/api/workspaces/{workspaceId}/objects/analyticalDashboards": {
-            "get": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@AnalyticalDashboards_1",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@AnalyticalDashboards_1",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4601,7 +2745,7 @@
         "/api/workspaces/{workspaceId}/objects/analyticalDashboards/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@AnalyticalDashboards_1",
+                "operationId": "getEntity@AnalyticalDashboards",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4651,7 +2795,7 @@
             },
             "put": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@AnalyticalDashboards_1",
+                "operationId": "updateEntity@AnalyticalDashboards",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4711,7 +2855,7 @@
             },
             "delete": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@AnalyticalDashboards_1",
+                "operationId": "deleteEntity@AnalyticalDashboards",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4748,7 +2892,7 @@
         "/api/workspaces/{workspaceId}/objects/attributes": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Attributes_1",
+                "operationId": "getEntities@Attributes",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4821,7 +2965,7 @@
         "/api/workspaces/{workspaceId}/objects/attributes/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Attributes_1",
+                "operationId": "getEntity@Attributes",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4873,7 +3017,7 @@
         "/api/workspaces/{workspaceId}/objects/datasets": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Datasets_1",
+                "operationId": "getEntities@Datasets",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4946,7 +3090,7 @@
         "/api/workspaces/{workspaceId}/objects/datasets/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Datasets_1",
+                "operationId": "getEntity@Datasets",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -4998,7 +3142,7 @@
         "/api/workspaces/{workspaceId}/objects/facts": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Facts_1",
+                "operationId": "getEntities@Facts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5071,7 +3215,7 @@
         "/api/workspaces/{workspaceId}/objects/facts/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Facts_1",
+                "operationId": "getEntity@Facts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5123,7 +3267,7 @@
         "/api/workspaces/{workspaceId}/objects/filterContexts": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@FilterContexts_1",
+                "operationId": "getEntities@FilterContexts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5194,7 +3338,7 @@
             },
             "post": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@FilterContexts_1",
+                "operationId": "createEntity@FilterContexts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5248,7 +3392,7 @@
         "/api/workspaces/{workspaceId}/objects/filterContexts/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@FilterContexts_1",
+                "operationId": "getEntity@FilterContexts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5298,7 +3442,7 @@
             },
             "put": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@FilterContexts_1",
+                "operationId": "updateEntity@FilterContexts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5358,7 +3502,7 @@
             },
             "delete": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@FilterContexts_1",
+                "operationId": "deleteEntity@FilterContexts",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5395,7 +3539,7 @@
         "/api/workspaces/{workspaceId}/objects/labels": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Labels_1",
+                "operationId": "getEntities@Labels",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5468,7 +3612,7 @@
         "/api/workspaces/{workspaceId}/objects/labels/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Labels_1",
+                "operationId": "getEntity@Labels",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5520,7 +3664,7 @@
         "/api/workspaces/{workspaceId}/objects/metrics": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Metrics_1",
+                "operationId": "getEntities@Metrics",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5591,7 +3735,7 @@
             },
             "post": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@Metrics_1",
+                "operationId": "createEntity@Metrics",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5645,7 +3789,7 @@
         "/api/workspaces/{workspaceId}/objects/metrics/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Metrics_1",
+                "operationId": "getEntity@Metrics",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5695,7 +3839,7 @@
             },
             "put": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@Metrics_1",
+                "operationId": "updateEntity@Metrics",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5755,7 +3899,7 @@
             },
             "delete": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@Metrics_1",
+                "operationId": "deleteEntity@Metrics",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5792,7 +3936,7 @@
         "/api/workspaces/{workspaceId}/objects/sources": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Sources_1",
+                "operationId": "getEntities@Sources",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5865,7 +4009,7 @@
         "/api/workspaces/{workspaceId}/objects/sources/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Sources_1",
+                "operationId": "getEntity@Sources",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5917,7 +4061,7 @@
         "/api/workspaces/{workspaceId}/objects/tables": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@Tables_1",
+                "operationId": "getEntities@Tables",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5990,7 +4134,7 @@
         "/api/workspaces/{workspaceId}/objects/tables/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@Tables_1",
+                "operationId": "getEntity@Tables",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6042,7 +4186,7 @@
         "/api/workspaces/{workspaceId}/objects/visualizationObjects": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@VisualizationObjects_1",
+                "operationId": "getEntities@VisualizationObjects",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6113,7 +4257,7 @@
             },
             "post": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@VisualizationObjects_1",
+                "operationId": "createEntity@VisualizationObjects",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6167,7 +4311,7 @@
         "/api/workspaces/{workspaceId}/objects/visualizationObjects/{objectId}": {
             "get": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@VisualizationObjects_1",
+                "operationId": "getEntity@VisualizationObjects",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6217,7 +4361,7 @@
             },
             "put": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@VisualizationObjects_1",
+                "operationId": "updateEntity@VisualizationObjects",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6277,7 +4421,7 @@
             },
             "delete": {
                 "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@VisualizationObjects_1",
+                "operationId": "deleteEntity@VisualizationObjects",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -6573,18 +4717,18 @@
                                 "HOUR",
                                 "DAY",
                                 "WEEK",
-                                "WEEK_EU",
+                                "EUWEEK",
                                 "MONTH",
                                 "QUARTER",
                                 "YEAR",
                                 "MINUTE_OF_HOUR",
                                 "HOUR_OF_DAY",
                                 "DAY_OF_WEEK",
-                                "DAY_OF_WEEK_EU",
+                                "DAY_OF_EUWEEK",
                                 "DAY_OF_MONTH",
                                 "DAY_OF_YEAR",
                                 "WEEK_OF_YEAR",
-                                "WEEK_OF_YEAR_EU",
+                                "EUWEEK_OF_YEAR",
                                 "MONTH_OF_YEAR",
                                 "QUARTER_OF_YEAR"
                             ]

--- a/libs/api-client-tiger/src/index.ts
+++ b/libs/api-client-tiger/src/index.ts
@@ -9,12 +9,12 @@ import {
     LabelElementsRequestArgs,
 } from "./labelElements";
 import {
-    tigerWorkspaceModelClientFactory,
+    tigerWorkspaceObjectsClientFactory,
     MetadataConfiguration,
     MetadataConfigurationParameters,
     MetadataBaseApi,
     MetadataRequestArgs,
-} from "./workspaceModel";
+} from "./workspaceObjects";
 import { tigerOrganizationObjectsClientFactory } from "./OrganizationObjects";
 import { tigerValidObjectsClientFactory } from "./validObjects";
 import { axios as defaultAxios, newAxios } from "./axios";
@@ -37,7 +37,7 @@ export * from "./generated/afm-rest-api/api";
 export * from "./generated/metadata-json-api/api";
 
 export {
-    tigerWorkspaceModelClientFactory,
+    tigerWorkspaceObjectsClientFactory,
     MetadataConfiguration,
     MetadataConfigurationParameters,
     MetadataBaseApi,
@@ -53,7 +53,7 @@ export {
 };
 
 export interface ITigerClient {
-    workspaceModel: ReturnType<typeof tigerWorkspaceModelClientFactory>;
+    workspaceObjects: ReturnType<typeof tigerWorkspaceObjectsClientFactory>;
     execution: ReturnType<typeof tigerExecutionClientFactory>;
     labelElements: ReturnType<typeof tigerLabelElementsClientFactory>;
     validObjects: ReturnType<typeof tigerValidObjectsClientFactory>;
@@ -67,14 +67,14 @@ export interface ITigerClient {
 export const tigerClientFactory = (axios: AxiosInstance): ITigerClient => {
     const execution = tigerExecutionClientFactory(axios);
     const labelElements = tigerLabelElementsClientFactory(axios);
-    const workspaceModel = tigerWorkspaceModelClientFactory(axios);
+    const workspaceObjects = tigerWorkspaceObjectsClientFactory(axios);
     const validObjects = tigerValidObjectsClientFactory(axios);
     const organizationObjects = tigerOrganizationObjectsClientFactory(axios);
 
     return {
         execution,
         labelElements,
-        workspaceModel,
+        workspaceObjects,
         validObjects,
         organizationObjects,
     };

--- a/libs/api-client-tiger/src/workspaceObjects.ts
+++ b/libs/api-client-tiger/src/workspaceObjects.ts
@@ -1,8 +1,8 @@
 // (C) 2019-2020 GoodData Corporation
 import { AxiosInstance } from "axios";
 import {
-    WorkspaceModelControllerApi,
-    WorkspaceModelControllerApiInterface,
+    WorkspaceObjectControllerApi,
+    WorkspaceObjectControllerApiInterface,
     Configuration,
     ConfigurationParameters,
 } from "./generated/metadata-json-api";
@@ -15,8 +15,6 @@ export {
     RequestArgs as MetadataRequestArgs,
 };
 
-// TODO consider to add clients for other controllers
-// Right now only the workspace model is utilized (to work with LDM and analytical objects)
-export const tigerWorkspaceModelClientFactory = (
+export const tigerWorkspaceObjectsClientFactory = (
     axios: AxiosInstance,
-): WorkspaceModelControllerApiInterface => new WorkspaceModelControllerApi({}, "", axios);
+): WorkspaceObjectControllerApiInterface => new WorkspaceObjectControllerApi({}, "", axios);

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -120,7 +120,7 @@ export async function loadAttributesAndDateDatasets(
     workspaceId: string,
     includeTags: string[],
 ): Promise<CatalogItem[]> {
-    const attributesResponse = await sdk.workspaceModel.getEntitiesAttributes(
+    const attributesResponse = await sdk.workspaceObjects.getEntitiesAttributes(
         {
             workspaceId: workspaceId,
         },

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -86,7 +86,7 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
 
     private loadMeasures = async (): Promise<ICatalogMeasure[]> => {
         const measures = await this.authCall((sdk) =>
-            sdk.workspaceModel.getEntitiesMetrics(
+            sdk.workspaceObjects.getEntitiesMetrics(
                 {
                     workspaceId: this.workspace,
                 },
@@ -102,7 +102,7 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
     private loadFacts = async (): Promise<ICatalogFact[]> => {
         const { includeTags = [] } = this.options;
         const facts = await this.authCall((sdk) =>
-            sdk.workspaceModel.getEntitiesFacts(
+            sdk.workspaceObjects.getEntitiesFacts(
                 {
                     workspaceId: this.workspace,
                 },

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -33,7 +33,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
     // Public methods
     public getDashboards = async (): Promise<IListedDashboard[]> => {
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.getEntitiesAnalyticalDashboards(
+            return sdk.workspaceObjects.getEntitiesAnalyticalDashboards(
                 {
                     workspaceId: this.workspace,
                 },
@@ -52,10 +52,10 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
 
         const id = await objRefToIdentifier(ref, this.authCall);
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.getEntityAnalyticalDashboards(
+            return sdk.workspaceObjects.getEntityAnalyticalDashboards(
                 {
                     workspaceId: this.workspace,
-                    id,
+                    objectId: id,
                 },
                 {
                     headers: jsonApiHeaders,
@@ -82,10 +82,10 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
 
         const id = await objRefToIdentifier(ref, this.authCall);
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.getEntityAnalyticalDashboards(
+            return sdk.workspaceObjects.getEntityAnalyticalDashboards(
                 {
                     workspaceId: this.workspace,
-                    id,
+                    objectId: id,
                 },
                 {
                     headers: jsonApiHeaders,
@@ -120,7 +120,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
 
         const dashboardContent = convertAnalyticalDashboard(dashboard, filterContext?.ref);
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.createEntityAnalyticalDashboards(
+            return sdk.workspaceObjects.createEntityAnalyticalDashboards(
                 {
                     workspaceId: this.workspace,
                     jsonApiAnalyticalDashboardDocument: {
@@ -152,9 +152,9 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
         const id = await objRefToIdentifier(ref, this.authCall);
 
         await this.authCall((sdk) =>
-            sdk.workspaceModel.deleteEntityAnalyticalDashboards(
+            sdk.workspaceObjects.deleteEntityAnalyticalDashboards(
                 {
-                    id: id,
+                    objectId: id,
                     workspaceId: this.workspace,
                 },
                 {
@@ -221,7 +221,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
         const tigerFilterContext = convertFilterContextToBackend(filterContext);
 
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.createEntityFilterContexts(
+            return sdk.workspaceObjects.createEntityFilterContexts(
                 {
                     workspaceId: this.workspace,
                     jsonApiFilterContextDocument: {
@@ -248,10 +248,10 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
     private getFilterContext = async (filterContextRef: ObjRef) => {
         const filterContextId = await objRefToIdentifier(filterContextRef, this.authCall);
         const result = await this.authCall((sdk) => {
-            return sdk.workspaceModel.getEntityFilterContexts(
+            return sdk.workspaceObjects.getEntityFilterContexts(
                 {
                     workspaceId: this.workspace,
-                    id: filterContextId,
+                    objectId: filterContextId,
                 },
                 {
                     headers: jsonApiHeaders,

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -72,7 +72,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
                   }
                 : undefined;
 
-            return sdk.workspaceModel.getEntitiesVisualizationObjects(
+            return sdk.workspaceObjects.getEntitiesVisualizationObjects(
                 {
                     workspaceId: this.workspace,
                 },
@@ -124,9 +124,9 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
     public getInsight = async (ref: ObjRef): Promise<IInsight> => {
         const id = await objRefToIdentifier(ref, this.authCall);
         const response = await this.authCall((sdk) =>
-            sdk.workspaceModel.getEntityVisualizationObjects(
+            sdk.workspaceObjects.getEntityVisualizationObjects(
                 {
-                    id: id,
+                    objectId: id,
                     workspaceId: this.workspace,
                 },
                 {
@@ -152,7 +152,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
 
     public createInsight = async (insight: IInsightDefinition): Promise<IInsight> => {
         const createResponse = await this.authCall((sdk) => {
-            return sdk.workspaceModel.createEntityVisualizationObjects(
+            return sdk.workspaceObjects.createEntityVisualizationObjects(
                 {
                     workspaceId: this.workspace,
                     jsonApiVisualizationObjectDocument: {
@@ -178,9 +178,9 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
 
     public updateInsight = async (insight: IInsight): Promise<IInsight> => {
         await this.authCall((sdk) => {
-            return sdk.workspaceModel.updateEntityVisualizationObjects(
+            return sdk.workspaceObjects.updateEntityVisualizationObjects(
                 {
-                    id: insightId(insight),
+                    objectId: insightId(insight),
                     workspaceId: this.workspace,
                     jsonApiVisualizationObjectDocument: {
                         data: {
@@ -206,8 +206,8 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
         const id = await objRefToIdentifier(ref, this.authCall);
 
         await this.authCall((sdk) =>
-            sdk.workspaceModel.deleteEntityVisualizationObjects({
-                id: id,
+            sdk.workspaceObjects.deleteEntityVisualizationObjects({
+                objectId: id,
                 workspaceId: this.workspace,
             }),
         );

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -21,9 +21,9 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
         }
 
         const metricMetadata = await this.authCall((sdk) =>
-            sdk.workspaceModel.getEntityMetrics(
+            sdk.workspaceObjects.getEntityMetrics(
                 {
-                    id: ref.identifier,
+                    objectId: ref.identifier,
                     workspaceId: this.workspace,
                 },
                 {

--- a/tools/catalog-export/README.md
+++ b/tools/catalog-export/README.md
@@ -65,7 +65,7 @@ setting in the `.gdcatalogrc`. Here is an example of full config for tiger:
     "projectId": "your workspace",
     "username": "username",
     "password": "password",
-    "output": "workspaceModel.ts"
+    "output": "workspaceObjects.ts"
 }
 ```
 

--- a/tools/catalog-export/src/loaders/tiger/index.ts
+++ b/tools/catalog-export/src/loaders/tiger/index.ts
@@ -15,7 +15,7 @@ import { createTigerClient } from "./tigerClient";
  */
 async function probeAccess(tigerClient: ITigerClient, projectId: string): Promise<boolean> {
     try {
-        await tigerClient.workspaceModel.getEntitiesMetrics(
+        await tigerClient.workspaceObjects.getEntitiesMetrics(
             {
                 workspaceId: projectId,
             },

--- a/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
@@ -14,7 +14,7 @@ export async function loadAnalyticalDashboards(
     _projectId: string,
     tigerClient: ITigerClient,
 ): Promise<ObjectMeta[]> {
-    const result = await tigerClient.workspaceModel.getEntitiesAnalyticalDashboards(
+    const result = await tigerClient.workspaceObjects.getEntitiesAnalyticalDashboards(
         {
             workspaceId: _projectId,
         },

--- a/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
@@ -59,7 +59,7 @@ function convertAttributes(attributes: JsonApiAttributeList): Attribute[] {
  */
 export async function loadCatalog(_projectId: string, tigerClient: ITigerClient): Promise<Catalog> {
     const [metricsResult, factsResult, attributesResult] = await Promise.all([
-        tigerClient.workspaceModel.getEntitiesMetrics(
+        tigerClient.workspaceObjects.getEntitiesMetrics(
             {
                 workspaceId: _projectId,
             },
@@ -67,7 +67,7 @@ export async function loadCatalog(_projectId: string, tigerClient: ITigerClient)
                 headers: jsonApiHeaders,
             },
         ),
-        tigerClient.workspaceModel.getEntitiesFacts(
+        tigerClient.workspaceObjects.getEntitiesFacts(
             {
                 workspaceId: _projectId,
             },
@@ -75,7 +75,7 @@ export async function loadCatalog(_projectId: string, tigerClient: ITigerClient)
                 headers: jsonApiHeaders,
             },
         ),
-        tigerClient.workspaceModel.getEntitiesAttributes(
+        tigerClient.workspaceObjects.getEntitiesAttributes(
             {
                 workspaceId: _projectId,
             },

--- a/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
@@ -79,7 +79,7 @@ export async function loadDateDataSets(
     _projectId: string,
     tigerClient: ITigerClient,
 ): Promise<DateDataSet[]> {
-    const result = await tigerClient.workspaceModel.getEntitiesAttributes(
+    const result = await tigerClient.workspaceObjects.getEntitiesAttributes(
         {
             workspaceId: _projectId,
         },

--- a/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
@@ -11,7 +11,7 @@ import { ITigerClient, jsonApiHeaders } from "@gooddata/api-client-tiger";
  * @param tigerClient - tiger client to use for communication
  */
 export async function loadInsights(_projectId: string, tigerClient: ITigerClient): Promise<ObjectMeta[]> {
-    const result = await tigerClient.workspaceModel.getEntitiesVisualizationObjects(
+    const result = await tigerClient.workspaceObjects.getEntitiesVisualizationObjects(
         {
             workspaceId: _projectId,
         },


### PR DESCRIPTION
One more round of the Tiger OAPI update.

Includes:
 * fixed granularities (EU ones)
 * removed WorkspaceModelController and switch to WorkspaceObjectController

Also updated in catalog-export and sdk-backend-tiger.
---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
