### PR TITLE
RELATED: RAIL-2956 several small fixes for dashboardEmbedding

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayout.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/DashboardLayout.tsx
@@ -47,7 +47,7 @@ export function DashboardLayout<TCustomContent = IDashboardViewLayoutContent>(
     const {
         layout,
         rowRenderer = DashboardLayoutRowRenderer,
-        rowHeaderRenderer,
+        rowHeaderRenderer = DashboardLayoutRowHeaderRenderer,
         rowKeyGetter,
         columnRenderer = DashboardLayoutColumnRenderer,
         columnKeyGetter,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer.tsx
@@ -74,14 +74,9 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
     const [possibleDrills, setPossibleDrills] = useState<IAvailableDrillTargetAttribute[]>([]);
     const [visualizationError, setVisualizationError] = useState<GoodDataSdkError | null>(null);
 
-    const handleLoadingChanged = useCallback<OnLoadingChanged>(
-        ({ isLoading }) => {
-            if (isLoading !== isVisualizationLoading) {
-                setIsVisualizationLoading(isLoading);
-            }
-        },
-        [isVisualizationLoading],
-    );
+    const handleLoadingChanged = useCallback<OnLoadingChanged>(({ isLoading }) => {
+        setIsVisualizationLoading(isLoading);
+    }, []);
 
     const handleError = useCallback<OnError>(
         (error) => {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
@@ -29,7 +29,7 @@ function getNodeDocumentRelativeOffsetTop(node: HTMLDivElement): number {
     // Get document-relative position by adding viewport scroll to viewport-relative gBCR
     const rect = node.getBoundingClientRect();
     const win = node.ownerDocument.defaultView;
-    return rect.top + win.pageYOffset;
+    return rect.top + (win?.pageYOffset ?? 0);
 }
 
 export interface IDashboardItemWithKpiAlertProps {
@@ -67,9 +67,9 @@ export interface IDashboardItemWithKpiAlertProps {
      */
     suppressAlertTriggered?: boolean;
 
-    children?: (params: { clientWidth: number }) => React.ReactNode;
-    renderHeadline?: () => React.ReactNode;
-    renderAlertDialog?: () => React.ReactNode;
+    children: (params: { clientWidth: number }) => React.ReactNode;
+    renderHeadline: () => React.ReactNode;
+    renderAlertDialog: () => React.ReactNode;
 }
 
 interface IDashboardItemWithKpiAlertState {
@@ -154,10 +154,13 @@ export class DashboardItemWithKpiAlert extends Component<
         }, timeout);
     }
 
-    clearUpdatingTimeout(name: string = null): void {
-        if (this.timeouts[name]) {
+    clearUpdatingTimeout(name?: string): void {
+        if (name && this.timeouts[name]) {
             clearTimeout(this.timeouts[name]);
             delete this.timeouts[name];
+        } else {
+            Object.keys(this.timeouts).forEach((key) => clearTimeout(this.timeouts[key]));
+            this.timeouts = {};
         }
     }
 
@@ -180,7 +183,7 @@ export class DashboardItemWithKpiAlert extends Component<
     renderAlertBox = (): React.ReactNode => {
         const isAlertingTemporarilyDisabled = isAlertingTemporarilyDisabledForGivenFilter(
             this.props.kpi,
-            this.props.filters,
+            this.props.filters!,
             this.props.userWorkspaceSettings,
         );
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialogBrokenFilters/utils/filterUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialogBrokenFilters/utils/filterUtils.ts
@@ -6,7 +6,7 @@ interface ILabelFilterData {
     selection: string;
     isDate: boolean;
     isAllSelected: boolean;
-    selectionSize: number;
+    selectionSize: number | null;
 }
 
 export function getFilterLabelFilter(item: IBrokenAlertFilter): ILabelFilterData {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/test/KpiAlertDialog.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/test/KpiAlertDialog.test.tsx
@@ -11,11 +11,11 @@ const DEFAULT_DATE_FORMAT = "MM/dd/yyyy";
 
 const defaultProps: IKpiAlertDialogProps = {
     dateFormat: DEFAULT_DATE_FORMAT,
-    onAlertDialogCloseClick: noop as any,
-    onAlertDialogDeleteClick: noop as any,
-    onAlertDialogSaveClick: noop as any,
-    onAlertDialogUpdateClick: noop as any,
-    onApplyAlertFiltersClick: noop as any,
+    onAlertDialogCloseClick: noop,
+    onAlertDialogDeleteClick: noop,
+    onAlertDialogSaveClick: noop,
+    onAlertDialogUpdateClick: noop,
+    onApplyAlertFiltersClick: noop,
     userEmail: "user@gooddata.com",
 };
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/translationUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/translationUtils.ts
@@ -12,42 +12,12 @@ import {
     isRelativeDateFilter,
     relativeDateFilterValues,
 } from "@gooddata/sdk-model";
-import {
-    DateFilterGranularity,
-    IAbsoluteDateFilterPreset,
-    IDashboardDateFilter,
-    IRelativeDateFilterPreset,
-} from "@gooddata/sdk-backend-spi";
+import { DateFilterGranularity, IDashboardDateFilter } from "@gooddata/sdk-backend-spi";
 
 export type KpiAlertTranslationData = {
     rangeText: string;
     intlIdRoot: string;
 } | null;
-
-export function dashboardDateFilterToPreset(
-    filter: IDashboardDateFilter,
-): IRelativeDateFilterPreset | IAbsoluteDateFilterPreset {
-    if (filter.dateFilter.type === "absolute") {
-        const result: IAbsoluteDateFilterPreset = {
-            localIdentifier: "",
-            type: "absolutePreset",
-            visible: true,
-            from: filter.dateFilter.from?.toString(),
-            to: filter.dateFilter.to?.toString(),
-        };
-        return result;
-    } else {
-        const result: IRelativeDateFilterPreset = {
-            localIdentifier: "",
-            type: "relativePreset",
-            visible: true,
-            granularity: filter.dateFilter.granularity,
-            from: Number.parseInt(filter.dateFilter.from?.toString() ?? "0", 10),
-            to: Number.parseInt(filter.dateFilter.to?.toString() ?? "0", 10),
-        };
-        return result;
-    }
-}
 
 interface IRelativeDateFilterMeta extends IRelativeDateFilterValues {
     type: "relative";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useAttributesWithDrillDown.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useAttributesWithDrillDown.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { useMemo } from "react";
 import { IAnalyticalBackend, ICatalogAttribute, ICatalogDateAttribute } from "@gooddata/sdk-backend-spi";
 import {
@@ -9,8 +9,8 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import { attributesWithDrillDownDataLoaderFactory } from "./dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -63,15 +63,8 @@ export function useAttributesWithDrillDown({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useAttributesWithDrillDown must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useAttributesWithDrillDown must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useAttributesWithDrillDown");
+    workspaceInvariant(effectiveWorkspace, "useAttributesWithDrillDown");
 
     const promise = useMemo(() => {
         return async () => {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useColorPalette.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useColorPalette.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IColorPalette } from "@gooddata/sdk-model";
 import {
@@ -9,8 +9,8 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import { colorPaletteDataLoaderFactory } from "../../../dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -51,15 +51,8 @@ export function useColorPalette({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useColorPalette must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useColorPalette must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useColorPalette");
+    workspaceInvariant(effectiveWorkspace, "useColorPalette");
 
     const loader = colorPaletteDataLoaderFactory.forWorkspace(effectiveWorkspace);
     const promise = () => loader.getColorPalette(effectiveBackend);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useCurrentUser.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useCurrentUser.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IUser } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -7,7 +7,7 @@ import {
     UseCancelablePromiseCallbacks,
     UseCancelablePromiseState,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant } from "./utils";
 
 /**
  * @beta
@@ -37,10 +37,7 @@ export function useCurrentUser({
 }: IUseCurrentUserConfig): UseCancelablePromiseState<IUser, any> {
     const effectiveBackend = useBackend(backend);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useCurrentUser must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useCurrentUser");
 
     const promise = () => effectiveBackend.currentUser().getUser();
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboard.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboard.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IDashboard } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -9,8 +9,8 @@ import {
     useWorkspace,
 } from "@gooddata/sdk-ui";
 import { ObjRef, objRefToString } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import { dashboardDataLoaderFactory } from "./dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -56,15 +56,8 @@ export function useDashboard({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useDashboard must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useDashboard must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useDashboard");
+    workspaceInvariant(effectiveWorkspace, "useDashboard");
 
     const loader = dashboardDataLoaderFactory.forWorkspace(effectiveWorkspace);
     const promise = () => loader.getDashboard(effectiveBackend, dashboard);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardAlerts.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardAlerts.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IWidgetAlert } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -9,8 +9,8 @@ import {
     useWorkspace,
 } from "@gooddata/sdk-ui";
 import { ObjRef, objRefToString } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import { dashboardAlertsDataLoaderFactory } from "./dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -57,15 +57,8 @@ export function useDashboardAlerts({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useDashboardAlerts must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useDashboardAlerts must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useDashboardAlerts");
+    workspaceInvariant(effectiveWorkspace, "useDashboardAlerts");
 
     const loader = dashboardAlertsDataLoaderFactory.forWorkspace(effectiveWorkspace);
     const promise = () => loader.getDashboardAlerts(effectiveBackend, dashboard);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardInsightExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardInsightExecution.ts
@@ -17,9 +17,9 @@ import {
     useCancelablePromise,
 } from "@gooddata/sdk-ui";
 import { IInsight } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "../converters";
 import { IDashboardFilter } from "../types";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -47,15 +47,8 @@ export function useInsightExecution(
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useInsightExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useInsightExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useInsightExecution");
+    workspaceInvariant(effectiveWorkspace, "useInsightExecution");
 
     const promise =
         insight && insightWidget

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardKpiExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardKpiExecution.ts
@@ -17,9 +17,9 @@ import {
     useExecution,
     UseCancelablePromiseState,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import compact from "lodash/compact";
 import { useKpiData } from "../DashboardView/KpiView/utils";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -46,15 +46,8 @@ export function useKpiExecution(
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useKpiExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useKpiExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useKpiExecution");
+    workspaceInvariant(effectiveWorkspace, "useKpiExecution");
 
     const { result, status, error } = useKpiData(config);
     const execution = useExecution({

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardViewLayout.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardViewLayout.ts
@@ -15,9 +15,9 @@ import {
     useWorkspace,
 } from "@gooddata/sdk-ui";
 import { areObjRefsEqual, IInsight, insightVisualizationUrl, ObjRef } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import { insightDataLoaderFactory } from "../../../dataLoaders";
 import { DashboardViewLayoutWidgetClass } from "../DashboardLayout/interfaces/dashboardLayoutSizing";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -72,15 +72,8 @@ export const useDashboardViewLayout = ({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useDashboardViewLayout must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useDashboardViewLayout must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useDashboardViewLayout");
+    workspaceInvariant(effectiveWorkspace, "useDashboardViewLayout");
 
     const promise = dashboardLayout
         ? async () => {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardWidgetExecution.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDashboardWidgetExecution.ts
@@ -16,11 +16,11 @@ import {
     UnexpectedSdkError,
 } from "@gooddata/sdk-ui";
 import { ObjRef, areObjRefsEqual, objRefToString } from "@gooddata/sdk-model";
-import invariant from "ts-invariant";
 import { useDashboard } from "./useDashboard";
 import { useKpiExecution } from "./useDashboardKpiExecution";
 import { useInsightExecution } from "./useDashboardInsightExecution";
 import { useDashboardViewLayout } from "./useDashboardViewLayout";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @alpha
@@ -73,15 +73,8 @@ export function useDashboardWidgetExecution({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useWidgetExecution must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useWidgetExecution must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useDashboardWidgetExecution");
+    workspaceInvariant(effectiveWorkspace, "useDashboardWidgetExecution");
 
     const { result: dashboardResult, status: dashboardStatus, error: dashboardError } = useDashboard({
         dashboard,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDeleteWidgetAlert.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useDeleteWidgetAlert.ts
@@ -8,7 +8,7 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -54,15 +54,8 @@ export function useDeleteWidgetAlert({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useDeleteKpiAlert must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useDeleteKpiAlert must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useDeleteWidgetAlert");
+    workspaceInvariant(effectiveWorkspace, "useDeleteWidgetAlert");
 
     const promise = widgetAlert
         ? () => effectiveBackend.workspace(effectiveWorkspace).dashboards().deleteWidgetAlert(widgetAlert.ref)

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useExportDashboardToPdf.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useExportDashboardToPdf.ts
@@ -8,9 +8,9 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import { IDashboardFilter } from "../types";
 import { dashboardFilterToFilterContextItem } from "../utils/filters";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -64,15 +64,8 @@ export function useExportDashboardToPdf({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useExportDashboardToPdf must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useExportDashboardToPdf must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useExportDashboardToPdf");
+    workspaceInvariant(effectiveWorkspace, "useExportDashboardToPdf");
 
     const promise = dashboard
         ? () =>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useSaveOrUpdateWidgetAlert.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useSaveOrUpdateWidgetAlert.ts
@@ -13,7 +13,7 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -60,15 +60,8 @@ export function useSaveOrUpdateWidgetAlert({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useSaveOrUpdateWidgetAlert must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useSaveOrUpdateWidgetAlert must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useSaveOrUpdateWidgetAlert");
+    workspaceInvariant(effectiveWorkspace, "useSaveOrUpdateWidgetAlert");
 
     const promise = widgetAlert
         ? () =>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useSaveScheduledMail.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useSaveScheduledMail.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import {
     IAnalyticalBackend,
     IFilterContextDefinition,
@@ -13,7 +13,7 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -67,15 +67,8 @@ export function useSaveScheduledMail({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useSaveScheduledMail must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useSaveScheduledMail must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useSaveScheduledMail");
+    workspaceInvariant(effectiveWorkspace, "useSaveScheduledMail");
 
     const promise = scheduledMail
         ? () =>

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUpdateWidgetAlert.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUpdateWidgetAlert.ts
@@ -8,7 +8,7 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -55,15 +55,8 @@ export function useUpdateWidgetAlert({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useUpdateKpiAlert must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useUpdateKpiAlert must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useUpdateWidgetAlert");
+    workspaceInvariant(effectiveWorkspace, "useUpdateWidgetAlert");
 
     const promise = widgetAlert
         ? () => effectiveBackend.workspace(effectiveWorkspace).dashboards().updateWidgetAlert(widgetAlert)

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUserWorkspacePermissions.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUserWorkspacePermissions.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -8,8 +8,8 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import { userWorkspacePermissionsDataLoaderFactory } from "./dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -50,15 +50,8 @@ export function useUserWorkspacePermissions({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useUserWorkspacePermissions must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useUserWorkspacePermissions must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useUserWorkspacePermissions");
+    workspaceInvariant(effectiveWorkspace, "useUserWorkspacePermissions");
 
     const loader = userWorkspacePermissionsDataLoaderFactory.forWorkspace(effectiveWorkspace);
     const promise = () => loader.getUserWorkspacePermissions(effectiveBackend);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUserWorkspaceSettings.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useUserWorkspaceSettings.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -8,8 +8,8 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
 import { userWorkspaceSettingsDataLoaderFactory } from "../../../dataLoaders";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -50,15 +50,8 @@ export function useUserWorkspaceSettings({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useUserWorkspaceSettings must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useUserWorkspaceSettings must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useUserWorkspaceSettings");
+    workspaceInvariant(effectiveWorkspace, "useUserWorkspaceSettings");
 
     const loader = userWorkspaceSettingsDataLoaderFactory.forWorkspace(effectiveWorkspace);
     const promise = () => loader.getUserWorkspaceSettings(effectiveBackend);

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useWorkspaceUsers.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/useWorkspaceUsers.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { IAnalyticalBackend, IWorkspaceUser } from "@gooddata/sdk-backend-spi";
 import {
     GoodDataSdkError,
@@ -8,7 +8,7 @@ import {
     UseCancelablePromiseState,
     useWorkspace,
 } from "@gooddata/sdk-ui";
-import invariant from "ts-invariant";
+import { backendInvariant, workspaceInvariant } from "./utils";
 
 /**
  * @beta
@@ -55,15 +55,8 @@ export function useWorkspaceUsers({
     const effectiveBackend = useBackend(backend);
     const effectiveWorkspace = useWorkspace(workspace);
 
-    invariant(
-        effectiveBackend,
-        "The backend in useDashboard must be defined. Either pass it as a config prop or make sure there is a BackendProvider up the component tree.",
-    );
-
-    invariant(
-        effectiveWorkspace,
-        "The workspace in useDashboard must be defined. Either pass it as a config prop or make sure there is a WorkspaceProvider up the component tree.",
-    );
+    backendInvariant(effectiveBackend, "useWorkspaceUsers");
+    workspaceInvariant(effectiveWorkspace, "useWorkspaceUsers");
 
     const promise = () => {
         let loader = effectiveBackend.workspace(effectiveWorkspace).users();

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/utils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/hooks/utils.ts
@@ -1,0 +1,22 @@
+// (C) 2020-2021 GoodData Corporation
+import invariant from "ts-invariant";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+
+function ambientInvariantFactory<T>(itemName: string, providerName: string) {
+    return (item: T | undefined | null, contextName: string): asserts item => {
+        return invariant(
+            item,
+            `The ${itemName} in ${contextName} must be defined. Either pass it as a config prop or make sure there is a ${providerName} up the component tree.`,
+        );
+    };
+}
+
+export const backendInvariant: (
+    item: IAnalyticalBackend | undefined | null,
+    contextName: string,
+) => asserts item = ambientInvariantFactory("backend", "BackendProvider");
+
+export const workspaceInvariant: (
+    item: string | undefined | null,
+    contextName: string,
+) => asserts item = ambientInvariantFactory("workspace", "WorkspaceProvider");

--- a/libs/sdk-ui-ext/tsconfig.json
+++ b/libs/sdk-ui-ext/tsconfig.json
@@ -12,6 +12,7 @@
         "esModuleInterop": true,
         "importHelpers": true,
         "noImplicitAny": true,
+        "noImplicitThis": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "outDir": "dist",


### PR DESCRIPTION
Assortment of small fixes/tweaks

* simplify work with invariants in dashboardEmbedding hooks
* remove obsolete code, remove `as any` casts
* fix unmounting of DashboardItemWithKpiAlert
* enable the `noImplicitThis` typescript flag
* add missing rowHeaderRenderer default
* simplify and fix a callback in InsightRenderer

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
