### PR TITLE
BUGFIX: BB-2801 bubble chart legend

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -1723,10 +1723,7 @@ describe("chartOptionsBuilder", () => {
                     stackByAttribute,
                     type,
                 );
-                expect(drillableMeasuresSeriesData[0].data.length).toEqual(0); // x is null
-                expect(drillableMeasuresSeriesData[1].data.length).toEqual(0); // y is null
-                expect(drillableMeasuresSeriesData[2].data.length).toEqual(0); // x and y are null
-                expect(drillableMeasuresSeriesData[3].data.length).toEqual(0); // z is null
+                expect(drillableMeasuresSeriesData.length).toEqual(16);
             });
         });
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/bubbleChart/bubbleChartSeries.ts
@@ -18,32 +18,34 @@ export function getBubbleChartSeries(
 ): any[] {
     const primaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.MEASURES);
     const secondaryMeasuresBucketEmpty = dv.def().isBucketEmpty(BucketNames.SECONDARY_MEASURES);
-
+    let legendIndex = 0;
     return dv
         .rawData()
         .twoDimData()
         .map((resData: any, index: number) => {
-            let data: any = [];
-            if (resData[0] !== null && resData[1] !== null && resData[2] !== null) {
-                const emptyBucketsCount = getCountOfEmptyBuckets([
-                    primaryMeasuresBucketEmpty,
-                    secondaryMeasuresBucketEmpty,
-                ]);
-                data = [
-                    {
-                        x: !primaryMeasuresBucketEmpty ? parseValue(resData[0]) : 0,
-                        y: !secondaryMeasuresBucketEmpty ? parseValue(resData[1 - emptyBucketsCount]) : 0,
-                        // we want to allow NaN on z to be able show bubble of default size when Size bucket is empty
-                        z: parseFloat(resData[2 - emptyBucketsCount]),
-                        format: unwrap(last(measureGroup.items)).format, // only for dataLabel format
-                    },
-                ];
+            if (resData[0] === null || resData[1] === null || resData[2] === null) {
+                return null;
             }
+            let data: any = [];
+            const emptyBucketsCount = getCountOfEmptyBuckets([
+                primaryMeasuresBucketEmpty,
+                secondaryMeasuresBucketEmpty,
+            ]);
+            data = [
+                {
+                    x: !primaryMeasuresBucketEmpty ? parseValue(resData[0]) : 0,
+                    y: !secondaryMeasuresBucketEmpty ? parseValue(resData[1 - emptyBucketsCount]) : 0,
+                    // we want to allow NaN on z to be able show bubble of default size when Size bucket is empty
+                    z: parseFloat(resData[2 - emptyBucketsCount]),
+                    format: unwrap(last(measureGroup.items)).format, // only for dataLabel format
+                },
+            ];
             return {
                 name: stackByAttribute ? stackByAttribute.items[index].attributeHeaderItem.name : "",
-                color: colorStrategy.getColorByIndex(index),
-                legendIndex: index,
+                color: colorStrategy.getColorByIndex(legendIndex),
+                legendIndex: legendIndex++,
                 data,
             };
-        });
+        })
+        .filter((serie) => serie !== null);
 }


### PR DESCRIPTION
null values are not displayed in legend

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
