### PR TITLE
RELATED: RAIL-2835 - Implement fact service for tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/index.ts
@@ -65,7 +65,7 @@ function loadAttributeDisplayForm(
     workspace: string,
     ref: ObjRef,
 ): Promise<IAttributeDisplayFormMetadataObject> {
-    invariant(isIdentifierRef(ref));
+    invariant(isIdentifierRef(ref), "tiger backend only supports referencing by identifier");
 
     return client.workspaceObjects
         .getEntityLabels(
@@ -88,7 +88,7 @@ function loadAttribute(
     workspace: string,
     ref: ObjRef,
 ): Promise<IAttributeMetadataObject> {
-    invariant(isIdentifierRef(ref));
+    invariant(isIdentifierRef(ref), "tiger backend only supports referencing by identifier");
 
     return client.workspaceObjects
         .getEntityAttributes(

--- a/libs/sdk-backend-tiger/src/backend/workspace/facts/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/facts/index.ts
@@ -1,14 +1,48 @@
-// (C) 2019-2020 GoodData Corporation
-import { IWorkspaceFactsService, IMetadataObject } from "@gooddata/sdk-backend-spi";
-import { ObjRef, idRef } from "@gooddata/sdk-model";
-import { newDataSetMetadataObject } from "@gooddata/sdk-backend-base";
+// (C) 2019-2021 GoodData Corporation
+import { IDataSetMetadataObject, IMetadataObject, IWorkspaceFactsService } from "@gooddata/sdk-backend-spi";
+import { isIdentifierRef, ObjRef } from "@gooddata/sdk-model";
+import { TigerAuthenticatedCallGuard } from "../../../types";
+import { ITigerClient, jsonApiHeaders } from "@gooddata/api-client-tiger";
+import { invariant } from "ts-invariant";
+import { convertDatasetWithLinks } from "../../../convertors/fromBackend/MetadataConverter";
 
 export class TigerWorkspaceFacts implements IWorkspaceFactsService {
-    constructor() {}
+    constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}
 
-    public async getFactDatasetMeta(_ref: ObjRef): Promise<IMetadataObject> {
-        return newDataSetMetadataObject(idRef("dummyDataset"), (m) =>
-            m.id("dummyDataset").uri("/dummy/dataset").title("Dummy dataset").description(""),
-        );
+    public async getFactDatasetMeta(ref: ObjRef): Promise<IMetadataObject> {
+        return this.authCall((client) => {
+            return loadFactDataset(client, this.workspace, ref);
+        });
     }
+}
+
+function loadFactDataset(
+    client: ITigerClient,
+    workspace: string,
+    ref: ObjRef,
+): Promise<IDataSetMetadataObject> {
+    invariant(isIdentifierRef(ref), "tiger backend only supports referencing by identifier");
+
+    return client.workspaceObjects
+        .getEntityFacts(
+            {
+                workspaceId: workspace,
+                objectId: ref.identifier,
+            },
+            {
+                headers: jsonApiHeaders,
+                params: {
+                    include: "datasets",
+                },
+            },
+        )
+        .then((res) => {
+            // if this happens then its either bad query parameterization or the backend is hosed badly
+            invariant(
+                res.data.included && res.data.included.length > 0,
+                "server returned that fact does not belong to any dataset",
+            );
+
+            return convertDatasetWithLinks(res.data.included[0]);
+        });
 }

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -81,7 +81,7 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
     }
 
     public facts(): IWorkspaceFactsService {
-        return new TigerWorkspaceFacts();
+        return new TigerWorkspaceFacts(this.authCall, this.workspace);
     }
 
     public styling(): IWorkspaceStylingService {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
@@ -4,6 +4,7 @@ import {
     JsonApiAttributeDocument,
     JsonApiAttributeList,
     JsonApiAttributeWithLinks,
+    JsonApiDatasetWithLinks,
     JsonApiFactWithLinks,
     JsonApiLabel,
     JsonApiLabelDocument,
@@ -12,11 +13,16 @@ import {
     JsonApiMetricWithLinks,
 } from "@gooddata/api-client-tiger";
 import keyBy from "lodash/keyBy";
-import { IAttributeDisplayFormMetadataObject, IAttributeMetadataObject } from "@gooddata/sdk-backend-spi";
+import {
+    IAttributeDisplayFormMetadataObject,
+    IAttributeMetadataObject,
+    IDataSetMetadataObject,
+} from "@gooddata/sdk-backend-spi";
 import {
     IMetadataObjectBuilder,
     newAttributeDisplayFormMetadataObject,
     newAttributeMetadataObject,
+    newDataSetMetadataObject,
 } from "@gooddata/sdk-backend-base";
 import { idRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -25,14 +31,15 @@ export type MetadataObjectFromApi =
     | JsonApiAttributeWithLinks
     | JsonApiFactWithLinks
     | JsonApiMetricWithLinks
-    | JsonApiLabelWithLinks;
+    | JsonApiLabelWithLinks
+    | JsonApiDatasetWithLinks;
 
 export const commonMetadataObjectModifications = <
     TItem extends MetadataObjectFromApi,
     T extends IMetadataObjectBuilder
 >(
     item: TItem,
-) => (builder: T) =>
+) => (builder: T): T =>
     builder
         .id(item.id)
         .uri(item.links!.self)
@@ -199,4 +206,15 @@ export function convertAttributesWithSideloadedLabels(
      */
 
     return attributes.data.map((attribute) => convertAttributeWithLinks(attribute, labels));
+}
+
+/**
+ * Converts sideloaded dataset into {@link IDataSetMetadataObject}
+ *
+ * @param dataset - sideloaded dataset
+ */
+export function convertDatasetWithLinks(dataset: JsonApiDatasetWithLinks): IDataSetMetadataObject {
+    return newDataSetMetadataObject(idRef(dataset.id, "dataSet"), (m) =>
+        m.modify(commonMetadataObjectModifications(dataset)),
+    );
 }


### PR DESCRIPTION
-  Load fact by ref & sideload data set
-  Convert and return dataset meta

JIRA: RAIL-2835, RAIL-2836

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
