### PR TITLE
RELATED: RAIL-2995 Sanitize filter contexts in bear

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/filterContexts.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/filterContexts.ts
@@ -1,0 +1,109 @@
+// (C) 2021 GoodData Corporation
+import compact from "lodash/compact";
+import flatMap from "lodash/flatMap";
+import zip from "lodash/zip";
+import {
+    FilterContextItem,
+    IDashboardAttributeFilterParent,
+    IFilterContextDefinition,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-backend-spi";
+import { ObjRef, uriRef } from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+
+type ObjRefsToUris = (refs: ObjRef[]) => Promise<string[]>;
+
+/**
+ * Since bear backend does not support idRefs in filter context objects, we need to covert them to uriRefs if they are present.
+ *
+ * @param filterContext - filter context to sanitize
+ * @param objRefsToUris - function converting ObjRefs to URIs
+ * @returns filter context that uses uriRefs exclusively in its filters
+ */
+export async function sanitizeFilterContext<T extends IFilterContextDefinition>(
+    filterContext: T,
+    objRefsToUris: ObjRefsToUris,
+): Promise<T> {
+    const { filters } = filterContext;
+    if (!filters.length) {
+        return filterContext;
+    }
+
+    const refs = compact(
+        flatMap(filters, (filter) => {
+            const ref = getDashboardFilterRef(filter);
+
+            const overRefs = isDashboardAttributeFilter(filter)
+                ? flatMap(filter.attributeFilter.filterElementsBy ?? [], (item) => item.over.attributes)
+                : [];
+
+            return [ref, ...overRefs];
+        }),
+    );
+
+    const convertedRefs = await objRefsToUris(refs);
+
+    const refUriPairs = zip(refs, convertedRefs) as [ObjRef, string][];
+
+    const sanitizedFilters = filters.map(
+        (filter): FilterContextItem => {
+            const originalRef = getDashboardFilterRef(filter);
+            if (!originalRef) {
+                return filter;
+            }
+
+            // we can use referential comparison here, the objects are the same
+            const refMatch = refUriPairs.find(([ref]) => ref === originalRef);
+
+            // this indicates a serious fault in the logic
+            invariant(refMatch);
+
+            const sanitizedRef = uriRef(refMatch[1]);
+
+            if (isDashboardAttributeFilter(filter)) {
+                const sanitizedFilterElementsBy = filter.attributeFilter.filterElementsBy?.map(
+                    (item): IDashboardAttributeFilterParent => ({
+                        ...item,
+                        over: {
+                            ...item.over,
+                            attributes: item.over.attributes.map((attrRef) => {
+                                // we can use referential comparison here, the objects are the same
+                                const attrMatch = refUriPairs.find(([ref]) => ref === attrRef);
+
+                                // this indicates a serious fault in the logic
+                                invariant(attrMatch);
+                                return uriRef(attrMatch[1]);
+                            }),
+                        },
+                    }),
+                );
+
+                return {
+                    attributeFilter: {
+                        ...filter.attributeFilter,
+                        displayForm: sanitizedRef,
+                        filterElementsBy: sanitizedFilterElementsBy,
+                    },
+                };
+            } else {
+                return {
+                    dateFilter: {
+                        ...filter.dateFilter,
+                        dataSet: sanitizedRef,
+                    },
+                };
+            }
+        },
+    );
+
+    return {
+        ...filterContext,
+        filters: sanitizedFilters,
+    };
+}
+
+function getDashboardFilterRef(filter: FilterContextItem): ObjRef | undefined {
+    return isDashboardAttributeFilter(filter)
+        ? filter.attributeFilter.displayForm
+        : filter.dateFilter.dataSet;
+}

--- a/libs/sdk-backend-bear/src/backend/workspace/dashboards/tests/filterContexts.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/dashboards/tests/filterContexts.test.ts
@@ -1,0 +1,132 @@
+// (C) 2021 GoodData Corporation
+import {
+    FilterContextItem,
+    IDashboardAttributeFilter,
+    IDashboardAttributeFilterParent,
+    IDashboardDateFilter,
+    IFilterContext,
+} from "@gooddata/sdk-backend-spi";
+import { idRef, isIdentifierRef, ObjRef, uriRef } from "@gooddata/sdk-model";
+
+import { sanitizeFilterContext } from "../filterContexts";
+
+describe("sanitizeFilterContext", () => {
+    function getFilterContext(filters: FilterContextItem[]): IFilterContext {
+        return {
+            description: "",
+            filters,
+            identifier: "some-id",
+            ref: idRef("some-id"),
+            title: "",
+            uri: "/gdc/md/some-id",
+        };
+    }
+
+    function getDateFilter(dataSet?: ObjRef): IDashboardDateFilter {
+        return {
+            dateFilter: {
+                granularity: "GDC.time.date",
+                type: "relative",
+                from: -5,
+                to: 5,
+                dataSet,
+            },
+        };
+    }
+
+    function getAttributeFilter(
+        displayForm: ObjRef,
+        filterElementsBy: IDashboardAttributeFilterParent[] = [],
+    ): IDashboardAttributeFilter {
+        return {
+            attributeFilter: {
+                attributeElements: { uris: [] },
+                displayForm,
+                negativeSelection: false,
+                filterElementsBy,
+            },
+        };
+    }
+
+    const objRefsToUrisMock: Parameters<typeof sanitizeFilterContext>[1] = (refs) =>
+        Promise.resolve(refs.map((ref) => (isIdentifierRef(ref) ? `/gdc/md/${ref.identifier}` : ref.uri)));
+
+    it("should return the original filter context if it has no filters", async () => {
+        const input = getFilterContext([]);
+        const expected = input;
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle date filter without dateDataset specified", async () => {
+        const input = getFilterContext([getDateFilter()]);
+        const expected = input;
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle date filter with dateDataset specified using uriRef", async () => {
+        const input = getFilterContext([getDateFilter(uriRef("some-uri"))]);
+        const expected = input;
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle date filter with dateDataset specified using idRef", async () => {
+        const input = getFilterContext([getDateFilter(idRef("some-id"))]);
+        const expected = getFilterContext([getDateFilter(uriRef("/gdc/md/some-id"))]);
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle attribute filter with uriRef", async () => {
+        const input = getFilterContext([getAttributeFilter(uriRef("some-uri"))]);
+        const expected = input;
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle attribute filter with idRef", async () => {
+        const input = getFilterContext([getAttributeFilter(idRef("some-id"))]);
+        const expected = getFilterContext([getAttributeFilter(uriRef("/gdc/md/some-id"))]);
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    it("should handle attribute filter with filterElementsBy with idRefs in it", async () => {
+        const input = getFilterContext([
+            getAttributeFilter(uriRef("/gdc/md/some-id"), [
+                {
+                    filterLocalIdentifier: "aaa",
+                    over: { attributes: [idRef("over-id")] },
+                },
+            ]),
+        ]);
+        const expected = getFilterContext([
+            getAttributeFilter(uriRef("/gdc/md/some-id"), [
+                {
+                    filterLocalIdentifier: "aaa",
+                    over: { attributes: [uriRef("/gdc/md/over-id")] },
+                },
+            ]),
+        ]);
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+
+    // tests that the logic can handle different number of filters and resolved uris
+    it("should handle date filter with no dataSet followed by attribute filter with idRef", async () => {
+        const input = getFilterContext([getDateFilter(), getAttributeFilter(idRef("some-id"))]);
+        const expected = getFilterContext([getDateFilter(), getAttributeFilter(uriRef("/gdc/md/some-id"))]);
+        const actual = await sanitizeFilterContext(input, objRefsToUrisMock);
+
+        expect(actual).toEqual(expected);
+    });
+});


### PR DESCRIPTION
Since bear [cannot handle ids in filter context items][1], we need to convert them to URIs.

[1]: https://github.com/gooddata/gdc-bear/blob/d8c30226e5470d96cc201fd0a99823ffbb4fec50/resources/specification/md/obj/kpiDashboard.res#L177-L219

JIRA: RAIL-2995

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
