### PR TITLE
RELATED: RAIL-2875 prevent unnecessary DashboardLayoutItem re-renders

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -328,12 +328,12 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         if (this.environment === DASHBOARDS_ENVIRONMENT) {
             this.renderFun(
                 <ReactMeasure client={true}>
-                    {({ measureRef, contentRect }: any) => {
+                    {({ measureRef, contentRect }) => {
                         const clientHeight = contentRect.client.height;
 
                         /*
                          * For some reason (unknown to me), there was a big if; nil height meant that
-                         * the wrapper was to 100%; non-nil height ment fixed size header with the 328 magic
+                         * the wrapper was to 100%; non-nil height meant fixed size header with the 328 magic
                          * number.
                          *
                          * For a while, there were more differences between the two branches, however after

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContentWrapper.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardItem/DashboardItemContentWrapper.tsx
@@ -1,18 +1,41 @@
 // (C) 2020 GoodData Corporation
-import React from "react";
+import React, { forwardRef, memo } from "react";
 import Measure from "react-measure";
 
 interface IDashboardItemContentWrapperProps {
     children: (params: { clientWidth: number }) => React.ReactNode;
 }
 
+interface IDashboardItemContentWrapperMeasureProxyProps extends IDashboardItemContentWrapperProps {
+    clientWidth: number;
+}
+
+// this is to make sure the item content re-renders only when width changes, nothing else
+// as we do not pass anything other than width down to the children,
+// but react-measure re-renders on any change to the client rect
+const DashboardItemContentWrapperMeasureProxy = memo(
+    forwardRef<HTMLDivElement, IDashboardItemContentWrapperMeasureProxyProps>(
+        ({ children, clientWidth }, ref) => {
+            return (
+                <div className="dash-item-content-wrapper" ref={ref}>
+                    {children({ clientWidth })}
+                </div>
+            );
+        },
+    ),
+);
+DashboardItemContentWrapperMeasureProxy.displayName = "DashboardItemContentWrapperMeasureProxy";
+
 export const DashboardItemContentWrapper: React.FC<IDashboardItemContentWrapperProps> = ({ children }) => {
     return (
         <Measure client>
             {({ measureRef, contentRect }) => (
-                <div className="dash-item-content-wrapper" ref={measureRef}>
-                    {children({ clientWidth: contentRect.client?.width })}
-                </div>
+                <DashboardItemContentWrapperMeasureProxy
+                    ref={measureRef}
+                    clientWidth={contentRect.client?.width}
+                >
+                    {children}
+                </DashboardItemContentWrapperMeasureProxy>
             )}
         </Measure>
     );


### PR DESCRIPTION
This makes sure that DashboardLayoutItem re-renders only on width
change. This is useful for cases when the inside of the item changes
height for some reason and this would create a re-render which can
make the height change again -> infinite loop.

JIRA: RAIL-2875

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
