### PR TITLE
RELATED: RAIL-2931 add read only prop to DashboardView and use it in examples

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardEmbedding/CustomDashboardView.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/CustomDashboardView.tsx
@@ -247,6 +247,7 @@ const CustomDashboardView: React.FC = () => {
                 // Render all other widgets in a common way, just wrap them with some component
                 return <CustomWidgetContainer>{renderedWidget}</CustomWidgetContainer>;
             }}
+            isReadOnly
         />
     );
 };

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithDrilling.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithDrilling.tsx
@@ -18,6 +18,7 @@ const DashboardViewWithDrilling: React.FC = () => {
                 // eslint-disable-next-line no-console
                 console.log("Drill event in DashboardView: ", e);
             }}
+            isReadOnly
         />
     );
 };

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithEmails.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithEmails.tsx
@@ -25,6 +25,7 @@ const DashboardViewWithEmails: React.FC = () => {
                     alert("Scheduled email error");
                     setIsEmailDialogOpen(false);
                 }}
+                isReadOnly
             />
         </>
     );

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithFilters.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithFilters.tsx
@@ -14,7 +14,7 @@ const filters = [
 const config = { mapboxToken: MAPBOX_TOKEN };
 
 const DashboardViewWithFilters: React.FC = () => {
-    return <DashboardView dashboard={dashboardRef} filters={filters} config={config} />;
+    return <DashboardView dashboard={dashboardRef} filters={filters} config={config} isReadOnly />;
 };
 
 export default DashboardViewWithFilters;

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithMergedFilters.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/DashboardViewWithMergedFilters.tsx
@@ -27,6 +27,7 @@ const DashboardViewWithMergedFilters: React.FC = () => {
             filters={mergedFilters}
             config={config}
             onDashboardLoaded={({ dashboard }) => setDashboard(dashboard)}
+            isReadOnly
         />
     );
 };

--- a/examples/sdk-examples/src/examples/dashboardEmbedding/SimpleDashboardView.tsx
+++ b/examples/sdk-examples/src/examples/dashboardEmbedding/SimpleDashboardView.tsx
@@ -8,7 +8,7 @@ const dashboardRef = idRef("aeO5PVgShc0T");
 const config = { mapboxToken: MAPBOX_TOKEN };
 
 const SimpleDashboardView: React.FC = () => {
-    return <DashboardView dashboard={dashboardRef} config={config} />;
+    return <DashboardView dashboard={dashboardRef} config={config} isReadOnly />;
 };
 
 export default SimpleDashboardView;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardView.tsx
@@ -21,6 +21,7 @@ import { DashboardRenderer } from "./DashboardRenderer";
 import { EmptyDashboardError } from "./EmptyDashboardError";
 import { DashboardAlertsProvider } from "./DashboardAlertsContext";
 import { filterArrayToFilterContextItems } from "../utils/filters";
