### PR TITLE
RELATED: RAIL-2932 make useCancelablePromise consistent with useEffect

### DIFF
--- a/libs/sdk-ui/src/base/react/safeSerialize.ts
+++ b/libs/sdk-ui/src/base/react/safeSerialize.ts
@@ -1,0 +1,14 @@
+// (C) 2019-2021 GoodData Corporation
+
+/**
+ * Safely serializes an object preventing errors that JSON.stringify might throw.
+ *
+ * @param obj - object to serialize
+ */
+export function safeSerialize(obj: unknown): string {
+    try {
+        return JSON.stringify(obj);
+    } catch {
+        return "";
+    }
+}

--- a/libs/sdk-ui/src/base/react/tests/__snapshots__/safeSerialize.test.ts.snap
+++ b/libs/sdk-ui/src/base/react/tests/__snapshots__/safeSerialize.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`safeSerialize should serialize array 1`] = `"[1,2,3]"`;
+
+exports[`safeSerialize should serialize null 1`] = `"null"`;
+
+exports[`safeSerialize should serialize number 1`] = `"42"`;
+
+exports[`safeSerialize should serialize object 1`] = `"{\\"a\\":42}"`;
+
+exports[`safeSerialize should serialize string 1`] = `"\\"hello\\""`;
+
+exports[`safeSerialize should serialize undefined 1`] = `undefined`;

--- a/libs/sdk-ui/src/base/react/tests/safeSerialize.test.ts
+++ b/libs/sdk-ui/src/base/react/tests/safeSerialize.test.ts
@@ -1,0 +1,27 @@
+// (C) 2019-2021 GoodData Corporation
+
+import { safeSerialize } from "../safeSerialize";
+
+describe("safeSerialize", () => {
+    type Scenario = [string, any];
+
+    const validScenarios: Scenario[] = [
+        ["null", null],
+        ["undefined", undefined],
+        ["number", 42],
+        ["string", "hello"],
+        ["array", [1, 2, 3]],
+        ["object", { a: 42 }],
+    ];
+
+    it.each(validScenarios)("should serialize %s", (_, input) => {
+        expect(safeSerialize(input)).toMatchSnapshot();
+    });
+
+    it("should handle circular objects", () => {
+        const circularReference: any = { otherData: 123 };
+        circularReference.myself = circularReference;
+
+        expect(safeSerialize(circularReference)).toEqual("");
+    });
+});

--- a/libs/sdk-ui/src/base/react/useCancelablePromise.ts
+++ b/libs/sdk-ui/src/base/react/useCancelablePromise.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { DependencyList, useEffect, useState } from "react";
 import { makeCancelable } from "./CancelablePromise";
 import noop from "lodash/noop";
@@ -107,7 +107,7 @@ export function useCancelablePromise<TResult, TError = any>(
     }: {
         promise: (() => Promise<TResult>) | undefined | null;
     } & UseCancelablePromiseCallbacks<TResult, TError>,
-    deps: DependencyList = [],
+    deps?: DependencyList,
 ): UseCancelablePromiseState<TResult, TError> {
     const getInitialState = (): UseCancelablePromiseState<TResult, TError> => ({
         result: undefined,
@@ -176,8 +176,12 @@ export function useCancelablePromise<TResult, TError = any>(
 
     // We want to avoid the return of the old state when some dependency has changed,
     // before another useEffect hook round starts.
-    const [prevDeps, setDeps] = useState<DependencyList>(deps);
-    if (deps.some((dep, i) => dep !== prevDeps[i])) {
+    const [prevDeps, setDeps] = useState(deps);
+    if (
+        (!deps && prevDeps) || // removed deps when we had some
+        (deps && !prevDeps) || // or added deps when we had none
+        deps?.some((dep, i) => dep !== prevDeps?.[i]) // or changed some dep
+    ) {
         setDeps(deps);
         const currentState = getInitialState();
         setState(currentState);


### PR DESCRIPTION
This removes the default of the deps parameters (which makes this behave like useEffect and makes this easier to apply useEffect intution to).

JIRA: RAIL-2932

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
