### PR TITLE
Fix sanitization of columnWidths when resized item is moved from rows…

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/widthItemHelpers.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/widthItemHelpers.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IBucketItem } from "../../../../interfaces/Visualization";
 
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
@@ -146,6 +146,27 @@ describe("adaptReferencePointWidthItemsToPivotTable", () => {
 
         const result = adaptReferencePointWidthItemsToPivotTable(
             sourceColumnWidthsWithweakMeasure,
+            measures,
+            [],
+            columnAttributes,
+            [],
+            [],
+            [],
+        );
+
+        expect(result).toEqual(expectedColumnWidthItems);
+    });
+
+    it("should remove attributeWidhtItem when attribute is located on column", () => {
+        const sourceColumnWidhtsWithAttributeColumn: ColumnWidthItem[] = [
+            validAttributeColumnWidthItem,
+            validWeakMeasureColumnWidthItem,
+        ];
+
+        const expectedColumnWidthItems: ColumnWidthItem[] = [validWeakMeasureColumnWidthItem];
+
+        const result = adaptReferencePointWidthItemsToPivotTable(
+            sourceColumnWidhtsWithAttributeColumn,
             measures,
             [],
             columnAttributes,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import includes from "lodash/includes";
 import {
     ColumnWidthItem,
@@ -122,8 +122,6 @@ function adaptWidthItemsToPivotTable(
         return originalColumnWidths;
     }
 
-    const attributeLocalIdentifiers = [...rowAttributeLocalIdentifiers, ...columnAttributeLocalIdentifiers];
-
     return originalColumnWidths.reduce((columnWidths: ColumnWidthItem[], columnWidth: ColumnWidthItem) => {
         if (isMeasureColumnWidthItem(columnWidth)) {
             const filteredMeasureColumnWidthItem: IMeasureColumnWidthItem = {
@@ -156,7 +154,10 @@ function adaptWidthItemsToPivotTable(
             }
         } else if (isAttributeColumnWidthItem(columnWidth)) {
             if (
-                includes(attributeLocalIdentifiers, columnWidth.attributeColumnWidthItem.attributeIdentifier)
+                includes(
+                    rowAttributeLocalIdentifiers,
+                    columnWidth.attributeColumnWidthItem.attributeIdentifier,
+                )
             ) {
                 return [...columnWidths, columnWidth];
             }


### PR DESCRIPTION
… to columns

 - attributeColumnWidthItems should be only applicable on rows, not columns.

JIRA: ONE-4779

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
