### PR TITLE
RELATED: RAIL-2890 Provide info about drill definitions on drill

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardRenderer.tsx
@@ -32,7 +32,6 @@ import {
     IHeaderPredicate,
     ILoadingProps,
     OnError,
-    OnFiredDrillEvent,
     VisType,
 } from "@gooddata/sdk-ui";
 import { useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
@@ -51,6 +50,7 @@ import {
     IDashboardWidgetRenderProps,
     IWidgetPredicates,
     DashboardLayoutTransform,
+    OnFiredDashboardViewDrillEvent,
 } from "./types";
 
 interface IDashboardRendererProps {
@@ -62,7 +62,7 @@ interface IDashboardRendererProps {
     onFiltersChange?: (filters: IDashboardFilter[]) => void;
     filterContext?: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
-    onDrill?: OnFiredDrillEvent;
+    onDrill?: OnFiredDashboardViewDrillEvent;
     ErrorComponent: React.ComponentType<IErrorProps>;
     LoadingComponent: React.ComponentType<ILoadingProps>;
     onError?: OnError;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/DashboardWidgetRenderer.tsx
@@ -17,7 +17,6 @@ import {
 import {
     IDrillableItem,
     IHeaderPredicate,
-    OnFiredDrillEvent,
     IErrorProps,
     ILoadingProps,
     OnError,
@@ -30,6 +29,7 @@ import { DashboardItemVisualization } from "../DashboardItem/DashboardItemVisual
 import { DashboardItem } from "../DashboardItem/DashboardItem";
 import { getVisTypeCssClass } from "./utils";
 import { IDashboardFilter } from "../types";
+import { OnFiredDashboardViewDrillEvent } from "./types";
 
 export type IDashboardWidgetRendererProps = {
     backend?: IAnalyticalBackend;
@@ -37,7 +37,7 @@ export type IDashboardWidgetRendererProps = {
     filters?: FilterContextItem[];
     filterContext: IFilterContext | ITempFilterContext;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
-    onDrill?: OnFiredDrillEvent;
+    onDrill?: OnFiredDashboardViewDrillEvent;
     ErrorComponent: React.ComponentType<IErrorProps>;
     LoadingComponent: React.ComponentType<ILoadingProps>;
     onError?: OnError;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer/drillingUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/InsightRenderer/drillingUtils.ts
@@ -1,37 +1,81 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import compact from "lodash/compact";
-import flatMap from "lodash/flatMap";
 import { DrillDefinition, ICatalogAttribute, ICatalogDateAttribute } from "@gooddata/sdk-backend-spi";
 import { isLocalIdRef, isIdentifierRef, isUriRef, areObjRefsEqual } from "@gooddata/sdk-model";
 import { HeaderPredicates, IAvailableDrillTargetAttribute, IHeaderPredicate } from "@gooddata/sdk-ui";
+import { IDrillDownDefinition } from "../types";
 
-export function widgetDrillsToDrillPredicates(drills: DrillDefinition[]): IHeaderPredicate[] {
-    return flatMap(drills, (drill): IHeaderPredicate[] => {
-        const origin = drill.origin.measure;
-        // add drillable items for all three types of objRefs that the origin measure can be
-        return compact([
-            isLocalIdRef(origin) && HeaderPredicates.localIdentifierMatch(origin.localIdentifier),
-            isIdentifierRef(origin) && HeaderPredicates.identifierMatch(origin.identifier),
-            isUriRef(origin) && HeaderPredicates.uriMatch(origin.uri),
-        ]);
-    });
+interface IImplicitDrillWithPredicates {
+    drillDefinition: DrillDefinition | IDrillDownDefinition;
+    predicates: IHeaderPredicate[];
 }
 
-export function insightDrillDownPredicates(
+function widgetDrillToDrillPredicates(drill: DrillDefinition): IHeaderPredicate[] {
+    const origin = drill.origin.measure;
+    // add drillable items for all three types of objRefs that the origin measure can be
+    return compact([
+        isLocalIdRef(origin) && HeaderPredicates.localIdentifierMatch(origin.localIdentifier),
+        isIdentifierRef(origin) && HeaderPredicates.identifierMatch(origin.identifier),
+        isUriRef(origin) && HeaderPredicates.uriMatch(origin.uri),
+    ]);
+}
+
+function insightWidgetImplicitDrills(insightWidgetDrills: DrillDefinition[]): IImplicitDrillWithPredicates[] {
+    return insightWidgetDrills.map(
+        (drill): IImplicitDrillWithPredicates => {
+            return {
+                drillDefinition: drill,
+                predicates: widgetDrillToDrillPredicates(drill),
+            };
+        },
+    );
+}
+
+function insightDrillDownImplicitDrills(
     possibleDrills: IAvailableDrillTargetAttribute[],
     attributesWithDrillDown: Array<ICatalogAttribute | ICatalogDateAttribute>,
-): IHeaderPredicate[] {
+): IImplicitDrillWithPredicates[] {
     const drillsWitDrillDown = possibleDrills.filter((candidate) => {
         return attributesWithDrillDown.some((attr) =>
             areObjRefsEqual(attr.attribute.ref, candidate.attribute.attributeHeader.formOf.ref),
         );
     });
 
-    return flatMap(drillsWitDrillDown, (drill): IHeaderPredicate[] => {
-        // add drillable items for both types of objRefs that the attribute can be
-        return [
-            HeaderPredicates.identifierMatch(drill.attribute.attributeHeader.identifier),
-            HeaderPredicates.uriMatch(drill.attribute.attributeHeader.uri),
-        ];
-    });
+    return drillsWitDrillDown.map(
+        (drill): IImplicitDrillWithPredicates => {
+            const matchingCatalogAttribute = attributesWithDrillDown.find((attr) =>
+                areObjRefsEqual(attr.attribute.ref, drill.attribute.attributeHeader.formOf.ref),
+            );
+
+            return {
+                drillDefinition: {
+                    type: "drillDown",
+                    target: matchingCatalogAttribute.attribute.drillDownStep!,
+                },
+                predicates: [
+                    // add drillable items for both types of objRefs that the header can be
+                    HeaderPredicates.identifierMatch(drill.attribute.attributeHeader.identifier),
+                    HeaderPredicates.uriMatch(drill.attribute.attributeHeader.uri),
+                ],
+            };
+        },
+    );
+}
+
+/**
+ * Returns a collection of pairs consisting of a drill definition and all its predicates.
+ *
+ * @param insightWidgetDrills - drills from the insight widget itself
+ * @param possibleDrills - possible drill targets returned by pushData (this contains all attributes in the visualization)
+ * @param attributesWithDrillDown - all the attributes in the catalog that have drill down step defined
+ */
+export function getImplicitDrillsWithPredicates(
+    insightWidgetDrills: DrillDefinition[],
+    possibleDrills: IAvailableDrillTargetAttribute[],
+    attributesWithDrillDown: Array<ICatalogAttribute | ICatalogDateAttribute>,
+): IImplicitDrillWithPredicates[] {
+    const insightImplicitDrills = insightWidgetImplicitDrills(insightWidgetDrills);
+    const drillDownImplicitDrills = insightDrillDownImplicitDrills(possibleDrills, attributesWithDrillDown);
+
+    return [...insightImplicitDrills, ...drillDownImplicitDrills];
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiExecutor.tsx
@@ -36,7 +36,6 @@ import {
     LoadingComponent as DefaultLoading,
     NoDataSdkError,
     OnError,
-    OnFiredDrillEvent,
     useDataView,
     useExecution,
 } from "@gooddata/sdk-ui";
@@ -60,6 +59,7 @@ import {
 } from "./alertManipulationHooks";
 import { KpiRenderer } from "./KpiRenderer";
 import { KpiAlertDialogWrapper } from "./KpiAlertDialogWrapper";
+import { OnFiredDashboardViewDrillEvent } from "../types";
 
 interface IKpiExecutorProps {
     dashboardRef: ObjRef;
@@ -78,7 +78,7 @@ interface IKpiExecutorProps {
     allFilters?: IDashboardFilter[];
     onFiltersChange?: (filters: IDashboardFilter[]) => void;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
-    onDrill?: OnFiredDrillEvent;
+    onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
     backend: IAnalyticalBackend;
     workspace: string;
@@ -146,14 +146,20 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
     );
 
     const handleOnDrill = useCallback(
-        (drillContext: IDrillEventContext): ReturnType<OnFiredDrillEvent> => {
+        (drillContext: IDrillEventContext): ReturnType<OnFiredDashboardViewDrillEvent> => {
             if (!onDrill || !result) {
                 return false;
             }
 
+            // only return the definitions if there are no custom-specified drillableItems
+            // if there are, we assume it was the custom drill
+            const drillDefinitions =
+                !drillableItems?.length && kpiWidget.drills.length > 0 ? kpiWidget.drills : undefined;
+
             return onDrill({
                 dataView: result.dataView,
                 drillContext,
+                drillDefinitions,
             });
         },
         [onDrill, result],

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/KpiRenderer.tsx
@@ -1,11 +1,12 @@
 // (C) 2020 GoodData Corporation
 import React, { useCallback } from "react";
-import { IDrillEventContext, OnFiredDrillEvent } from "@gooddata/sdk-ui";
+import { IDrillEventContext } from "@gooddata/sdk-ui";
 import { ISeparators, IKpiWidget, IKpiWidgetDefinition } from "@gooddata/sdk-backend-spi";
 import { IFilter } from "@gooddata/sdk-model";
 
 import { KpiContent } from "../../KpiContent";
 import { IKpiResult } from "../../types";
+import { OnFiredDashboardViewDrillEvent } from "../types";
 
 interface IKpiRendererProps {
     kpi: IKpiWidget | IKpiWidgetDefinition;
@@ -14,7 +15,7 @@ interface IKpiRendererProps {
     separators: ISeparators;
     disableDrillUnderline?: boolean;
     isDrillable?: boolean;
-    onDrill?: (drillContext: IDrillEventContext) => ReturnType<OnFiredDrillEvent>;
+    onDrill?: (drillContext: IDrillEventContext) => ReturnType<OnFiredDashboardViewDrillEvent>;
     clientWidth: number;
 }
 

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/KpiView/index.tsx
@@ -1,6 +1,5 @@
 // (C) 2020 GoodData Corporation
-import React, { useMemo } from "react";
-import compact from "lodash/compact";
+import React from "react";
 import {
     FilterContextItem,
     IAnalyticalBackend,
@@ -17,7 +16,6 @@ import {
     LoadingComponent as DefaultLoading,
     IDrillableItem,
     IHeaderPredicate,
-    OnFiredDrillEvent,
     OnError,
 } from "@gooddata/sdk-ui";
 import invariant from "ts-invariant";
@@ -26,6 +24,7 @@ import { KpiExecutor } from "./KpiExecutor";
 import { useDashboardViewConfig, useDashboardViewIsReadOnly } from "../contexts";
 import { useKpiData } from "../../hooks/internal";
 import { IDashboardFilter } from "../../types";
+import { OnFiredDashboardViewDrillEvent } from "../types";
 
 interface IKpiViewProps {
     /**
@@ -67,7 +66,7 @@ interface IKpiViewProps {
     /**
      * Called when user triggers a drill on a visualization.
      */
-    onDrill?: OnFiredDrillEvent;
+    onDrill?: OnFiredDashboardViewDrillEvent;
 
     /**
      * Called in case of any error, either in the dashboard loading or any of the widgets execution.
@@ -112,7 +111,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
     filters,
     onFiltersChange,
     filterContext,
-    drillableItems = [],
+    drillableItems,
     onDrill,
     onError,
     backend,
@@ -134,12 +133,6 @@ export const KpiView: React.FC<IKpiViewProps> = ({
     const config = useDashboardViewConfig();
     const isReadOnly = useDashboardViewIsReadOnly();
 
-    // add drilling predicate for the metric if the KPI has any drills defined from KPI dashboards
-    const effectiveDrillableItems: Array<IDrillableItem | IHeaderPredicate> = useMemo(
-        () => compact([...drillableItems, kpiWidget.drills.length > 0 && kpiWidget.kpi.metric]),
-        [kpiWidget, drillableItems],
-    );
-
     if (status === "loading" || status === "pending") {
         return <LoadingComponent />;
     }
@@ -160,7 +153,7 @@ export const KpiView: React.FC<IKpiViewProps> = ({
             onFiltersChange={onFiltersChange}
             onDrill={onDrill}
             onError={onError}
-            drillableItems={effectiveDrillableItems}
+            drillableItems={drillableItems}
             separators={config?.separators}
             disableDrillUnderline={config?.disableKpiDrillUnderline}
             backend={backend}

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardView/types.ts
@@ -1,4 +1,5 @@
 // (C) 2020-2021 GoodData Corporation
+import isEmpty from "lodash/isEmpty";
 import {
     IAnalyticalBackend,
     ITheme,
@@ -10,17 +11,19 @@ import {
     IWidget,
     FilterContextItem,
     ILegacyKpi,
+    DrillDefinition,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef, IInsight } from "@gooddata/sdk-model";
 import {
     IDrillableItem,
     IHeaderPredicate,
-    OnFiredDrillEvent,
     IErrorProps,
     ILoadingProps,
     OnError,
     ILocale,
     VisType,
+    IDrillEvent,
+    OnFiredDrillEvent,
 } from "@gooddata/sdk-ui";
 import { IDashboardFilter } from "../types";
 import { IDashboardLayoutBuilder } from "../DashboardLayout/builder/interfaces";
@@ -85,6 +88,35 @@ export interface IDashboardViewConfig {
 }
 
 /**
+ * Information about the DrillDown interaction - the attribute that is next in the drill down hierarchy.
+ */
+export interface IDrillDownDefinition {
+    type: "drillDown";
+    target: ObjRef;
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IDrillDownDefinition}.
+ * @alpha
+ */
+export function isDrillDownDefinition(obj: unknown): obj is IDrillDownDefinition {
+    return !isEmpty(obj) && (obj as IDrillDownDefinition).type === "drillDown";
+}
+
+/**
+ * A {@link IDrillEvent} with added field that contains info about all the drilling interactions set in KPI dashboards
+ * that are relevant to the given drill event (including drill downs).
+ */
+export interface IDashboardDrillEvent extends IDrillEvent {
+    drillDefinitions?: Array<DrillDefinition | IDrillDownDefinition>;
+}
+
+/**
+ * Callback called when a drill event occurs.
+ */
+export type OnFiredDashboardViewDrillEvent = (event: IDashboardDrillEvent) => ReturnType<OnFiredDrillEvent>;
+
+/**
  * @beta
  */
 export interface IDashboardViewProps {
@@ -125,7 +157,7 @@ export interface IDashboardViewProps {
     /**
      * Called when user triggers a drill on a visualization.
      */
-    onDrill?: OnFiredDrillEvent;
+    onDrill?: OnFiredDashboardViewDrillEvent;
 
     /**
      * Backend to work with.


### PR DESCRIPTION
This allows the user to access the original DrillDefinitions when
an implicit drill is triggered. Since there can be more than one
definition responsible for a given drill event, all relevant are included.

Since there is no DrillDown definition, a special DrillDefinition-like
type was defined and used.

Useless logic from KpiView was removed.

The DrillDefinitions are returned as-is (so no custom URL resolution
is done for example). This might be improved later.

JIRA: RAIL-2890

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
