### PR TITLE
RELATED: RAIL-2993 prevent pivot table growing in height on its own

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -327,13 +327,13 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
         if (this.environment === DASHBOARDS_ENVIRONMENT) {
             this.renderFun(
-                <ReactMeasure client={true}>
-                    {({ measureRef, contentRect }: any) => {
+                <ReactMeasure client>
+                    {({ measureRef, contentRect }) => {
                         const clientHeight = contentRect.client.height;
 
                         /*
                          * For some reason (unknown to me), there was a big if; nil height meant that
-                         * the wrapper was to 100%; non-nil height ment fixed size header with the 328 magic
+                         * the wrapper was to 100%; non-nil height meant fixed size header with the 328 magic
                          * number.
                          *
                          * For a while, there were more differences between the two branches, however after
@@ -346,7 +346,20 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
 
                         const configWithMaxHeight: IPivotTableConfig = {
                             ...tableConfig,
-                            maxHeight: clientHeight,
+                            /*
+                             * For some mysterious reason, there sometimes is exactly 2px discrepancy between
+                             * the 100% div and the actual CorePivotTable. This 2px seems to be unrelated to any
+                             * CSS property (border, padding, etc.) not even the leeway variable in CorePivotTable.
+                             * So we compensate for those 2px, because otherwise the maxHeight will play catch up
+                             * with the 100% gd-table-dashboard-wrapper div which causes the table to grow
+                             * in height in 2px increments until it reaches its full size (then the resizing
+                             * stops as bodyHeight of the table gets smaller than the maxHeight and "wins")...
+                             *
+                             * Ideally, this maxHeight would not be needed at all (if I remove it altogether,
+                             * the problem goes away), however, it is necessary for ONE-4322 (there seems to be
+                             * no native way of doing this in ag-grid itself).
+                             */
+                            maxHeight: clientHeight - 2,
                             ...customVisualizationConfig,
                         };
 


### PR DESCRIPTION
There is sometimes exactly 2px discrepancy between the height of
gd-table-dashboard-wrapper (set to 100%)
and gd-table-component that gets its height from its parent's maxHeight.
These 2px create a positive feedback loop which causes the table to
grow in height in 2px increments until it reaches its full height.

To avoid this, the maxHeight is reduced by the 2 pixels which avoids
the discrepancy.

This is as a symptomatic fix as they come, but I was unable to find
the reason why it is always exactly 2 pixels and what causes them.

Also "fixing" this in the PluggablePivotTable prevents impact on any
usage of the PivotTable outside of dashboards environment.

JIRA: RAIL-2993

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
