### PR TITLE
RELATED: FET-553 remove goodstrap from charts and vis-commons

### DIFF
--- a/libs/sdk-ui-charts/__mocks__/styleMock.ts
+++ b/libs/sdk-ui-charts/__mocks__/styleMock.ts
@@ -1,0 +1,2 @@
+// (C) 2007-2018 GoodData Corporation
+module.exports = {};

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -53,11 +53,11 @@
         "validate-ci": "npm run dep-cruiser-ci && npm run eslint-ci && npm run stylelint-ci && npm run prettier-check"
     },
     "dependencies": {
-        "@gooddata/goodstrap": "^70.2.2",
         "@gooddata/numberjs": "^3.2.5",
         "@gooddata/sdk-backend-spi": "^8.3.0-alpha.26",
         "@gooddata/sdk-model": "^8.3.0-alpha.26",
         "@gooddata/sdk-ui": "^8.3.0-alpha.26",
+        "@gooddata/sdk-ui-kit": "^8.3.0-alpha.26",
         "@gooddata/sdk-ui-theme-provider": "^8.3.0-alpha.26",
         "@gooddata/sdk-ui-vis-commons": "^8.3.0-alpha.26",
         "@gooddata/util": "^8.3.0-alpha.26",
@@ -71,8 +71,7 @@
         "react-intl": "^3.6.0",
         "react-measure": "^2.3.0",
         "ts-invariant": "^0.6.0",
-        "tslib": "^2.0.0",
-        "@gooddata/sdk-ui-kit": "^8.3.0-alpha.26"
+        "tslib": "^2.0.0"
     },
     "peerDependencies": {
         "react": "^16.10.0",

--- a/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
@@ -1,7 +1,7 @@
 // (C) 2007-2018 GoodData Corporation
 import React, { createRef } from "react";
 import Measure from "react-measure";
-import ResponsiveText from "@gooddata/goodstrap/lib/ResponsiveText/ResponsiveText";
+import { ResponsiveText } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
 import { HeadlineElementType } from "@gooddata/sdk-ui";
 import { IChartConfig } from "../../../interfaces";

--- a/libs/sdk-ui-charts/src/highcharts/adapter/HighChartsRenderer.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/HighChartsRenderer.tsx
@@ -17,8 +17,7 @@ import { VisualizationTypes } from "@gooddata/sdk-ui";
 import Highcharts from "../lib";
 import { alignChart } from "../chartTypes/_chartCreators/helpers";
 import { ILegendProps, Legend, ILegendOptions } from "@gooddata/sdk-ui-vis-commons";
-import Bubble from "@gooddata/goodstrap/lib/Bubble/Bubble";
-import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
+import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
 import { BOTTOM, LEFT, RIGHT, TOP } from "../typings/mess";
 
 /**

--- a/libs/sdk-ui-charts/src/highcharts/adapter/test/HighChartsRenderer.test.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/test/HighChartsRenderer.test.tsx
@@ -10,7 +10,7 @@ import { getHighchartsOptions } from "../../chartTypes/_chartCreators/highCharts
 import { Chart } from "../Chart";
 import { VisualizationTypes, IDrillConfig } from "@gooddata/sdk-ui";
 import { Legend } from "@gooddata/sdk-ui-vis-commons";
-import BubbleHoverTrigger from "@gooddata/goodstrap/lib/Bubble/BubbleHoverTrigger";
+import { BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
 
 import { BOTTOM, LEFT, RIGHT, TOP } from "../../typings/mess";
 

--- a/libs/sdk-ui-charts/styles/scss/charts.scss
+++ b/libs/sdk-ui-charts/styles/scss/charts.scss
@@ -1,5 +1,4 @@
 // (C) 2007-2020 GoodData Corporation
-@import "~@gooddata/goodstrap/lib/core/styles/variables";
 @import "variables";
 
 .viz-line-family-chart-wrap {

--- a/libs/sdk-ui-vis-commons/package.json
+++ b/libs/sdk-ui-vis-commons/package.json
@@ -54,18 +54,17 @@
         "validate-ci": "npm run dep-cruiser-ci && npm run eslint-ci && npm run stylelint-ci && npm run prettier-check"
     },
     "dependencies": {
-        "@gooddata/goodstrap": "^70.2.2",
         "@gooddata/numberjs": "^3.2.5",
         "@gooddata/sdk-backend-spi": "^8.3.0-alpha.26",
         "@gooddata/sdk-model": "^8.3.0-alpha.26",
         "@gooddata/sdk-ui": "^8.3.0-alpha.26",
+        "@gooddata/sdk-ui-kit": "^8.3.0-alpha.26",
+        "@gooddata/sdk-ui-theme-provider": "^8.3.0-alpha.26",
         "classnames": "^2.2.6",
         "lodash": "^4.17.19",
         "react-intl": "^3.6.0",
         "react-measure": "^2.3.0",
-        "tslib": "^2.0.0",
-        "@gooddata/sdk-ui-kit": "^8.3.0-alpha.26",
-        "@gooddata/sdk-ui-theme-provider": "^8.3.0-alpha.26"
+        "tslib": "^2.0.0"
     },
     "peerDependencies": {
         "react": "^16.10.0",


### PR DESCRIPTION
These two packages were doable without any significant rewrites, just simple replacements/removals.

Other packages are blocked by:

* indigo fonts imported from goodstrap
* missing components in sdk-ui-kit
* missing svg assets

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
