### PR TITLE
Sanitize automatically generated localIds

### DIFF
--- a/libs/sdk-model/src/execution/attribute/factory.ts
+++ b/libs/sdk-model/src/execution/attribute/factory.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import identity from "lodash/identity";
 import cloneDeep from "lodash/cloneDeep";
 import isEmpty from "lodash/isEmpty";
@@ -6,6 +6,7 @@ import { IAttribute, isAttribute } from "./index";
 import { ObjRef, objRefToString, Identifier, isObjRef } from "../../objRef";
 import { idRef } from "../../objRef/factory";
 import SparkMD5 from "spark-md5";
+import { sanitizeLocalId } from "../../sanitizeLocalId";
 
 /**
  * Input to the AttributeBuilder.
@@ -133,9 +134,11 @@ export class AttributeBuilder {
             return this.attribute.localIdentifier;
         }
 
-        return ["a", this.calculateAliasHash(), objRefToString(this.attribute.displayForm)]
-            .filter((part) => !isEmpty(part))
-            .join("_");
+        return sanitizeLocalId(
+            ["a", this.calculateAliasHash(), objRefToString(this.attribute.displayForm)]
+                .filter((part) => !isEmpty(part))
+                .join("_"),
+        );
     }
 
     private calculateAliasHash(): string {

--- a/libs/sdk-model/src/execution/attribute/tests/__snapshots__/factory.test.ts.snap
+++ b/libs/sdk-model/src/execution/attribute/tests/__snapshots__/factory.test.ts.snap
@@ -62,3 +62,15 @@ Object {
   },
 }
 `;
+
+exports[`newAttribute should sanitize automatically generated localId 1`] = `
+Object {
+  "attribute": Object {
+    "displayForm": Object {
+      "identifier": "id:with:colons",
+      "type": "displayForm",
+    },
+    "localIdentifier": "a_id_with_colons",
+  },
+}
+`;

--- a/libs/sdk-model/src/execution/attribute/tests/factory.test.ts
+++ b/libs/sdk-model/src/execution/attribute/tests/factory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { modifyAttribute, newAttribute } from "../factory";
 import { Account } from "../../../../__mocks__/model";
 
@@ -13,6 +13,10 @@ describe("newAttribute", () => {
 
     it("should return an attribute with a custom localId", () => {
         expect(newAttribute("foo", (a) => a.localId("custom"))).toMatchSnapshot();
+    });
+
+    it("should sanitize automatically generated localId", () => {
+        expect(newAttribute("id:with:colons")).toMatchSnapshot();
     });
 });
 

--- a/libs/sdk-model/src/execution/measure/factory.ts
+++ b/libs/sdk-model/src/execution/measure/factory.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import isEmpty from "lodash/isEmpty";
 import identity from "lodash/identity";
@@ -25,6 +25,7 @@ import { IMeasureFilter } from "../filter";
 import { idRef } from "../../objRef/factory";
 import SparkMD5 from "spark-md5";
 import invariant, { InvariantError } from "ts-invariant";
+import { sanitizeLocalId } from "../../sanitizeLocalId";
 
 /**
  * Simplified Previous Period Data DataSet specification
@@ -232,9 +233,11 @@ export abstract class MeasureBuilderBase<T extends IMeasureDefinitionType> {
             return this.measure.localIdentifier!;
         }
 
-        return ["m", this.buildEnvelopeLocalIdPart(), this.generateLocalId()]
-            .filter((part) => !isEmpty(part))
-            .join("_");
+        return sanitizeLocalId(
+            ["m", this.buildEnvelopeLocalIdPart(), this.generateLocalId()]
+                .filter((part) => !isEmpty(part))
+                .join("_"),
+        );
     }
 
     private buildEnvelopeLocalIdPart(): string {

--- a/libs/sdk-model/src/execution/measure/tests/__snapshots__/factory.test.ts.snap
+++ b/libs/sdk-model/src/execution/measure/tests/__snapshots__/factory.test.ts.snap
@@ -273,6 +273,21 @@ Object {
 }
 `;
 
+exports[`measure factories newMeasure should sanitize automatically generated localId 1`] = `
+Object {
+  "measure": Object {
+    "definition": Object {
+      "measureDefinition": Object {
+        "item": Object {
+          "identifier": "id:with:colons",
+        },
+      },
+    },
+    "localIdentifier": "m_id_with_colons",
+  },
+}
+`;
+
 exports[`measure factories newPopMeasure should return a simple PoP measure from attribute ref 1`] = `
 Object {
   "measure": Object {

--- a/libs/sdk-model/src/execution/measure/tests/factory.test.ts
+++ b/libs/sdk-model/src/execution/measure/tests/factory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { Velocity, Won } from "../../../../__mocks__/model";
 import { newPositiveAttributeFilter } from "../../filter/factory";
 import {
@@ -41,6 +41,9 @@ describe("measure factories", () => {
             expect(
                 newMeasure("foo", (m) => m.filters(newPositiveAttributeFilter("filter", { uris: ["baz"] }))),
             ).toMatchSnapshot();
+        });
+        it("should sanitize automatically generated localId", () => {
+            expect(newMeasure("id:with:colons")).toMatchSnapshot();
         });
     });
 

--- a/libs/sdk-model/src/sanitizeLocalId.ts
+++ b/libs/sdk-model/src/sanitizeLocalId.ts
@@ -1,0 +1,10 @@
+// (C) 2021 GoodData Corporation
+
+/**
+ * Removes all non MAQL compatible characters from an identifier by replacing them with an underscore.
+ * @param identifier - identifier to sanitize
+ * @returns sanitized identifier
+ */
+export function sanitizeLocalId(identifier: string): string {
+    return identifier.replace(/[^a-zA-Z0-9_.]/g, "_");
+}


### PR DESCRIPTION
On tiger some of the identifiers contain colons ":",
which cannot be part of localId.

https://gitlab.com/gooddata/gdc-nas/-/issues/1171

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
