### PR TITLE
RELATED: RAIL-2964 - Workspace selection in catalog export for tiger

### DIFF
--- a/tools/catalog-export/README.md
+++ b/tools/catalog-export/README.md
@@ -50,7 +50,7 @@ The program is able to run in interactive or silent modes:
 
 ## Tiger usage notes
 
-The program can retrieve and generate catalogs from either GoodData Platform (bear) or GoodData Anywhere (tiger)
+The program can retrieve and generate catalogs from either GoodData Platform (bear) or GoodData Cloud Native (tiger)
 backends. The program does not do auto-detection of the backend type - you have to indicate type of backend
 either through config or on command line.
 
@@ -62,14 +62,11 @@ setting in the `.gdcatalogrc`. Here is an example of full config for tiger:
 {
     "hostname": "https://your.hostname.or.ip",
     "backend": "tiger",
-    "projectId": "your workspace",
+    "workspaceId": "your workspace identifier",
     "username": "tiger_user_id",
     "output": "workspaceObjects.ts"
 }
 ```
-
-> Note: you have to enter `projectId` or use the `--project-id` option with tiger. Unlike for bear, the
-> catalog-export will not prompt you to select a workspace from a list of available workspaces.
 
 ### Tiger Authentication
 

--- a/tools/catalog-export/README.md
+++ b/tools/catalog-export/README.md
@@ -77,6 +77,24 @@ Tiger backend.
 While the configuration allows to specify `username` this is optional and will be used only to open a browser window
 at location where you can obtain an API Token.
 
+## Workspace or project?
+
+The GoodData Cloud Native (tiger backend) uses the term 'workspace' to identify the entity which contains LDM and data and from
+which you can calculate analytics.
+
+On the other hand, the GoodData Platform (bear backend) historically uses the term 'project' to identify the same type of entity and
+started using the term 'workspace' recently.
+
+For this reason, the program supports both workspace-id and project-id command line arguments and workspaceId and projectId
+configuration parameters. These are essentially synonymous for now with the plan to remove the project-id argument and
+projectId configuration parameter in favor for the workspace variant.
+
+At the moment you can use either project-id or workspace-id and the end result will be the same. If you specify both
+of these parameters then the workspace-id has the priority.
+
+If you use the project-id when exporting catalog from tiger backend the program will warn you that you are using a
+deprecated option.
+
 ## Recommendations
 
 Working with the catalog-export and its outputs on daily basis, we found a few good practices that we suggest for

--- a/tools/catalog-export/src/base/config.ts
+++ b/tools/catalog-export/src/base/config.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import get from "lodash/get";
 import identity from "lodash/identity";
 import pick from "lodash/pick";
@@ -16,6 +16,8 @@ function mergeConfigs(config: CatalogExportConfig, prevConfig = DEFAULT_CONFIG):
                 "hostname",
                 "projectId",
                 "projectName",
+                "workspaceId",
+                "workspaceName",
                 "username",
                 "password",
                 "output",
@@ -31,6 +33,8 @@ function retrieveConfigFromObject(obj: object): CatalogExportConfig {
         hostname: get(obj, "hostname", null),
         projectId: get(obj, "projectId", null),
         projectName: get(obj, "projectName", null),
+        workspaceId: get(obj, "workspaceId", null),
+        workspaceName: get(obj, "workspaceName", null),
         username: get(obj, "username", null),
         password: get(obj, "password", null),
         output: get(obj, "output", null),

--- a/tools/catalog-export/src/base/constants.ts
+++ b/tools/catalog-export/src/base/constants.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { CatalogExportConfig } from "./types";
 
 export const DEFAULT_HOSTNAME = "https://secure.gooddata.com";
@@ -9,6 +9,8 @@ export const DEFAULT_CONFIG: CatalogExportConfig = {
     hostname: null,
     projectId: null,
     projectName: null,
+    workspaceId: null,
+    workspaceName: null,
     username: null,
     password: null,
     output: null,

--- a/tools/catalog-export/src/base/tests/__snapshots__/config.test.ts.snap
+++ b/tools/catalog-export/src/base/tests/__snapshots__/config.test.ts.snap
@@ -9,6 +9,8 @@ Object {
   "projectId": null,
   "projectName": "project",
   "username": "valid",
+  "workspaceId": null,
+  "workspaceName": null,
 }
 `;
 
@@ -21,6 +23,8 @@ Object {
   "projectId": null,
   "projectName": null,
   "username": "valid",
+  "workspaceId": null,
+  "workspaceName": null,
 }
 `;
 
@@ -33,6 +37,8 @@ Object {
   "projectId": null,
   "projectName": null,
   "username": null,
+  "workspaceId": null,
+  "workspaceName": null,
 }
 `;
 
@@ -45,6 +51,8 @@ Object {
   "projectId": null,
   "projectName": null,
   "username": "noone",
+  "workspaceId": null,
+  "workspaceName": null,
 }
 `;
 
@@ -57,6 +65,8 @@ Object {
   "projectId": "abc",
   "projectName": null,
   "username": "valid",
+  "workspaceId": "abc",
+  "workspaceName": null,
 }
 `;
 
