### PR TITLE
RELATED: RAIL-2847 minor fixes for alerts migration

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -68,6 +68,9 @@ export type AttributeBuilderInput = Identifier | ObjRef | IAttribute;
 export function attributeDisplayFormRef(attribute: IAttribute): ObjRef;
 
 // @internal
+export function attributeElementsCount(attributeElements: IAttributeElements): number;
+
+// @internal
 export function attributeElementsIsEmpty(attributeElements: IAttributeElements): boolean;
 
 // @public

--- a/libs/sdk-model/src/execution/filter/index.ts
+++ b/libs/sdk-model/src/execution/filter/index.ts
@@ -462,6 +462,23 @@ export function attributeElementsIsEmpty(attributeElements: IAttributeElements):
 }
 
 /**
+ * Gets the number of items in the {@link IAttributeElements}.
+ *
+ * @param attributeElements - object to test
+ * @returns the number of items
+ * @internal
+ */
+export function attributeElementsCount(attributeElements: IAttributeElements): number {
+    invariant(attributeElements, "attribute elements must be specified");
+
+    if (isAttributeElementsByRef(attributeElements)) {
+        return attributeElements.uris.length;
+    }
+
+    return attributeElements.values.length;
+}
+
+/**
  * Gets attribute elements specified on the attribute filter.
  *
  * @param filter - attribute filter to work with

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -103,6 +103,7 @@ export {
     isRelativeDateFilter,
     isAllTimeDateFilter,
     attributeElementsIsEmpty,
+    attributeElementsCount,
     isPositiveAttributeFilter,
     isNegativeAttributeFilter,
     isDateFilter,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
@@ -13,6 +13,7 @@ import {
 } from "@gooddata/sdk-backend-spi";
 import {
     areObjRefsEqual,
+    attributeElementsCount,
     attributeElementsIsEmpty,
     filterObjRef,
     IFilter,
@@ -222,9 +223,7 @@ function enrichBrokenAttributeFilter(
 
     const selection = elements.map((el) => el.title).join(", ");
     const title = meta.title;
-    const selectedCount = isAttributeElementsByRef(alertFilter.attributeFilter.attributeElements)
-        ? alertFilter.attributeFilter.attributeElements.uris.length
-        : alertFilter.attributeFilter.attributeElements.values.length;
+    const selectedCount = attributeElementsCount(alertFilter.attributeFilter.attributeElements);
 
     return {
         type: "attribute",

--- a/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
@@ -290,8 +290,8 @@
     }
 }
 
-.dash-item-action-alert,
-.dash-item-action-options {
+.dash-item-action.dash-item-action-alert,
+.dash-item-action.dash-item-action-options {
     display: none;
     color: $gd-color-label;
     background-color: $is-focused-background;
@@ -302,7 +302,7 @@
     }
 }
 
-.dash-item-action-alert {
+.dash-item-action.dash-item-action-alert {
     &.disabled {
         background-image: url("~@gooddata/sdk-ui-ext/esm/internal/assets/icons/alert-bell-na.svg");
         background-repeat: no-repeat;


### PR DESCRIPTION
* fix selector specificity as now it is imported before KPI Dashboards code (not after as before)
* add attributeElementsCount and use it

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
