### PR TITLE
RELATED: RAIL-2994 Do not underline KPIs without onDrill

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiRenderer.tsx
@@ -54,7 +54,7 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
             kpi={kpi}
             kpiResult={kpiResult}
             isKpiUnderlineHiddenWhenClickable={disableDrillUnderline}
-            onKpiValueClick={isDrillable && onPrimaryValueClick}
+            onKpiValueClick={isDrillable && onDrill && onPrimaryValueClick}
             filters={filters}
             separators={separators}
         />


### PR DESCRIPTION
To keep consistent with insights, KPI should not be underlined if they
have some drilling set, but no onDrill handler has been provided.

This prevents confusion of user clicking on it and nothing happening.

JIRA: RAIL-2994

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
