### PR TITLE
RELATED: RAIL-2853 expose translations in sdk-ui-ext

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/test/KpiAlertDialog.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/test/KpiAlertDialog.test.tsx
@@ -5,7 +5,7 @@ import noop from "lodash/noop";
 import { DefaultLocale, withIntl } from "@gooddata/sdk-ui";
 
 import KpiAlertDialog, { IKpiAlertDialogProps } from "../KpiAlertDialog";
-import { messagesMap } from "../../../../utils/internalIntlProvider";
+import { translations } from "../../../../utils/translations";
 
 const DEFAULT_DATE_FORMAT = "MM/dd/yyyy";
 
@@ -23,7 +23,7 @@ function renderKpiAlertDialog(options: Partial<IKpiAlertDialogProps>) {
     const Wrapped: React.ComponentType<IKpiAlertDialogProps> = withIntl(
         KpiAlertDialog,
         undefined,
-        messagesMap[DefaultLocale],
+        translations[DefaultLocale],
     );
     return mount(<Wrapped {...defaultProps} {...options} />);
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/translationUtils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/translationUtils.test.ts
@@ -5,10 +5,10 @@ import { ReferenceLdm } from "@gooddata/reference-workspace";
 import { DateFilterGranularity, IDashboardDateFilter } from "@gooddata/sdk-backend-spi";
 
 import { getKpiAlertTranslationData, KpiAlertTranslationData } from "../translationUtils";
-import { messagesMap } from "../../../../utils/internalIntlProvider";
+import { translations } from "../../../../utils/translations";
 
 // we need to have both sdk-ui and sdk-ui-ext messages available
-const intl = createIntlMock(messagesMap[DefaultLocale], DefaultLocale);
+const intl = createIntlMock(translations[DefaultLocale], DefaultLocale);
 
 type TranslationTestPair = [IDateFilter | IDashboardDateFilter, KpiAlertTranslationData];
 

--- a/libs/sdk-ui-ext/src/internal/index.ts
+++ b/libs/sdk-ui-ext/src/internal/index.ts
@@ -9,6 +9,7 @@ export {
     DefaultVisualizationCatalog,
     FullVisualizationCatalog,
 } from "./components/VisualizationCatalog";
+export { translations } from "./utils/translations";
 
 export {
     IVisualization,

--- a/libs/sdk-ui-ext/src/internal/utils/internalIntlProvider.tsx
+++ b/libs/sdk-ui-ext/src/internal/utils/internalIntlProvider.tsx
@@ -1,37 +1,12 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { IntlProvider, IntlShape, createIntl } from "react-intl";
-import { translationUtils } from "@gooddata/util";
-
-import enUS from "../translations/en-US.json";
-import deDE from "../translations/de-DE.json";
-import esES from "../translations/es-ES.json";
-import frFR from "../translations/fr-FR.json";
-import jaJP from "../translations/ja-JP.json";
-import nlNL from "../translations/nl-NL.json";
-import ptBR from "../translations/pt-BR.json";
-import ptPT from "../translations/pt-PT.json";
-import zhHans from "../translations/zh-Hans.json";
 import { DefaultLocale, ILocale } from "@gooddata/sdk-ui";
 
-export interface ITranslations {
-    [key: string]: string;
-}
-
-export const messagesMap: { [locale: string]: ITranslations } = {
-    "en-US": translationUtils.removeMetadata(enUS),
-    "de-DE": deDE,
-    "es-ES": esES,
-    "fr-FR": frFR,
-    "ja-JP": jaJP,
-    "nl-NL": nlNL,
-    "pt-BR": ptBR,
-    "pt-PT": ptPT,
-    "zh-Hans": zhHans,
-};
+import { translations } from "./translations";
 
 export function createInternalIntl(locale: ILocale = DefaultLocale): IntlShape {
-    return createIntl({ locale, messages: messagesMap[locale] });
+    return createIntl({ locale, messages: translations[locale] });
 }
 
 interface IInternalIntlWrapperProps {
@@ -45,7 +20,7 @@ export class InternalIntlWrapper extends React.PureComponent<IInternalIntlWrappe
     public render(): React.ReactNode {
         const { locale } = this.props;
         return (
-            <IntlProvider locale={locale} messages={messagesMap[locale]}>
+            <IntlProvider locale={locale} messages={translations[locale]}>
                 {this.props.children}
             </IntlProvider>
         );

--- a/libs/sdk-ui-ext/src/internal/utils/translations.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/translations.ts
@@ -1,5 +1,15 @@
 // (C) 2019-2020 GoodData Corporation
 import { IntlShape } from "react-intl";
+import { translationUtils } from "@gooddata/util";
+import enUS from "../translations/en-US.json";
+import deDE from "../translations/de-DE.json";
+import esES from "../translations/es-ES.json";
+import frFR from "../translations/fr-FR.json";
+import jaJP from "../translations/ja-JP.json";
+import nlNL from "../translations/nl-NL.json";
+import ptBR from "../translations/pt-BR.json";
+import ptPT from "../translations/pt-PT.json";
+import zhHans from "../translations/zh-Hans.json";
 import { IDropdownItem } from "../interfaces/Dropdown";
 
 export function getTranslation(
@@ -16,3 +26,18 @@ export function getTranslatedDropdownItems(dropdownItems: IDropdownItem[], intl:
         return { ...item, ...translatedTitleProp };
     });
 }
+
+/**
+ * @internal
+ */
+export const translations: { [locale: string]: Record<string, string> } = {
+    "en-US": translationUtils.removeMetadata(enUS),
+    "de-DE": deDE,
+    "es-ES": esES,
+    "fr-FR": frFR,
+    "ja-JP": jaJP,
+    "nl-NL": nlNL,
+    "pt-BR": ptBR,
+    "pt-PT": ptPT,
+    "zh-Hans": zhHans,
+};


### PR DESCRIPTION
We need this to be able to use these from other apps.

JIRA: RAIL-2853

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
