### PR TITLE
Introduced complementary palette

### DIFF
--- a/libs/api-model-bear/api/api-model-bear.api.md
+++ b/libs/api-model-bear/api/api-model-bear.api.md
@@ -1581,7 +1581,32 @@ export namespace GdcMetadata {
         light?: ThemeColor;
     }
     // (undocumented)
+    export interface IThemeComplementaryPalette {
+        // (undocumented)
+        shade0: ThemeColor;
+        // (undocumented)
+        shade1?: ThemeColor;
+        // (undocumented)
+        shade2?: ThemeColor;
+        // (undocumented)
+        shade3?: ThemeColor;
+        // (undocumented)
+        shade4?: ThemeColor;
+        // (undocumented)
+        shade5?: ThemeColor;
+        // (undocumented)
+        shade6?: ThemeColor;
+        // (undocumented)
+        shade7?: ThemeColor;
+        // (undocumented)
+        shade8?: ThemeColor;
+        // (undocumented)
+        shade9: ThemeColor;
+    }
+    // (undocumented)
     export interface IThemePalette {
+        // (undocumented)
+        complementary?: IThemeComplementaryPalette;
         // (undocumented)
         error?: IThemeColorFamily;
         // (undocumented)

--- a/libs/api-model-bear/src/meta/GdcMetadata.ts
+++ b/libs/api-model-bear/src/meta/GdcMetadata.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import isEmpty from "lodash/fp/isEmpty";
 import has from "lodash/has";
 import {
@@ -155,12 +155,26 @@ export namespace GdcMetadata {
         contrast?: ThemeColor;
     }
 
+    export interface IThemeComplementaryPalette {
+        shade0: ThemeColor;
+        shade1?: ThemeColor;
+        shade2?: ThemeColor;
+        shade3?: ThemeColor;
+        shade4?: ThemeColor;
+        shade5?: ThemeColor;
+        shade6?: ThemeColor;
+        shade7?: ThemeColor;
+        shade8?: ThemeColor;
+        shade9: ThemeColor;
+    }
+
     export interface IThemePalette {
         primary?: IThemeColorFamily;
         error?: IThemeColorFamily;
         warning?: IThemeColorFamily;
         success?: IThemeColorFamily;
         info?: IThemeColorFamily;
+        complementary?: IThemeComplementaryPalette;
     }
 
     export interface ITheme extends IMetadataObject {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1393,6 +1393,30 @@ export interface IThemeColorFamily {
 }
 
 // @beta
+export interface IThemeComplementaryPalette {
+    // (undocumented)
+    shade0: ThemeColor;
+    // (undocumented)
+    shade1?: ThemeColor;
+    // (undocumented)
+    shade2?: ThemeColor;
+    // (undocumented)
+    shade3?: ThemeColor;
+    // (undocumented)
+    shade4?: ThemeColor;
+    // (undocumented)
+    shade5?: ThemeColor;
+    // (undocumented)
+    shade6?: ThemeColor;
+    // (undocumented)
+    shade7?: ThemeColor;
+    // (undocumented)
+    shade8?: ThemeColor;
+    // (undocumented)
+    shade9: ThemeColor;
+}
+
+// @beta
 export interface IThemeKpi {
     primaryMeasureColor?: ThemeColor;
     secondaryInfoColor?: ThemeColor;
@@ -1405,6 +1429,7 @@ export interface IThemeKpi {
 
 // @beta
 export interface IThemePalette {
+    complementary?: IThemeComplementaryPalette;
     error?: IThemeColorFamily;
     info?: IThemeColorFamily;
     primary?: IThemeColorFamily;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -93,6 +93,7 @@ export {
     ThemeFontUri,
     ThemeColor,
     IThemeColorFamily,
+    IThemeComplementaryPalette,
     IThemeWidgetTitle,
     IThemeTypography,
     IThemePalette,

--- a/libs/sdk-backend-spi/src/workspace/styling/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/styling/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IColorPalette } from "@gooddata/sdk-model";
 
 import { ITheme } from "./theme";
@@ -7,6 +7,7 @@ export {
     ThemeFontUri,
     ThemeColor,
     IThemeColorFamily,
+    IThemeComplementaryPalette,
     IThemeWidgetTitle,
     IThemeTypography,
     IThemePalette,

--- a/libs/sdk-backend-spi/src/workspace/styling/theme.ts
+++ b/libs/sdk-backend-spi/src/workspace/styling/theme.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 
 /**
  * Custom font URI which is used to override the default font
@@ -61,6 +61,31 @@ export interface IThemeColorFamily {
 }
 
 /**
+ * Used to color various elements across many components by replacing
+ * the default complementary palette of gray color shades
+ *
+ * Contains up to 10 shades, typically the first one being the lightest
+ * and the last being the darkest, or vice-versa for the dark-based designs
+ *
+ * The first and last shades are mandatory, the rest is automatically
+ * calculated if not provided
+ *
+ * @beta
+ */
+export interface IThemeComplementaryPalette {
+    shade0: ThemeColor;
+    shade1?: ThemeColor;
+    shade2?: ThemeColor;
+    shade3?: ThemeColor;
+    shade4?: ThemeColor;
+    shade5?: ThemeColor;
+    shade6?: ThemeColor;
+    shade7?: ThemeColor;
+    shade8?: ThemeColor;
+    shade9: ThemeColor;
+}
+
+/**
  * Customizable palette of major colors
  *
  * Inspired by Material UI palette: https://material-ui.com/customization/palette/
@@ -92,6 +117,13 @@ export interface IThemePalette {
      * Used to express info or progress
      */
     info?: IThemeColorFamily;
+
+    /**
+     * Used to color various elements across many components
+     *
+     * See {@link IThemeComplementaryPalette} for more details.
+     */
+    complementary?: IThemeComplementaryPalette;
 }
 
 /**

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
@@ -7,6 +7,7 @@ import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
 import { clearCssProperties, setCssProperties } from "../cssProperties";
 import { ThemeContextProvider } from "./Context";
+import { getComplementaryPalette } from "../complementaryPalette";
 
 /**
  * @public
@@ -45,6 +46,21 @@ export interface IThemeProviderProps {
      */
     modifier?: ThemeModifier;
 }
+
+const prepareComplementaryPalette = (theme: ITheme): ITheme => {
+    if (theme?.palette?.complementary) {
+        return {
+            ...theme,
+            palette: {
+                ...theme.palette,
+                complementary: getComplementaryPalette(theme.palette.complementary),
+            },
+        };
+    }
+
+    return theme;
+};
+const prepareTheme = (theme: ITheme): ITheme => ({ ...theme, ...prepareComplementaryPalette(theme) });
 
 /**
  * Fetches the theme object from the backend upon mounting and passes both theme object and isThemeLoading flag
@@ -90,9 +106,10 @@ export const ThemeProvider: React.FC<IThemeProviderProps> = ({
 
             if (lastWorkspace.current === workspace) {
                 const modifiedTheme = modifier(selectedTheme);
-                setTheme(modifiedTheme);
+                const preparedTheme = prepareTheme(modifiedTheme);
+                setTheme(preparedTheme);
                 setIsLoading(false);
-                setCssProperties(modifiedTheme);
+                setCssProperties(preparedTheme);
             }
         };
 

--- a/libs/sdk-ui-theme-provider/src/complementaryPalette.ts
+++ b/libs/sdk-ui-theme-provider/src/complementaryPalette.ts
@@ -1,0 +1,44 @@
+// (C) 2021 GoodData Corporation
+import { mix } from "polished";
+import { IThemeComplementaryPalette } from "@gooddata/sdk-backend-spi";
+
+const COMPLEMENTARY_PALETTE_PREFIX = "shade";
+
+type IComplementaryPaletteKey = keyof IThemeComplementaryPalette;
+
+const getShade = (palette: IThemeComplementaryPalette, index: number): string => {
+    const paletteKeys = Object.keys(palette).map((shade) =>
+        parseInt(shade.replace(COMPLEMENTARY_PALETTE_PREFIX, "")),
+    );
+
+    const nearestPrevShadeKey = paletteKeys.filter((paletteKey) => paletteKey < index).slice(-1)[0] || 0;
+    const nearestNextShadeKey = paletteKeys.filter((paletteKey) => paletteKey > index)[0] || 9;
+
+    const shadesCount = nearestNextShadeKey - nearestPrevShadeKey;
+    const mixStep = 1 / shadesCount;
+
+    const nearestPrevShade = palette[`shade${nearestPrevShadeKey}` as IComplementaryPaletteKey] || "#fff";
+    const nearestNextShade = palette[`shade${nearestNextShadeKey}` as IComplementaryPaletteKey] || "#000";
+
+    return mix(mixStep * (nearestNextShadeKey - index), nearestPrevShade, nearestNextShade);
+};
+
+/**
+ * Completes provided complementary palette with missing shades by mixing nearest known shades
+ *
+ * @internal
+ */
+export const getComplementaryPalette = (palette: IThemeComplementaryPalette): IThemeComplementaryPalette => {
+    return {
+        shade0: palette.shade0,
+        shade1: palette.shade1 || getShade(palette, 1),
+        shade2: palette.shade2 || getShade(palette, 2),
+        shade3: palette.shade3 || getShade(palette, 3),
+        shade4: palette.shade4 || getShade(palette, 4),
+        shade5: palette.shade5 || getShade(palette, 5),
+        shade6: palette.shade6 || getShade(palette, 6),
+        shade7: palette.shade7 || getShade(palette, 7),
+        shade8: palette.shade8 || getShade(palette, 8),
+        shade9: palette.shade9,
+    };
+};

--- a/libs/sdk-ui-theme-provider/src/tests/__snapshots__/complementaryPalette.test.ts.snap
+++ b/libs/sdk-ui-theme-provider/src/tests/__snapshots__/complementaryPalette.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`complementaryPalette getComplementaryPalette should generate missing colors in complementary palette 1`] = `
+Object {
+  "shade0": "#001122",
+  "shade1": "#01191f",
+  "shade2": "#02221d",
+  "shade3": "#032b1b",
+  "shade4": "#043319",
+  "shade5": "#053c17",
+  "shade6": "#064515",
+  "shade7": "#074d13",
+  "shade8": "#085611",
+  "shade9": "#095f0f",
+}
+`;
+
+exports[`complementaryPalette getComplementaryPalette should generate missing colors in complementary palette 2`] = `
+Object {
+  "shade0": "#001122",
+  "shade1": "#32321b",
+  "shade2": "#645415",
+  "shade3": "#97760f",
+  "shade4": "#c99809",
+  "shade5": "#fcba03",
+  "shade6": "#bfa306",
+  "shade7": "#828c09",
+  "shade8": "#45750c",
+  "shade9": "#095f0f",
+}
+`;
+
+exports[`complementaryPalette getComplementaryPalette should generate missing colors in complementary palette 3`] = `
+Object {
+  "shade0": "#001122",
+  "shade1": "#01191f",
+  "shade2": "#02221d",
+  "shade3": "#032b1b",
+  "shade4": "#043319",
+  "shade5": "#053c17",
+  "shade6": "#064515",
+  "shade7": "#074d13",
+  "shade8": "#085611",
+  "shade9": "#095f0f",
+}
+`;

--- a/libs/sdk-ui-theme-provider/src/tests/complementaryPalette.test.ts
+++ b/libs/sdk-ui-theme-provider/src/tests/complementaryPalette.test.ts
@@ -1,0 +1,31 @@
+// (C) 2019-2020 GoodData Corporation
+import { IThemeComplementaryPalette } from "@gooddata/sdk-backend-spi";
+
+import { getComplementaryPalette } from "../complementaryPalette";
+
+describe("complementaryPalette", () => {
+    describe("getComplementaryPalette", () => {
+        const Scenarios: Array<[IThemeComplementaryPalette]> = [
+            [{ shade0: "#001122", shade9: "#095f0f" }],
+            [{ shade0: "#001122", shade5: "#fcba03", shade9: "#095f0f" }],
+            [
+                {
+                    shade0: "#001122",
+                    shade1: "#01191f",
+                    shade2: "#02221d",
+                    shade3: "#032b1b",
+                    shade4: "#043319",
+                    shade5: "#053c17",
+                    shade6: "#064515",
+                    shade7: "#074d13",
+                    shade8: "#085611",
+                    shade9: "#095f0f",
+                },
+            ],
+        ];
+
+        it.each(Scenarios)("should generate missing colors in complementary palette", (providedPalette) => {
+            expect(getComplementaryPalette(providedPalette)).toMatchSnapshot();
+        });
+    });
+});


### PR DESCRIPTION
- with auto-generated missing shades
- rendered as css variables: --gd-palette-complementary-<0-9>

JIRA: BB-2813

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
