### PR TITLE
RELATED: RAIL-2875 avoid unnecessary re-renders in InsightRenderer

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -46,7 +46,10 @@ const visualizationUriRootStyle = {
     height: "100%",
 };
 
-class InsightRendererCore extends React.Component<IInsightRendererProps & WrappedComponentProps> {
+// this needs to be a pure component as it can happen that this might be rendered multiple times
+// with the same props (referentially) - this might make the rendered visualization behave unpredictably
+// and is bad for performance so we need to make sure the re-renders are performed only if necessary
+class InsightRendererCore extends React.PureComponent<IInsightRendererProps & WrappedComponentProps> {
     private elementId = getElementId();
     private visualization: IVisualization | undefined;
     private containerRef = React.createRef<HTMLDivElement>();


### PR DESCRIPTION
This helps with performance and avoids the bug with highcharts sometimes
changing height slightly (or at least makes it so that it does not create
an infinite loop when it happens).

This also explains why this bug was only happening in the SDK and not in KPI Dashboards.

JIRA: RAIL-2875

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
