### PR TITLE
Several DateFilter fixes

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-1870-date-filter-fixes_2021-03-01-09-12.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-1870-date-filter-fixes_2021-03-01-09-12.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "DateFilter now hides options with visible: false.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "dan.homola@gooddata.com"
+}

--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-1870-date-filter-fixes_2021-03-01-09-14.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-1870-date-filter-fixes_2021-03-01-09-14.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "DateFilter now respects name property in AbsoluteForm, RelativeForm and AllTime options.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "dan.homola@gooddata.com"
+}

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -66,6 +66,7 @@ export const DateFilterHelpers: {
     mapOptionToAfm: (value: import("./interfaces").DateFilterOption, dateDataSet: import("@gooddata/sdk-model").ObjRef, excludeCurrentPeriod: boolean) => import("@gooddata/sdk-model").IDateFilter;
     formatAbsoluteDateRange: (from: string | Date, to: string | Date, dateFormat: string) => string;
     formatRelativeDateRange: (from: number, to: number, granularity: import("@gooddata/sdk-backend-spi").DateFilterGranularity, translator: import("./utils/Translations/Translators").IDateAndMessageTranslator) => string;
+    filterVisibleDateFilterOptions: typeof filterVisibleDateFilterOptions;
 };
 
 // @beta
@@ -78,6 +79,9 @@ export type DateFilterRelativeOptionGroup = {
 
 // @beta (undocumented)
 export const defaultDateFilterOptions: IDateFilterOptionsByType;
+
+// @beta
+export function filterVisibleDateFilterOptions(dateFilterOptions: IDateFilterOptionsByType): IDateFilterOptionsByType;
 
 // @beta (undocumented)
 export interface IAttributeDropdownItem {

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/AllTimeFilterItem.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/AllTimeFilterItem.tsx
@@ -17,6 +17,6 @@ export const AllTimeFilterItem: React.FC<{
         onClick={() => onSelectedFilterOptionChange(filterOption)}
         className={cx("s-all-time", className)}
     >
-        <FormattedMessage id="filters.allTime.title" />
+        {filterOption.name ? filterOption.name : <FormattedMessage id="filters.allTime.title" />}
     </ListItem>
 );

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
@@ -224,7 +224,11 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
                             isMobile && ITEM_CLASS_MOBILE,
                         )}
                     >
-                        <FormattedMessage id="filters.staticPeriod" />
+                        {filterOptions.absoluteForm.name ? (
+                            filterOptions.absoluteForm.name
+                        ) : (
+                            <FormattedMessage id="filters.staticPeriod" />
+                        )}
                     </ListItem>
                 )}
                 {isSelected && (!isMobile || isOnRoute) && (
@@ -276,7 +280,11 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
                             isMobile && ITEM_CLASS_MOBILE,
                         )}
                     >
