### PR TITLE
BUGFIX: RAIL-2978, BB-2811 - Pivot fixes

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -134,6 +134,7 @@ import { IGridRow } from "./impl/data/resultTypes";
 import { isSomeTotal } from "./impl/data/dataSourceUtils";
 import last from "lodash/last";
 import { isCellDrillable } from "./impl/drilling/cellDrillabilityPredicate";
+import debounce from "lodash/debounce";
 
 const AG_NUMERIC_CELL_CLASSNAME = "ag-numeric-cell";
 const AG_NUMERIC_HEADER_CLASSNAME = "ag-numeric-header";
@@ -145,6 +146,7 @@ const DEFAULT_ROW_HEIGHT = 28;
 const DEFAULT_AUTOSIZE_PADDING = 12;
 const HEADER_CELL_BORDER = 1;
 const COLUMN_RESIZE_TIMEOUT = 300;
+const AGGRID_ON_RESIZE_TIMEOUT = 300;
 
 export const DEFAULT_COLUMN_WIDTH = 200;
 export const WATCHING_TABLE_RENDERED_INTERVAL = 500;
@@ -216,6 +218,10 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
     private isMetaOrCtrlKeyPressed = false;
     private isAltKeyPressed = false;
 
+    private lastResizedWidth = 0;
+    private lastResizedHeight = 0;
+    private readonly debouncedGridSizeChanged: (gridSizeChangedEvent: any) => Promise<void> | undefined;
+
     constructor(props: ICorePivotTableProps) {
         super(props);
 
@@ -229,6 +235,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         };
 
         this.errorMap = newErrorMapping(props.intl);
+        this.debouncedGridSizeChanged = debounce(this.gridSizeChanged, AGGRID_ON_RESIZE_TIMEOUT);
         this.resizedColumnsStore = new ResizedColumnsStore();
     }
 
@@ -261,6 +268,8 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             top: 0,
             left: 0,
         };
+        this.lastResizedHeight = 0;
+        this.lastResizedWidth = 0;
 
         this.clearTimeouts();
     };
@@ -1231,6 +1240,20 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
         this.updateStickyRowContent(scrollPosition);
     };
 
