### PR TITLE
RELATED: RAIL-2774 take ThemeProvider out of beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ For changes and migration guide between GoodData.UI SDK v7 and v8 please see doc
 
 For changes on top of GoodData.UI SDK v8 please see the main changelog:
 
-Please see [CHANGELOG.md](libs/sdk-ui-all).
+Please see [CHANGELOG.md](libs/sdk-ui-all/CHANGELOG.md).

--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-2774-date-filter-theme-beta_2021-02-18-14-45.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-2774-date-filter-theme-beta_2021-02-18-14-45.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "ThemeProvider is out of beta and is considered stable",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "dan.homola@gooddata.com"
+}

--- a/libs/sdk-ui-theme-provider/api/sdk-ui-theme-provider.api.md
+++ b/libs/sdk-ui-theme-provider/api/sdk-ui-theme-provider.api.md
@@ -8,13 +8,13 @@ import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { ITheme } from '@gooddata/sdk-backend-spi';
 import { default as React_2 } from 'react';
 
-// @beta (undocumented)
+// @public (undocumented)
 export interface IThemeContextProviderProps {
     theme: ITheme;
     themeIsLoading: boolean;
 }
 
-// @beta (undocumented)
+// @public (undocumented)
 export interface IThemeProviderProps {
     backend?: IAnalyticalBackend;
     modifier?: ThemeModifier;
@@ -22,22 +22,22 @@ export interface IThemeProviderProps {
     workspace?: string;
 }
 
-// @beta
+// @public
 export const ThemeContextProvider: React_2.FC<IThemeContextProviderProps>;
 
-// @beta (undocumented)
+// @public (undocumented)
 export type ThemeModifier = (theme: ITheme) => ITheme;
 
-// @beta
+// @public
 export const ThemeProvider: React_2.FC<IThemeProviderProps>;
 
-// @beta
+// @public
 export const useTheme: (theme?: ITheme) => ITheme | undefined;
 
-// @beta
+// @public
 export const useThemeIsLoading: () => boolean | undefined;
 
-// @beta
+// @public
 export function withTheme<T extends {
     theme?: ITheme;
     workspace?: string;

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/Context.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/Context.tsx
@@ -11,7 +11,7 @@ const ThemeIsLoadingContext = React.createContext<boolean | undefined>(undefined
 ThemeIsLoadingContext.displayName = "ThemeIsLoadingContext";
 
 /**
- * @beta
+ * @public
  */
 export interface IThemeContextProviderProps {
     /**
@@ -28,7 +28,7 @@ export interface IThemeContextProviderProps {
 /**
  * Provides the theme object and themeIsLoading flag into context
  *
- * @beta
+ * @public
  */
 export const ThemeContextProvider: React.FC<IThemeContextProviderProps> = ({
     children,
@@ -56,7 +56,7 @@ export const ThemeContextProvider: React.FC<IThemeContextProviderProps> = ({
  * const theme = useTheme(fromArguments);
  *
  * @param theme - theme to use instead of context value. If undefined, the context value is used.
- * @beta
+ * @public
  */
 export const useTheme = (theme?: ITheme): ITheme | undefined => {
     const themeFromContext = React.useContext(ThemeContext);
@@ -66,7 +66,7 @@ export const useTheme = (theme?: ITheme): ITheme | undefined => {
 /**
  * Hook for reaching the themeIsLoading flag from context
  *
- * @beta
+ * @public
  */
 export const useThemeIsLoading = (): boolean | undefined => {
     const themeIsLoading = React.useContext(ThemeIsLoadingContext);
@@ -110,7 +110,7 @@ export function withThemeIsLoading<T extends { themeIsLoading?: boolean }>(
 /**
  * Injects both theme object and isThemeLoading flag into component as properties
  *
- * @beta
+ * @public
  */
 export function withTheme<T extends { theme?: ITheme; workspace?: string }>(
     Chart: React.ComponentType<T>,

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
@@ -1,5 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { useEffect, useState, useRef } from "react";
+import identity from "lodash/identity";
 import { useBackend, useWorkspace } from "@gooddata/sdk-ui";
 import { ITheme } from "@gooddata/sdk-backend-spi";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
@@ -8,14 +9,12 @@ import { clearCssProperties, setCssProperties } from "../cssProperties";
 import { ThemeContextProvider } from "./Context";
 
 /**
- *
- * @beta
+ * @public
  */
 export type ThemeModifier = (theme: ITheme) => ITheme;
 
 /**
- *
- * @beta
+ * @public
  */
 export interface IThemeProviderProps {
     /**
@@ -55,14 +54,14 @@ export interface IThemeProviderProps {
  *
  * Both backend and workspace can be passed as an arguments, otherwise the component tries to get these from the context
  *
- * @beta
+ * @public
  */
 export const ThemeProvider: React.FC<IThemeProviderProps> = ({
     children,
     theme: themeParam,
     backend: backendParam,
     workspace: workspaceParam,
-    modifier = (theme: ITheme): ITheme => theme,
+    modifier = identity,
 }) => {
     const backend = useBackend(backendParam);
     const workspace = useWorkspace(workspaceParam);

--- a/libs/sdk-ui-theme-provider/src/cssProperties.ts
+++ b/libs/sdk-ui-theme-provider/src/cssProperties.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import isObject from "lodash/isObject";
 import { transparentize, darken, lighten, mix, setLightness } from "polished";
 import { IThemePalette, ITheme, IThemeChart } from "@gooddata/sdk-backend-spi";
@@ -334,7 +334,7 @@ export const clearCssProperties = (): void => {
  * }
  * is converted to "palette-primary-base" variable with value #14b2e2
  *
- * @beta
+ * @internal
  */
 export function setCssProperties(theme: ITheme): void {
     const cssProperties = [


### PR DESCRIPTION
Mark ThemeProvider as public as it is stable enough to be marked as such.
Fix the root changelog link to link directly to the target changelog, not the package containing it.

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