-                        <FormattedMessage id="filters.floatingRange" />
+                        {filterOptions.relativeForm.name ? (
+                            filterOptions.relativeForm.name
+                        ) : (
+                            <FormattedMessage id="filters.floatingRange" />
+                        )}
                         {!isMobile && (
                             <ListItemTooltip>
                                 <FormattedMessage id="filters.floatingRange.tooltip" />

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterCore.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterCore.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2019 GoodData Corporation
-import React from "react";
+import React, { useMemo } from "react";
 import { DateFilterGranularity } from "@gooddata/sdk-backend-spi";
 import Dropdown from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import MediaQuery from "react-responsive";
@@ -11,6 +11,7 @@ import { DateFilterBody } from "./DateFilterBody/DateFilterBody";
 import { applyExcludeCurrentPeriod } from "./utils/PeriodExlusion";
 import { formatAbsoluteDate } from "./utils/Translations/DateFilterTitle";
 import { DEFAULT_DATE_FORMAT } from "./constants/Platform";
+import { filterVisibleDateFilterOptions } from "./utils/OptionUtils";
 
 export interface IDateFilterCoreProps {
     dateFormat: string;
@@ -79,9 +80,13 @@ export const DateFilterCore: React.FC<IDateFilterCoreProps> = ({
     dateFormat,
     disabled,
     locale,
+    filterOptions,
     ...dropdownBodyProps
 }) => {
     const verifiedDateFormat = verifyDateFormat(dateFormat);
+    const filteredFilterOptions = useMemo(() => {
+        return filterVisibleDateFilterOptions(filterOptions);
+    }, [filterOptions]);
     return (
         <IntlWrapper locale={locale || "en-US"}>
             <MediaQuery query={MediaQueries.IS_MOBILE_DEVICE}>
@@ -125,6 +130,7 @@ export const DateFilterCore: React.FC<IDateFilterCoreProps> = ({
                                     {({ closeDropdown }) => (
                                         <DateFilterBody
                                             {...dropdownBodyProps}
+                                            filterOptions={filteredFilterOptions}
                                             isMobile={isMobile}
                                             closeDropdown={closeDropdown}
                                             dateFilterButton={dateFilterButton}

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterCore.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterCore.tsx
@@ -1,5 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import React, { useMemo } from "react";
+import flow from "lodash/flow";
 import { DateFilterGranularity } from "@gooddata/sdk-backend-spi";
 import Dropdown from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import MediaQuery from "react-responsive";
@@ -11,7 +12,7 @@ import { DateFilterBody } from "./DateFilterBody/DateFilterBody";
 import { applyExcludeCurrentPeriod } from "./utils/PeriodExlusion";
 import { formatAbsoluteDate } from "./utils/Translations/DateFilterTitle";
 import { DEFAULT_DATE_FORMAT } from "./constants/Platform";
-import { filterVisibleDateFilterOptions } from "./utils/OptionUtils";
+import { filterVisibleDateFilterOptions, sanitizePresetIntervals } from "./utils/OptionUtils";
 
 export interface IDateFilterCoreProps {
     dateFormat: string;
@@ -85,7 +86,7 @@ export const DateFilterCore: React.FC<IDateFilterCoreProps> = ({
 }) => {
     const verifiedDateFormat = verifyDateFormat(dateFormat);
     const filteredFilterOptions = useMemo(() => {
-        return filterVisibleDateFilterOptions(filterOptions);
+        return flow(filterVisibleDateFilterOptions, sanitizePresetIntervals)(filterOptions);
     }, [filterOptions]);
     return (
         <IntlWrapper locale={locale || "en-US"}>

--- a/libs/sdk-ui-filters/src/DateFilter/index.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/index.ts
@@ -4,6 +4,7 @@ import { defaultDateFilterOptions } from "./constants/config";
 import { validateFilterOption } from "./validation/OptionValidation";
 import { mapOptionToAfm } from "./utils/AFMConversions";
 import { applyExcludeCurrentPeriod, canExcludeCurrentPeriod } from "./utils/PeriodExlusion";
+import { filterVisibleDateFilterOptions } from "./utils/OptionUtils";
 import {
     getDateFilterTitle,
     getDateFilterRepresentation,
@@ -35,6 +36,7 @@ const DateFilterHelpers = {
     mapOptionToAfm,
     formatAbsoluteDateRange,
     formatRelativeDateRange,
+    filterVisibleDateFilterOptions,
 };
 
 // This is 1:1 reexported by root index.ts and is part of SDK's public API
@@ -46,6 +48,7 @@ export {
     IDateFilterState,
     DateFilterHelpers,
     IDateFilterStatePropsIntersection,
+    filterVisibleDateFilterOptions,
 };
 
 export {

--- a/libs/sdk-ui-filters/src/DateFilter/utils/OptionUtils.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/OptionUtils.ts
@@ -1,7 +1,10 @@
-// (C) 2019-2020 GoodData Corporation
-import { DateFilterOption } from "../interfaces";
+// (C) 2019-2021 GoodData Corporation
+import isEmpty from "lodash/isEmpty";
+import { DateFilterOption, DateFilterRelativeOptionGroup, IDateFilterOptionsByType } from "../interfaces";
 import {
     DateFilterGranularity,
+    IDateFilterOption,
+    IRelativeDateFilterPreset,
     isRelativeDateFilterForm,
     isRelativeDateFilterPreset,
 } from "@gooddata/sdk-backend-spi";
@@ -10,4 +13,71 @@ export function getDateFilterOptionGranularity(dateFilterOption: DateFilterOptio
     return isRelativeDateFilterForm(dateFilterOption) || isRelativeDateFilterPreset(dateFilterOption)
         ? dateFilterOption.granularity
         : undefined;
+}
+
+function isDateFilterOptionVisible(option: IDateFilterOption) {
+    return option && option.visible;
+}
+
+function pickDateFilterOptionIfVisible<T extends IDateFilterOption>(option: T) {
+    return isDateFilterOptionVisible(option) ? option : undefined;
+}
+
+function filterVisibleRelativePresets(
+    relativePreset: DateFilterRelativeOptionGroup,
+): DateFilterRelativeOptionGroup {
+    return Object.keys(relativePreset).reduce((filtered: DateFilterRelativeOptionGroup, granularity) => {
+        const presetsOfGranularity: IRelativeDateFilterPreset[] = relativePreset[granularity];
+        const visiblePresetsOfGranularity = presetsOfGranularity.filter(isDateFilterOptionVisible);
+
+        if (visiblePresetsOfGranularity.length) {
+            filtered[granularity] = visiblePresetsOfGranularity;
+        }
+
+        return filtered;
+    }, {});
+}
+
+function removeEmptyKeysFromDateFilterOptions(
+    dateFilterOptions: IDateFilterOptionsByType,
+): IDateFilterOptionsByType {
+    const { absoluteForm, absolutePreset, allTime, relativeForm, relativePreset } = dateFilterOptions;
+    return {
+        ...(allTime && { allTime }),
+        ...(absoluteForm && { absoluteForm }),
+        ...(!isEmpty(absolutePreset) && { absolutePreset }),
+        ...(relativeForm && { relativeForm }),
+        ...(!isEmpty(relativePreset) && { relativePreset }),
+    };
+}
+
+/**
+ * Returns dateFilterOptions with only items that have visible set to true.
+ *
+ * @param dateFilterOptions - options to filter
+ * @beta
+ */
+export function filterVisibleDateFilterOptions(
+    dateFilterOptions: IDateFilterOptionsByType,
+): IDateFilterOptionsByType {
+    const allTime = pickDateFilterOptionIfVisible(dateFilterOptions.allTime);
+
+    const absoluteForm = pickDateFilterOptionIfVisible(dateFilterOptions.absoluteForm);
+
+    const relativeForm = pickDateFilterOptionIfVisible(dateFilterOptions.relativeForm);
+
+    const absolutePreset =
+        dateFilterOptions.absolutePreset &&
+        dateFilterOptions.absolutePreset.filter(isDateFilterOptionVisible);
+
+    const relativePreset =
+        dateFilterOptions.relativePreset && filterVisibleRelativePresets(dateFilterOptions.relativePreset);
+
+    return removeEmptyKeysFromDateFilterOptions({
+        allTime,
+        absoluteForm,
+        absolutePreset,
+        relativeForm,
+        relativePreset,
+    });
 }

--- a/libs/sdk-ui-filters/src/DateFilter/utils/tests/OptionUtils.test.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/tests/OptionUtils.test.ts
@@ -1,5 +1,14 @@
-// (C) 2019 GoodData Corporation
-import { getDateFilterOptionGranularity } from "../OptionUtils";
+// (C) 2019-2021 GoodData Corporation
+import {
+    IAbsoluteDateFilterForm,
+    IAbsoluteDateFilterPreset,
+    IAllTimeDateFilterOption,
+    IRelativeDateFilterForm,
+    IRelativeDateFilterPresetOfGranularity,
+} from "@gooddata/sdk-backend-spi";
+
+import { IDateFilterOptionsByType } from "../../interfaces";
+import { getDateFilterOptionGranularity, filterVisibleDateFilterOptions } from "../OptionUtils";
 import { absoluteFormFilter, relativePresetFilter } from "../Translations/tests/fixtures";
 
 describe("optionUtils", () => {
@@ -7,6 +16,233 @@ describe("optionUtils", () => {
         it("should return date filter value", () => {
             expect(getDateFilterOptionGranularity(absoluteFormFilter)).toEqual(undefined);
             expect(getDateFilterOptionGranularity(relativePresetFilter)).toEqual("GDC.time.date");
+        });
+    });
+});
+
+describe("filterVisibleDateFilterOptions", () => {
+    describe("all time filter", () => {
+        const visibleAllTime: IAllTimeDateFilterOption = {
+            localIdentifier: "ALL_TIME",
+            name: "",
+            type: "allTime",
+            visible: true,
+        };
+
+        const hiddenAllTime: IAllTimeDateFilterOption = {
+            ...visibleAllTime,
+            visible: false,
+        };
+
+        it("should preserve visible all time filter", () => {
+            const input: IDateFilterOptionsByType = {
+                allTime: visibleAllTime,
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(input);
+        });
+
+        it("should discard hidden all time filter", () => {
+            const input: IDateFilterOptionsByType = {
+                allTime: hiddenAllTime,
+            };
+
+            const expected = {};
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+    });
+
+    describe("absolute form", () => {
+        const visibleAbsoluteForm: IAbsoluteDateFilterForm = {
+            localIdentifier: "ABSOLUTE_FORM",
+            name: "",
+            type: "absoluteForm",
+            visible: true,
+        };
+
+        const hiddenAbsoluteForm: IAbsoluteDateFilterForm = {
+            ...visibleAbsoluteForm,
+            visible: false,
+        };
+
+        it("should preserve visible absolute form", () => {
+            const input: IDateFilterOptionsByType = {
+                absoluteForm: visibleAbsoluteForm,
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(input);
+        });
+
+        it("should discard hidden absolute form", () => {
+            const input: IDateFilterOptionsByType = {
+                absoluteForm: hiddenAbsoluteForm,
+            };
+
+            const expected = {};
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+    });
+
+    describe("relative form", () => {
+        const visibleRelativeForm: IRelativeDateFilterForm = {
+            localIdentifier: "RELATIVE_FORM",
+            name: "",
+            type: "relativeForm",
+            availableGranularities: ["GDC.time.date"],
+            visible: true,
+        };
+
+        const hiddenAbsoluteForm: IRelativeDateFilterForm = {
+            ...visibleRelativeForm,
+            visible: false,
+        };
+
+        it("should preserve visible relative form", () => {
+            const input: IDateFilterOptionsByType = {
+                relativeForm: visibleRelativeForm,
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(input);
+        });
+
+        it("should discard hidden relative form", () => {
+            const input: IDateFilterOptionsByType = {
+                relativeForm: hiddenAbsoluteForm,
+            };
+
+            const expected = {};
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+    });
+
+    describe("absolute preset", () => {
+        const visiblePreset: IAbsoluteDateFilterPreset = {
+            from: "2019-01-01",
+            localIdentifier: "YEAR_2019",
+            name: "The year 2019",
+            to: "2019-12-31",
+            type: "absolutePreset",
+            visible: true,
+        };
+
+        const hiddenPreset: IAbsoluteDateFilterPreset = {
+            ...visiblePreset,
+            visible: false,
+        };
+
+        it("should preserve visible preset", () => {
+            const input: IDateFilterOptionsByType = {
+                absolutePreset: [visiblePreset],
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(input);
+        });
+
+        it("should discard hidden preset", () => {
+            const input: IDateFilterOptionsByType = {
+                absolutePreset: [visiblePreset, hiddenPreset],
+            };
+
+            const expected: IDateFilterOptionsByType = {
+                absolutePreset: [visiblePreset],
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+
+        it("should discard the absolute preset section altogether if it has no visible preset", () => {
+            const input: IDateFilterOptionsByType = {
+                absolutePreset: [hiddenPreset],
+            };
+
+            const expected: IDateFilterOptionsByType = {};
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+    });
+
+    describe("relative preset", () => {
+        const visibleMonthPreset: IRelativeDateFilterPresetOfGranularity<"GDC.time.month"> = {
+            from: 0,
+            granularity: "GDC.time.month",
+            localIdentifier: "THIS_MONTH",
+            to: 0,
+            type: "relativePreset",
+            name: "",
+            visible: true,
+        };
+
+        const hiddenMonthPreset: IRelativeDateFilterPresetOfGranularity<"GDC.time.month"> = {
+            ...visibleMonthPreset,
+            visible: false,
+        };
+
+        const visibleYearPreset: IRelativeDateFilterPresetOfGranularity<"GDC.time.year"> = {
+            from: -1,
+            granularity: "GDC.time.year",
+            localIdentifier: "LAST_YEAR",
+            to: -1,
+            type: "relativePreset",
+            name: "",
+            visible: true,
+        };
+
+        it("should preserve visible relative preset", () => {
+            const input: IDateFilterOptionsByType = {
+                relativePreset: {
+                    "GDC.time.month": [visibleMonthPreset],
+                },
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(input);
+        });
+
+        it("should discard invisible relative preset", () => {
+            const input: IDateFilterOptionsByType = {
+                relativePreset: {
+                    "GDC.time.month": [visibleMonthPreset, hiddenMonthPreset],
+                },
+            };
+
+            const expected = {
+                relativePreset: {
+                    "GDC.time.month": [visibleMonthPreset],
+                },
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+
+        it("should discard a relative preset granularity altogether if it has no visible items", () => {
+            const input: IDateFilterOptionsByType = {
+                relativePreset: {
+                    "GDC.time.month": [hiddenMonthPreset],
+                    "GDC.time.year": [visibleYearPreset],
+                },
+            };
+
+            const expected = {
+                relativePreset: {
+                    "GDC.time.year": [visibleYearPreset],
+                },
+            };
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
+        });
+
+        it("should discard the relative preset section altogether if it has no visible preset in any granularity", () => {
+            const input: IDateFilterOptionsByType = {
+                relativePreset: {
+                    "GDC.time.month": [hiddenMonthPreset],
+                },
+            };
+
+            const expected = {};
+
+            expect(filterVisibleDateFilterOptions(input)).toEqual(expected);
         });
     });
 });

--- a/libs/sdk-ui-filters/src/index.ts
+++ b/libs/sdk-ui-filters/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 export { AttributeElements, IAttributeElementsProps } from "./AttributeElements/AttributeElements";
 export { IAttributeElementsChildren } from "./AttributeElements/types";
@@ -22,6 +22,7 @@ export {
     isRelativeDateFilterOption,
     IUiAbsoluteDateFilterForm,
     IUiRelativeDateFilterForm,
+    filterVisibleDateFilterOptions,
 } from "./DateFilter";
 export {
     MeasureValueFilter,


### PR DESCRIPTION
* RAIL-1870 Respect visible property of date filter options - visible: false options are no longer shown. The related function was exported so that other apps can use it as well.
* RAIL-1843 Respect dateFilterOption names - All time and Forms now respect their names if there is any.
* RAIL-1875 Sanitize presets in DateFilter  - This makes sure that all presets have from <= to.

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
