### PR TITLE
RELATED: RAIL-2697 - Make tiger filtering convertors more lenient

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
@@ -1,6 +1,6 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { convertFilter, newFilterWithApplyOnResult } from "../FilterConverter";
-import { absoluteFilter, relativeFilter, visualizationObjectFilter } from "./InvalidInputs.fixture";
+import { absoluteFilter, relativeFilter } from "./InvalidInputs.fixture";
 import {
     DateGranularity,
     idRef,
@@ -98,13 +98,22 @@ describe("tiger filter converter from model to AFM", () => {
     describe("convert filter", () => {
         const positiveAttributeFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, ["value"]);
         const negativeAttributeFilter = newNegativeAttributeFilter(ReferenceLdm.Product.Name, ["value 2"]);
+        const positiveAttributeFilterWithUris = newPositiveAttributeFilter(ReferenceLdm.Product.Name, {
+            uris: ["value"],
+        });
+        const negativeAttributeFilterWithUris = newNegativeAttributeFilter(ReferenceLdm.Product.Name, {
+            uris: ["value"],
+        });
+
         const Scenarios: Array<[string, any]> = [
             ["positive attribute filter", positiveAttributeFilter],
+            ["positive attribute filter with uri attribute elements", positiveAttributeFilterWithUris],
             [
                 "positive attribute filter with applyOnResult true",
                 newFilterWithApplyOnResult(positiveAttributeFilter, true),
             ],
             ["negative attribute filter", negativeAttributeFilter],
+            ["negative attribute filter with uri attribute elements", negativeAttributeFilterWithUris],
             [
                 "negative attribute filter with applyOnResult false",
                 newFilterWithApplyOnResult(negativeAttributeFilter, false),
@@ -139,18 +148,6 @@ describe("tiger filter converter from model to AFM", () => {
         ];
         it.each(Scenarios)("should return %s", (_desc, input) => {
             expect(convertFilter(input)).toMatchSnapshot();
-        });
-
-        it("should throw an error since tiger database only supports specifying positive attribute elements by value", () => {
-            expect(() =>
-                convertFilter(visualizationObjectFilter.positiveAttributeFilter),
-            ).toThrowErrorMatchingSnapshot();
-        });
-
-        it("should throw an error since tiger database only supports specifying negative attribute elements by value", () => {
-            expect(() =>
-                convertFilter(visualizationObjectFilter.negativeAttributeFilter),
-            ).toThrowErrorMatchingSnapshot();
         });
 
         it("should filter out empty attribute filters and not cause RAIL-2083", () => {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/InvalidInputs.fixture.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/InvalidInputs.fixture.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 /**
@@ -10,9 +10,6 @@ import {
     newAbsoluteDateFilter,
     newRelativeDateFilter,
     DateGranularity,
-    newPositiveAttributeFilter,
-    newNegativeAttributeFilter,
-    newMeasureValueFilter,
     IMeasure,
     newPreviousPeriodMeasure,
     newAttribute,
@@ -37,14 +34,6 @@ export const relativeFilter = {
         undefined,
         30,
     ),
-};
-
-export const visualizationObjectFilter = {
-    // Tiger only allows specifying attribute elements by value
-    positiveAttributeFilter: newPositiveAttributeFilter(ReferenceLdm.Product.Name, { uris: "value" }),
-    negativeAttributeFilter: newNegativeAttributeFilter(ReferenceLdm.Product.Name, { uris: "value" }),
-    // Tiger does not support measure value filters
-    measureValueFilter: newMeasureValueFilter(ReferenceLdm.Amount, "GREATER_THAN_OR_EQUAL_TO", 5),
 };
 
 // Measure converter: unsupported measure definition

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -97,6 +97,24 @@ Object {
 }
 `;
 
+exports[`tiger filter converter from model to AFM convert filter should return negative attribute filter with uri attribute elements 1`] = `
+Object {
+  "negativeAttributeFilter": Object {
+    "displayForm": Object {
+      "identifier": Object {
+        "id": "label.product.id.name",
+        "type": "label",
+      },
+    },
+    "notIn": Object {
+      "values": Array [
+        "value",
+      ],
+    },
+  },
+}
+`;
+
 exports[`tiger filter converter from model to AFM convert filter should return positive attribute filter 1`] = `
 Object {
   "positiveAttributeFilter": Object {
@@ -119,6 +137,24 @@ exports[`tiger filter converter from model to AFM convert filter should return p
 Object {
   "positiveAttributeFilter": Object {
     "applyOnResult": true,
+    "displayForm": Object {
+      "identifier": Object {
+        "id": "label.product.id.name",
+        "type": "label",
+      },
+    },
+    "in": Object {
+      "values": Array [
+        "value",
+      ],
+    },
+  },
+}
+`;
+
+exports[`tiger filter converter from model to AFM convert filter should return positive attribute filter with uri attribute elements 1`] = `
+Object {
+  "positiveAttributeFilter": Object {
     "displayForm": Object {
       "identifier": Object {
         "id": "label.product.id.name",
@@ -227,10 +263,6 @@ Object {
   },
 }
 `;
-
-exports[`tiger filter converter from model to AFM convert filter should throw an error since tiger database only supports specifying negative attribute elements by value 1`] = `"Tiger backend only allows specifying attribute elements by value"`;
-
-exports[`tiger filter converter from model to AFM convert filter should throw an error since tiger database only supports specifying positive attribute elements by value 1`] = `"Tiger backend only allows specifying attribute elements by value"`;
 
 exports[`tiger filter converter from model to AFM convert measure value filter should convert specified using id of metric 1`] = `
 Object {


### PR DESCRIPTION
-  KD only supports uri-based attr filters and it is not feasible to change this now. So this is
   part of the 'hack' where all uri-based filters in KD actually use values in the 'uris'.
-  The convertor code in tiger backend impl is then more lenient and will just grab the content of
   'uris' and use it as values

JIRA: RAIL-2697

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