+    private gridSizeChanged = async (gridSizeChangedEvent: any): Promise<void> => {
+        if (
+            this.firstDataRendered &&
+            !this.resizing &&
+            (this.lastResizedWidth !== gridSizeChangedEvent.clientWidth ||
+                this.lastResizedHeight !== gridSizeChangedEvent.clientHeight)
+        ) {
+            this.lastResizedWidth = gridSizeChangedEvent.clientWidth;
+            this.lastResizedHeight = gridSizeChangedEvent.clientHeight;
+
+            this.autoresizeColumns(this.gridApi!, this.columnApi!, true);
+        }
+    };
+
     private onContainerMouseDown = (event: MouseEvent) => {
         if (event.target && this.isHeaderResizer(event.target as HTMLElement)) {
             event.stopPropagation();
@@ -1331,6 +1354,7 @@ export class CorePivotTablePure extends React.Component<ICorePivotTableProps, IC
             onGridReady: this.onGridReady,
             onFirstDataRendered: this.onFirstDataRendered,
             onBodyScroll: this.onBodyScroll,
+            onGridSizeChanged: this.debouncedGridSizeChanged,
 
             // Column types
             columnTypes: {

--- a/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
@@ -144,9 +144,10 @@ export class AgGridDatasource implements IDatasource {
                         this.gridApiProvider()?.setInfiniteRowCount(dataView.totalCount[0]);
                         this.currentSorts = dv.meta().effectiveSortItems();
 
-                        // Table descriptors contain attribute metadata & this attribute metadata contains totalItems
-                        // it is essential to update the total items in descriptors to keep the descriptors in-sync
-                        this.config.tableDescriptor.updateTotalItems(dv);
+                        // Table descriptors contain information about effective totals (e.g. totals set for the
+                        // table right now). After redrive of execution to change sorts/totals, code must make
+                        // sure that the new settings are reflected in the table descriptor.
+                        this.config.tableDescriptor.updateEffectiveTotals(dv);
 
                         this.processData(dv, params);
                     })

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -151,8 +151,7 @@ export function getRowTotals(
     const leafColumns = tableDescriptor.zippedLeaves;
 
     return colGrandTotals.map((totalsPerLeafColumn: string[], totalIdx: number) => {
-        const grandTotalName = grandTotalAttrDescriptor.attributeHeader.totalItems![totalIdx].totalHeaderItem
-            .name;
+        const grandTotalName = grandTotalColDescriptor.effectiveTotals[totalIdx].totalHeaderItem.name;
         const measureCells: Record<string, string> = {};
         const calculatedForColumns: string[] = [];
         const calculatedForMeasures = colGrandTotalDefs

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
@@ -363,23 +363,18 @@ export class TableDescriptor {
     }
 
     /**
-     * Updates all attribute descriptors used in table's column descriptors so that they reflect total items
-     * specified in the provided data view facade.
+     * Updates effective totals for the slice cols using the new total descriptors included for their respective
+     * attributes in the new data view facade.
      *
      * @param dv - data view with same attribute structure but with added totals
      */
-    public updateTotalItems(dv: DataViewFacade): void {
+    public updateEffectiveTotals(dv: DataViewFacade): void {
         const idToDescriptor: Record<string, IAttributeDescriptor> = keyBy(
             dv.meta().attributeDescriptors(),
             (desc) => desc.attributeHeader.localIdentifier,
         );
 
-        this.headers.sliceCols.forEach((sliceCol) =>
-            updateAttributeDescriptorTotals(idToDescriptor, sliceCol.attributeDescriptor),
-        );
-        this.headers.groupingAttributes.forEach((attribute) =>
-            updateAttributeDescriptorTotals(idToDescriptor, attribute),
-        );
+        this.headers.sliceCols.forEach((sliceCol) => updateEffectiveTotals(sliceCol, idToDescriptor));
     }
 }
 
@@ -389,11 +384,8 @@ function attributeDescriptorLocalIdMatch(localId: string): (b: IAttributeDescrip
     };
 }
 
-function updateAttributeDescriptorTotals(
-    newDescriptors: Record<string, IAttributeDescriptor>,
-    target: IAttributeDescriptor,
-) {
-    const attributeLocalId = target.attributeHeader.localIdentifier;
+function updateEffectiveTotals(col: SliceCol, newDescriptors: Record<string, IAttributeDescriptor>) {
+    const attributeLocalId = col.attributeDescriptor.attributeHeader.localIdentifier;
     const newDescriptor = newDescriptors[attributeLocalId];
 
     // if this bombs then reinit logic of the entire pivot table is flawed because upon change of table structure is
@@ -403,5 +395,5 @@ function updateAttributeDescriptorTotals(
         `attempting to refresh attribute descriptors for different table. attribute with local id ${attributeLocalId} not found`,
     );
 
-    target.attributeHeader.totalItems = newDescriptor.attributeHeader.totalItems;
+    col.effectiveTotals = newDescriptor.attributeHeader.totalItems ?? [];
 }

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorFactory.ts
@@ -247,6 +247,7 @@ function createRowDescriptors(dv: DataViewFacade): SliceCol[] {
                 index: idx,
                 attributeDescriptor,
                 fullIndexPathToHere: [idx],
+                effectiveTotals: attributeDescriptor.attributeHeader.totalItems ?? [],
             };
         });
 }

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptorTypes.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2021 GoodData Corporation
-import { IAttributeDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
+import { IAttributeDescriptor, IResultAttributeHeader, ITotalDescriptor } from "@gooddata/sdk-backend-spi";
 import { DataSeriesDescriptor, DataSeriesId } from "@gooddata/sdk-ui";
 import { ColDef, ColGroupDef, Column } from "@ag-grid-community/all-modules";
 
@@ -31,7 +31,18 @@ export type SliceCol = {
     readonly attributeDescriptor: IAttributeDescriptor;
 
     /**
-     * column index among all slice columns
+     * Descriptors of totals that are defined on this column's granularity. Note that while the total
+     * descriptors are also part of the attributeDescriptor (above) the total descriptors there are a snapshot done
+     * at the time of table descriptor construction.
+     *
+     * User may change effective totals by configuring aggregations using the table's aggregation menu. If that
+     * happens the table will drive a new execution with updated totals. After it finishes, the effective totals
+     * in this field will be updated.
+     */
+    effectiveTotals: ITotalDescriptor[];
+
+    /**
+     * Column index among all slice columns
      */
     index: number;
 


### PR DESCRIPTION
FIX: autoresize & grow to fit was not triggered during window/div resize since 8.1 as some code to trigger this was deleted by mistake
HOTFIX: pivot table mutates exec result descriptors, causing extra havoc when caching is turned on


---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