+import { DashboardViewIsReadOnlyProvider } from "./DashboardViewIsReadOnlyContext";
 
 export const DashboardView: React.FC<IDashboardViewProps> = ({
     dashboard,
@@ -45,6 +46,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
     ErrorComponent = DefaultError,
     LoadingComponent = DefaultLoading,
     widgetRenderer,
+    isReadOnly = false,
 }) => {
     const { error: dashboardError, result: dashboardData, status: dashboardStatus } = useDashboard({
         dashboard,
@@ -173,43 +175,47 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                 <ColorPaletteProvider palette={colorPalette}>
                     <AttributesWithDrillDownProvider attributes={drillDownAttributes}>
                         <DashboardAlertsProvider alerts={alertsData}>
-                            <ScheduledMailDialog
-                                backend={backend}
-                                workspace={workspace}
-                                locale={effectiveLocale}
-                                dashboard={dashboard}
-                                filters={applyFiltersToScheduledMail ? sanitizedFilters : undefined}
-                                onSubmit={onScheduledMailDialogSubmit}
-                                onSubmitSuccess={onScheduledMailSubmitSuccess}
-                                onSubmitError={onScheduledMailSubmitError}
-                                onCancel={onScheduledMailDialogCancel}
-                                onError={onError}
-                                isVisible={isScheduledMailDialogVisible}
-                            />
-                            {isFluidLayoutEmpty(dashboardData.layout) ? (
-                                <EmptyDashboardError ErrorComponent={ErrorComponent} />
-                            ) : (
-                                <DashboardRenderer
+                            <DashboardViewIsReadOnlyProvider isReadOnly={isReadOnly}>
+                                <ScheduledMailDialog
                                     backend={backend}
                                     workspace={workspace}
-                                    dashboardRef={dashboard}
-                                    dashboardViewLayout={dashboardData?.layout}
-                                    filters={sanitizedFilters}
-                                    onFiltersChange={onFiltersChange}
-                                    filterContext={dashboardData.filterContext}
-                                    onDrill={onDrill}
-                                    drillableItems={drillableItems}
-                                    ErrorComponent={ErrorComponent}
-                                    LoadingComponent={LoadingComponent}
-                                    className="gd-dashboards-root"
-                                    getDashboardViewLayoutWidgetClass={
-                                        dashboardViewLayoutResult.getDashboardViewLayoutWidgetClass
-                                    }
-                                    getInsightByRef={dashboardViewLayoutResult.getInsightByRef}
-                                    widgetRenderer={widgetRenderer}
-                                    areSectionHeadersEnabled={userWorkspaceSettings?.areSectionHeadersEnabled}
+                                    locale={effectiveLocale}
+                                    dashboard={dashboard}
+                                    filters={applyFiltersToScheduledMail ? sanitizedFilters : undefined}
+                                    onSubmit={onScheduledMailDialogSubmit}
+                                    onSubmitSuccess={onScheduledMailSubmitSuccess}
+                                    onSubmitError={onScheduledMailSubmitError}
+                                    onCancel={onScheduledMailDialogCancel}
+                                    onError={onError}
+                                    isVisible={isScheduledMailDialogVisible}
                                 />
-                            )}
+                                {isFluidLayoutEmpty(dashboardData.layout) ? (
+                                    <EmptyDashboardError ErrorComponent={ErrorComponent} />
+                                ) : (
+                                    <DashboardRenderer
+                                        backend={backend}
+                                        workspace={workspace}
+                                        dashboardRef={dashboard}
+                                        dashboardViewLayout={dashboardData?.layout}
+                                        filters={sanitizedFilters}
+                                        onFiltersChange={onFiltersChange}
+                                        filterContext={dashboardData.filterContext}
+                                        onDrill={onDrill}
+                                        drillableItems={drillableItems}
+                                        ErrorComponent={ErrorComponent}
+                                        LoadingComponent={LoadingComponent}
+                                        className="gd-dashboards-root"
+                                        getDashboardViewLayoutWidgetClass={
+                                            dashboardViewLayoutResult.getDashboardViewLayoutWidgetClass
+                                        }
+                                        getInsightByRef={dashboardViewLayoutResult.getInsightByRef}
+                                        widgetRenderer={widgetRenderer}
+                                        areSectionHeadersEnabled={
+                                            userWorkspaceSettings?.areSectionHeadersEnabled
+                                        }
+                                    />
+                                )}
+                            </DashboardViewIsReadOnlyProvider>
                         </DashboardAlertsProvider>
                     </AttributesWithDrillDownProvider>
                 </ColorPaletteProvider>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardViewIsReadOnlyContext.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardViewIsReadOnlyContext.tsx
@@ -1,0 +1,33 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+
+const DashboardViewIsReadOnlyContext = React.createContext<boolean>(false);
+DashboardViewIsReadOnlyContext.displayName = "DashboardViewIsReadOnlyContext";
+
+/**
+ * @internal
+ */
+export interface IDashboardViewIsReadOnlyProviderProps {
+    isReadOnly: boolean;
+}
+
+/**
+ * @internal
+ */
+export const DashboardViewIsReadOnlyProvider: React.FC<IDashboardViewIsReadOnlyProviderProps> = ({
+    children,
+    isReadOnly,
+}) => {
+    return (
+        <DashboardViewIsReadOnlyContext.Provider value={isReadOnly}>
+            {children}
+        </DashboardViewIsReadOnlyContext.Provider>
+    );
+};
+
+/**
+ * @internal
+ */
+export const useDashboardViewIsReadOnly = (): boolean => {
+    return React.useContext(DashboardViewIsReadOnlyContext);
+};

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -85,6 +85,7 @@ interface IKpiExecutorProps {
     workspace: string;
     separators: ISeparators;
     disableDrillUnderline?: boolean;
+    isReadOnly?: boolean;
     ErrorComponent: React.ComponentType<IErrorProps>;
     LoadingComponent: React.ComponentType<ILoadingProps>;
 }
@@ -110,6 +111,7 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
     separators,
     disableDrillUnderline,
     intl,
+    isReadOnly,
     ErrorComponent = DefaultError,
     LoadingComponent = DefaultLoading,
 }) => {
@@ -179,8 +181,6 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
     const { result: permissions } = useUserWorkspacePermissions({ backend, workspace });
     const canSetAlert = permissions?.canCreateScheduledMail;
 
-    const isReadonlyMode = false; // TODO we need to support proper read only mode for live examples with proxy (RAIL-2931)
-
     if (status === "loading" || status === "pending") {
         return <LoadingComponent />;
     }
@@ -205,7 +205,7 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
             renderHeadline={() => <DashboardItemHeadline title={kpiWidget.title} />}
             kpiAlertResult={kpiAlertResult}
             canSetAlert={canSetAlert}
-            isReadOnlyMode={isReadonlyMode}
+            isReadOnlyMode={isReadOnly}
             alertExecutionError={
                 alertError ??
                 /*

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
@@ -25,6 +25,7 @@ import invariant from "ts-invariant";
 import { useKpiData } from "./utils";
 import { KpiExecutor } from "./KpiExecutor";
 import { useDashboardViewConfig } from "../DashboardViewConfigContext";
+import { useDashboardViewIsReadOnly } from "../DashboardViewIsReadOnlyContext";
 import { IDashboardFilter } from "../../types";
 
 export interface IKpiViewProps {
@@ -132,6 +133,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
     });
 
     const config = useDashboardViewConfig();
+    const isReadOnly = useDashboardViewIsReadOnly();
 
     // add drilling predicate for the metric if the KPI has any drills defined from KPI dashboards
     const effectiveDrillableItems: Array<IDrillableItem | IHeaderPredicate> = useMemo(
@@ -166,6 +168,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
             workspace={workspace}
             ErrorComponent={ErrorComponent}
             LoadingComponent={LoadingComponent}
+            isReadOnly={isReadOnly}
         />
     );
 };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -214,6 +214,14 @@ export interface IDashboardViewProps {
      * Note: Custom widget rendering is not supported for dashboard exports & scheduled e-mails.
      */
     widgetRenderer?: IDashboardWidgetRenderer;
+
+    /**
+     * If set to true, the dashboard will be embedded in a read-only mode disabling any user interaction
+     * that would alter any backend state (disabling creating/changing alerts for example).
+     *
+     * @default false i.e. NOT a read-only mode.
+     */
+    isReadOnly?: boolean;
 }
 
 /**

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
@@ -197,7 +197,11 @@ export class DashboardItemWithKpiAlert extends Component<
 
         // TODO: Remove "isAlertingTemporarilyDisabledForGivenFilter" when alerts support absolute filters (RAIL-1456, RAIL-1457).
         //       When alert is set, we allow opening the alert box so user can edit/delete it.
-        if (!this.props.canSetAlert || (isAlertingTemporarilyDisabled && !this.props.alert)) {
+        if (
+            this.props.isReadOnlyMode ||
+            !this.props.canSetAlert ||
+            (isAlertingTemporarilyDisabled && !this.props.alert)
+        ) {
             const bubbleMessage = this.props.isReadOnlyMode ? (
                 <FormattedMessage id="kpi.alertBox.disabledInReadOnly" />
             ) : (


### PR DESCRIPTION
Since the mechanism relies on passing a prop anyway, there
is no need to create a special build of examples (since missing
the prop would disable the readonly mode anyway).
Instead, we just use the appropriate flag in all examples.

Also, a bug in DashboardItemWithKpiAlert was fixed related to read only.
This bug does not manifest in KPI Dashboards because the readonly prop
is reflected in the canSetAlert prop as well.

JIRA: RAIL-2931

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
