### PR TITLE
RELATED: RAIL-2697 - Add date filter config service

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -54,6 +54,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsLegacyReports: true,
     supportsRankingFilter: true,
     supportsElementsQueryParentFiltering: true,
+    supportsKpiWidget: true,
 };
 
 /**

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -282,6 +282,7 @@ export interface IBackendCapabilities {
     supportsCsvUploader?: boolean;
     supportsElementsQueryParentFiltering?: boolean;
     supportsElementUris?: boolean;
+    supportsKpiWidget?: boolean;
     supportsObjectUris?: boolean;
     supportsRankingFilter?: boolean;
 }

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -68,6 +68,11 @@ export interface IBackendCapabilities {
     supportsElementsQueryParentFiltering?: boolean;
 
     /**
+     * Indicates whether backend supports a special dashboard-specific KPI Widget.
+     */
+    supportsKpiWidget?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -49,6 +49,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsCsvUploader: false,
     supportsRankingFilter: true,
     supportsElementsQueryParentFiltering: false,
+    supportsKpiWidget: false,
 };
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/dateFilterConfigs/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dateFilterConfigs/index.ts
@@ -1,0 +1,184 @@
+// (C) 2019-2021 GoodData Corporation
+import {
+    IDateFilterConfig,
+    IDateFilterConfigsQuery,
+    IDateFilterConfigsQueryResult,
+} from "@gooddata/sdk-backend-spi";
+import { idRef } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+
+const DefaultDateFilterConfig: IDateFilterConfig = {
+    ref: idRef("defaultDateFilterProjectConfig"),
+    selectedOption: "THIS_MONTH",
+    allTime: {
+        localIdentifier: "ALL_TIME",
+        type: "allTime",
+        name: "",
+        visible: true,
+    },
+    absoluteForm: {
+        localIdentifier: "ABSOLUTE_FORM",
+        type: "absoluteForm",
+        name: "",
+        visible: true,
+    },
+    relativeForm: {
+        type: "relativeForm",
+        // month has to be the first as it should be the default selected option
+        availableGranularities: ["GDC.time.month", "GDC.time.date", "GDC.time.quarter", "GDC.time.year"],
+        localIdentifier: "RELATIVE_FORM",
+        name: "",
+        visible: true,
+    },
+    relativePresets: [
+        {
+            from: -6,
+            to: 0,
+            granularity: "GDC.time.date",
+            localIdentifier: "LAST_7_DAYS",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -29,
+            to: 0,
+            granularity: "GDC.time.date",
+            localIdentifier: "LAST_30_DAYS",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -89,
+            to: 0,
+            granularity: "GDC.time.date",
+            localIdentifier: "LAST_90_DAYS",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: 0,
+            to: 0,
+            granularity: "GDC.time.month",
+            localIdentifier: "THIS_MONTH",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -1,
+            to: -1,
+            granularity: "GDC.time.month",
+            localIdentifier: "LAST_MONTH",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -11,
+            to: 0,
+            granularity: "GDC.time.month",
+            localIdentifier: "LAST_12_MONTHS",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: 0,
+            to: 0,
+            granularity: "GDC.time.quarter",
+            localIdentifier: "THIS_QUARTER",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -1,
+            to: -1,
+            granularity: "GDC.time.quarter",
+            localIdentifier: "LAST_QUARTER",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -3,
+            to: 0,
+            granularity: "GDC.time.quarter",
+            localIdentifier: "LAST_4_QUARTERS",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: 0,
+            to: 0,
+            granularity: "GDC.time.year",
+            localIdentifier: "THIS_YEAR",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+        {
+            from: -1,
+            to: -1,
+            granularity: "GDC.time.year",
+            localIdentifier: "LAST_YEAR",
+            type: "relativePreset",
+            visible: true,
+            name: "",
+        },
+    ],
+    absolutePresets: [],
+};
+
+export class TigerWorkspaceDateFilterConfigsQuery implements IDateFilterConfigsQuery {
+    private limit: number | undefined;
+    private offset: number | undefined;
+
+    constructor() {}
+
+    public withLimit(limit: number): IDateFilterConfigsQuery {
+        invariant(limit > 0, `limit must be a positive number, got: ${limit}`);
+
+        this.limit = limit;
+
+        return this;
+    }
+
+    public withOffset(offset: number): IDateFilterConfigsQuery {
+        this.offset = offset;
+        return this;
+    }
+
+    public async query(): Promise<IDateFilterConfigsQueryResult> {
+        return this.queryWorker(this.offset, this.limit);
+    }
+
+    private async queryWorker(
+        offset: number | undefined = 0,
+        limit: number | undefined,
+    ): Promise<IDateFilterConfigsQueryResult> {
+        const emptyResult: IDateFilterConfigsQueryResult = {
+            items: [],
+            limit: 0,
+            offset: 1,
+            totalCount: 1,
+            next: () => Promise.resolve(emptyResult),
+        };
+
+        if (!offset && (!limit || limit > 0)) {
+            return {
+                items: [DefaultDateFilterConfig],
+                offset: 0,
+                limit: 1,
+                totalCount: 1,
+                next: () => Promise.resolve(emptyResult),
+            };
+        }
+
+        return emptyResult;
+    }
+}

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 import {
     IAnalyticalWorkspace,
@@ -31,6 +31,7 @@ import { TigerWorkspaceDashboards } from "./dashboards";
 import { DateFormatter } from "../../convertors/fromBackend/dateFormatting/types";
 import { TigerWorkspaceMeasures } from "./measures";
 import { TigerWorkspaceFacts } from "./facts";
+import { TigerWorkspaceDateFilterConfigsQuery } from "./dateFilterConfigs";
 
 export class TigerWorkspace implements IAnalyticalWorkspace {
     constructor(
@@ -95,6 +96,6 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
         throw new NotSupported("Not supported");
     }
     public dateFilterConfigs(): IDateFilterConfigsQuery {
-        throw new NotSupported("not supported");
+        return new TigerWorkspaceDateFilterConfigsQuery();
     }
 }


### PR DESCRIPTION
-  Serves single hard-coded config

JIRA: RAIL-2697


---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
