### PR TITLE
Fix display form transformation inconsistencies

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/index.ts
@@ -30,16 +30,7 @@ export class BearWorkspaceAttributes implements IWorkspaceAttributesService {
         );
         const displayFormDetails = wrappedDisplayForm.attributeDisplayForm;
 
-        const attrRef = uriRef(displayFormDetails.content.formOf);
-
-        return newAttributeDisplayFormMetadataObject(ref, (df) =>
-            df
-                .attribute(attrRef)
-                .title(displayFormDetails.meta.title)
-                .description(displayFormDetails.meta.summary!)
-                .id(displayFormDetails.meta.identifier!)
-                .uri(displayFormDetails.meta.uri!),
-        );
+        return this.buildAttributeDisplayForm(displayFormDetails);
     };
 
     public getAttribute = async (ref: ObjRef): Promise<IAttributeMetadataObject> => {
@@ -50,15 +41,7 @@ export class BearWorkspaceAttributes implements IWorkspaceAttributesService {
         const { title, uri, isProduction, identifier, summary } = wrappedAttribute.attribute.meta;
         const { displayForms } = wrappedAttribute.attribute.content;
         const attributeDisplayForms = displayForms.map((displayForm) =>
-            newAttributeDisplayFormMetadataObject(uriRef(displayForm.meta.uri!), (df) =>
-                df
-                    .attribute(ref)
-                    .title(displayForm.meta.title)
-                    .description(displayForm.meta.summary!)
-                    .id(displayForm.meta.identifier!)
-                    .uri(displayForm.meta.uri!)
-                    .displayFormType(displayForm.content.type),
-            ),
+            this.buildAttributeDisplayForm(displayForm),
         );
 
         return newAttributeMetadataObject(ref, (a) =>
@@ -147,7 +130,7 @@ export class BearWorkspaceAttributes implements IWorkspaceAttributesService {
     ): IAttributeDisplayFormMetadataObject => {
         const {
             meta: { title, summary, identifier, uri },
-            content: { formOf, default: defaultDisplayForm },
+            content: { formOf, default: defaultDisplayForm, type },
         } = displayFormDetails;
         const ref: UriRef = uriRef(uri!);
         const isDefaultDf = !!(defaultDisplayForm === 1);
@@ -158,7 +141,8 @@ export class BearWorkspaceAttributes implements IWorkspaceAttributesService {
                 .description(summary!)
                 .isDefault(isDefaultDf)
                 .id(identifier!)
-                .uri(uri!),
+                .uri(uri!)
+                .displayFormType(type),
         );
     };
 }


### PR DESCRIPTION
- use one transformation in all methods

JIRA: RAIL-3009

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
