### PR TITLE
RELATED: RAIL-2994 Only pass drillableItems down if there is onDrill

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
@@ -210,6 +210,13 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
     // we need sdk-ui intl wrapper (this is how InsightView does this as well) for error messages etc.
     // ideally, we would merge InternalIntlWrapper and sdk-ui intl wrapper, but there is no clean way to do that
     const locale = dashboardViewConfig?.locale ?? userWorkspaceSettings?.locale;
+    /*
+     * if there are drillable items from the user, use them and only them
+     *
+     * also pass any drillable items only if there is an onDrill specified, otherwise pass undefined
+     * so that the items are not shown as active since nothing can happen on click without the onDrill provided
+     */
+    const drillableItemsToUse = onDrill ? drillableItems ?? implicitDrills : undefined;
     return (
         <IntlWrapper locale={locale}>
             {(status === "loading" || status === "pending" || isVisualizationLoading) && <LoadingComponent />}
@@ -225,8 +232,7 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
                     insight={insightWithAddedWidgetProperties}
                     backend={effectiveBackend}
                     workspace={effectiveWorkspace}
-                    // if there are drillable items from the user, use them and only them
-                    drillableItems={drillableItems ?? implicitDrills}
+                    drillableItems={drillableItemsToUse}
                     onDrill={onDrill ? handleDrill : undefined}
                     config={chartConfig}
                     onLoadingChanged={handleLoadingChanged}


### PR DESCRIPTION
Follow up to #1064 that makes it consistent in insights as well

JIRA: RAIL-2994

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
