### PR TITLE
Avoid null containerRef in getAutoResizedColumns

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/resizing/agGridColumnSizing.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/agGridColumnSizing.ts
@@ -903,14 +903,14 @@ export const getAutoResizedColumns = (
     gridApi: GridApi | null,
     columnApi: ColumnApi | null,
     execution: IExecutionResult | null,
-    containerRef: HTMLDivElement,
+    containerRef: HTMLDivElement | null,
     options: {
         measureHeaders: boolean;
         padding: number;
         separators: any;
     },
 ): IResizedColumns => {
-    if (tableDescriptor && gridApi && columnApi && execution) {
+    if (tableDescriptor && gridApi && columnApi && execution && containerRef) {
         const columns = columnApi.getPrimaryColumns();
         const { headerFont, rowFont, subtotalFont, totalFont } = getTableFonts(containerRef);
         const canvas = document.createElement("canvas");


### PR DESCRIPTION
JIRA: RAIL-2983

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
