### PR TITLE
RELATED: RAIL-1446 improve DateFilter wording

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/utils/Translations/DateFilterTitle.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/Translations/DateFilterTitle.ts
@@ -84,6 +84,24 @@ const relativeDateRangeFormatters: Array<{
             ),
     },
     {
+        // From N days ago to N days ago
+        predicate: (from, to) => from < 0 && from === to,
+        formatter: (from, _to, intlGranularity, translator) =>
+            translator.formatMessage(
+                { id: `filters.interval.${intlGranularity}s.past.sameValue` },
+                { value: Math.abs(from) },
+            ),
+    },
+    {
+        // From N days ago to N days ahead
+        predicate: (from, to) => from > 0 && from === to,
+        formatter: (from, _to, intlGranularity, translator) =>
+            translator.formatMessage(
+                { id: `filters.interval.${intlGranularity}s.future.sameValue` },
+                { value: Math.abs(from) },
+            ),
+    },
+    {
         // From N days ago to M days ago
         predicate: (from, to) => from < 0 && to < 0,
         formatter: (from, to, intlGranularity, translator) =>

--- a/libs/sdk-ui-filters/src/DateFilter/utils/Translations/tests/DateFilterTitle.test.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/Translations/tests/DateFilterTitle.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { DEFAULT_DATE_FORMAT } from "../../../constants/Platform";
 import {
     getDateFilterRepresentation,
@@ -69,7 +69,9 @@ describe("getDateFilterTitleUsingTranslator", () => {
         [-6, 0, "GDC.time.date", "filters.lastNDays", { n: 7 }],
         [0, 6, "GDC.time.date", "filters.nextNDays", { n: 7 }],
         [-6, -2, "GDC.time.date", "filters.interval.days.past", { from: 6, to: 2 }],
+        [-6, -6, "GDC.time.date", "filters.interval.days.past.sameValue", { value: 6 }],
         [2, 6, "GDC.time.date", "filters.interval.days.future", { from: 2, to: 6 }],
+        [6, 6, "GDC.time.date", "filters.interval.days.future.sameValue", { value: 6 }],
         [-5, 5, "GDC.time.date", "filters.interval.days.mixed", { from: 5, to: 5 }],
         // weeks
         [0, 0, "GDC.time.week_us", "filters.thisWeek.title", undefined],
@@ -78,7 +80,9 @@ describe("getDateFilterTitleUsingTranslator", () => {
         [-6, 0, "GDC.time.week_us", "filters.lastNWeeks", { n: 7 }],
         [0, 6, "GDC.time.week_us", "filters.nextNWeeks", { n: 7 }],
         [-6, -2, "GDC.time.week_us", "filters.interval.weeks.past", { from: 6, to: 2 }],
+        [-6, -6, "GDC.time.week_us", "filters.interval.weeks.past.sameValue", { value: 6 }],
         [2, 6, "GDC.time.week_us", "filters.interval.weeks.future", { from: 2, to: 6 }],
+        [6, 6, "GDC.time.week_us", "filters.interval.weeks.future.sameValue", { value: 6 }],
         [-5, 5, "GDC.time.week_us", "filters.interval.weeks.mixed", { from: 5, to: 5 }],
         // months
         [0, 0, "GDC.time.month", "filters.thisMonth.title", undefined],
@@ -87,7 +91,9 @@ describe("getDateFilterTitleUsingTranslator", () => {
         [-6, 0, "GDC.time.month", "filters.lastNMonths", { n: 7 }],
         [0, 6, "GDC.time.month", "filters.nextNMonths", { n: 7 }],
         [-6, -2, "GDC.time.month", "filters.interval.months.past", { from: 6, to: 2 }],
+        [-6, -6, "GDC.time.month", "filters.interval.months.past.sameValue", { value: 6 }],
         [2, 6, "GDC.time.month", "filters.interval.months.future", { from: 2, to: 6 }],
+        [6, 6, "GDC.time.month", "filters.interval.months.future.sameValue", { value: 6 }],
         [-5, 5, "GDC.time.month", "filters.interval.months.mixed", { from: 5, to: 5 }],
         // quarters
         [0, 0, "GDC.time.quarter", "filters.thisQuarter.title", undefined],
@@ -96,7 +102,9 @@ describe("getDateFilterTitleUsingTranslator", () => {
         [-6, 0, "GDC.time.quarter", "filters.lastNQuarters", { n: 7 }],
         [0, 6, "GDC.time.quarter", "filters.nextNQuarters", { n: 7 }],
         [-6, -2, "GDC.time.quarter", "filters.interval.quarters.past", { from: 6, to: 2 }],
+        [-6, -6, "GDC.time.quarter", "filters.interval.quarters.past.sameValue", { value: 6 }],
         [2, 6, "GDC.time.quarter", "filters.interval.quarters.future", { from: 2, to: 6 }],
+        [6, 6, "GDC.time.quarter", "filters.interval.quarters.future.sameValue", { value: 6 }],
         [-5, 5, "GDC.time.quarter", "filters.interval.quarters.mixed", { from: 5, to: 5 }],
         // years
         [0, 0, "GDC.time.year", "filters.thisYear.title", undefined],

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -528,9 +528,19 @@
         "comment": "Example: 'From 5 to 3 days ago'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {DAY} other {DAYS}}' translate only uppercase words.",
         "limit": 0
     },
+    "filters.interval.days.past.sameValue": {
+        "value": "{value} {value, plural, one {day} other {days}} ago",
+        "comment": "Example: '5 days ago'. Don't translate placeholder '{value}'. In '{value, plural, one {DAY} other {DAYS}}' translate only uppercase words.",
+        "limit": 0
+    },
     "filters.interval.days.future": {
         "value": "From {from} to {to} {to, plural, one {day} other {days}} ahead",
         "comment": "Example: 'From 3 to 5 days ahead'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {DAY} other {DAYS}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "filters.interval.days.future.sameValue": {
+        "value": "{value} {value, plural, one {day} other {days}} ahead",
+        "comment": "Example: '5 days ahead'. Don't translate placeholder '{value}'. In '{value, plural, one {DAY} other {DAYS}}' translate only uppercase words.",
         "limit": 0
     },
     "filters.interval.days.mixed": {
@@ -543,9 +553,19 @@
         "comment": "Example: 'From 5 to 3 weeks ago'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {WEEK} other {WEEKS}}' translate only uppercase words.",
         "limit": 0
     },
+    "filters.interval.weeks.past.sameValue": {
+        "value": "{value} {value, plural, one {week} other {weeks}} ago",
+        "comment": "Example: '5 weeks ago'. Don't translate placeholder '{value}'. In '{value, plural, one {WEEK} other {WEEKS}}' translate only uppercase words.",
+        "limit": 0
+    },
     "filters.interval.weeks.future": {
         "value": "From {from} to {to} {to, plural, one {week} other {weeks}} ahead",
         "comment": "Example: 'From 3 to 5 weeks ahead'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {WEEK} other {WEEKS}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "filters.interval.weeks.future.sameValue": {
+        "value": "{value} {value, plural, one {week} other {weeks}} ahead",
+        "comment": "Example: '5 weeks ahead'. Don't translate placeholder '{value}'. In '{value, plural, one {WEEK} other {WEEKS}}' translate only uppercase words.",
         "limit": 0
     },
     "filters.interval.weeks.mixed": {
@@ -558,9 +578,19 @@
         "comment": "Example: 'From 5 to 3 months ago'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {MONTH} other {MONTHS}}' translate only uppercase words.",
         "limit": 0
     },
+    "filters.interval.months.past.sameValue": {
+        "value": "{value} {value, plural, one {month} other {months}} ago",
+        "comment": "Example: '5 months ago'. Don't translate placeholder '{value}'. In '{value, plural, one {MONTH} other {MONTHS}}' translate only uppercase words.",
+        "limit": 0
+    },
     "filters.interval.months.future": {
         "value": "From {from} to {to} {to, plural, one {month} other {months}} ahead",
         "comment": "Example: 'From 3 to 5 months ahead'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {MONTH} other {MONTHS}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "filters.interval.months.future.sameValue": {
+        "value": "{value} {value, plural, one {month} other {months}} ahead",
+        "comment": "Example: '5 months ahead'. Don't translate placeholder '{value}'. In '{value, plural, one {MONTH} other {MONTHS}}' translate only uppercase words.",
         "limit": 0
     },
     "filters.interval.months.mixed": {
@@ -573,9 +603,19 @@
         "comment": "Example: 'From 5 to 3 quarters ago'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {QUARTER} other {QUARTERS}}' translate only uppercase words.",
         "limit": 0
     },
+    "filters.interval.quarters.past.sameValue": {
+        "value": "{value} {value, plural, one {quarter} other {quarters}} ago",
+        "comment": "Example: '5 quarters ago'. Don't translate placeholder '{value}'. In '{value, plural, one {QUARTER} other {QUARTERS}}' translate only uppercase words.",
+        "limit": 0
+    },
     "filters.interval.quarters.future": {
         "value": "From {from} to {to} {to, plural, one {quarter} other {quarters}} ahead",
         "comment": "Example: 'From 3 to 5 quarters ahead'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {QUARTER} other {QUARTERS}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "filters.interval.quarters.future.sameValue": {
+        "value": "{value} {value, plural, one {quarter} other {quarters}} ahead",
+        "comment": "Example: '5 quarters ahead'. Don't translate placeholder '{value}'. In '{value, plural, one {QUARTER} other {QUARTERS}}' translate only uppercase words.",
         "limit": 0
     },
     "filters.interval.quarters.mixed": {
@@ -588,9 +628,19 @@
         "comment": "Example: 'From 5 to 3 years ago'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {YEAR} other {YEARS}}' translate only uppercase words.",
         "limit": 0
     },
+    "filters.interval.years.past.sameValue": {
+        "value": "{value} {value, plural, one {year} other {years}} ago",
+        "comment": "Example: '5 years ago'. Don't translate placeholder '{value}'. In '{value, plural, one {YEAR} other {YEARS}}' translate only uppercase words.",
+        "limit": 0
+    },
     "filters.interval.years.future": {
         "value": "From {from} to {to} {to, plural, one {year} other {years}} ahead",
         "comment": "Example: 'From 3 to 5 years ahead'. Don't translate placeholders '{from}', '{to}'. In '{to, plural, one {YEAR} other {YEARS}}' translate only uppercase words.",
+        "limit": 0
+    },
+    "filters.interval.years.future.sameValue": {
+        "value": "{value} {value, plural, one {year} other {years}} ahead",
+        "comment": "Example: '5 years ahead'. Don't translate placeholder '{value}'. In '{value, plural, one {YEAR} other {YEARS}}' translate only uppercase words.",
         "limit": 0
     },
     "filters.interval.years.mixed": {


### PR DESCRIPTION
In case the from and to is the same, we can make the message shorter
and more natural.

So instead of "From 2 to 2 days ago" we now have "2 days ago".

JIRA: RAIL-1446

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
