### PR TITLE
RELATED: ONE-4890 - Date bucket items should not be always removed from the request

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/ine-one-4890_2021-02-25-16-35.json
+++ b/common/changes/@gooddata/sdk-ui-all/ine-one-4890_2021-02-25-16-35.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Date bucket items are never removed from request loadDateDataset (api-client-bear). If you need to remove bucket date items from the request, you have to filter them manually. ",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "patrik.braborec@gooddata.com"
+}

--- a/libs/api-client-bear/src/catalogue.ts
+++ b/libs/api-client-bear/src/catalogue.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import get from "lodash/get";
 import find from "lodash/find";
 import omit from "lodash/omit";
@@ -229,7 +229,7 @@ export class CatalogueModule {
     }> {
         const mdObj = cloneDeep(options).bucketItems;
         const bucketItems = mdObj
-            ? await this.loadItemDescriptions(projectId, mdObj, get(options, "attributesMap")!, true)
+            ? await this.loadItemDescriptions(projectId, mdObj, get(options, "attributesMap")!)
             : undefined;
 
         const omittedOptions = [

--- a/libs/api-client-bear/src/tests/catalogue.test.ts
+++ b/libs/api-client-bear/src/tests/catalogue.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 
@@ -255,7 +255,7 @@ describe("Catalogue", () => {
                 .then(() => {
                     const { bucketItems } = getRequestBody().dateDataSetsRequest;
 
-                    expect(bucketItems).toHaveLength(0);
+                    expect(bucketItems).toEqual(["/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1233"]);
                 });
         });
 


### PR DESCRIPTION
- Remove `removeDateItems` in loadDateDataSets api
- Changelog

JIRA: ONE-4890


---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
