### PR TITLE
Simplify the structure of dateDataset ref from dateDataset to dateDat…

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -192,7 +192,7 @@ describe("PluggableAreaChart", () => {
         it("should keep only first date attribute in view by bucket when comming from pivot table with different dimensions", async () => {
             const areaChart = createComponent(defaultProps);
             const mockRefPoint = cloneDeep(referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint);
-            mockRefPoint.buckets[2].items[0].dateDataset.ref = {
+            mockRefPoint.buckets[2].items[0].dateDatasetRef = {
                 uri: "closed",
             };
             const expectedBuckets: IBucketOfFun[] = [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -269,7 +269,7 @@ describe("PluggableBulletChart", () => {
 
         it("should keep first Date item when items have different dimensions", async () => {
             const mockRefPoint = cloneDeep(referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint);
-            mockRefPoint.buckets[2].items[0].dateDataset.ref = {
+            mockRefPoint.buckets[2].items[0].dateDatasetRef = {
                 uri: "closed",
             };
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -396,7 +396,7 @@ describe("PluggableColumnBarCharts", () => {
         it("should keep only first date attribute in view by bucket when comming from pivot table with different dimensions", async () => {
             const columnChart = createComponent(defaultProps);
             const mockRefPoint = cloneDeep(referencePointMocks.dateAttributeOnRowsAndColumnsReferencePoint);
-            mockRefPoint.buckets[2].items[0].dateDataset.ref = {
+            mockRefPoint.buckets[2].items[0].dateDatasetRef = {
                 uri: "closed",
             };
             const expectedBuckets: IBucketOfFun[] = [

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -182,9 +182,7 @@ export interface IBucketItem {
 
     dfRef?: ObjRef;
     locationDisplayFormRef?: ObjRef;
-    dateDataset?: {
-        ref: ObjRef;
-    };
+    dateDatasetRef?: ObjRef;
 }
 
 export interface IFiltersBucketItem extends IBucketItem {

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -271,9 +271,7 @@ export const samePeriodPrevYearFiltersBucket: IFilters = {
                 },
             ],
             aggregation: null,
-            dateDataset: {
-                ref: dateDatasetRef,
-            },
+            dateDatasetRef: dateDatasetRef,
         },
     ],
 };
@@ -495,9 +493,7 @@ export const overTimeComparisonDateItem: IBucketItem = {
     localIdentifier: "2fb4a818526f4ca18c926b1a11adc859",
     filters: [dateFilterSamePeriodPreviousYear],
     attribute: "attr.datedataset",
-    dateDataset: {
-        ref: dateDatasetRef,
-    },
+    dateDatasetRef,
 };
 
 export const dateItemWithDateDataset: IBucketItem = {
@@ -506,9 +502,7 @@ export const dateItemWithDateDataset: IBucketItem = {
     attribute: "attr.datedataset",
     aggregation: null,
     showInPercent: null,
-    dateDataset: {
-        ref: dateDatasetRef,
-    },
+    dateDatasetRef,
 };
 
 const defaultSortItem = {
@@ -1745,10 +1739,8 @@ export const dateAttributeOnRowsAndColumnsReferencePoint: IReferencePoint = {
             items: [
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "created",
-                        },
+                    dateDatasetRef: {
+                        uri: "created",
                     },
                     localIdentifier: "date1",
                 },
@@ -1759,10 +1751,8 @@ export const dateAttributeOnRowsAndColumnsReferencePoint: IReferencePoint = {
             items: [
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "created",
-                        },
+                    dateDatasetRef: {
+                        uri: "created",
                     },
                     localIdentifier: "date2",
                 },
@@ -1786,37 +1776,29 @@ export const dateAttributesOnRowsReferencePoint: IReferencePoint = {
             items: [
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "created",
-                        },
+                    dateDatasetRef: {
+                        uri: "created",
                     },
                     localIdentifier: "date1",
                 },
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "closed",
-                        },
+                    dateDatasetRef: {
+                        uri: "closed",
                     },
                     localIdentifier: "date2",
                 },
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "snapshot",
-                        },
+                    dateDatasetRef: {
+                        uri: "snapshot",
                     },
                     localIdentifier: "date3",
                 },
                 {
                     ...dateItem,
-                    dateDataset: {
-                        ref: {
-                            uri: "created",
-                        },
+                    dateDatasetRef: {
+                        uri: "created",
                     },
                     localIdentifier: "date4",
                 },

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -963,7 +963,7 @@ export const transformMeasureBuckets = (
 
 const hasSameDateDimension = (dateItem: IBucketItem, referenceDateItem: IBucketItem): boolean => {
     if (isDateBucketItem(dateItem) && isDateBucketItem(referenceDateItem)) {
-        return areObjRefsEqual(dateItem.dateDataset?.ref, referenceDateItem.dateDataset?.ref);
+        return areObjRefsEqual(dateItem.dateDatasetRef, referenceDateItem.dateDatasetRef);
     }
     return false;
 };
@@ -982,7 +982,7 @@ const getDateFilterRef = (filters: IFilters): ObjRef | undefined => {
     if (!dateFilter) {
         return undefined;
     }
-    return dateFilter.dateDataset?.ref;
+    return dateFilter.dateDatasetRef;
 };
 
 export const isComparisonAvailable = (buckets: IBucketOfFun[], filters: IFilters): boolean => {
@@ -997,6 +997,6 @@ export const isComparisonAvailable = (buckets: IBucketOfFun[], filters: IFilters
         return true;
     }
     return bucketDateItems.some((bucketDateItem: IBucketItem) =>
-        areObjRefsEqual(bucketDateItem.dateDataset?.ref, dateFilterRef),
+        areObjRefsEqual(bucketDateItem.dateDatasetRef, dateFilterRef),
     );
 };

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketConfig.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketConfig.test.ts
@@ -17,9 +17,7 @@ describe("configure Percent and Over Time Comparison helper functions", () => {
         attribute: DATE_DATASET_ATTRIBUTE,
         localIdentifier: "f1",
         filters: [referencePointMocks.dateFilterSamePeriodPreviousYear],
-        dateDataset: {
-            ref: referencePointMocks.dateDatasetRef,
-        },
+        dateDatasetRef: referencePointMocks.dateDatasetRef,
     };
 
     function getSingleMeasureNoFilterReferencePoint(numberOfMeasures: number): IExtendedReferencePoint {
@@ -140,18 +138,14 @@ describe("configure Percent and Over Time Comparison helper functions", () => {
             attribute: DATE_DATASET_ATTRIBUTE,
             localIdentifier: "f1",
             filters: [referencePointMocks.dateFilter],
-            dateDataset: {
-                ref: referencePointMocks.dateDatasetRef,
-            },
+            dateDatasetRef: referencePointMocks.dateDatasetRef,
         };
 
         const dateFilterWithSamePeriodPreviousYear: IFiltersBucketItem = {
             attribute: DATE_DATASET_ATTRIBUTE,
             localIdentifier: "f1",
             filters: [referencePointMocks.dateFilterSamePeriodPreviousYear],
-            dateDataset: {
-                ref: referencePointMocks.dateDatasetRef,
-            },
+            dateDatasetRef: referencePointMocks.dateDatasetRef,
         };
 
         it("should keep all derived measures if over time comparison is available due to non-all-time date filter", () => {
@@ -342,9 +336,7 @@ describe("configure Percent and Over Time Comparison helper functions", () => {
                                 type: DATE,
                                 attribute: DATE_DATASET_ATTRIBUTE,
                                 granularity: GRANULARITY.week,
-                                dateDataset: {
-                                    ref: referencePointMocks.dateDatasetRef,
-                                },
+                                dateDatasetRef: referencePointMocks.dateDatasetRef,
                             },
                         ],
                     },
@@ -489,10 +481,8 @@ describe("configure Percent and Over Time Comparison helper functions", () => {
                 attribute: DATE_DATASET_ATTRIBUTE,
                 localIdentifier: "f1",
                 filters: [referencePointMocks.dateFilterSamePeriodPreviousYear],
-                dateDataset: {
-                    ref: {
-                        uri: "different.date.dataset",
-                    },
+                dateDatasetRef: {
+                    uri: "different.date.dataset",
                 },
             };
             const referencePoint = getOverTimeComparisonReferencePoint(dateFilterWithDifferentDateDataset);

--- a/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/bucketHelper.test.ts
@@ -2780,9 +2780,7 @@ describe("isComparisonAvailable", () => {
         attribute: DATE_DATASET_ATTRIBUTE,
         localIdentifier: "f1",
         filters: [referencePointMocks.dateFilter],
-        dateDataset: {
-            ref: referencePointMocks.dateDatasetRef,
-        },
+        dateDatasetRef: referencePointMocks.dateDatasetRef,
     };
     const referencePoint: IExtendedReferencePoint = {
         buckets: [
@@ -2793,9 +2791,7 @@ describe("isComparisonAvailable", () => {
                         localIdentifier: "date",
                         type: DATE,
                         attribute: DATE_DATASET_ATTRIBUTE,
-                        dateDataset: {
-                            ref: referencePointMocks.dateDatasetRef,
-                        },
+                        dateDatasetRef: referencePointMocks.dateDatasetRef,
                     },
                 ],
             },
@@ -2821,10 +2817,8 @@ describe("isComparisonAvailable", () => {
                         attribute: DATE_DATASET_ATTRIBUTE,
                         localIdentifier: "f1",
                         filters: [referencePointMocks.dateFilter],
-                        dateDataset: {
-                            ref: {
-                                uri: "date.dataset.2",
-                            },
+                        dateDatasetRef: {
+                            uri: "date.dataset.2",
                         },
                     },
                 ],


### PR DESCRIPTION
…asetRef in buckets

JIRA: ONE-4865

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
