### PR TITLE
RELATED: RAIL-2973 fix creating alerts with relative filters

### DIFF
--- a/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
+++ b/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { GdcFilterContext, GdcExport } from "@gooddata/api-model-bear";
@@ -18,8 +18,8 @@ describe("exportDashboard", () => {
     const relativeDateFilter: GdcFilterContext.FilterContextItem = {
         dateFilter: {
             type: "relative",
-            from: -11,
-            to: 11,
+            from: "-11",
+            to: "11",
             granularity: "GDC.time.month",
         },
     };

--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -1100,8 +1100,8 @@ export namespace GdcFilterContext {
         dateFilter: {
             type: DateFilterType;
             granularity: GdcExtendedDateFilters.DateFilterGranularity;
-            from?: GdcExtendedDateFilters.DateString | number;
-            to?: GdcExtendedDateFilters.DateString | number;
+            from?: GdcExtendedDateFilters.DateString | NumberAsString;
+            to?: GdcExtendedDateFilters.DateString | NumberAsString;
             dataSet?: string;
             attribute?: string;
         };

--- a/libs/api-model-bear/src/filterContext/GdcFilterContext.ts
+++ b/libs/api-model-bear/src/filterContext/GdcFilterContext.ts
@@ -1,8 +1,8 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { GdcExtendedDateFilters } from "../extendedDateFilters/GdcExtendedDateFilters";
 import { GdcMetadata } from "../meta/GdcMetadata";
-import { Uri, Timestamp } from "../aliases";
+import { Uri, Timestamp, NumberAsString } from "../aliases";
 
 /**
  * @public
@@ -55,8 +55,8 @@ export namespace GdcFilterContext {
         dateFilter: {
             type: DateFilterType;
             granularity: GdcExtendedDateFilters.DateFilterGranularity;
-            from?: GdcExtendedDateFilters.DateString | number;
-            to?: GdcExtendedDateFilters.DateString | number;
+            from?: GdcExtendedDateFilters.DateString | NumberAsString;
+            to?: GdcExtendedDateFilters.DateString | NumberAsString;
             dataSet?: string;
             attribute?: string;
         };

--- a/libs/api-model-bear/src/filterContext/tests/utils.fixtures.ts
+++ b/libs/api-model-bear/src/filterContext/tests/utils.fixtures.ts
@@ -1,11 +1,11 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { GdcFilterContext } from "../GdcFilterContext";
 
 export const relativeDateFilter: GdcFilterContext.FilterContextItem = {
     dateFilter: {
         type: "relative",
-        from: -11,
-        to: 0,
+        from: "-11",
+        to: "0",
         granularity: "GDC.time.month",
     },
 };

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/tests/DashboardConverter.fixtures.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/tests/DashboardConverter.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 import {
     GdcDashboard,
@@ -53,8 +53,8 @@ export const filterContext: GdcFilterContext.IWrappedFilterContext = {
                         granularity: "GDC.time.month",
                         type: "relative",
                         attribute: "testAttr",
-                        from: -10,
-                        to: 0,
+                        from: "-10",
+                        to: "0",
                     },
                 },
             ],

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
@@ -109,9 +109,9 @@ Object {
           "attribute": Object {
             "uri": "testAttr",
           },
-          "from": -10,
+          "from": "-10",
           "granularity": "GDC.time.month",
-          "to": 0,
+          "to": "0",
           "type": "relative",
         },
       },

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -191,8 +191,8 @@ export const convertFilterContextItem = (
             dateFilter: {
                 granularity,
                 type,
-                from,
-                to,
+                from: from?.toString(),
+                to: to?.toString(),
             },
         };
 

--- a/libs/sdk-backend-bear/src/convertors/toBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/tests/__snapshots__/DashboardConverter.test.ts.snap
@@ -270,9 +270,9 @@ Object {
           "dateFilter": Object {
             "attribute": "/attrId",
             "dataSet": "/dataSet",
-            "from": -12,
+            "from": "-12",
             "granularity": "GDC.time.month",
-            "to": -2,
+            "to": "-2",
             "type": "relative",
           },
         },
@@ -297,9 +297,9 @@ Object {
         "dateFilter": Object {
           "attribute": "/attrId",
           "dataSet": "/dataSet",
-          "from": -12,
+          "from": "-12",
           "granularity": "GDC.time.month",
-          "to": -2,
+          "to": "-2",
           "type": "relative",
         },
       },

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -51,7 +51,7 @@ import {
     getBrokenAlertFiltersBasicInfo,
 } from "../../KpiAlerts";
 import { IDashboardFilter, IKpiAlertResult, IKpiResult } from "../../types";
-import { dashboardFilterToFilterContextItem } from "../../utils/filters";
+import { dashboardFilterToFilterContextItem, stripDateDatasets } from "../../utils/filters";
 import { useUserWorkspaceSettings } from "../UserWorkspaceSettingsContext";
 
 import {
@@ -254,7 +254,9 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                                   filterContext: {
                                       title: "filterContext",
                                       description: "",
-                                      filters: effectiveFilters.map(dashboardFilterToFilterContextItem),
+                                      filters: effectiveFilters
+                                          .map(dashboardFilterToFilterContextItem)
+                                          .map(stripDateDatasets),
                                   },
                                   description: "",
                                   title: "",
@@ -273,7 +275,9 @@ export const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps
                             // change the filters to the filters currently used by the KPI
                             filterContext: {
                                 ...alert.filterContext,
-                                filters: effectiveFilters.map(dashboardFilterToFilterContextItem),
+                                filters: effectiveFilters
+                                    .map(dashboardFilterToFilterContextItem)
+                                    .map(stripDateDatasets),
                             },
                         });
                     }}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/utils/filters.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/utils/filters.ts
@@ -82,6 +82,21 @@ export function dashboardFilterToFilterContextItem(filter: IDashboardFilter): Fi
     throw new NotSupported("Unsupported filter type! Please provide valid dashboard filter.");
 }
 
+/**
+ * Remove information about the date dataset from Date filters. Attribute filters are returned unchanged.
+ * @param filter - filter to strip date dataset from
+ */
+export function stripDateDatasets(filter: FilterContextItem): FilterContextItem {
+    if (!isDashboardDateFilter(filter)) {
+        return filter;
+    }
+
+    const { dataSet: _, ...rest } = filter.dateFilter;
+    return {
+        dateFilter: rest,
+    };
+}
+
 export function filterArrayToFilterContextItems(
     filters: Array<IDashboardFilter | FilterContextItem>,
 ): FilterContextItem[] {


### PR DESCRIPTION
The fix is two-fold

1. fix the api-model-bear filterContext spec to align to bear schema in [gdc-bear](https://github.com/gooddata/gdc-bear/blob/d8c30226e5470d96cc201fd0a99823ffbb4fec50/resources/specification/md/obj/kpiDashboard.res#L206-L218)
2. strip dateDataset information from date filters when creating the alert (this mimics the KD behavior)

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
