### PR TITLE
RELATED RAIL-2847: clean up date filter intl in dashboard embedding

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
@@ -21,15 +21,13 @@ import {
     isAttributeFilter,
     objRefToString,
 } from "@gooddata/sdk-model";
-import { ILocale } from "@gooddata/sdk-ui";
-import { DateFilterHelpers } from "@gooddata/sdk-ui-filters";
 import last from "lodash/last";
 import partition from "lodash/partition";
 import { IntlShape } from "react-intl";
 
 import { isAttributeFilterIgnored, isDateFilterIrrelevant } from "../../utils/filters";
 
-import { dashboardDateFilterToPreset } from "./translationUtils";
+import { translateDateFilter } from "./translationUtils";
 import {
     BrokenAlertType,
     IBrokenAlertAttributeFilter,
@@ -182,12 +180,7 @@ function enrichBrokenDateFilter(
     dateDataSets: IDataSetMetadataObject[],
 ): IBrokenAlertDateFilter {
     const { alertFilter, brokenType } = brokenFilter;
-    // TODO clear this up so that the conversion is not needed
-    const dateFilterTitle = DateFilterHelpers.getDateFilterTitle(
-        dashboardDateFilterToPreset(alertFilter),
-        intl.locale as ILocale,
-        dateFormat,
-    );
+    const dateFilterTitle = translateDateFilter(alertFilter, intl, dateFormat);
 
     const matchingDateDataset = dateDataSets.find((dataset) =>
         areObjRefsEqual(dataset, alertFilter.dateFilter.dataSet),

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialog.tsx
@@ -173,7 +173,8 @@ export const ScheduledMailDialog: React.FC<ScheduledMailDialogProps> = (props) =
     // Bear model expects that all refs are sanitized to uriRefs.
     const dashboardUriRef = useMemo(() => (dashboard ? uriRef(dashboard.uri) : null), [dashboard]);
 
-    if (featureFlags) {
+    // trigger the invariant only if the user tries to open the dialog
+    if (featureFlags && isVisible) {
         invariant(
             featureFlags.enableKPIDashboardSchedule,
             "Feature flag enableKPIDashboardSchedule must be enabled to make ScheduledMailDialog work properly.",

--- a/libs/sdk-ui-kit/src/List/InsightListItem.tsx
+++ b/libs/sdk-ui-kit/src/List/InsightListItem.tsx
@@ -94,8 +94,7 @@ export class InsightListItemCore extends Component<IInsightListItemProps & Wrapp
 
     public componentDidUpdate(prevProps: IInsightListItemProps & WrappedComponentProps): void {
         if (prevProps.width !== this.props.width && this.shortenedTextRef.current) {
-            // TODO INE remove any when GD has correct typings
-            (this.shortenedTextRef.current as any).recomputeShortening();
+            this.shortenedTextRef.current.recomputeShortening();
         }
     }
 


### PR DESCRIPTION
This avoids unnecessary conversions and uses the translation
methods more directly.

Also, an obsolete any cast was removed and an edge case in ScheduleMailDialog was handled.

JIRA: RAIL-2847

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
