### PR TITLE
RELATED: RAIL-2853 Merge sdk-ui translations in sdk-ui-ext

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/index.ts
@@ -18,6 +18,7 @@ export { mergeFiltersWithDashboard } from "./mergeFiltersWithDashboard";
 export { isDateFilterIrrelevant } from "./utils/filters";
 export { useDashboardWidgetExecution } from "./hooks/useDashboardWidgetExecution";
 export { useDashboardPdfExporter } from "./hooks/convenience/useDashboardPdfExporter";
+export { clearDashboardViewCaches } from "./hooks/dataLoaders";
 
 // TODO: RAIL-2869 Migrate to Responsive context
 export {

--- a/libs/sdk-ui-ext/src/internal/utils/translations.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/translations.ts
@@ -1,6 +1,9 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IntlShape } from "react-intl";
+import merge from "lodash/merge";
 import { translationUtils } from "@gooddata/util";
+import { messagesMap as sdkUiTranslations } from "@gooddata/sdk-ui";
+
 import enUS from "../translations/en-US.json";
 import deDE from "../translations/de-DE.json";
 import esES from "../translations/es-ES.json";
@@ -27,10 +30,7 @@ export function getTranslatedDropdownItems(dropdownItems: IDropdownItem[], intl:
     });
 }
 
-/**
- * @internal
- */
-export const translations: { [locale: string]: Record<string, string> } = {
+const sdkUiExtTranslations: { [locale: string]: Record<string, string> } = {
     "en-US": translationUtils.removeMetadata(enUS),
     "de-DE": deDE,
     "es-ES": esES,
@@ -41,3 +41,11 @@ export const translations: { [locale: string]: Record<string, string> } = {
     "pt-PT": ptPT,
     "zh-Hans": zhHans,
 };
+
+/**
+ * @internal
+ */
+export const translations: { [locale: string]: Record<string, string> } = merge(
+    sdkUiTranslations, // we use also some of the sdk-ui strings here so we need to merge them in here
+    sdkUiExtTranslations,
+);


### PR DESCRIPTION
sdk-ui-ext depends on some of the strings in sdk-ui
so we must make them available.

Also, adds a missing export

JIRA: RAIL-2853

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