@@ -69,5 +79,7 @@ Object {
   "projectId": null,
   "projectName": null,
   "username": null,
+  "workspaceId": null,
+  "workspaceName": null,
 }
 `;

--- a/tools/catalog-export/src/base/tests/config.test.ts
+++ b/tools/catalog-export/src/base/tests/config.test.ts
@@ -1,14 +1,16 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { getConfigFromProgram } from "../config";
 import { CatalogExportConfig } from "../types";
 
 describe("getConfigFromProgram", () => {
     const EMPTY_CONFIG: CatalogExportConfig = {
         projectName: null,
+        workspaceName: null,
         hostname: null,
         output: null,
         password: null,
         projectId: null,
+        workspaceId: null,
         username: null,
         backend: null,
     };
@@ -24,8 +26,8 @@ describe("getConfigFromProgram", () => {
         ],
         [
             "prefer input over default",
-            { username: "valid", projectId: "abc" },
-            { ...EMPTY_CONFIG, projectId: "xyz" },
+            { username: "valid", projectId: "abc", workspaceId: "abc" },
+            { ...EMPTY_CONFIG, projectId: "xyz", workspaceId: "abc" },
         ],
         ["propagate tiger backend type", { backend: "tiger" }, null],
     ];

--- a/tools/catalog-export/src/base/types.ts
+++ b/tools/catalog-export/src/base/types.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
+import { logWarn } from "../cli/loggers";
 
 /**
  * This exception is thrown when a fatal error occurs during the export processing - be it during interfacing with
@@ -33,14 +34,29 @@ export type CatalogExportConfig = {
 
     /**
      * Identifier of the project
+     *
+     * @deprecated in favor of workspaceId
      */
     projectId: string | null;
+
+    /**
+     * Identifier of the workspace
+     */
+    workspaceId: string | null;
+
+    /**
+     * Name of the project - if project ID is not specified, then name must be specified and
+     * will be used to find projects that match (fully) this name.
+     *
+     * @deprecated in favor of workspaceName
+     */
+    projectName: string | null;
 
     /**
      * Name of the project - if project ID is not specified, then name must be specified and
      * will be used to find projects that match (fully) this name.
      */
-    projectName: string | null;
+    workspaceName: string | null;
 
     /**
      * User to authenticate as.
@@ -62,6 +78,48 @@ export type CatalogExportConfig = {
      */
     backend: SupportedBackendTypes | null;
 };
+
+export function getConfiguredWorkspaceId(
+    config: CatalogExportConfig,
+    deprecationWarning: boolean = false,
+): string | null {
+    if (config.workspaceId) {
+        return config.workspaceId;
+    }
+
+    if (config.projectId) {
+        if (deprecationWarning) {
+            logWarn(
+                "The use of `project-id` argument and `projectId` configuration parameter are deprecated and will be removed in next major release. Please switch to use `workspace-id` argument or `workspaceId` parameter instead. This is just a naming change and has no functional impact.",
+            );
+        }
+
+        return config.projectId;
+    }
+
+    return null;
+}
+
+export function getConfiguredWorkspaceName(
+    config: CatalogExportConfig,
+    deprecationWarning: boolean = false,
+): string | null {
+    if (config.workspaceName) {
+        return config.workspaceName;
+    }
+
+    if (config.projectName) {
+        if (deprecationWarning) {
+            logWarn(
+                "The use of `project-name` argument and `projectName` configuration parameter are deprecated and will be removed in next major release. Please switch to use `workspace-name` argument or `workspaceName` parameter instead. This is just a naming change and has no functional impact.",
+            );
+        }
+
+        return config.projectName;
+    }
+
+    return null;
+}
 
 /**
  * Subset of object meta used in exporter

--- a/tools/catalog-export/src/base/types.ts
+++ b/tools/catalog-export/src/base/types.ts
@@ -181,8 +181,8 @@ export type Catalog = {
     facts: Fact[];
 };
 
-export type ProjectMetadata = {
-    projectId: string;
+export type WorkspaceMetadata = {
+    workspaceId: string;
     catalog: Catalog;
     dateDataSets: DateDataSet[];
     insights: ObjectMeta[];

--- a/tools/catalog-export/src/cli/prompts.ts
+++ b/tools/catalog-export/src/cli/prompts.ts
@@ -26,13 +26,13 @@ export async function promptPassword(): Promise<string> {
     return passwordResponse.password;
 }
 
-export type ProjectChoices = {
+export type WorkspaceChoices = {
     name: string;
     value: string;
 };
 
 export async function promptWorkspaceId(
-    choices: ProjectChoices[],
+    choices: WorkspaceChoices[],
     wording: string = "project",
 ): Promise<string> {
     const question: DistinctQuestion = {

--- a/tools/catalog-export/src/cli/prompts.ts
+++ b/tools/catalog-export/src/cli/prompts.ts
@@ -31,16 +31,19 @@ export type ProjectChoices = {
     value: string;
 };
 
-export async function promptProjectId(choices: ProjectChoices[]): Promise<string> {
-    const projectQuestion: DistinctQuestion = {
+export async function promptWorkspaceId(
+    choices: ProjectChoices[],
+    wording: string = "project",
+): Promise<string> {
+    const question: DistinctQuestion = {
         type: "list",
-        name: "projectId",
-        message: "Choose a project:",
+        name: "id",
+        message: `Choose a ${wording}:`,
         choices,
     };
 
-    const projectResponse = await prompt(projectQuestion);
-    return projectResponse.projectId;
+    const response = await prompt(question);
+    return response.id;
 }
 
 export async function confirmFileRewrite(fileName: string): Promise<boolean> {

--- a/tools/catalog-export/src/cli/prompts.ts
+++ b/tools/catalog-export/src/cli/prompts.ts
@@ -1,6 +1,5 @@
 // (C) 2007-2021 GoodData Corporation
 import { DistinctQuestion, prompt } from "inquirer";
-import gooddata from "@gooddata/api-client-bear";
 import { DEFAULT_OUTPUT_FILE_NAME } from "../base/constants";
 import * as path from "path";
 import * as fs from "fs";
@@ -27,21 +26,17 @@ export async function promptPassword(): Promise<string> {
     return passwordResponse.password;
 }
 
-export async function promptProjectId(): Promise<string> {
-    const metadataResponse = await gooddata.xhr.get("/gdc/md");
-    const metadata = metadataResponse.getData();
-    const projectChoices = metadata.about.links.map((link: any) => {
-        return {
-            name: link.title,
-            value: link.identifier,
-        };
-    });
+export type ProjectChoices = {
+    name: string;
+    value: string;
+};
 
+export async function promptProjectId(choices: ProjectChoices[]): Promise<string> {
     const projectQuestion: DistinctQuestion = {
         type: "list",
         name: "projectId",
         message: "Choose a project:",
-        choices: projectChoices,
+        choices,
     };
 
     const projectResponse = await prompt(projectQuestion);
@@ -49,10 +44,16 @@ export async function promptProjectId(): Promise<string> {
 }
 
 export async function confirmFileRewrite(fileName: string): Promise<boolean> {
+    let message = `The file ${fileName} already exists. Would you like to merge the new data with the file? (It will keep your possibly renamed "keys")`;
+
+    if (!fileName.endsWith(".json")) {
+        message = `The file ${fileName} already exists. Would you like to overwrite it?`;
+    }
+
     const shouldRewriteQuestion: DistinctQuestion = {
         type: "confirm",
         name: "shouldRewrite",
-        message: `The file ${fileName} already exists. Would you like to merge the new data with the file? (It will keep your possibly renamed "keys")`,
+        message,
         default: true,
     };
 

--- a/tools/catalog-export/src/exports/metaToCatalog.ts
+++ b/tools/catalog-export/src/exports/metaToCatalog.ts
@@ -1,7 +1,7 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { transformToCatalog } from "../transform/toCatalog";
 import * as fs from "fs";
-import { ProjectMetadata } from "../base/types";
+import { WorkspaceMetadata } from "../base/types";
 
 /**
  * Exports project metadata into catalog JSON file. If the output file already exists, its contents
@@ -11,7 +11,7 @@ import { ProjectMetadata } from "../base/types";
  * @param outputFile - output file where the catalog should be saved
  */
 export async function exportMetadataToCatalog(
-    projectMetadata: ProjectMetadata,
+    projectMetadata: WorkspaceMetadata,
     outputFile: string,
 ): Promise<void> {
     let existingCatalog: any | undefined;

--- a/tools/catalog-export/src/exports/metaToJavascript.ts
+++ b/tools/catalog-export/src/exports/metaToJavascript.ts
@@ -1,8 +1,8 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { transformToTypescript } from "../transform/toTypescript";
 import { format } from "prettier";
 import * as fs from "fs";
-import { ProjectMetadata } from "../base/types";
+import { WorkspaceMetadata } from "../base/types";
 
 /**
  * Exports project metadata into javascript file containing sdk-model entity definitions (attribute, measure, etc)
@@ -14,7 +14,7 @@ import { ProjectMetadata } from "../base/types";
  * @param outputFile - output typescript file - WILL be overwritten
  */
 export async function exportMetadataToJavascript(
-    projectMetadata: ProjectMetadata,
+    projectMetadata: WorkspaceMetadata,
     outputFile: string,
     tiger = false,
 ): Promise<void> {

--- a/tools/catalog-export/src/exports/metaToTypescript.ts
+++ b/tools/catalog-export/src/exports/metaToTypescript.ts
@@ -1,8 +1,8 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { transformToTypescript } from "../transform/toTypescript";
 import { format } from "prettier";
 import * as fs from "fs";
-import { ProjectMetadata } from "../base/types";
+import { WorkspaceMetadata } from "../base/types";
 
 /**
  * Exports project metadata into typescript file containing sdk-model entity definitions (attribute, measure, etc)
@@ -12,7 +12,7 @@ import { ProjectMetadata } from "../base/types";
  * @param tiger - indicates whether running against tiger, this influences naming strategy to use for date datasets as they are different from bear
  */
 export async function exportMetadataToTypescript(
-    projectMetadata: ProjectMetadata,
+    projectMetadata: WorkspaceMetadata,
     outputFile: string,
     tiger = false,
 ): Promise<void> {

--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -9,12 +9,12 @@ import { clearTerminal } from "./cli/clear";
 import { requestFilePath } from "./cli/prompts";
 import { getConfigFromConfigFile, getConfigFromProgram } from "./base/config";
 import { DEFAULT_CONFIG_FILE_NAME, DEFAULT_HOSTNAME, DEFAULT_OUTPUT_FILE_NAME } from "./base/constants";
-import { CatalogExportConfig, isCatalogExportError, ProjectMetadata } from "./base/types";
+import { CatalogExportConfig, isCatalogExportError, WorkspaceMetadata } from "./base/types";
 import { exportMetadataToCatalog } from "./exports/metaToCatalog";
 import { exportMetadataToTypescript } from "./exports/metaToTypescript";
 import { exportMetadataToJavascript } from "./exports/metaToJavascript";
-import { loadProjectMetadataFromBear } from "./loaders/bear";
-import { loadProjectMetadataFromTiger } from "./loaders/tiger";
+import { loadWorkspaceMetadataFromBear } from "./loaders/bear";
+import { loadWorkspaceMetadataFromTiger } from "./loaders/tiger";
 
 program
     .version(pkg.version)
@@ -42,12 +42,12 @@ program
     .option("--accept-untrusted-ssl", "Allows to run the tool with host, that has untrusted ssl certificate")
     .parse(process.argv);
 
-async function loadProjectMetadataFromBackend(config: CatalogExportConfig): Promise<ProjectMetadata> {
+async function loadProjectMetadataFromBackend(config: CatalogExportConfig): Promise<WorkspaceMetadata> {
     if (config.backend === "tiger") {
-        return loadProjectMetadataFromTiger(config);
+        return loadWorkspaceMetadataFromTiger(config);
     }
 
-    return loadProjectMetadataFromBear(config);
+    return loadWorkspaceMetadataFromBear(config);
 }
 
 async function run() {

--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -18,8 +18,14 @@ import { loadWorkspaceMetadataFromTiger } from "./loaders/tiger";
 
 program
     .version(pkg.version)
-    .option("--project-id <id>", "Project id for which you want to export the catalog.")
-    .option("--project-name <value>", "Project name for which you want to export the catalog.")
+    .option(
+        "--project-id <id>",
+        "Project id for which you want to export the catalog. This option is deprecated in favor of workspace-id. It will disappear in the next major release.",
+    )
+    .option(
+        "--project-name <value>",
+        "Project name for which you want to export the catalog. This option is deprecated in favor of workspace-id. It will disappear in the next major release.",
+    )
     .option(
         "--workspace-id <id>",
         "Workspace id for which you want to export the catalog. This is a synonym for project-id. If not specified, code will fall back to use project-id.",

--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import program from "commander";
 import chalk from "chalk";
 import * as path from "path";
@@ -20,6 +20,14 @@ program
     .version(pkg.version)
     .option("--project-id <id>", "Project id for which you want to export the catalog.")
     .option("--project-name <value>", "Project name for which you want to export the catalog.")
+    .option(
+        "--workspace-id <id>",
+        "Workspace id for which you want to export the catalog. This is a synonym for project-id. If not specified, code will fall back to use project-id.",
+    )
+    .option(
+        "--workspace-name <value>",
+        "Workspace name for which you want to export the catalog. This is a synonym for project-name. If not specified, code will fall back to use project-name.",
+    )
     .option("--username <email>", "Your username that you use to log in to GoodData platform.")
     .option(
         "--output <value>",

--- a/tools/catalog-export/src/loaders/bear/bearAnalyticalDashboard.ts
+++ b/tools/catalog-export/src/loaders/bear/bearAnalyticalDashboard.ts
@@ -3,14 +3,14 @@ import gooddata from "@gooddata/api-client-bear";
 import { ObjectMeta } from "../../base/types";
 
 /**
- * Loads information about analytical dashboards defined in the project. Only descriptive information about
+ * Loads information about analytical dashboards defined in the workspace. Only descriptive information about
  * each analytical dashboard is returned.
  *
- * @param projectId - project to get analytical dashboards from
+ * @param workspaceId - workspace to get analytical dashboards from
  * @return array of analytical dashboard meta
  */
-export async function loadAnalyticalDashboard(projectId: string): Promise<ObjectMeta[]> {
-    const analyticalDashboards = await gooddata.md.getAnalyticalDashboards(projectId);
+export async function loadAnalyticalDashboard(workspaceId: string): Promise<ObjectMeta[]> {
+    const analyticalDashboards = await gooddata.md.getAnalyticalDashboards(workspaceId);
 
     return analyticalDashboards.map((dashboard: any) => {
         return {

--- a/tools/catalog-export/src/loaders/bear/bearCatalog.ts
+++ b/tools/catalog-export/src/loaders/bear/bearCatalog.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import gooddata from "@gooddata/api-client-bear";
 import pmap from "p-map";
 import flatMap from "lodash/flatMap";
@@ -28,9 +28,9 @@ function getRequestOptions(offset: number = 0) {
     };
 }
 
-async function loadCatalogueItems(projectId: string): Promise<CatalogItem[]> {
+async function loadCatalogueItems(workspaceId: string): Promise<CatalogItem[]> {
     const options = getRequestOptions(0);
-    const response: CatalogItemsResponse = await gooddata.catalogue.loadItems(projectId, options);
+    const response: CatalogItemsResponse = await gooddata.catalogue.loadItems(workspaceId, options);
     const { totals, catalog: firstPageItems } = response;
     const { available } = totals;
 
@@ -46,7 +46,7 @@ async function loadCatalogueItems(projectId: string): Promise<CatalogItem[]> {
     const loadPage = async (offset: number): Promise<CatalogItemsResponse> => {
         const pageOpts = getRequestOptions(offset);
 
-        return gooddata.catalogue.loadItems(projectId, pageOpts);
+        return gooddata.catalogue.loadItems(workspaceId, pageOpts);
     };
 
     // and dispatch their load in concurrent fashion
@@ -56,14 +56,14 @@ async function loadCatalogueItems(projectId: string): Promise<CatalogItem[]> {
 }
 
 /**
- * This function loads attributes, metrics and facts from project's catalog. It uses the same data source
+ * This function loads attributes, metrics and facts from workspace's catalog. It uses the same data source
  * as the Analytical Designer.
  *
- * @param projectId - project to get metadata from
+ * @param workspaceId - workspace to get metadata from
  * @returns catalog with attributes, metrics and facts
  */
-export async function loadCatalog(projectId: string): Promise<Catalog> {
-    const allCatalogueItems = await loadCatalogueItems(projectId);
+export async function loadCatalog(workspaceId: string): Promise<Catalog> {
+    const allCatalogueItems = await loadCatalogueItems(workspaceId);
     const result: Catalog = {
         attributes: [],
         metrics: [],

--- a/tools/catalog-export/src/loaders/bear/bearDateDatasets.ts
+++ b/tools/catalog-export/src/loaders/bear/bearDateDatasets.ts
@@ -1,21 +1,21 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import gooddata from "@gooddata/api-client-bear";
 import { GdcDataSets } from "@gooddata/api-model-bear";
 import get from "lodash/get";
 import { Attribute, DateDataSet, DisplayForm } from "../../base/types";
 
 /**
- * Loads date data sets defined in the provided project. This function retrieves the minimum
+ * Loads date data sets defined in the provided workspace. This function retrieves the minimum
  * descriptive information about the data set, its attributes and display forms.
  *
- * @param projectId - project to get date data sets from
+ * @param workspaceId - workspace to get date data sets from
  * @returns list of date data sets
  */
-export async function loadDateDataSets(projectId: string): Promise<DateDataSet[]> {
+export async function loadDateDataSets(workspaceId: string): Promise<DateDataSet[]> {
     const dateDataSets: DateDataSet[] = [];
     const attributeUriToDs: { [uri: string]: DateDataSet } = {};
 
-    const dataSets = await gooddata.md.getObjectsByQuery<GdcDataSets.IWrappedDataSet>(projectId, {
+    const dataSets = await gooddata.md.getObjectsByQuery<GdcDataSets.IWrappedDataSet>(workspaceId, {
         category: "dataSet",
     });
 
@@ -43,7 +43,7 @@ export async function loadDateDataSets(projectId: string): Promise<DateDataSet[]
             });
         });
 
-    const objects = await gooddata.md.getObjects(projectId, Object.keys(attributeUriToDs));
+    const objects = await gooddata.md.getObjects(workspaceId, Object.keys(attributeUriToDs));
 
     objects.forEach((attr: any) => {
         const dataSet = attributeUriToDs[attr.attribute.meta.uri];

--- a/tools/catalog-export/src/loaders/bear/bearInsights.ts
+++ b/tools/catalog-export/src/loaders/bear/bearInsights.ts
@@ -1,16 +1,16 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import gooddata from "@gooddata/api-client-bear";
 import { ObjectMeta } from "../../base/types";
 
 /**
- * Loads information about insights defined in the project. Only descriptive information about
+ * Loads information about insights defined in the workspace. Only descriptive information about
  * each insight is returned.
  *
- * @param projectId - project to get insights from
+ * @param workspaceId - workspace to get insights from
  * @return array of insight metadata
  */
-export async function loadInsights(projectId: string): Promise<ObjectMeta[]> {
-    const visualizations = await gooddata.md.getVisualizations(projectId);
+export async function loadInsights(workspaceId: string): Promise<ObjectMeta[]> {
+    const visualizations = await gooddata.md.getVisualizations(workspaceId);
 
     return visualizations.map((vis: any) => {
         return {

--- a/tools/catalog-export/src/loaders/bear/bearLoad.ts
+++ b/tools/catalog-export/src/loaders/bear/bearLoad.ts
@@ -1,39 +1,39 @@
 // (C) 2007-2021 GoodData Corporation
 import ora from "ora";
 import { logError } from "../../cli/loggers";
-import { CatalogExportError, ProjectMetadata } from "../../base/types";
+import { CatalogExportError, WorkspaceMetadata } from "../../base/types";
 import { loadCatalog } from "./bearCatalog";
 import { loadDateDataSets } from "./bearDateDatasets";
 import { loadInsights } from "./bearInsights";
 import { loadAnalyticalDashboard } from "./bearAnalyticalDashboard";
 
 /**
- * Loads all project metadata that can be used for exporting into catalog.
+ * Loads all workspace metadata that can be used for exporting into catalog.
  *
- * @param projectId - project identifier
+ * @param workspaceId - workspace identifier
  * @throws CatalogExportError
  */
-export async function bearLoad(projectId: string): Promise<ProjectMetadata> {
+export async function bearLoad(workspaceId: string): Promise<WorkspaceMetadata> {
     const spinner = ora();
 
     try {
         spinner.start("Loading catalog of attributes and metrics…");
-        const catalog = await loadCatalog(projectId);
+        const catalog = await loadCatalog(workspaceId);
         spinner.succeed("Catalog loaded");
 
         spinner.start("Loading date data sets…");
-        const dateDataSets = await loadDateDataSets(projectId);
+        const dateDataSets = await loadDateDataSets(workspaceId);
         spinner.succeed("Date data sets loaded");
 
         spinner.start("Loading insights…");
-        const insights = await loadInsights(projectId);
+        const insights = await loadInsights(workspaceId);
         spinner.succeed("Insights loaded");
 
         spinner.start("Loading analytical dashboards…");
-        const analyticalDashboards = await loadAnalyticalDashboard(projectId);
+        const analyticalDashboards = await loadAnalyticalDashboard(workspaceId);
         spinner.succeed("Analytical dashboards loaded");
         return {
-            projectId,
+            workspaceId,
             catalog,
             dateDataSets,
             insights,

--- a/tools/catalog-export/src/loaders/bear/index.ts
+++ b/tools/catalog-export/src/loaders/bear/index.ts
@@ -5,7 +5,7 @@ import { DEFAULT_HOSTNAME } from "../../base/constants";
 import * as pkg from "../../../package.json";
 import ora from "ora";
 import { log, logError } from "../../cli/loggers";
-import { promptPassword, promptProjectId, promptUsername } from "../../cli/prompts";
+import { promptPassword, promptWorkspaceId, promptUsername } from "../../cli/prompts";
 import { clearLine } from "../../cli/clear";
 import gooddata, { SDK } from "@gooddata/api-client-bear";
 import { bearLoad } from "./bearLoad";
@@ -20,7 +20,7 @@ async function selectBearWorkspace(client: SDK): Promise<string> {
         };
     });
 
-    return promptProjectId(projectChoices);
+    return promptWorkspaceId(projectChoices);
 }
 
 /**

--- a/tools/catalog-export/src/loaders/bear/index.ts
+++ b/tools/catalog-export/src/loaders/bear/index.ts
@@ -1,6 +1,12 @@
 // (C) 2007-2021 GoodData Corporation
 
-import { CatalogExportConfig, CatalogExportError, ProjectMetadata } from "../../base/types";
+import {
+    CatalogExportConfig,
+    CatalogExportError,
+    getConfiguredWorkspaceId,
+    getConfiguredWorkspaceName,
+    WorkspaceMetadata,
+} from "../../base/types";
 import { DEFAULT_HOSTNAME } from "../../base/constants";
 import * as pkg from "../../../package.json";
 import ora from "ora";
@@ -13,30 +19,33 @@ import { bearLoad } from "./bearLoad";
 async function selectBearWorkspace(client: SDK): Promise<string> {
     const metadataResponse = await client.xhr.get("/gdc/md");
     const metadata = metadataResponse.getData();
-    const projectChoices = metadata.about.links.map((link: any) => {
+    const choices = metadata.about.links.map((link: any) => {
         return {
             name: link.title,
             value: link.identifier,
         };
     });
 
-    return promptWorkspaceId(projectChoices);
+    return promptWorkspaceId(choices);
 }
 
 /**
- * Given the export config, ask for any missing information and then load project metadata from
+ * Given the export config, ask for any missing information and then load workspace metadata from
  * a bear project.
  *
- * @param config - tool configuration, may be missing username, password and project id - in that case code
- *  will promp
+ * @param config - tool configuration, may be missing username, password and workspace id - in that case code
+ *  will prompt
  *
- * @returns loaded project metadata
+ * @returns loaded workspace metadata
  *
  * @throws CatalogExportError upon any error.
  */
-export async function loadProjectMetadataFromBear(config: CatalogExportConfig): Promise<ProjectMetadata> {
-    const { projectName, hostname } = config;
-    let { projectId, username, password } = config;
+export async function loadWorkspaceMetadataFromBear(config: CatalogExportConfig): Promise<WorkspaceMetadata> {
+    const workspaceName = getConfiguredWorkspaceName(config);
+    let workspaceId = getConfiguredWorkspaceId(config);
+
+    const { hostname } = config;
+    let { username, password } = config;
 
     gooddata.config.setCustomDomain(hostname || DEFAULT_HOSTNAME);
     gooddata.config.setJsPackage(pkg.name, pkg.version);
@@ -70,34 +79,34 @@ export async function loadProjectMetadataFromBear(config: CatalogExportConfig): 
         throw new CatalogExportError(`Unable to log in to platform. The error was: ${err}`, 1);
     }
 
-    const projectSpinner = ora();
+    const workspaceSpinner = ora();
     try {
-        if (projectName && !projectId) {
-            log("Project Name", projectName);
-            projectSpinner.start("Loading project");
+        if (workspaceName && !workspaceId) {
+            log("Project Name", workspaceName);
+            workspaceSpinner.start("Loading project");
             const metadataResponse = await gooddata.xhr.get("/gdc/md");
             const metadata = metadataResponse.getData();
-            projectSpinner.stop();
-            const projectMetadata = metadata.about
+            workspaceSpinner.stop();
+            const workspaceMetadata = metadata.about
                 ? metadata.about.links.find((link: any) => {
-                      return link.title === projectName;
+                      return link.title === workspaceName;
                   })
                 : null;
-            if (projectMetadata) {
-                projectId = projectMetadata.identifier;
+            if (workspaceMetadata) {
+                workspaceId = workspaceMetadata.identifier;
             } else {
-                logError(`Could not find a project with name '${projectName}'`);
+                logError(`Could not find a project with name '${workspaceName}'`);
             }
         }
-        if (projectId) {
-            log("Project ID", projectId);
+        if (workspaceId) {
+            log("Project ID", workspaceId);
         } else {
-            projectId = await selectBearWorkspace(gooddata);
+            workspaceId = await selectBearWorkspace(gooddata);
         }
 
-        return bearLoad(projectId);
+        return bearLoad(workspaceId);
     } catch (err) {
-        projectSpinner.stop();
+        workspaceSpinner.stop();
 
         throw new CatalogExportError(
             `Unable to obtain project metadata from platform. The error was: ${err}`,

--- a/tools/catalog-export/src/loaders/bear/tests/__snapshots__/bearLoad.test.ts.snap
+++ b/tools/catalog-export/src/loaders/bear/tests/__snapshots__/bearLoad.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loadProjectMetadata should load analytical dashboards 1`] = `
+exports[`bearLoad should load analytical dashboards 1`] = `
 Array [
   Object {
     "identifier": "afMA17GSbk31",
@@ -20,7 +20,7 @@ Array [
 ]
 `;
 
-exports[`loadProjectMetadata should load date data sets 1`] = `
+exports[`bearLoad should load date data sets 1`] = `
 Array [
   Object {
     "dateDataSet": Object {
@@ -545,7 +545,7 @@ Array [
 ]
 `;
 
-exports[`loadProjectMetadata should load ldm 1`] = `
+exports[`bearLoad should load ldm 1`] = `
 Object {
   "attributes": Array [
     Object {
@@ -1026,7 +1026,7 @@ Object {
 }
 `;
 
-exports[`loadProjectMetadata should load visualizations 1`] = `
+exports[`bearLoad should load visualizations 1`] = `
 Array [
   Object {
     "identifier": "abhJpedgcfU2",

--- a/tools/catalog-export/src/loaders/bear/tests/bearLoad.test.ts
+++ b/tools/catalog-export/src/loaders/bear/tests/bearLoad.test.ts
@@ -3,11 +3,11 @@ import { bearLoad } from "../bearLoad";
 
 jest.mock("@gooddata/api-client-bear");
 
-describe("loadProjectMetadata", () => {
+describe("bearLoad", () => {
     it("should transfer project ID", async () => {
         const result = await bearLoad("test");
 
-        expect(result.projectId).toEqual("test");
+        expect(result.workspaceId).toEqual("test");
     });
 
     it("should load ldm", async () => {

--- a/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
@@ -7,16 +7,16 @@ import { ITigerClient, jsonApiHeaders } from "@gooddata/api-client-tiger";
  * Load analytical dashboards that are stored in workspace metadata so that their links can be included
  * in the generated output for easy embedding access.
  *
- * @param _projectId - project id, ignored for now as tiger is single-workspace
+ * @param workspaceId - workspace id
  * @param tigerClient - tiger client to use for communication
  */
 export async function loadAnalyticalDashboards(
-    _projectId: string,
+    workspaceId: string,
     tigerClient: ITigerClient,
 ): Promise<ObjectMeta[]> {
     const result = await tigerClient.workspaceObjects.getEntitiesAnalyticalDashboards(
         {
-            workspaceId: _projectId,
+            workspaceId,
         },
         {
             headers: jsonApiHeaders,

--- a/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
@@ -54,14 +54,14 @@ function convertAttributes(attributes: JsonApiAttributeList): Attribute[] {
 
 /**
  * Loads metric, attribute and fact catalog
- * @param _projectId
+ * @param workspaceId
  * @param tigerClient
  */
-export async function loadCatalog(_projectId: string, tigerClient: ITigerClient): Promise<Catalog> {
+export async function loadCatalog(workspaceId: string, tigerClient: ITigerClient): Promise<Catalog> {
     const [metricsResult, factsResult, attributesResult] = await Promise.all([
         tigerClient.workspaceObjects.getEntitiesMetrics(
             {
-                workspaceId: _projectId,
+                workspaceId,
             },
             {
                 headers: jsonApiHeaders,
@@ -69,7 +69,7 @@ export async function loadCatalog(_projectId: string, tigerClient: ITigerClient)
         ),
         tigerClient.workspaceObjects.getEntitiesFacts(
             {
-                workspaceId: _projectId,
+                workspaceId,
             },
             {
                 headers: jsonApiHeaders,
@@ -77,7 +77,7 @@ export async function loadCatalog(_projectId: string, tigerClient: ITigerClient)
         ),
         tigerClient.workspaceObjects.getEntitiesAttributes(
             {
-                workspaceId: _projectId,
+                workspaceId,
             },
             {
                 headers: jsonApiHeaders,

--- a/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
@@ -77,12 +77,12 @@ function convertToExportableFormat(
 }
 
 export async function loadDateDataSets(
-    _projectId: string,
+    workspaceId: string,
     tigerClient: ITigerClient,
 ): Promise<DateDataSet[]> {
     const result = await tigerClient.workspaceObjects.getEntitiesAttributes(
         {
-            workspaceId: _projectId,
+            workspaceId,
         },
         {
             headers: jsonApiHeaders,

--- a/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
@@ -7,13 +7,13 @@ import { ITigerClient, jsonApiHeaders } from "@gooddata/api-client-tiger";
  * Load insights that are stored in workspace metadata so that their links can be included
  * in the generated output for easy embedding access.
  *
- * @param _projectId - project id, ignored for now as tiger is single-workspace
+ * @param workspaceId - workspace id
  * @param tigerClient - tiger client to use for communication
  */
-export async function loadInsights(_projectId: string, tigerClient: ITigerClient): Promise<ObjectMeta[]> {
+export async function loadInsights(workspaceId: string, tigerClient: ITigerClient): Promise<ObjectMeta[]> {
     const result = await tigerClient.workspaceObjects.getEntitiesVisualizationObjects(
         {
-            workspaceId: _projectId,
+            workspaceId,
         },
         {
             headers: jsonApiHeaders,

--- a/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2021 GoodData Corporation
-import { CatalogExportError, ProjectMetadata } from "../../base/types";
+import { CatalogExportError, WorkspaceMetadata } from "../../base/types";
 import { ITigerClient } from "@gooddata/api-client-tiger";
 import ora from "ora";
 import { logError } from "../../cli/loggers";
@@ -8,28 +8,28 @@ import { loadInsights } from "./tigerInsights";
 import { loadDateDataSets } from "./tigerDateDatasets";
 import { loadAnalyticalDashboards } from "./tigerAnalyticalDashboards";
 
-export async function tigerLoad(projectId: string, tigerClient: ITigerClient): Promise<ProjectMetadata> {
+export async function tigerLoad(workspaceId: string, tigerClient: ITigerClient): Promise<WorkspaceMetadata> {
     const spinner = ora();
 
     try {
         spinner.start("Loading catalog of attributes and metrics…");
-        const catalog = await loadCatalog(projectId, tigerClient);
+        const catalog = await loadCatalog(workspaceId, tigerClient);
         spinner.succeed("Catalog loaded");
 
         spinner.start("Loading date data sets…");
-        const dateDataSets = await loadDateDataSets(projectId, tigerClient);
+        const dateDataSets = await loadDateDataSets(workspaceId, tigerClient);
         spinner.succeed("Date data sets loaded");
 
         spinner.start("Loading insights…");
-        const insights = await loadInsights(projectId, tigerClient);
+        const insights = await loadInsights(workspaceId, tigerClient);
         spinner.succeed("Insights loaded");
 
         spinner.start("Loading analytical dashboards");
-        const analyticalDashboards = await loadAnalyticalDashboards(projectId, tigerClient);
+        const analyticalDashboards = await loadAnalyticalDashboards(workspaceId, tigerClient);
         spinner.succeed("Analytical dashboards loaded");
 
         return {
-            projectId,
+            workspaceId: workspaceId,
             catalog,
             dateDataSets,
             insights,
@@ -40,6 +40,6 @@ export async function tigerLoad(projectId: string, tigerClient: ITigerClient): P
         const more = err.response ? err.response.url : "";
         logError(`Exception: ${err.message} ${more}\n${err.stack}`);
 
-        throw new CatalogExportError("A fatal error has occurred while loading project metadata", 1);
+        throw new CatalogExportError("A fatal error has occurred while loading workspace metadata", 1);
     }
 }

--- a/tools/catalog-export/src/transform/toCatalog.ts
+++ b/tools/catalog-export/src/transform/toCatalog.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2021 GoodData Corporation
-import { ProjectMetadata, Attribute } from "../base/types";
+import { WorkspaceMetadata, Attribute } from "../base/types";
 import { createUniqueName } from "./titles";
 import cloneDeep from "lodash/cloneDeep";
 import findKey from "lodash/findKey";
@@ -58,7 +58,7 @@ type TitleToItemMap = { [key: string]: IIdentifierWithTags };
 // transformation functions
 //
 
-function createMeasures(projectMeta: ProjectMetadata): TitleToItemMap {
+function createMeasures(projectMeta: WorkspaceMetadata): TitleToItemMap {
     const newMapping: TitleToItemMap = {};
 
     projectMeta.catalog.metrics.forEach((metric) => {
@@ -118,11 +118,11 @@ function createAttributes(attributes: Attribute[]): IAttrs {
     return newAttrs;
 }
 
-function createCatalogAttributes(projectMeta: ProjectMetadata): IAttrs {
+function createCatalogAttributes(projectMeta: WorkspaceMetadata): IAttrs {
     return createAttributes(projectMeta.catalog.attributes);
 }
 
-function createDateDatasets(projectMeta: ProjectMetadata): TitleToDataSet {
+function createDateDatasets(projectMeta: WorkspaceMetadata): TitleToDataSet {
     const newDataSets: TitleToDataSet = {};
 
     projectMeta.dateDataSets.forEach((dd) => {
@@ -141,7 +141,7 @@ function createDateDatasets(projectMeta: ProjectMetadata): TitleToDataSet {
     return newDataSets;
 }
 
-function createVisualizations(projectMeta: ProjectMetadata): TitleToItemMap {
+function createVisualizations(projectMeta: WorkspaceMetadata): TitleToItemMap {
     const newMapping: TitleToItemMap = {};
 
     projectMeta.insights.forEach((insight) => {
@@ -153,7 +153,7 @@ function createVisualizations(projectMeta: ProjectMetadata): TitleToItemMap {
     return newMapping;
 }
 
-function createDashboards(projectMeta: ProjectMetadata): TitleToItemMap {
+function createDashboards(projectMeta: WorkspaceMetadata): TitleToItemMap {
     const newMapping: TitleToItemMap = {};
 
     projectMeta.analyticalDashboards.forEach((dashboard) => {
@@ -229,7 +229,7 @@ function mergeData(
  * @param projectMeta - project metadata to work with
  * @param existingCatalog - existing catalog structure to merge with
  */
-export function transformToCatalog(projectMeta: ProjectMetadata, existingCatalog?: object): any {
+export function transformToCatalog(projectMeta: WorkspaceMetadata, existingCatalog?: object): any {
     const measures = createMeasures(projectMeta);
     const measuresProp = !isEmpty(measures) ? { measures } : {};
     const attributes = createCatalogAttributes(projectMeta);
@@ -238,7 +238,7 @@ export function transformToCatalog(projectMeta: ProjectMetadata, existingCatalog
     const dashboards = createDashboards(projectMeta);
 
     const newCatalog: ICatalog = {
-        projectId: projectMeta.projectId,
+        projectId: projectMeta.workspaceId,
         ...measuresProp,
         attributes,
         visualizations,

--- a/tools/catalog-export/src/transform/toTypescript.ts
+++ b/tools/catalog-export/src/transform/toTypescript.ts
@@ -8,7 +8,7 @@ import {
     VariableDeclarationKind,
     VariableStatementStructure,
 } from "ts-morph";
-import { Attribute, DateDataSet, DisplayForm, Fact, Metric, ProjectMetadata } from "../base/types";
+import { Attribute, DateDataSet, DisplayForm, Fact, Metric, WorkspaceMetadata } from "../base/types";
 import { createUniqueVariableName, TakenNamesSet } from "./titles";
 
 export type TypescriptOutput = {
@@ -279,7 +279,7 @@ function generateAttributeConstant(
 }
 
 function generateAttributes(
-    projectMeta: ProjectMetadata,
+    projectMeta: WorkspaceMetadata,
 ): ReadonlyArray<OptionalKind<VariableStatementStructure>> {
     return projectMeta.catalog.attributes.map((a) => generateAttributeConstant(a));
 }
@@ -342,7 +342,7 @@ function generateMeasuresFromFacts(fact: Fact): OptionalKind<VariableStatementSt
  * @param projectMeta
  */
 function generateMeasures(
-    projectMeta: ProjectMetadata,
+    projectMeta: WorkspaceMetadata,
 ): ReadonlyArray<OptionalKind<VariableStatementStructure>> {
     const fromMetrics = projectMeta.catalog.metrics.map(generateMeasureFromMetric);
     const fromFacts = projectMeta.catalog.facts.map(generateMeasuresFromFacts);
@@ -436,7 +436,7 @@ function generateDateDataSetMapping(
 }
 
 function generateDateDataSets(
-    projectMeta: ProjectMetadata,
+    projectMeta: WorkspaceMetadata,
     tiger: boolean,
 ): ReadonlyArray<OptionalKind<VariableStatementStructure>> {
     let naming = DateDataSetNaming;
@@ -455,7 +455,7 @@ function generateDateDataSets(
  *
  * @param projectMeta - project metadata containing the insights
  */
-function generateInsights(projectMeta: ProjectMetadata): OptionalKind<VariableStatementStructure> {
+function generateInsights(projectMeta: WorkspaceMetadata): OptionalKind<VariableStatementStructure> {
     const insightInitializer: string[] = projectMeta.insights.map((insight) => {
         const propName = uniqueVariable(insight.title);
         const jsDoc = `/** \n* Insight Title: ${insight.title}  \n* Insight ID: ${insight.identifier}\n*/`;
@@ -481,7 +481,7 @@ function generateInsights(projectMeta: ProjectMetadata): OptionalKind<VariableSt
  * @param projectMeta - project metadata containing the analyticalDashboards
  */
 function generateAnalyticalDashboards(
-    projectMeta: ProjectMetadata,
+    projectMeta: WorkspaceMetadata,
 ): OptionalKind<VariableStatementStructure> {
     const analyticalDashboardInitializer: string[] = projectMeta.analyticalDashboards.map((dashboard) => {
         const propName = uniqueVariable(dashboard.title);
@@ -519,7 +519,7 @@ function generateAnalyticalDashboards(
  * @return return of the transformation process, new file is not saved at this point
  */
 export function transformToTypescript(
-    projectMeta: ProjectMetadata,
+    projectMeta: WorkspaceMetadata,
     outputFile: string,
     tiger: boolean,
 ): TypescriptOutput {


### PR DESCRIPTION
-  Added workspace prompting and name -> id lookup for tiger
-  Prepared the entire tool for platform-wide switch from project -> workspace
-  Internals are all using 'workspace'
-  Tiger uses workspace nomenclature
-  CLI arguments and config parameterization allows use of 'workspaceId' and 'workspaceName'; this is synonym for projectId and projectName. On tiger, tool logs warning that projectId / projectName is deprecated.
-  Deprecation warnings are not in bear yet. All messaging in bear so far still uses project. This will change once we do the respective epic that deals with this change platform-wide


---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
