### PR TITLE
BUGFIX: FET-608 - Fix pivot table race conditions

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -480,7 +480,18 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
     };
 
     private onGridSizeChanged = (gridSizeChangedEvent: any): void => {
-        invariant(this.internal.table);
+        if (!this.internal.firstDataRendered) {
+            // ag-grid does emit the grid size changed even before first data gets rendered (i suspect this is
+            // to cater for the initial render where it goes from nothing to something that has the headers, and then
+            // it starts rendering the data itself)
+            //
+            // Don't do anything, the resizing will be triggered after the first data is rendered
+            return;
+        }
+
+        if (!this.internal.table) {
+            return;
+        }
 
         if (this.internal.table.isResizing()) {
             // don't do anything if the table is already resizing. this copies what we have in v7 line however
@@ -489,15 +500,6 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
             //
             // keeping it like this for now. if needed, we can enqueue an auto-resize request somewhere and process
             // it after resizing finishes.
-            return;
-        }
-
-        if (!this.internal.firstDataRendered) {
-            // ag-grid does emit the grid size changed even before first data gets rendered (i suspect this is
-            // to cater for the initial render where it goes from nothing to something that has the headers, and then
-            // it starts rendering the data itself)
-            //
-            // Don't do anything, the resizing will be triggered after the first data is rendered
             return;
         }
 

--- a/libs/sdk-ui-pivot/src/tableState.ts
+++ b/libs/sdk-ui-pivot/src/tableState.ts
@@ -38,6 +38,7 @@ export class InternalTableState {
     public destroy = (): void => {
         this.abandonInitialization();
         this.stopWatching();
+        this.table?.destroy();
     };
 
     /**


### PR DESCRIPTION
Upon table reinit and internal state destruction:

-  The facade needs to be destructed as well, it's gridApi instance cleared
-  The rest of the code, finding this will mute any of its work with the table
-  Without this, ag-grid errors with these symptoms appear:
   https://github.com/ag-grid/ag-grid/issues/3334

JIRA: FET-608

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
