### PR TITLE
Tiger client - update OpenAPI schemas and regenerate client

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -53,6 +53,12 @@ export interface AFM {
 
 // @public
 export class AfmControllerApi extends LabelElementsBaseApi implements AfmControllerApiInterface {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -63,6 +69,12 @@ export class AfmControllerApi extends LabelElementsBaseApi implements AfmControl
 
 // @public
 export const AfmControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean | undefined;
+        timestamp?: string | undefined;
+    }, options?: any): LabelElementsRequestArgs;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -73,6 +85,12 @@ export const AfmControllerApiAxiosParamCreator: (configuration?: LabelElementsCo
 
 // @public
 export const AfmControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -83,6 +101,12 @@ export const AfmControllerApiFactory: (configuration?: LabelElementsConfiguratio
 
 // @public
 export const AfmControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -93,6 +117,12 @@ export const AfmControllerApiFp: (configuration?: LabelElementsConfiguration | u
 
 // @public
 export interface AfmControllerApiInterface {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -381,15 +411,6 @@ export enum DeclarativeColumnDataTypeEnum {
 }
 
 // @public
-export interface DeclarativeDataDiscriminator {
-    columnName: string;
-    dataSourceName: string;
-    description?: string;
-    id: string;
-    title: string;
-}
-
-// @public
 export interface DeclarativeDataset {
     attributes: Array<DeclarativeAttribute>;
     description?: string;
@@ -484,6 +505,7 @@ export class DeclarativeLayoutControllerApi extends MetadataBaseApi implements D
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -501,6 +523,9 @@ export class DeclarativeLayoutControllerApi extends MetadataBaseApi implements D
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -515,6 +540,7 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator: (configuration?: M
         workspaceId: string;
     }, options?: any): MetadataRequestArgs;
     getOrganizationLayout(params: {}, options?: any): MetadataRequestArgs;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): MetadataRequestArgs;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): MetadataRequestArgs;
@@ -532,6 +558,9 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator: (configuration?: M
         declarativeModel: DeclarativeModel;
     }, options?: any): MetadataRequestArgs;
     setOrganizationLayout(params: {}, options?: any): MetadataRequestArgs;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): MetadataRequestArgs;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): MetadataRequestArgs;
@@ -546,6 +575,7 @@ export const DeclarativeLayoutControllerApiFactory: (configuration?: MetadataCon
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -563,6 +593,9 @@ export const DeclarativeLayoutControllerApiFactory: (configuration?: MetadataCon
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -577,6 +610,7 @@ export const DeclarativeLayoutControllerApiFp: (configuration?: MetadataConfigur
         workspaceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeWorkspaceModel>;
@@ -594,6 +628,9 @@ export const DeclarativeLayoutControllerApiFp: (configuration?: MetadataConfigur
         declarativeModel: DeclarativeModel;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
@@ -608,6 +645,7 @@ export interface DeclarativeLayoutControllerApiInterface {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -625,6 +663,9 @@ export interface DeclarativeLayoutControllerApiInterface {
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -686,15 +727,40 @@ export interface DeclarativeWorkspace {
 }
 
 // @public
+export interface DeclarativeWorkspaceDataFilter {
+    columnName: string;
+    dataSourceName: string;
+    description?: string;
+    id: string;
+    title: string;
+    workspace?: WorkspaceIdentifier;
+    workspaceDataFilterSettings: Array<DeclarativeWorkspaceDataFilterSetting>;
+}
+
+// @public
+export interface DeclarativeWorkspaceDataFilters {
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
+}
+
+// @public
+export interface DeclarativeWorkspaceDataFilterSetting {
+    description?: string;
+    filterValues: Array<string>;
+    id: string;
+    title: string;
+    workspace: WorkspaceIdentifier;
+}
+
+// @public
 export interface DeclarativeWorkspaceModel {
     analytics: DeclarativeAnalyticsLayer;
-    dataDiscriminators: Array<DeclarativeDataDiscriminator>;
     ldm: DeclarativeLdm;
     pdm: DeclarativePdm;
 }
 
 // @public
 export interface DeclarativeWorkspaces {
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
     workspaces: Array<DeclarativeWorkspace>;
 }
 
@@ -737,6 +803,17 @@ export { Element_2 as Element }
 
 // @public
 export class ElementsControllerApi extends LabelElementsBaseApi implements ElementsControllerApiInterface {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -752,6 +829,17 @@ export class ElementsControllerApi extends LabelElementsBaseApi implements Eleme
 
 // @public
 export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC" | undefined;
+        includeTotalWithoutFilters?: boolean | undefined;
+        complementFilter?: boolean | undefined;
+        patternFilter?: string | undefined;
+        offset?: number | undefined;
+        limit?: number | undefined;
+        skipCache?: boolean | undefined;
+    }, options?: any): LabelElementsRequestArgs;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -767,6 +855,17 @@ export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelEleme
 
 // @public
 export const ElementsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -782,6 +881,17 @@ export const ElementsControllerApiFactory: (configuration?: LabelElementsConfigu
 
 // @public
 export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -797,6 +907,17 @@ export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguratio
 
 // @public
 export interface ElementsControllerApiInterface {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -961,7 +1082,7 @@ export interface InlineMeasureDefinitionInline {
 export function isAttributeHeader(header: ResultDimensionHeader): header is AttributeHeader;
 
 // @public (undocumented)
-export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContext;
+export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn;
 
 // @public (undocumented)
 export const isObjectIdentifier: (value: unknown) => value is ObjectIdentifier;
@@ -970,7 +1091,7 @@ export const isObjectIdentifier: (value: unknown) => value is ObjectIdentifier;
 export function isResultAttributeHeader(header: ExecutionResultHeader): header is AttributeExecutionResultHeader;
 
 // @public (undocumented)
-export function isVisualizationObjectsItem(visualizationObject: unknown): visualizationObject is JsonApiVisualizationObject;
+export function isVisualizationObjectsItem(visualizationObject: unknown): visualizationObject is JsonApiVisualizationObjectIn;
 
 // @public (undocumented)
 export interface ITigerClient {
@@ -993,28 +1114,41 @@ export interface ITigerClient {
 export const JSON_API_HEADER_VALUE = "application/vnd.gooddata.api+json";
 
 // @public
-export interface JsonApiACL {
-    attributes?: JsonApiACLAttributes;
+export interface JsonApiACLIn {
+    attributes?: JsonApiACLOutAttributes;
     id: string;
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiACLAttributes {
-    access?: JsonApiACLAttributesAccessEnum;
-    control?: JsonApiACLAttributesControlEnum;
+export interface JsonApiACLInDocument {
+    data: JsonApiACLIn;
+}
+
+// @public
+export interface JsonApiACLOut {
+    attributes?: JsonApiACLOutAttributes;
+    id: string;
+    relationships?: JsonApiACLOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiACLOutAttributes {
+    access?: JsonApiACLOutAttributesAccessEnum;
+    control?: JsonApiACLOutAttributesControlEnum;
     priority?: number;
 }
 
 // @public
-export enum JsonApiACLAttributesAccessEnum {
+export enum JsonApiACLOutAttributesAccessEnum {
     // (undocumented)
     FULLACCESS = "FULL_ACCESS"
 }
 
 // @public
-export enum JsonApiACLAttributesControlEnum {
+export enum JsonApiACLOutAttributesControlEnum {
     // (undocumented)
     ALLOW = "ALLOW",
     // (undocumented)
@@ -1022,49 +1156,61 @@ export enum JsonApiACLAttributesControlEnum {
 }
 
 // @public
-export interface JsonApiACLDocument {
-    data: JsonApiACL;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiACLOutDocument {
+    data: JsonApiACLOut;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiACLList {
-    data: Array<JsonApiACLWithLinks>;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiACLOutList {
+    data: Array<JsonApiACLOutWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiACLRelationships {
-    userGroups?: JsonApiACLRelationshipsUsers;
-    users?: JsonApiACLRelationshipsUsers;
+export interface JsonApiACLOutRelationships {
+    userGroups?: JsonApiACLOutRelationshipsUsers;
+    users?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiACLRelationshipsUsers {
+export interface JsonApiACLOutRelationshipsUsers {
     data?: Array<JsonApiLinkage>;
 }
 
 // @public
-export interface JsonApiACLWithLinks {
-    attributes?: JsonApiACLAttributes;
+export interface JsonApiACLOutWithLinks {
+    attributes?: JsonApiACLOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboard {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiAnalyticalDashboardIn {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
-    relationships?: JsonApiAnalyticalDashboardRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardAttributes {
+export interface JsonApiAnalyticalDashboardInDocument {
+    data: JsonApiAnalyticalDashboardIn;
+}
+
+// @public
+export interface JsonApiAnalyticalDashboardOut {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    id: string;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiAnalyticalDashboardOutAttributes {
     content?: object;
     description?: string;
     tags?: Array<string>;
@@ -1072,87 +1218,99 @@ export interface JsonApiAnalyticalDashboardAttributes {
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardDocument {
-    data: JsonApiAnalyticalDashboard;
-    included?: Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>;
+export interface JsonApiAnalyticalDashboardOutDocument {
+    data: JsonApiAnalyticalDashboardOut;
+    included?: Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardList {
-    data: Array<JsonApiAnalyticalDashboardWithLinks>;
-    included?: Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>;
+export interface JsonApiAnalyticalDashboardOutList {
+    data: Array<JsonApiAnalyticalDashboardOutWithLinks>;
+    included?: Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardRelationships {
-    datasets?: JsonApiACLRelationshipsUsers;
-    filterContexts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
-    visualizationObjects?: JsonApiACLRelationshipsUsers;
+export interface JsonApiAnalyticalDashboardOutRelationships {
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    filterContexts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
+    visualizationObjects?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiAnalyticalDashboardOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiApiToken {
-    attributes?: JsonApiApiTokenAttributes;
+export interface JsonApiApiTokenIn {
+    attributes?: object;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiApiTokenAttributes {
+export interface JsonApiApiTokenInDocument {
+    data: JsonApiApiTokenIn;
+}
+
+// @public
+export interface JsonApiApiTokenOut {
+    attributes?: JsonApiApiTokenOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiApiTokenOutAttributes {
     bearerToken?: string;
 }
 
 // @public
-export interface JsonApiApiTokenDocument {
-    data: JsonApiApiToken;
+export interface JsonApiApiTokenOutDocument {
+    data: JsonApiApiTokenOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiApiTokenList {
-    data: Array<JsonApiApiTokenWithLinks>;
+export interface JsonApiApiTokenOutList {
+    data: Array<JsonApiApiTokenOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiApiTokenWithLinks {
-    attributes?: JsonApiApiTokenAttributes;
+export interface JsonApiApiTokenOutWithLinks {
+    attributes?: JsonApiApiTokenOutAttributes;
     id: string;
     links?: ObjectLinks;
     type: string;
 }
 
 // @public
-export interface JsonApiAttribute {
-    attributes?: JsonApiAttributeAttributes;
+export interface JsonApiAttributeOut {
+    attributes?: JsonApiAttributeOutAttributes;
     id: string;
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAttributeAttributes {
+export interface JsonApiAttributeOutAttributes {
     description?: string;
-    granularity?: JsonApiAttributeAttributesGranularityEnum;
+    granularity?: JsonApiAttributeOutAttributesGranularityEnum;
     tags?: Array<string>;
     title?: string;
 }
 
 // @public
-export enum JsonApiAttributeAttributesGranularityEnum {
+export enum JsonApiAttributeOutAttributesGranularityEnum {
     // (undocumented)
     DAY = "DAY",
     // (undocumented)
@@ -1186,95 +1344,60 @@ export enum JsonApiAttributeAttributesGranularityEnum {
 }
 
 // @public
-export interface JsonApiAttributeDocument {
-    data: JsonApiAttribute;
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiAttributeOutDocument {
+    data: JsonApiAttributeOut;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiAttributeList {
-    data: Array<JsonApiAttributeWithLinks>;
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiAttributeOutList {
+    data: Array<JsonApiAttributeOutWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiAttributeRelationships {
-    dataset?: JsonApiOrganizationRelationshipsUser;
-    labels?: JsonApiACLRelationshipsUsers;
+export interface JsonApiAttributeOutRelationships {
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiAttributeWithLinks {
-    attributes?: JsonApiAttributeAttributes;
+export interface JsonApiAttributeOutWithLinks {
+    attributes?: JsonApiAttributeOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataDiscriminator {
-    attributes?: JsonApiDataDiscriminatorAttributes;
+export interface JsonApiDatasetOut {
+    attributes?: JsonApiDatasetOutAttributes;
     id: string;
+    relationships?: JsonApiDatasetOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataDiscriminatorAttributes {
-    columnName?: string;
-    dataSourceName?: string;
+export interface JsonApiDatasetOutAttributes {
     description?: string;
-    title?: string;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorDocument {
-    data: JsonApiDataDiscriminator;
-    links?: ObjectLinks;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorList {
-    data: Array<JsonApiDataDiscriminatorWithLinks>;
-    links?: ListLinks;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorWithLinks {
-    attributes?: JsonApiDataDiscriminatorAttributes;
-    id: string;
-    links?: ObjectLinks;
-    type: string;
-}
-
-// @public
-export interface JsonApiDataset {
-    attributes?: JsonApiDatasetAttributes;
-    id: string;
-    relationships?: JsonApiDatasetRelationships;
-    type: string;
-}
-
-// @public
-export interface JsonApiDatasetAttributes {
-    description?: string;
-    grain?: Array<JsonApiDatasetAttributesGrain>;
-    referenceProperties?: Array<JsonApiDatasetAttributesReferenceProperties>;
+    grain?: Array<JsonApiDatasetOutAttributesGrain>;
+    referenceProperties?: Array<JsonApiDatasetOutAttributesReferenceProperties>;
     tags?: Array<string>;
     title?: string;
-    type?: JsonApiDatasetAttributesTypeEnum;
+    type?: JsonApiDatasetOutAttributesTypeEnum;
 }
 
 // @public
-export interface JsonApiDatasetAttributesGrain {
+export interface JsonApiDatasetOutAttributesGrain {
     id: string;
-    type: JsonApiDatasetAttributesGrainTypeEnum;
+    type: JsonApiDatasetOutAttributesGrainTypeEnum;
 }
 
 // @public
-export enum JsonApiDatasetAttributesGrainTypeEnum {
+export enum JsonApiDatasetOutAttributesGrainTypeEnum {
     // (undocumented)
     Attribute = "attribute",
     // (undocumented)
@@ -1282,14 +1405,14 @@ export enum JsonApiDatasetAttributesGrainTypeEnum {
 }
 
 // @public
-export interface JsonApiDatasetAttributesReferenceProperties {
+export interface JsonApiDatasetOutAttributesReferenceProperties {
     identifier: DatasetReferenceIdentifier;
     multivalue: boolean;
     sourceColumns: Array<string>;
 }
 
 // @public
-export enum JsonApiDatasetAttributesTypeEnum {
+export enum JsonApiDatasetOutAttributesTypeEnum {
     // (undocumented)
     DATE = "DATE",
     // (undocumented)
@@ -1297,57 +1420,57 @@ export enum JsonApiDatasetAttributesTypeEnum {
 }
 
 // @public
-export interface JsonApiDatasetDocument {
-    data: JsonApiDataset;
-    included?: Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiDatasetOutDocument {
+    data: JsonApiDatasetOut;
+    included?: Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiDatasetList {
-    data: Array<JsonApiDatasetWithLinks>;
-    included?: Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiDatasetOutList {
+    data: Array<JsonApiDatasetOutWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiDatasetRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    table?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiDatasetOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    table?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiDatasetWithLinks {
-    attributes?: JsonApiDatasetAttributes;
+export interface JsonApiDatasetOutWithLinks {
+    attributes?: JsonApiDatasetOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiDatasetRelationships;
+    relationships?: JsonApiDatasetOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataSource {
-    attributes?: JsonApiDataSourceAttributes;
+export interface JsonApiDataSourceIn {
+    attributes?: JsonApiDataSourceInAttributes;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiDataSourceAttributes {
+export interface JsonApiDataSourceInAttributes {
     enableCaching?: boolean;
     name?: string;
     password?: string;
     schema?: string;
-    type?: JsonApiDataSourceAttributesTypeEnum;
+    type?: JsonApiDataSourceInAttributesTypeEnum;
     uploadId?: string;
     url?: string;
     username?: string;
 }
 
 // @public
-export enum JsonApiDataSourceAttributesTypeEnum {
+export enum JsonApiDataSourceInAttributesTypeEnum {
     // (undocumented)
     ADS = "ADS",
     // (undocumented)
@@ -1367,35 +1490,78 @@ export enum JsonApiDataSourceAttributesTypeEnum {
 }
 
 // @public
-export interface JsonApiDataSourceDocument {
-    data: JsonApiDataSource;
+export interface JsonApiDataSourceInDocument {
+    data: JsonApiDataSourceIn;
+}
+
+// @public
+export interface JsonApiDataSourceOut {
+    attributes?: JsonApiDataSourceOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiDataSourceOutAttributes {
+    enableCaching?: boolean;
+    name?: string;
+    schema?: string;
+    type?: JsonApiDataSourceOutAttributesTypeEnum;
+    uploadId?: string;
+    url?: string;
+    username?: string;
+}
+
+// @public
+export enum JsonApiDataSourceOutAttributesTypeEnum {
+    // (undocumented)
+    ADS = "ADS",
+    // (undocumented)
+    BIGQUERY = "BIGQUERY",
+    // (undocumented)
+    MSSQL = "MSSQL",
+    // (undocumented)
+    POSTGRESQL = "POSTGRESQL",
+    // (undocumented)
+    PRESTO = "PRESTO",
+    // (undocumented)
+    REDSHIFT = "REDSHIFT",
+    // (undocumented)
+    SNOWFLAKE = "SNOWFLAKE",
+    // (undocumented)
+    VERTICA = "VERTICA"
+}
+
+// @public
+export interface JsonApiDataSourceOutDocument {
+    data: JsonApiDataSourceOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiDataSourceList {
-    data: Array<JsonApiDataSourceWithLinks>;
+export interface JsonApiDataSourceOutList {
+    data: Array<JsonApiDataSourceOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiDataSourceWithLinks {
-    attributes?: JsonApiDataSourceAttributes;
+export interface JsonApiDataSourceOutWithLinks {
+    attributes?: JsonApiDataSourceOutAttributes;
     id: string;
     links?: ObjectLinks;
     type: string;
 }
 
 // @public
-export interface JsonApiFact {
-    attributes?: JsonApiFactAttributes;
+export interface JsonApiFactOut {
+    attributes?: JsonApiFactOutAttributes;
     id: string;
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFactAttributes {
+export interface JsonApiFactOutAttributes {
     description?: string;
     sourceColumn?: string;
     tags?: Array<string>;
@@ -1403,68 +1569,80 @@ export interface JsonApiFactAttributes {
 }
 
 // @public
-export interface JsonApiFactDocument {
-    data: JsonApiFact;
-    included?: Array<JsonApiDatasetWithLinks>;
+export interface JsonApiFactOutDocument {
+    data: JsonApiFactOut;
+    included?: Array<JsonApiDatasetOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiFactList {
-    data: Array<JsonApiFactWithLinks>;
-    included?: Array<JsonApiDatasetWithLinks>;
+export interface JsonApiFactOutList {
+    data: Array<JsonApiFactOutWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiFactRelationships {
-    dataset?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiFactOutRelationships {
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiFactWithLinks {
-    attributes?: JsonApiFactAttributes;
+export interface JsonApiFactOutWithLinks {
+    attributes?: JsonApiFactOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFilterContext {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiFilterContextIn {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
-    relationships?: JsonApiFilterContextRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFilterContextDocument {
-    data: JsonApiFilterContext;
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiFilterContextInDocument {
+    data: JsonApiFilterContextIn;
+}
+
+// @public
+export interface JsonApiFilterContextOut {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    id: string;
+    relationships?: JsonApiFilterContextOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiFilterContextOutDocument {
+    data: JsonApiFilterContextOut;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiFilterContextList {
-    data: Array<JsonApiFilterContextWithLinks>;
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiFilterContextOutList {
+    data: Array<JsonApiFilterContextOutWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiFilterContextRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
+export interface JsonApiFilterContextOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiFilterContextWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiFilterContextOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiFilterContextRelationships;
+    relationships?: JsonApiFilterContextOutRelationships;
     type: string;
 }
 
@@ -1475,15 +1653,15 @@ export const jsonApiHeaders: {
 };
 
 // @public
-export interface JsonApiLabel {
-    attributes?: JsonApiLabelAttributes;
+export interface JsonApiLabelOut {
+    attributes?: JsonApiLabelOutAttributes;
     id: string;
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiLabelAttributes {
+export interface JsonApiLabelOutAttributes {
     description?: string;
     primary?: boolean;
     sourceColumn?: string;
@@ -1492,30 +1670,30 @@ export interface JsonApiLabelAttributes {
 }
 
 // @public
-export interface JsonApiLabelDocument {
-    data: JsonApiLabel;
-    included?: Array<JsonApiAttributeWithLinks>;
+export interface JsonApiLabelOutDocument {
+    data: JsonApiLabelOut;
+    included?: Array<JsonApiAttributeOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiLabelList {
-    data: Array<JsonApiLabelWithLinks>;
-    included?: Array<JsonApiAttributeWithLinks>;
+export interface JsonApiLabelOutList {
+    data: Array<JsonApiLabelOutWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiLabelRelationships {
-    attribute?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiLabelOutRelationships {
+    attribute?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiLabelWithLinks {
-    attributes?: JsonApiLabelAttributes;
+export interface JsonApiLabelOutWithLinks {
+    attributes?: JsonApiLabelOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     type: string;
 }
 
@@ -1526,79 +1704,103 @@ export interface JsonApiLinkage {
 }
 
 // @public
-export interface JsonApiMetric {
-    attributes?: JsonApiMetricAttributes;
+export interface JsonApiMetricIn {
+    attributes?: JsonApiMetricOutAttributes;
     id: string;
-    relationships?: JsonApiMetricRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiMetricAttributes {
-    content?: JsonApiMetricAttributesContent;
+export interface JsonApiMetricInDocument {
+    data: JsonApiMetricIn;
+}
+
+// @public
+export interface JsonApiMetricOut {
+    attributes?: JsonApiMetricOutAttributes;
+    id: string;
+    relationships?: JsonApiMetricOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiMetricOutAttributes {
+    content?: JsonApiMetricOutAttributesContent;
     description?: string;
     tags?: Array<string>;
     title?: string;
 }
 
 // @public
-export interface JsonApiMetricAttributesContent {
+export interface JsonApiMetricOutAttributesContent {
     format?: string;
     maql?: string;
 }
 
 // @public
-export interface JsonApiMetricDocument {
-    data: JsonApiMetric;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>;
+export interface JsonApiMetricOutDocument {
+    data: JsonApiMetricOut;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiMetricList {
-    data: Array<JsonApiMetricWithLinks>;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>;
+export interface JsonApiMetricOutList {
+    data: Array<JsonApiMetricOutWithLinks>;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiMetricRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
+export interface JsonApiMetricOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiMetricWithLinks {
-    attributes?: JsonApiMetricAttributes;
+export interface JsonApiMetricOutWithLinks {
+    attributes?: JsonApiMetricOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiMetricRelationships;
+    relationships?: JsonApiMetricOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiModelModule {
+export interface JsonApiModelModuleIn {
     attributes?: object;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiModelModuleDocument {
-    data: JsonApiModelModule;
+export interface JsonApiModelModuleInDocument {
+    data: JsonApiModelModuleIn;
+}
+
+// @public
+export interface JsonApiModelModuleOut {
+    attributes?: object;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiModelModuleOutDocument {
+    data: JsonApiModelModuleOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiModelModuleList {
-    data: Array<JsonApiModelModuleWithLinks>;
+export interface JsonApiModelModuleOutList {
+    data: Array<JsonApiModelModuleOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiModelModuleWithLinks {
+export interface JsonApiModelModuleOutWithLinks {
     attributes?: object;
     id: string;
     links?: ObjectLinks;
@@ -1606,15 +1808,14 @@ export interface JsonApiModelModuleWithLinks {
 }
 
 // @public
-export interface JsonApiOrganization {
-    attributes?: JsonApiOrganizationAttributes;
+export interface JsonApiOrganizationIn {
+    attributes?: JsonApiOrganizationInAttributes;
     id: string;
-    relationships?: JsonApiOrganizationRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiOrganizationAttributes {
+export interface JsonApiOrganizationInAttributes {
     hostname?: string;
     name?: string;
     oauthClientId?: string;
@@ -1623,36 +1824,57 @@ export interface JsonApiOrganizationAttributes {
 }
 
 // @public
-export interface JsonApiOrganizationDocument {
-    data: JsonApiOrganization;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiOrganizationInDocument {
+    data: JsonApiOrganizationIn;
+}
+
+// @public
+export interface JsonApiOrganizationOut {
+    attributes?: JsonApiOrganizationOutAttributes;
+    id: string;
+    relationships?: JsonApiOrganizationOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiOrganizationOutAttributes {
+    hostname?: string;
+    name?: string;
+    oauthClientId?: string;
+    oauthIssuerLocation?: string;
+}
+
+// @public
+export interface JsonApiOrganizationOutDocument {
+    data: JsonApiOrganizationOut;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiOrganizationList {
-    data: Array<JsonApiOrganizationWithLinks>;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiOrganizationOutList {
+    data: Array<JsonApiOrganizationOutWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiOrganizationRelationships {
-    user?: JsonApiOrganizationRelationshipsUser;
-    userGroup?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiOrganizationOutRelationships {
+    user?: JsonApiOrganizationOutRelationshipsUser;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiOrganizationRelationshipsUser {
+export interface JsonApiOrganizationOutRelationshipsUser {
     data?: JsonApiRelToOne | null;
 }
 
 // @public
-export interface JsonApiOrganizationWithLinks {
-    attributes?: JsonApiOrganizationAttributes;
+export interface JsonApiOrganizationOutWithLinks {
+    attributes?: JsonApiOrganizationOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiOrganizationRelationships;
+    relationships?: JsonApiOrganizationOutRelationships;
     type: string;
 }
 
@@ -1660,27 +1882,27 @@ export interface JsonApiOrganizationWithLinks {
 export type JsonApiRelToOne = JsonApiLinkage;
 
 // @public
-export interface JsonApiSourceTable {
-    attributes?: JsonApiSourceTableAttributes;
+export interface JsonApiSourceTableOut {
+    attributes?: JsonApiSourceTableOutAttributes;
     id: string;
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTableAttributes {
-    columns?: Array<JsonApiSourceTableAttributesColumns>;
+export interface JsonApiSourceTableOutAttributes {
+    columns?: Array<JsonApiSourceTableOutAttributesColumns>;
     path?: Array<string>;
 }
 
 // @public
-export interface JsonApiSourceTableAttributesColumns {
-    dataType: JsonApiSourceTableAttributesColumnsDataTypeEnum;
+export interface JsonApiSourceTableOutAttributesColumns {
+    dataType: JsonApiSourceTableOutAttributesColumnsDataTypeEnum;
     name: string;
 }
 
 // @public
-export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
+export enum JsonApiSourceTableOutAttributesColumnsDataTypeEnum {
     // (undocumented)
     BOOLEAN = "BOOLEAN",
     // (undocumented)
@@ -1696,221 +1918,371 @@ export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
 }
 
 // @public
-export interface JsonApiSourceTableDocument {
-    data: JsonApiSourceTable;
-    included?: Array<JsonApiSourceTablesWithLinks>;
+export interface JsonApiSourceTableOutDocument {
+    data: JsonApiSourceTableOut;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiSourceTableList {
-    data: Array<JsonApiSourceTableWithLinks>;
-    included?: Array<JsonApiSourceTablesWithLinks>;
+export interface JsonApiSourceTableOutList {
+    data: Array<JsonApiSourceTableOutWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiSourceTableRelationships {
-    source?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiSourceTableOutRelationships {
+    source?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiSourceTables {
-    attributes?: object;
+export interface JsonApiSourceTableOutWithLinks {
+    attributes?: JsonApiSourceTableOutAttributes;
     id: string;
-    relationships?: JsonApiSourceTablesRelationships;
+    links?: ObjectLinks;
+    relationships?: JsonApiSourceTableOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTablesDocument {
-    data: JsonApiSourceTables;
-    included?: Array<JsonApiSourceTableWithLinks>;
+export interface JsonApiSourceTablesOut {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiSourceTablesOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiSourceTablesOutDocument {
+    data: JsonApiSourceTablesOut;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiSourceTablesList {
-    data: Array<JsonApiSourceTablesWithLinks>;
-    included?: Array<JsonApiSourceTableWithLinks>;
+export interface JsonApiSourceTablesOutList {
+    data: Array<JsonApiSourceTablesOutWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiSourceTablesRelationships {
-    tables?: JsonApiACLRelationshipsUsers;
+export interface JsonApiSourceTablesOutRelationships {
+    tables?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiSourceTablesWithLinks {
+export interface JsonApiSourceTablesOutWithLinks {
     attributes?: object;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTableWithLinks {
-    attributes?: JsonApiSourceTableAttributes;
+export interface JsonApiUserGroupIn {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserGroupInDocument {
+    data: JsonApiUserGroupIn;
+}
+
+// @public
+export interface JsonApiUserGroupOut {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserGroupOutDocument {
+    data: JsonApiUserGroupOut;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiUserGroupOutList {
+    data: Array<JsonApiUserGroupOutWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+    links?: ListLinks;
+}
+
+// @public
+export interface JsonApiUserGroupOutRelationships {
+    acls?: JsonApiACLOutRelationshipsUsers;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
+}
+
+// @public
+export interface JsonApiUserGroupOutWithLinks {
+    attributes?: object;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUser {
-    attributes?: JsonApiUserAttributes;
+export interface JsonApiUserIn {
+    attributes?: JsonApiUserOutAttributes;
     id: string;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUserAttributes {
+export interface JsonApiUserInDocument {
+    data: JsonApiUserIn;
+}
+
+// @public
+export interface JsonApiUserOut {
+    attributes?: JsonApiUserOutAttributes;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserOutAttributes {
     authenticationId?: string;
 }
 
 // @public
-export interface JsonApiUserDocument {
-    data: JsonApiUser;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiUserOutDocument {
+    data: JsonApiUserOut;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiUserGroup {
-    attributes?: object;
-    id: string;
-    relationships?: JsonApiUserGroupRelationships;
-    type: string;
-}
-
-// @public
-export interface JsonApiUserGroupDocument {
-    data: JsonApiUserGroup;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-    links?: ObjectLinks;
-}
-
-// @public
-export interface JsonApiUserGroupList {
-    data: Array<JsonApiUserGroupWithLinks>;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiUserOutList {
+    data: Array<JsonApiUserOutWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiUserGroupRelationships {
-    acls?: JsonApiACLRelationshipsUsers;
-    userGroup?: JsonApiOrganizationRelationshipsUser;
-}
-
-// @public
-export interface JsonApiUserGroupWithLinks {
-    attributes?: object;
+export interface JsonApiUserOutWithLinks {
+    attributes?: JsonApiUserOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUserList {
-    data: Array<JsonApiUserWithLinks>;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiVisualizationObjectIn {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiVisualizationObjectInDocument {
+    data: JsonApiVisualizationObjectIn;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOut {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    id: string;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutDocument {
+    data: JsonApiVisualizationObjectOut;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutList {
+    data: Array<JsonApiVisualizationObjectOutWithLinks>;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiUserWithLinks {
-    attributes?: JsonApiUserAttributes;
+export interface JsonApiVisualizationObjectOutRelationships {
+    analyticalDashboards?: JsonApiACLOutRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiVisualizationObject {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiWorkspaceDataFilterIn {
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
     id: string;
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiVisualizationObjectDocument {
-    data: JsonApiVisualizationObject;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiWorkspaceDataFilterInDocument {
+    data: JsonApiWorkspaceDataFilterIn;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterOut {
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
+    id: string;
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterOutAttributes {
+    columnName?: string;
+    dataSourceName?: string;
+    description?: string;
+    title?: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterOutDocument {
+    data: JsonApiWorkspaceDataFilterOut;
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiVisualizationObjectList {
-    data: Array<JsonApiVisualizationObjectWithLinks>;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiWorkspaceDataFilterOutList {
+    data: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiVisualizationObjectRelationships {
-    analyticalDashboards?: JsonApiACLRelationshipsUsers;
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
+export interface JsonApiWorkspaceDataFilterOutRelationships {
+    workspaceDataFilterSettings?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiVisualizationObjectWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiWorkspaceDataFilterOutWithLinks {
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiWorkspace {
-    attributes?: JsonApiWorkspaceAttributes;
+export interface JsonApiWorkspaceDataFilterSettingOut {
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
     id: string;
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiWorkspaceAttributes {
+export interface JsonApiWorkspaceDataFilterSettingOutAttributes {
+    description?: string;
+    filterValues?: Array<string>;
+    title?: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutDocument {
+    data: JsonApiWorkspaceDataFilterSettingOut;
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutList {
+    data: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    links?: ListLinks;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutRelationships {
+    workspaceDataFilter?: JsonApiOrganizationOutRelationshipsUser;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutWithLinks {
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    id: string;
+    links?: ObjectLinks;
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceIn {
+    attributes?: JsonApiWorkspaceOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceInDocument {
+    data: JsonApiWorkspaceIn;
+}
+
+// @public
+export interface JsonApiWorkspaceOut {
+    attributes?: JsonApiWorkspaceOutAttributes;
+    id: string;
+    relationships?: JsonApiWorkspaceOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceOutAttributes {
     name?: string;
 }
 
 // @public
-export interface JsonApiWorkspaceDocument {
-    data: JsonApiWorkspace;
-    included?: Array<JsonApiWorkspaceWithLinks>;
+export interface JsonApiWorkspaceOutDocument {
+    data: JsonApiWorkspaceOut;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiWorkspaceList {
-    data: Array<JsonApiWorkspaceWithLinks>;
-    included?: Array<JsonApiWorkspaceWithLinks>;
+export interface JsonApiWorkspaceOutList {
+    data: Array<JsonApiWorkspaceOutWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiWorkspaceRelationships {
-    workspace?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiWorkspaceOutRelationships {
+    workspace?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiWorkspaceWithLinks {
-    attributes?: JsonApiWorkspaceAttributes;
+export interface JsonApiWorkspaceOutWithLinks {
+    attributes?: JsonApiWorkspaceOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceOutRelationships;
     type: string;
 }
 
@@ -2176,581 +2548,28 @@ export interface OptionsControllerApiInterface {
 // @public
 export class OrganizationControllerApi extends MetadataBaseApi implements OrganizationControllerApiInterface {
     // (undocumented)
-    getEntityAcls1(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    // (undocumented)
-    getEntityDataSources(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    // (undocumented)
-    getEntityModelModules(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    // (undocumented)
-    getEntityOrganizations(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    // (undocumented)
-    getEntityUserGroups(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    // (undocumented)
-    getEntityUsers(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    // (undocumented)
-    getEntityWorkspaces(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
-    // (undocumented)
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiACLDocument | JsonApiDataSourceDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserDocument | JsonApiUserGroupDocument | JsonApiWorkspaceDocument>;
-    // (undocumented)
-    updateEntityAcls1(params: {
-        id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    // (undocumented)
-    updateEntityDataSources(params: {
-        id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    // (undocumented)
-    updateEntityModelModules(params: {
-        id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    // (undocumented)
-    updateEntityOrganizations(params: {
-        id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    // (undocumented)
-    updateEntityUserGroups(params: {
-        id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    // (undocumented)
-    updateEntityUsers(params: {
-        id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    // (undocumented)
-    updateEntityWorkspaces(params: {
-        id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    getOrganizationUsers(params: {}, options?: any): AxiosPromise<JsonApiACLOutDocument | JsonApiDataSourceOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
 }
 
 // @public
 export const OrganizationControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
-    getEntityAcls1(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityDataSources(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityModelModules(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityOrganizations(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityUserGroups(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityUsers(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityWorkspaces(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getOrganizationUsers11(params: {}, options?: any): MetadataRequestArgs;
-    updateEntityAcls1(params: {
-        id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityDataSources(params: {
-        id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityModelModules(params: {
-        id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityOrganizations(params: {
-        id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityUserGroups(params: {
-        id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityUsers(params: {
-        id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    updateEntityWorkspaces(params: {
-        id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
+    getOrganizationUsers(params: {}, options?: any): MetadataRequestArgs;
 };
 
 // @public
 export const OrganizationControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
-    getEntityAcls1(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    getEntityDataSources(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    getEntityModelModules(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    getEntityOrganizations(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    getEntityUserGroups(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    getEntityUsers(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    getEntityWorkspaces(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
-    updateEntityAcls1(params: {
-        id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    updateEntityDataSources(params: {
-        id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    updateEntityModelModules(params: {
-        id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    updateEntityOrganizations(params: {
-        id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    updateEntityUserGroups(params: {
-        id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    updateEntityUsers(params: {
-        id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    updateEntityWorkspaces(params: {
-        id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    getOrganizationUsers(params: {}, options?: any): AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
 };
 
 // @public
 export const OrganizationControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
-    getEntityAcls1(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
-    getEntityDataSources(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
-    getEntityModelModules(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
-    getEntityOrganizations(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
-    getEntityUserGroups(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
-    getEntityUsers(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
-    getEntityWorkspaces(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
-    getOrganizationUsers11(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
-    updateEntityAcls1(params: {
-        id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
-    updateEntityDataSources(params: {
-        id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
-    updateEntityModelModules(params: {
-        id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
-    updateEntityOrganizations(params: {
-        id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
-    updateEntityUserGroups(params: {
-        id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
-    updateEntityUsers(params: {
-        id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
-    updateEntityWorkspaces(params: {
-        id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    getOrganizationUsers(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
 };
 
 // @public
 export interface OrganizationControllerApiInterface {
     // (undocumented)
-    getEntityAcls1(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    // (undocumented)
-    getEntityDataSources(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    // (undocumented)
-    getEntityModelModules(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    // (undocumented)
-    getEntityOrganizations(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    // (undocumented)
-    getEntityUserGroups(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    // (undocumented)
-    getEntityUsers(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    // (undocumented)
-    getEntityWorkspaces(params: {
-        id: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
-    // (undocumented)
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
-    // (undocumented)
-    updateEntityAcls1(params: {
-        id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    // (undocumented)
-    updateEntityDataSources(params: {
-        id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    // (undocumented)
-    updateEntityModelModules(params: {
-        id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    // (undocumented)
-    updateEntityOrganizations(params: {
-        id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    // (undocumented)
-    updateEntityUserGroups(params: {
-        id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    // (undocumented)
-    updateEntityUsers(params: {
-        id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    // (undocumented)
-    updateEntityWorkspaces(params: {
-        id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    getOrganizationUsers(params: {}, options?: any): AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
 }
 
 // @public
@@ -2758,94 +2577,136 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
     // (undocumented)
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     deleteEntityAcls(params: {
         id: string;
@@ -2904,7 +2765,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     // (undocumented)
     getAllEntitiesDataSources(params: {
         variableParam?: {
@@ -2914,7 +2775,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     // (undocumented)
     getAllEntitiesModelModules(params: {
         variableParam?: {
@@ -2924,7 +2785,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     // (undocumented)
     getAllEntitiesOrganizations(params: {
         variableParam?: {
@@ -2934,7 +2795,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     // (undocumented)
     getAllEntitiesUserGroups(params: {
         variableParam?: {
@@ -2944,7 +2805,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     // (undocumented)
     getAllEntitiesUsers(params: {
         variableParam?: {
@@ -2954,7 +2815,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     // (undocumented)
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
@@ -2964,7 +2825,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     // (undocumented)
     getEntityAcls(params: {
         id: string;
@@ -2972,198 +2833,233 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
-    getEntityDataSources1(params: {
+    getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
-    getEntityModelModules1(params: {
+    getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
-    getEntityOrganizations1(params: {
+    getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
-    getEntityUserGroups1(params: {
+    getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
-    getEntityUsers1(params: {
+    getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
-    getEntityWorkspaces1(params: {
+    getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
-    updateEntityDataSources1(params: {
+    updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
-    updateEntityModelModules1(params: {
+    updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
-    updateEntityOrganizations1(params: {
+    updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
-    updateEntityUserGroups1(params: {
+    updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
-    updateEntityUsers1(params: {
+    updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
-    updateEntityWorkspaces1(params: {
+    updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @public
 export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
     }, options?: any): MetadataRequestArgs;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
     }, options?: any): MetadataRequestArgs;
     deleteEntityAcls(params: {
         id: string;
@@ -3277,42 +3173,42 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityDataSources1(params: {
+    getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityModelModules1(params: {
+    getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityOrganizations1(params: {
+    getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityUserGroups1(params: {
+    getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityUsers1(params: {
+    getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    getEntityWorkspaces1(params: {
+    getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
@@ -3321,55 +3217,55 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityDataSources1(params: {
+    updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityModelModules1(params: {
+    updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityOrganizations1(params: {
+    updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityUserGroups1(params: {
+    updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityUsers1(params: {
+    updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityWorkspaces1(params: {
+    updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3381,81 +3277,116 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
 export const OrganizationModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     deleteEntityAcls(params: {
         id: string;
         variableParam?: {
@@ -3506,7 +3437,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     getAllEntitiesDataSources(params: {
         variableParam?: {
             [key: string]: object;
@@ -3515,7 +3446,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     getAllEntitiesModelModules(params: {
         variableParam?: {
             [key: string]: object;
@@ -3524,7 +3455,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     getAllEntitiesOrganizations(params: {
         variableParam?: {
             [key: string]: object;
@@ -3533,7 +3464,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     getAllEntitiesUserGroups(params: {
         variableParam?: {
             [key: string]: object;
@@ -3542,7 +3473,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     getAllEntitiesUsers(params: {
         variableParam?: {
             [key: string]: object;
@@ -3551,7 +3482,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
             [key: string]: object;
@@ -3560,193 +3491,228 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     getEntityAcls(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    getEntityDataSources1(params: {
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    getEntityModelModules1(params: {
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    getEntityOrganizations1(params: {
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    getEntityUserGroups1(params: {
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    getEntityUsers1(params: {
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    getEntityWorkspaces1(params: {
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
-    updateEntityDataSources1(params: {
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
-    updateEntityModelModules1(params: {
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
-    updateEntityOrganizations1(params: {
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
-    updateEntityUserGroups1(params: {
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
-    updateEntityUsers1(params: {
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
-    updateEntityWorkspaces1(params: {
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
 export const OrganizationModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     deleteEntityAcls(params: {
         id: string;
         variableParam?: {
@@ -3797,7 +3763,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutList>;
     getAllEntitiesDataSources(params: {
         variableParam?: {
             [key: string]: object;
@@ -3806,7 +3772,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutList>;
     getAllEntitiesModelModules(params: {
         variableParam?: {
             [key: string]: object;
@@ -3815,7 +3781,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutList>;
     getAllEntitiesOrganizations(params: {
         variableParam?: {
             [key: string]: object;
@@ -3824,7 +3790,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutList>;
     getAllEntitiesUserGroups(params: {
         variableParam?: {
             [key: string]: object;
@@ -3833,7 +3799,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutList>;
     getAllEntitiesUsers(params: {
         variableParam?: {
             [key: string]: object;
@@ -3842,7 +3808,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutList>;
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
             [key: string]: object;
@@ -3851,112 +3817,112 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutList>;
     getEntityAcls(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
-    getEntityDataSources1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
+    getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
-    getEntityModelModules1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
+    getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
-    getEntityOrganizations1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
+    getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
-    getEntityUserGroups1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
+    getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
-    getEntityUsers1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
+    getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
-    getEntityWorkspaces1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
+    getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
-    updateEntityDataSources1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
+    updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
-    updateEntityModelModules1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
+    updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
-    updateEntityOrganizations1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
+    updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
-    updateEntityUserGroups1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
+    updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
-    updateEntityUsers1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
+    updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
-    updateEntityWorkspaces1(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
+    updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
@@ -3964,94 +3930,136 @@ export interface OrganizationModelControllerApiInterface {
     // (undocumented)
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     deleteEntityAcls(params: {
         id: string;
@@ -4110,7 +4118,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     // (undocumented)
     getAllEntitiesDataSources(params: {
         variableParam?: {
@@ -4120,7 +4128,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     // (undocumented)
     getAllEntitiesModelModules(params: {
         variableParam?: {
@@ -4130,7 +4138,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     // (undocumented)
     getAllEntitiesOrganizations(params: {
         variableParam?: {
@@ -4140,7 +4148,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     // (undocumented)
     getAllEntitiesUserGroups(params: {
         variableParam?: {
@@ -4150,7 +4158,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     // (undocumented)
     getAllEntitiesUsers(params: {
         variableParam?: {
@@ -4160,7 +4168,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     // (undocumented)
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
@@ -4170,7 +4178,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     // (undocumented)
     getEntityAcls(params: {
         id: string;
@@ -4178,118 +4186,118 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
-    getEntityDataSources1(params: {
+    getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
-    getEntityModelModules1(params: {
+    getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
-    getEntityOrganizations1(params: {
+    getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
-    getEntityUserGroups1(params: {
+    getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
-    getEntityUsers1(params: {
+    getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
-    getEntityWorkspaces1(params: {
+    getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
-    updateEntityDataSources1(params: {
+    updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
-    updateEntityModelModules1(params: {
+    updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
-    updateEntityOrganizations1(params: {
+    updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
-    updateEntityUserGroups1(params: {
+    updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
-    updateEntityUsers1(params: {
+    updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
-    updateEntityWorkspaces1(params: {
+    updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @public
@@ -4536,11 +4544,23 @@ export class ResultControllerApi extends LabelElementsBaseApi implements ResultC
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
 }
 
 // @public
 export const ResultControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
     getResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: number[] | undefined;
+        limit?: number[] | undefined;
+    }, options?: any): LabelElementsRequestArgs;
+    retrieveResult(params: {
         workspaceId: string;
         resultId: string;
         offset?: number[] | undefined;
@@ -4556,6 +4576,12 @@ export const ResultControllerApiFactory: (configuration?: LabelElementsConfigura
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
 };
 
 // @public
@@ -4566,11 +4592,23 @@ export const ResultControllerApiFp: (configuration?: LabelElementsConfiguration 
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ExecutionResult>;
 };
 
 // @public
 export interface ResultControllerApiInterface {
     getResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
         workspaceId: string;
         resultId: string;
         offset?: Array<number>;
@@ -4684,12 +4722,12 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
     // (undocumented)
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     // (undocumented)
     deleteEntityApiTokens(params: {
         userId: string;
@@ -4708,7 +4746,7 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     // (undocumented)
     getEntityApiTokens(params: {
         userId: string;
@@ -4720,14 +4758,14 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 // @public
 export const UserModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -4767,12 +4805,12 @@ export const UserModelControllerApiAxiosParamCreator: (configuration?: MetadataC
 export const UserModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     deleteEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4789,7 +4827,7 @@ export const UserModelControllerApiFactory: (configuration?: MetadataConfigurati
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4800,19 +4838,19 @@ export const UserModelControllerApiFactory: (configuration?: MetadataConfigurati
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 };
 
 // @public
 export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutDocument>;
     deleteEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4829,7 +4867,7 @@ export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | 
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4840,7 +4878,7 @@ export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | 
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutDocument>;
 };
 
 // @public
@@ -4848,12 +4886,12 @@ export interface UserModelControllerApiInterface {
     // (undocumented)
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     // (undocumented)
     deleteEntityApiTokens(params: {
         userId: string;
@@ -4872,7 +4910,7 @@ export interface UserModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     // (undocumented)
     getEntityApiTokens(params: {
         userId: string;
@@ -4884,11 +4922,15 @@ export interface UserModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 // @public
 export class ValidObjectsControllerApi extends LabelElementsBaseApi implements ValidObjectsControllerApiInterface {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -4897,6 +4939,10 @@ export class ValidObjectsControllerApi extends LabelElementsBaseApi implements V
 
 // @public
 export const ValidObjectsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): LabelElementsRequestArgs;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -4905,6 +4951,10 @@ export const ValidObjectsControllerApiAxiosParamCreator: (configuration?: LabelE
 
 // @public
 export const ValidObjectsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -4913,6 +4963,10 @@ export const ValidObjectsControllerApiFactory: (configuration?: LabelElementsCon
 
 // @public
 export const ValidObjectsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -4921,6 +4975,10 @@ export const ValidObjectsControllerApiFp: (configuration?: LabelElementsConfigur
 
 // @public
 export interface ValidObjectsControllerApiInterface {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -5022,58 +5080,50 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
     // (undocumented)
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         };
-    }, options?: any): AxiosPromise<void>;
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     // (undocumented)
-    deleteEntityDataDiscriminators(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5105,6 +5155,14 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+    }, options?: any): AxiosPromise<void>;
+    // (undocumented)
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5114,7 +5172,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     // (undocumented)
     getEntitiesAttributes(params: {
         workspaceId: string;
@@ -5125,18 +5183,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     // (undocumented)
     getEntitiesDatasets(params: {
         workspaceId: string;
@@ -5147,7 +5194,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     // (undocumented)
     getEntitiesFacts(params: {
         workspaceId: string;
@@ -5158,7 +5205,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     // (undocumented)
     getEntitiesFilterContexts(params: {
         workspaceId: string;
@@ -5169,7 +5216,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     // (undocumented)
     getEntitiesLabels(params: {
         workspaceId: string;
@@ -5180,7 +5227,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     // (undocumented)
     getEntitiesMetrics(params: {
         workspaceId: string;
@@ -5191,7 +5238,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     // (undocumented)
     getEntitiesSources(params: {
         workspaceId: string;
@@ -5202,7 +5249,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     // (undocumented)
     getEntitiesTables(params: {
         workspaceId: string;
@@ -5213,7 +5260,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     // (undocumented)
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
@@ -5224,7 +5271,29 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
     // (undocumented)
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
@@ -5233,7 +5302,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     getEntityAttributes(params: {
         workspaceId: string;
@@ -5242,16 +5311,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     // (undocumented)
     getEntityDatasets(params: {
         workspaceId: string;
@@ -5260,7 +5320,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     // (undocumented)
     getEntityFacts(params: {
         workspaceId: string;
@@ -5269,7 +5329,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     // (undocumented)
     getEntityFilterContexts(params: {
         workspaceId: string;
@@ -5278,7 +5338,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     getEntityLabels(params: {
         workspaceId: string;
@@ -5287,7 +5347,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     // (undocumented)
     getEntityMetrics(params: {
         workspaceId: string;
@@ -5296,7 +5356,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     getEntitySources(params: {
         workspaceId: string;
@@ -5305,7 +5365,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     // (undocumented)
     getEntityTables(params: {
         workspaceId: string;
@@ -5314,7 +5374,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     // (undocumented)
     getEntityVisualizationObjects(params: {
         workspaceId: string;
@@ -5323,72 +5383,82 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
     // (undocumented)
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 // @public
 export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5396,7 +5466,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5404,7 +5474,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5412,20 +5482,21 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    createEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     deleteEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityDataDiscriminators(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5453,6 +5524,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): MetadataRequestArgs;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5464,16 +5542,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
     getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesDataDiscriminators(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5563,6 +5631,26 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): MetadataRequestArgs;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): MetadataRequestArgs;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -5572,14 +5660,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     getEntityAttributes(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityDataDiscriminators(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5651,19 +5731,26 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityAnalyticalDashboards(params: {
+    getEntityWorkspaceDataFilterSettings(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityDataDiscriminators(params: {
+    getEntityWorkspaceDataFilters(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    updateEntityAnalyticalDashboards(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5672,7 +5759,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5681,7 +5768,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5690,7 +5777,16 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5702,52 +5798,45 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
 export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    deleteEntityDataDiscriminators(params: {
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5775,6 +5864,13 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): AxiosPromise<void>;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5784,7 +5880,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
@@ -5794,17 +5890,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
@@ -5814,7 +5900,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
@@ -5824,7 +5910,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
@@ -5834,7 +5920,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
@@ -5844,7 +5930,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
@@ -5854,7 +5940,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
@@ -5864,7 +5950,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
@@ -5874,7 +5960,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
@@ -5884,7 +5970,27 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -5892,7 +5998,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
@@ -5900,15 +6006,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
@@ -5916,7 +6014,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
@@ -5924,7 +6022,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
@@ -5932,7 +6030,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
@@ -5940,7 +6038,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
@@ -5948,7 +6046,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     getEntitySources(params: {
         workspaceId: string;
         objectId: string;
@@ -5956,7 +6054,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     getEntityTables(params: {
         workspaceId: string;
         objectId: string;
@@ -5964,7 +6062,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
@@ -5972,104 +6070,113 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 };
 
 // @public
 export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityDataDiscriminators(params: {
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6097,6 +6204,13 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -6106,7 +6220,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
@@ -6116,17 +6230,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeOutList>;
     getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
@@ -6136,7 +6240,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetOutList>;
     getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
@@ -6146,7 +6250,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactOutList>;
     getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
@@ -6156,7 +6260,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutList>;
     getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
@@ -6166,7 +6270,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelOutList>;
     getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
@@ -6176,7 +6280,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutList>;
     getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
@@ -6186,7 +6290,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesOutList>;
     getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
@@ -6196,7 +6300,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableOutList>;
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
@@ -6206,7 +6310,27 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutList>;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -6214,7 +6338,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
@@ -6222,15 +6346,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeOutDocument>;
     getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
@@ -6238,7 +6354,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetOutDocument>;
     getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
@@ -6246,7 +6362,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactOutDocument>;
     getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
@@ -6254,7 +6370,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
@@ -6262,7 +6378,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelOutDocument>;
     getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
@@ -6270,7 +6386,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     getEntitySources(params: {
         workspaceId: string;
         objectId: string;
@@ -6278,7 +6394,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesOutDocument>;
     getEntityTables(params: {
         workspaceId: string;
         objectId: string;
@@ -6286,7 +6402,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableOutDocument>;
     getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
@@ -6294,52 +6410,68 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 };
 
 // @public
@@ -6347,58 +6479,50 @@ export interface WorkspaceObjectControllerApiInterface {
     // (undocumented)
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         };
-    }, options?: any): AxiosPromise<void>;
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     // (undocumented)
-    deleteEntityDataDiscriminators(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6430,6 +6554,14 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+    }, options?: any): AxiosPromise<void>;
+    // (undocumented)
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -6439,7 +6571,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     // (undocumented)
     getEntitiesAttributes(params: {
         workspaceId: string;
@@ -6450,18 +6582,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     // (undocumented)
     getEntitiesDatasets(params: {
         workspaceId: string;
@@ -6472,7 +6593,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     // (undocumented)
     getEntitiesFacts(params: {
         workspaceId: string;
@@ -6483,7 +6604,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     // (undocumented)
     getEntitiesFilterContexts(params: {
         workspaceId: string;
@@ -6494,7 +6615,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     // (undocumented)
     getEntitiesLabels(params: {
         workspaceId: string;
@@ -6505,7 +6626,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     // (undocumented)
     getEntitiesMetrics(params: {
         workspaceId: string;
@@ -6516,7 +6637,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     // (undocumented)
     getEntitiesSources(params: {
         workspaceId: string;
@@ -6527,7 +6648,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     // (undocumented)
     getEntitiesTables(params: {
         workspaceId: string;
@@ -6538,7 +6659,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     // (undocumented)
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
@@ -6549,7 +6670,29 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
     // (undocumented)
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
@@ -6558,7 +6701,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     getEntityAttributes(params: {
         workspaceId: string;
@@ -6567,16 +6710,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     // (undocumented)
     getEntityDatasets(params: {
         workspaceId: string;
@@ -6585,7 +6719,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     // (undocumented)
     getEntityFacts(params: {
         workspaceId: string;
@@ -6594,7 +6728,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     // (undocumented)
     getEntityFilterContexts(params: {
         workspaceId: string;
@@ -6603,7 +6737,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     getEntityLabels(params: {
         workspaceId: string;
@@ -6612,7 +6746,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     // (undocumented)
     getEntityMetrics(params: {
         workspaceId: string;
@@ -6621,7 +6755,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     getEntitySources(params: {
         workspaceId: string;
@@ -6630,7 +6764,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     // (undocumented)
     getEntityTables(params: {
         workspaceId: string;
@@ -6639,7 +6773,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     // (undocumented)
     getEntityVisualizationObjects(params: {
         workspaceId: string;
@@ -6648,57 +6782,75 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
     // (undocumented)
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 

--- a/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
@@ -7,7 +7,7 @@ import {
     ObjectIdentifier,
     ResultDimension,
 } from "../generated/afm-rest-api";
-import { JsonApiFilterContext, JsonApiVisualizationObject } from "../generated/metadata-json-api";
+import { JsonApiFilterContextIn, JsonApiVisualizationObjectIn } from "../generated/metadata-json-api";
 
 export type ResultDimensionHeader = ResultDimension["headers"][number];
 
@@ -30,10 +30,10 @@ export function isResultAttributeHeader(
 
 export function isVisualizationObjectsItem(
     visualizationObject: unknown,
-): visualizationObject is JsonApiVisualizationObject {
-    return (visualizationObject as JsonApiVisualizationObject).type === "visualizationObject";
+): visualizationObject is JsonApiVisualizationObjectIn {
+    return (visualizationObject as JsonApiVisualizationObjectIn).type === "visualizationObject";
 }
 
-export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContext {
-    return (filterContext as JsonApiFilterContext).type === "filterContext";
+export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn {
+    return (filterContext as JsonApiFilterContextIn).type === "filterContext";
 }

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -1,5 +1,3 @@
-// (C) 2021 GoodData Corporation
-
 /* eslint-disable */
 /**
  * OpenAPI definition
@@ -1937,6 +1935,79 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, afmExecution, skipCache, timestamp } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeReport.",
+                );
+            }
+            // verify required parameter 'afmExecution' is not null or undefined
+            if (afmExecution === null || afmExecution === undefined) {
+                throw new RequiredError(
+                    "afmExecution",
+                    "Required parameter afmExecution was null or undefined when calling computeReport.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/afm/execute`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (skipCache !== undefined && skipCache !== null) {
+                localVarHeaderParameter["skip-cache"] = String(JSON.stringify(skipCache));
+            }
+
+            if (timestamp !== undefined && timestamp !== null) {
+                localVarHeaderParameter["timestamp"] = String(timestamp);
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof afmExecution !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(afmExecution !== undefined ? afmExecution : {})
+                : afmExecution || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2019,6 +2090,37 @@ export const AfmControllerApiFp = function (configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmExecutionResponse> {
+            const localVarAxiosArgs = AfmControllerApiAxiosParamCreator(configuration).computeReport(
+                params,
+                options,
+            );
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2063,6 +2165,27 @@ export const AfmControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options?: any,
+        ): AxiosPromise<AfmExecutionResponse> {
+            return AfmControllerApiFp(configuration).computeReport(params, options)(axios, basePath);
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2083,6 +2206,27 @@ export const AfmControllerApiFactory = function (
  * @interface AfmControllerApi
  */
 export interface AfmControllerApiInterface {
+    /**
+     * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+     * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmExecution} afmExecution
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {string} [timestamp]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AfmControllerApiInterface
+     */
+    computeReport(
+        params: {
+            workspaceId: string;
+            afmExecution: AfmExecution;
+            skipCache?: boolean;
+            timestamp?: string;
+        },
+        options?: any,
+    ): AxiosPromise<AfmExecutionResponse>;
+
     /**
      * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
      * @summary Executes analytical request and returns link to the result
@@ -2123,6 +2267,32 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
      * @throws {RequiredError}
      * @memberof AfmControllerApi
      */
+    public computeReport(
+        params: {
+            workspaceId: string;
+            afmExecution: AfmExecution;
+            skipCache?: boolean;
+            timestamp?: string;
+        },
+        options?: any,
+    ) {
+        return AfmControllerApiFp(this.configuration).computeReport(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
+    /**
+     * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+     * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmExecution} afmExecution
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {string} [timestamp]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AfmControllerApi
+     */
     public processAfmRequest(
         params: {
             workspaceId: string;
@@ -2145,6 +2315,143 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
  */
 export const ElementsControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const {
+                workspaceId,
+                label,
+                sortOrder,
+                includeTotalWithoutFilters,
+                complementFilter,
+                patternFilter,
+                offset,
+                limit,
+                skipCache,
+            } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeLabelElements.",
+                );
+            }
+            // verify required parameter 'label' is not null or undefined
+            if (label === null || label === undefined) {
+                throw new RequiredError(
+                    "label",
+                    "Required parameter label was null or undefined when calling computeLabelElements.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/collectLabelElements`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (label !== undefined) {
+                if (typeof label === "object") {
+                    addFlattenedObjectTo(label, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["label"] = label;
+                }
+            }
+
+            if (sortOrder !== undefined) {
+                if (typeof sortOrder === "object") {
+                    addFlattenedObjectTo(sortOrder, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["sortOrder"] = sortOrder;
+                }
+            }
+
+            if (includeTotalWithoutFilters !== undefined) {
+                if (typeof includeTotalWithoutFilters === "object") {
+                    addFlattenedObjectTo(includeTotalWithoutFilters, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["includeTotalWithoutFilters"] = includeTotalWithoutFilters;
+                }
+            }
+
+            if (complementFilter !== undefined) {
+                if (typeof complementFilter === "object") {
+                    addFlattenedObjectTo(complementFilter, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["complementFilter"] = complementFilter;
+                }
+            }
+
+            if (patternFilter !== undefined) {
+                if (typeof patternFilter === "object") {
+                    addFlattenedObjectTo(patternFilter, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["patternFilter"] = patternFilter;
+                }
+            }
+
+            if (offset !== undefined) {
+                if (typeof offset === "object") {
+                    addFlattenedObjectTo(offset, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["offset"] = offset;
+                }
+            }
+
+            if (limit !== undefined) {
+                if (typeof limit === "object") {
+                    addFlattenedObjectTo(limit, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["limit"] = limit;
+                }
+            }
+
+            if (skipCache !== undefined && skipCache !== null) {
+                localVarHeaderParameter["skip-cache"] = String(JSON.stringify(skipCache));
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
@@ -2306,6 +2613,46 @@ export const ElementsControllerApiFp = function (configuration?: Configuration) 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ElementsResponse> {
+            const localVarAxiosArgs = ElementsControllerApiAxiosParamCreator(
+                configuration,
+            ).computeLabelElements(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processElementsRequest(
             params: {
                 workspaceId: string;
@@ -2344,6 +2691,40 @@ export const ElementsControllerApiFactory = function (
     axios?: AxiosInstance,
 ) {
     return {
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options?: any,
+        ): AxiosPromise<ElementsResponse> {
+            return ElementsControllerApiFp(configuration).computeLabelElements(params, options)(
+                axios,
+                basePath,
+            );
+        },
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
@@ -2403,6 +2784,37 @@ export interface ElementsControllerApiInterface {
      * @throws {RequiredError}
      * @memberof ElementsControllerApiInterface
      */
+    computeLabelElements(
+        params: {
+            workspaceId: string;
+            label: string;
+            sortOrder?: "ASC" | "DESC";
+            includeTotalWithoutFilters?: boolean;
+            complementFilter?: boolean;
+            patternFilter?: string;
+            offset?: number;
+            limit?: number;
+            skipCache?: boolean;
+        },
+        options?: any,
+    ): AxiosPromise<ElementsResponse>;
+
+    /**
+     * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+     * @summary Listing of label values.
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} label Requested label.
+     * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+     * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+     * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+     * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+     * @param {number} [offset] Request page with this offset.
+     * @param {number} [limit] Return only this number of items.
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ElementsControllerApiInterface
+     */
     processElementsRequest(
         params: {
             workspaceId: string;
@@ -2426,6 +2838,42 @@ export interface ElementsControllerApiInterface {
  * @extends {BaseAPI}
  */
 export class ElementsControllerApi extends BaseAPI implements ElementsControllerApiInterface {
+    /**
+     * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+     * @summary Listing of label values.
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} label Requested label.
+     * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+     * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+     * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+     * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+     * @param {number} [offset] Request page with this offset.
+     * @param {number} [limit] Return only this number of items.
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ElementsControllerApi
+     */
+    public computeLabelElements(
+        params: {
+            workspaceId: string;
+            label: string;
+            sortOrder?: "ASC" | "DESC";
+            includeTotalWithoutFilters?: boolean;
+            complementFilter?: boolean;
+            patternFilter?: string;
+            offset?: number;
+            limit?: number;
+            skipCache?: boolean;
+        },
+        options?: any,
+    ) {
+        return ElementsControllerApiFp(this.configuration).computeLabelElements(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
     /**
      * Returns paged list of elements (values) of given label satisfying given filtering criteria.
      * @summary Listing of label values.
@@ -2533,6 +2981,70 @@ export const ResultControllerApiAxiosParamCreator = function (configuration?: Co
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, resultId, offset, limit } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling retrieveResult.",
+                );
+            }
+            // verify required parameter 'resultId' is not null or undefined
+            if (resultId === null || resultId === undefined) {
+                throw new RequiredError(
+                    "resultId",
+                    "Required parameter resultId was null or undefined when calling retrieveResult.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/result/{resultId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"resultId"}}`, encodeURIComponent(String(resultId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (offset) {
+                localVarQueryParameter["offset"] = offset;
+            }
+
+            if (limit) {
+                localVarQueryParameter["limit"] = limit;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     };
 };
 
@@ -2562,6 +3074,37 @@ export const ResultControllerApiFp = function (configuration?: Configuration) {
             options: any = {},
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ExecutionResult> {
             const localVarAxiosArgs = ResultControllerApiAxiosParamCreator(configuration).getResult(
+                params,
+                options,
+            );
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ExecutionResult> {
+            const localVarAxiosArgs = ResultControllerApiAxiosParamCreator(configuration).retrieveResult(
                 params,
                 options,
             );
@@ -2607,6 +3150,27 @@ export const ResultControllerApiFactory = function (
         ): AxiosPromise<ExecutionResult> {
             return ResultControllerApiFp(configuration).getResult(params, options)(axios, basePath);
         },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options?: any,
+        ): AxiosPromise<ExecutionResult> {
+            return ResultControllerApiFp(configuration).retrieveResult(params, options)(axios, basePath);
+        },
     };
 };
 
@@ -2628,6 +3192,27 @@ export interface ResultControllerApiInterface {
      * @memberof ResultControllerApiInterface
      */
     getResult(
+        params: {
+            workspaceId: string;
+            resultId: string;
+            offset?: Array<number>;
+            limit?: Array<number>;
+        },
+        options?: any,
+    ): AxiosPromise<ExecutionResult>;
+
+    /**
+     * Gets a single execution result.
+     * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} resultId Result ID
+     * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+     * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ResultControllerApiInterface
+     */
+    retrieveResult(
         params: {
             workspaceId: string;
             resultId: string;
@@ -2670,6 +3255,32 @@ export class ResultControllerApi extends BaseAPI implements ResultControllerApiI
             this.basePath,
         );
     }
+
+    /**
+     * Gets a single execution result.
+     * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} resultId Result ID
+     * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+     * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ResultControllerApi
+     */
+    public retrieveResult(
+        params: {
+            workspaceId: string;
+            resultId: string;
+            offset?: Array<number>;
+            limit?: Array<number>;
+        },
+        options?: any,
+    ) {
+        return ResultControllerApiFp(this.configuration).retrieveResult(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
 }
 
 /**
@@ -2678,6 +3289,67 @@ export class ResultControllerApi extends BaseAPI implements ResultControllerApiI
  */
 export const ValidObjectsControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, afmValidObjectsQuery } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeValidObjects.",
+                );
+            }
+            // verify required parameter 'afmValidObjectsQuery' is not null or undefined
+            if (afmValidObjectsQuery === null || afmValidObjectsQuery === undefined) {
+                throw new RequiredError(
+                    "afmValidObjectsQuery",
+                    "Required parameter afmValidObjectsQuery was null or undefined when calling computeValidObjects.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/afm/computeValidObjects`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof afmValidObjectsQuery !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(afmValidObjectsQuery !== undefined ? afmValidObjectsQuery : {})
+                : afmValidObjectsQuery || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
         /**
          * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
          * @summary Valid objects
@@ -2756,6 +3428,32 @@ export const ValidObjectsControllerApiFp = function (configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmValidObjectsResponse> {
+            const localVarAxiosArgs = ValidObjectsControllerApiAxiosParamCreator(
+                configuration,
+            ).computeValidObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmValidObjectsQuery(
             params: {
                 workspaceId: string;
@@ -2795,6 +3493,26 @@ export const ValidObjectsControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options?: any,
+        ): AxiosPromise<AfmValidObjectsResponse> {
+            return ValidObjectsControllerApiFp(configuration).computeValidObjects(params, options)(
+                axios,
+                basePath,
+            );
+        },
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmValidObjectsQuery(
             params: {
                 workspaceId: string;
@@ -2825,6 +3543,23 @@ export interface ValidObjectsControllerApiInterface {
      * @throws {RequiredError}
      * @memberof ValidObjectsControllerApiInterface
      */
+    computeValidObjects(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ): AxiosPromise<AfmValidObjectsResponse>;
+
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApiInterface
+     */
     processAfmValidObjectsQuery(
         params: {
             workspaceId: string;
@@ -2841,6 +3576,28 @@ export interface ValidObjectsControllerApiInterface {
  * @extends {BaseAPI}
  */
 export class ValidObjectsControllerApi extends BaseAPI implements ValidObjectsControllerApiInterface {
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApi
+     */
+    public computeValidObjects(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ) {
+        return ValidObjectsControllerApiFp(this.configuration).computeValidObjects(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
     /**
      * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
      * @summary Valid objects

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -11,6 +11,321 @@
         }
     ],
     "paths": {
+        "/api/actions/workspaces/{workspaceId}/execution/afm/execute": {
+            "post": {
+                "tags": ["afm-controller"],
+                "summary": "Executes analytical request and returns link to the result",
+                "description": "AFM is a combination of attributes, measures and filters that describe a query you want to execute.",
+                "operationId": "computeReport",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "skip-cache",
+                        "in": "header",
+                        "description": "Ignore all caches during execution of current request.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "header",
+                        "required": false,
+                        "example": "2020-06-03T10:15:30+01:00",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AfmExecution"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "AFM Execution response with links to the result and server-enhanced dimensions from the original request.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AfmExecutionResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/execution/afm/computeValidObjects": {
+            "post": {
+                "tags": ["validObjects-controller"],
+                "summary": "Valid objects",
+                "description": "Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.",
+                "operationId": "computeValidObjects",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AfmValidObjectsQuery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "List of attributes, facts and measures valid with respect to given AFM.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AfmValidObjectsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/execution/collectLabelElements": {
+            "get": {
+                "tags": ["elements-controller"],
+                "summary": "Listing of label values.",
+                "description": "Returns paged list of elements (values) of given label satisfying given filtering criteria.",
+                "operationId": "computeLabelElements",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "label",
+                        "in": "query",
+                        "description": "Requested label.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sortOrder",
+                        "in": "query",
+                        "description": "Sort order of returned items.\nItems are sorted by ```label``` title.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["ASC", "DESC"],
+                            "default": "ASC"
+                        }
+                    },
+                    {
+                        "name": "includeTotalWithoutFilters",
+                        "in": "query",
+                        "description": "Specify if ```totalCountWithoutFilters``` should be returned.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "complementFilter",
+                        "in": "query",
+                        "description": "Inverse filter:\n* ```false``` - return items matching ```patternFilter```\n* ```true``` - return items not matching ```patternFilter```",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "patternFilter",
+                        "in": "query",
+                        "description": "Return only items, whose ```label``` title case insensitively contains ```filter``` as substring.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Request page with this offset.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 0
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Return only this number of items.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 1000
+                        }
+                    },
+                    {
+                        "name": "skip-cache",
+                        "description": "Ignore all caches during execution of current request.",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of label values.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ElementsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/result/{resultId}": {
+            "get": {
+                "tags": ["result-controller"],
+                "summary": "Get a single execution result",
+                "description": "Gets a single execution result.",
+                "operationId": "retrieveResult",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "resultId",
+                        "in": "path",
+                        "description": "Result ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "a9b28f9dc55f37ea9f4a5fb0c76895923591e781"
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Request page with these offsets. Format is offset=1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "default": []
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Return only this number of items. Format is limit=1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "default": []
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Execution result was found and returned.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExecutionResult"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Limit and/or offset query parameters (paging) were invalid.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Execution result was not found.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "The result processing has failed unexpectedly.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/workspaces/{workspaceId}/afm": {
             "post": {
                 "tags": ["afm-controller"],

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -1,5 +1,3 @@
-// (C) 2021 GoodData Corporation
-
 /* eslint-disable */
 /**
  * OpenAPI definition
@@ -197,43 +195,6 @@ export enum DeclarativeColumnDataTypeEnum {
     BOOLEAN = "BOOLEAN",
 }
 
-/**
- * Data discriminators serving the discrimination of what data users can see in workspaces.
- * @export
- * @interface DeclarativeDataDiscriminator
- */
-export interface DeclarativeDataDiscriminator {
-    /**
-     * Data Discriminator ID. This ID is further used to refer to this instance of DD.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    id: string;
-    /**
-     * Data Discriminator title.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    title: string;
-    /**
-     * Data Discriminator description.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    description?: string;
-    /**
-     * Data Discriminator column name. Data are filtered using this physical column.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    columnName: string;
-    /**
-     * Data source name (ID). Data Discriminator must always be connected to single data source.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    dataSourceName: string;
-}
 /**
  * A data source.
  * @export
@@ -662,6 +623,105 @@ export interface DeclarativeWorkspace {
     parent?: WorkspaceIdentifier;
 }
 /**
+ * Workspace Data Filters serving the filtering of what data users can see in workspaces.
+ * @export
+ * @interface DeclarativeWorkspaceDataFilter
+ */
+export interface DeclarativeWorkspaceDataFilter {
+    /**
+     * Workspace Data Filters ID. This ID is further used to refer to this instance.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    id: string;
+    /**
+     * Workspace Data Filters title.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    title: string;
+    /**
+     * Workspace Data Filters description.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    description?: string;
+    /**
+     * Workspace Data Filters column name. Data are filtered using this physical column.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    columnName: string;
+    /**
+     * Data source name (ID). Workspace Data Filters must always be connected to single data source.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    dataSourceName: string;
+    /**
+     * Filter settings specifying values of filters valid for the workspace.
+     * @type {Array<DeclarativeWorkspaceDataFilterSetting>}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    workspaceDataFilterSettings: Array<DeclarativeWorkspaceDataFilterSetting>;
+    /**
+     *
+     * @type {WorkspaceIdentifier}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    workspace?: WorkspaceIdentifier;
+}
+/**
+ * Workspace Data Filters serving the filtering of what data users can see in workspaces.
+ * @export
+ * @interface DeclarativeWorkspaceDataFilterSetting
+ */
+export interface DeclarativeWorkspaceDataFilterSetting {
+    /**
+     * Workspace Data Filters ID. This ID is further used to refer to this instance.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    id: string;
+    /**
+     * Workspace Data Filters setting title.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    title: string;
+    /**
+     * Workspace Data Filters setting description.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    description?: string;
+    /**
+     * Only those rows are returned, where columnName from filter matches those values.
+     * @type {Array<string>}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    filterValues: Array<string>;
+    /**
+     *
+     * @type {WorkspaceIdentifier}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    workspace: WorkspaceIdentifier;
+}
+/**
+ *
+ * @export
+ * @interface DeclarativeWorkspaceDataFilters
+ */
+export interface DeclarativeWorkspaceDataFilters {
+    /**
+     *
+     * @type {Array<DeclarativeWorkspaceDataFilter>}
+     * @memberof DeclarativeWorkspaceDataFilters
+     */
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
+}
+/**
  *
  * @export
  * @interface DeclarativeWorkspaceModel
@@ -685,12 +745,6 @@ export interface DeclarativeWorkspaceModel {
      * @memberof DeclarativeWorkspaceModel
      */
     analytics: DeclarativeAnalyticsLayer;
-    /**
-     *
-     * @type {Array<DeclarativeDataDiscriminator>}
-     * @memberof DeclarativeWorkspaceModel
-     */
-    dataDiscriminators: Array<DeclarativeDataDiscriminator>;
 }
 /**
  *
@@ -704,6 +758,12 @@ export interface DeclarativeWorkspaces {
      * @memberof DeclarativeWorkspaces
      */
     workspaces: Array<DeclarativeWorkspace>;
+    /**
+     *
+     * @type {Array<DeclarativeWorkspaceDataFilter>}
+     * @memberof DeclarativeWorkspaces
+     */
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
 }
 /**
  * A grain identifier.
@@ -756,72 +816,116 @@ export interface GranularitiesFormatting {
 /**
  * JSON:API representation of acl entity.
  * @export
- * @interface JsonApiACL
+ * @interface JsonApiACLIn
  */
-export interface JsonApiACL {
+export interface JsonApiACLIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiACL
+     * @memberof JsonApiACLIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiACL
+     * @memberof JsonApiACLIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiACLAttributes}
-     * @memberof JsonApiACL
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLIn
      */
-    attributes?: JsonApiACLAttributes;
+    attributes?: JsonApiACLOutAttributes;
     /**
      *
-     * @type {JsonApiACLRelationships}
-     * @memberof JsonApiACL
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLIn
      */
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiACLAttributes
+ * @interface JsonApiACLInDocument
  */
-export interface JsonApiACLAttributes {
+export interface JsonApiACLInDocument {
+    /**
+     *
+     * @type {JsonApiACLIn}
+     * @memberof JsonApiACLInDocument
+     */
+    data: JsonApiACLIn;
+}
+/**
+ * JSON:API representation of acl entity.
+ * @export
+ * @interface JsonApiACLOut
+ */
+export interface JsonApiACLOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiACLOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiACLOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLOut
+     */
+    attributes?: JsonApiACLOutAttributes;
+    /**
+     *
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLOut
+     */
+    relationships?: JsonApiACLOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiACLOutAttributes
+ */
+export interface JsonApiACLOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
-    access?: JsonApiACLAttributesAccessEnum;
+    access?: JsonApiACLOutAttributesAccessEnum;
     /**
      *
      * @type {number}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
     priority?: number;
     /**
      *
      * @type {string}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
-    control?: JsonApiACLAttributesControlEnum;
+    control?: JsonApiACLOutAttributesControlEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiACLAttributesAccessEnum {
+export enum JsonApiACLOutAttributesAccessEnum {
     FULLACCESS = "FULL_ACCESS",
 }
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiACLAttributesControlEnum {
+export enum JsonApiACLOutAttributesControlEnum {
     ALLOW = "ALLOW",
     DENY = "DENY",
 }
@@ -829,495 +933,571 @@ export enum JsonApiACLAttributesControlEnum {
 /**
  *
  * @export
- * @interface JsonApiACLDocument
+ * @interface JsonApiACLOutDocument
  */
-export interface JsonApiACLDocument {
+export interface JsonApiACLOutDocument {
     /**
      *
-     * @type {JsonApiACL}
-     * @memberof JsonApiACLDocument
+     * @type {JsonApiACLOut}
+     * @memberof JsonApiACLOutDocument
      */
-    data: JsonApiACL;
+    data: JsonApiACLOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiACLDocument
+     * @memberof JsonApiACLOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiACLDocument
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiACLOutDocument
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiACLList
+ * @interface JsonApiACLOutList
  */
-export interface JsonApiACLList {
+export interface JsonApiACLOutList {
     /**
      *
-     * @type {Array<JsonApiACLWithLinks>}
-     * @memberof JsonApiACLList
+     * @type {Array<JsonApiACLOutWithLinks>}
+     * @memberof JsonApiACLOutList
      */
-    data: Array<JsonApiACLWithLinks>;
+    data: Array<JsonApiACLOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiACLList
+     * @memberof JsonApiACLOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiACLList
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiACLOutList
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiACLRelationships
+ * @interface JsonApiACLOutRelationships
  */
-export interface JsonApiACLRelationships {
+export interface JsonApiACLOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiACLRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiACLOutRelationships
      */
-    users?: JsonApiACLRelationshipsUsers;
+    users?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiACLRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiACLOutRelationships
      */
-    userGroups?: JsonApiACLRelationshipsUsers;
+    userGroups?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiACLRelationshipsUsers
+ * @interface JsonApiACLOutRelationshipsUsers
  */
-export interface JsonApiACLRelationshipsUsers {
+export interface JsonApiACLOutRelationshipsUsers {
     /**
      *
      * @type {Array<JsonApiLinkage>}
-     * @memberof JsonApiACLRelationshipsUsers
+     * @memberof JsonApiACLOutRelationshipsUsers
      */
     data?: Array<JsonApiLinkage>;
 }
 /**
  *
  * @export
- * @interface JsonApiACLWithLinks
+ * @interface JsonApiACLOutWithLinks
  */
-export interface JsonApiACLWithLinks {
+export interface JsonApiACLOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiACLAttributes}
-     * @memberof JsonApiACLWithLinks
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLOutWithLinks
      */
-    attributes?: JsonApiACLAttributes;
+    attributes?: JsonApiACLOutAttributes;
     /**
      *
-     * @type {JsonApiACLRelationships}
-     * @memberof JsonApiACLWithLinks
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLOutWithLinks
      */
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of analyticalDashboard entity.
  * @export
- * @interface JsonApiAnalyticalDashboard
+ * @interface JsonApiAnalyticalDashboardIn
  */
-export interface JsonApiAnalyticalDashboard {
+export interface JsonApiAnalyticalDashboardIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboard
+     * @memberof JsonApiAnalyticalDashboardIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboard
+     * @memberof JsonApiAnalyticalDashboardIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiAnalyticalDashboard
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiAnalyticalDashboardIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiAnalyticalDashboardRelationships}
-     * @memberof JsonApiAnalyticalDashboard
-     */
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardAttributes
+ * @interface JsonApiAnalyticalDashboardInDocument
  */
-export interface JsonApiAnalyticalDashboardAttributes {
+export interface JsonApiAnalyticalDashboardInDocument {
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardIn}
+     * @memberof JsonApiAnalyticalDashboardInDocument
+     */
+    data: JsonApiAnalyticalDashboardIn;
+}
+/**
+ * JSON:API representation of analyticalDashboard entity.
+ * @export
+ * @interface JsonApiAnalyticalDashboardOut
+ */
+export interface JsonApiAnalyticalDashboardOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiAnalyticalDashboardOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiAnalyticalDashboardOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiAnalyticalDashboardOut
+     */
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOutRelationships}
+     * @memberof JsonApiAnalyticalDashboardOut
+     */
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiAnalyticalDashboardOutAttributes
+ */
+export interface JsonApiAnalyticalDashboardOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardOutAttributes
      */
     tags?: Array<string>;
     /**
      * Free-form JSON content.
      * @type {object}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardOutAttributes
      */
     content?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardDocument
+ * @interface JsonApiAnalyticalDashboardOutDocument
  */
-export interface JsonApiAnalyticalDashboardDocument {
+export interface JsonApiAnalyticalDashboardOutDocument {
     /**
      *
-     * @type {JsonApiAnalyticalDashboard}
-     * @memberof JsonApiAnalyticalDashboardDocument
+     * @type {JsonApiAnalyticalDashboardOut}
+     * @memberof JsonApiAnalyticalDashboardOutDocument
      */
-    data: JsonApiAnalyticalDashboard;
+    data: JsonApiAnalyticalDashboardOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiAnalyticalDashboardDocument
+     * @memberof JsonApiAnalyticalDashboardOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardDocument
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutDocument
      */
     included?: Array<
-        | JsonApiVisualizationObjectWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiDatasetWithLinks
-        | JsonApiFilterContextWithLinks
+        | JsonApiVisualizationObjectOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiDatasetOutWithLinks
+        | JsonApiFilterContextOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiAnalyticalDashboardList
+ * @interface JsonApiAnalyticalDashboardOutList
  */
-export interface JsonApiAnalyticalDashboardList {
+export interface JsonApiAnalyticalDashboardOutList {
     /**
      *
-     * @type {Array<JsonApiAnalyticalDashboardWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardList
+     * @type {Array<JsonApiAnalyticalDashboardOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutList
      */
-    data: Array<JsonApiAnalyticalDashboardWithLinks>;
+    data: Array<JsonApiAnalyticalDashboardOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiAnalyticalDashboardList
+     * @memberof JsonApiAnalyticalDashboardOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardList
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutList
      */
     included?: Array<
-        | JsonApiVisualizationObjectWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiDatasetWithLinks
-        | JsonApiFilterContextWithLinks
+        | JsonApiVisualizationObjectOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiDatasetOutWithLinks
+        | JsonApiFilterContextOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardRelationships
+ * @interface JsonApiAnalyticalDashboardOutRelationships
  */
-export interface JsonApiAnalyticalDashboardRelationships {
+export interface JsonApiAnalyticalDashboardOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
      */
-    visualizationObjects?: JsonApiACLRelationshipsUsers;
+    visualizationObjects?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
      */
-    metrics?: JsonApiACLRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
      */
-    filterContexts?: JsonApiACLRelationshipsUsers;
+    filterContexts?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardWithLinks
+ * @interface JsonApiAnalyticalDashboardOutWithLinks
  */
-export interface JsonApiAnalyticalDashboardWithLinks {
+export interface JsonApiAnalyticalDashboardOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardRelationships}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @type {JsonApiAnalyticalDashboardOutRelationships}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of apiToken entity.
  * @export
- * @interface JsonApiApiToken
+ * @interface JsonApiApiTokenIn
  */
-export interface JsonApiApiToken {
+export interface JsonApiApiTokenIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiApiToken
+     * @memberof JsonApiApiTokenIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiApiToken
+     * @memberof JsonApiApiTokenIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiApiTokenAttributes}
-     * @memberof JsonApiApiToken
+     * @type {object}
+     * @memberof JsonApiApiTokenIn
      */
-    attributes?: JsonApiApiTokenAttributes;
+    attributes?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenAttributes
+ * @interface JsonApiApiTokenInDocument
  */
-export interface JsonApiApiTokenAttributes {
+export interface JsonApiApiTokenInDocument {
+    /**
+     *
+     * @type {JsonApiApiTokenIn}
+     * @memberof JsonApiApiTokenInDocument
+     */
+    data: JsonApiApiTokenIn;
+}
+/**
+ * JSON:API representation of apiToken entity.
+ * @export
+ * @interface JsonApiApiTokenOut
+ */
+export interface JsonApiApiTokenOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiApiTokenOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiApiTokenOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiApiTokenOutAttributes}
+     * @memberof JsonApiApiTokenOut
+     */
+    attributes?: JsonApiApiTokenOutAttributes;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiApiTokenOutAttributes
+ */
+export interface JsonApiApiTokenOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiApiTokenAttributes
+     * @memberof JsonApiApiTokenOutAttributes
      */
     bearerToken?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenDocument
+ * @interface JsonApiApiTokenOutDocument
  */
-export interface JsonApiApiTokenDocument {
+export interface JsonApiApiTokenOutDocument {
     /**
      *
-     * @type {JsonApiApiToken}
-     * @memberof JsonApiApiTokenDocument
+     * @type {JsonApiApiTokenOut}
+     * @memberof JsonApiApiTokenOutDocument
      */
-    data: JsonApiApiToken;
+    data: JsonApiApiTokenOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiApiTokenDocument
+     * @memberof JsonApiApiTokenOutDocument
      */
     links?: ObjectLinks;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiApiTokenList
+ * @interface JsonApiApiTokenOutList
  */
-export interface JsonApiApiTokenList {
+export interface JsonApiApiTokenOutList {
     /**
      *
-     * @type {Array<JsonApiApiTokenWithLinks>}
-     * @memberof JsonApiApiTokenList
+     * @type {Array<JsonApiApiTokenOutWithLinks>}
+     * @memberof JsonApiApiTokenOutList
      */
-    data: Array<JsonApiApiTokenWithLinks>;
+    data: Array<JsonApiApiTokenOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiApiTokenList
+     * @memberof JsonApiApiTokenOutList
      */
     links?: ListLinks;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenWithLinks
+ * @interface JsonApiApiTokenOutWithLinks
  */
-export interface JsonApiApiTokenWithLinks {
+export interface JsonApiApiTokenOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiApiTokenAttributes}
-     * @memberof JsonApiApiTokenWithLinks
+     * @type {JsonApiApiTokenOutAttributes}
+     * @memberof JsonApiApiTokenOutWithLinks
      */
-    attributes?: JsonApiApiTokenAttributes;
+    attributes?: JsonApiApiTokenOutAttributes;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of attribute entity.
  * @export
- * @interface JsonApiAttribute
+ * @interface JsonApiAttributeOut
  */
-export interface JsonApiAttribute {
+export interface JsonApiAttributeOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAttribute
+     * @memberof JsonApiAttributeOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAttribute
+     * @memberof JsonApiAttributeOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiAttributeAttributes}
-     * @memberof JsonApiAttribute
+     * @type {JsonApiAttributeOutAttributes}
+     * @memberof JsonApiAttributeOut
      */
-    attributes?: JsonApiAttributeAttributes;
+    attributes?: JsonApiAttributeOutAttributes;
     /**
      *
-     * @type {JsonApiAttributeRelationships}
-     * @memberof JsonApiAttribute
+     * @type {JsonApiAttributeOutRelationships}
+     * @memberof JsonApiAttributeOut
      */
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeAttributes
+ * @interface JsonApiAttributeOutAttributes
  */
-export interface JsonApiAttributeAttributes {
+export interface JsonApiAttributeOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
-    granularity?: JsonApiAttributeAttributesGranularityEnum;
+    granularity?: JsonApiAttributeOutAttributesGranularityEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiAttributeAttributesGranularityEnum {
+export enum JsonApiAttributeOutAttributesGranularityEnum {
     MINUTE = "MINUTE",
     HOUR = "HOUR",
     DAY = "DAY",
@@ -1338,311 +1518,186 @@ export enum JsonApiAttributeAttributesGranularityEnum {
 /**
  *
  * @export
- * @interface JsonApiAttributeDocument
+ * @interface JsonApiAttributeOutDocument
  */
-export interface JsonApiAttributeDocument {
+export interface JsonApiAttributeOutDocument {
     /**
      *
-     * @type {JsonApiAttribute}
-     * @memberof JsonApiAttributeDocument
+     * @type {JsonApiAttributeOut}
+     * @memberof JsonApiAttributeOutDocument
      */
-    data: JsonApiAttribute;
+    data: JsonApiAttributeOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiAttributeDocument
+     * @memberof JsonApiAttributeOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiAttributeDocument
+     * @type {Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiAttributeOutDocument
      */
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiAttributeList
+ * @interface JsonApiAttributeOutList
  */
-export interface JsonApiAttributeList {
+export interface JsonApiAttributeOutList {
     /**
      *
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiAttributeList
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiAttributeOutList
      */
-    data: Array<JsonApiAttributeWithLinks>;
+    data: Array<JsonApiAttributeOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiAttributeList
+     * @memberof JsonApiAttributeOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiAttributeList
+     * @type {Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiAttributeOutList
      */
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeRelationships
+ * @interface JsonApiAttributeOutRelationships
  */
-export interface JsonApiAttributeRelationships {
+export interface JsonApiAttributeOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiAttributeRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiAttributeOutRelationships
      */
-    dataset?: JsonApiOrganizationRelationshipsUser;
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAttributeRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAttributeOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeWithLinks
+ * @interface JsonApiAttributeOutWithLinks
  */
-export interface JsonApiAttributeWithLinks {
+export interface JsonApiAttributeOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAttributeWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAttributeWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAttributeAttributes}
-     * @memberof JsonApiAttributeWithLinks
+     * @type {JsonApiAttributeOutAttributes}
+     * @memberof JsonApiAttributeOutWithLinks
      */
-    attributes?: JsonApiAttributeAttributes;
+    attributes?: JsonApiAttributeOutAttributes;
     /**
      *
-     * @type {JsonApiAttributeRelationships}
-     * @memberof JsonApiAttributeWithLinks
+     * @type {JsonApiAttributeOutRelationships}
+     * @memberof JsonApiAttributeOutWithLinks
      */
-    relationships?: JsonApiAttributeRelationships;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiAttributeWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * JSON:API representation of dataDiscriminator entity.
- * @export
- * @interface JsonApiDataDiscriminator
- */
-export interface JsonApiDataDiscriminator {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataDiscriminator
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataDiscriminator
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDataDiscriminatorAttributes}
-     * @memberof JsonApiDataDiscriminator
-     */
-    attributes?: JsonApiDataDiscriminatorAttributes;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorAttributes
- */
-export interface JsonApiDataDiscriminatorAttributes {
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    title?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    description?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    columnName?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    dataSourceName?: string;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorDocument
- */
-export interface JsonApiDataDiscriminatorDocument {
-    /**
-     *
-     * @type {JsonApiDataDiscriminator}
-     * @memberof JsonApiDataDiscriminatorDocument
-     */
-    data: JsonApiDataDiscriminator;
+    relationships?: JsonApiAttributeOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDataDiscriminatorDocument
-     */
-    links?: ObjectLinks;
-}
-/**
- * A JSON:API document with a list of resources
- * @export
- * @interface JsonApiDataDiscriminatorList
- */
-export interface JsonApiDataDiscriminatorList {
-    /**
-     *
-     * @type {Array<JsonApiDataDiscriminatorWithLinks>}
-     * @memberof JsonApiDataDiscriminatorList
-     */
-    data: Array<JsonApiDataDiscriminatorWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiDataDiscriminatorList
-     */
-    links?: ListLinks;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorWithLinks
- */
-export interface JsonApiDataDiscriminatorWithLinks {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDataDiscriminatorAttributes}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    attributes?: JsonApiDataDiscriminatorAttributes;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataDiscriminatorWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of dataSource entity.
  * @export
- * @interface JsonApiDataSource
+ * @interface JsonApiDataSourceIn
  */
-export interface JsonApiDataSource {
+export interface JsonApiDataSourceIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDataSource
+     * @memberof JsonApiDataSourceIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDataSource
+     * @memberof JsonApiDataSourceIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiDataSourceAttributes}
-     * @memberof JsonApiDataSource
+     * @type {JsonApiDataSourceInAttributes}
+     * @memberof JsonApiDataSourceIn
      */
-    attributes?: JsonApiDataSourceAttributes;
+    attributes?: JsonApiDataSourceInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiDataSourceAttributes
+ * @interface JsonApiDataSourceInAttributes
  */
-export interface JsonApiDataSourceAttributes {
+export interface JsonApiDataSourceInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
-    type?: JsonApiDataSourceAttributesTypeEnum;
+    type?: JsonApiDataSourceInAttributesTypeEnum;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     url?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     schema?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     username?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     password?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     uploadId?: string;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     enableCaching?: boolean;
 }
@@ -1651,7 +1706,7 @@ export interface JsonApiDataSourceAttributes {
  * @export
  * @enum {string}
  */
-export enum JsonApiDataSourceAttributesTypeEnum {
+export enum JsonApiDataSourceInAttributesTypeEnum {
     POSTGRESQL = "POSTGRESQL",
     REDSHIFT = "REDSHIFT",
     VERTICA = "VERTICA",
@@ -1665,152 +1720,255 @@ export enum JsonApiDataSourceAttributesTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDataSourceDocument
+ * @interface JsonApiDataSourceInDocument
  */
-export interface JsonApiDataSourceDocument {
+export interface JsonApiDataSourceInDocument {
     /**
      *
-     * @type {JsonApiDataSource}
-     * @memberof JsonApiDataSourceDocument
+     * @type {JsonApiDataSourceIn}
+     * @memberof JsonApiDataSourceInDocument
      */
-    data: JsonApiDataSource;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataSourceDocument
-     */
-    links?: ObjectLinks;
+    data: JsonApiDataSourceIn;
 }
 /**
- * A JSON:API document with a list of resources
+ * JSON:API representation of dataSource entity.
  * @export
- * @interface JsonApiDataSourceList
+ * @interface JsonApiDataSourceOut
  */
-export interface JsonApiDataSourceList {
-    /**
-     *
-     * @type {Array<JsonApiDataSourceWithLinks>}
-     * @memberof JsonApiDataSourceList
-     */
-    data: Array<JsonApiDataSourceWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiDataSourceList
-     */
-    links?: ListLinks;
-}
-/**
- *
- * @export
- * @interface JsonApiDataSourceWithLinks
- */
-export interface JsonApiDataSourceWithLinks {
+export interface JsonApiDataSourceOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDataSourceWithLinks
+     * @memberof JsonApiDataSourceOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDataSourceWithLinks
+     * @memberof JsonApiDataSourceOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiDataSourceAttributes}
-     * @memberof JsonApiDataSourceWithLinks
+     * @type {JsonApiDataSourceOutAttributes}
+     * @memberof JsonApiDataSourceOut
      */
-    attributes?: JsonApiDataSourceAttributes;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataSourceWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * JSON:API representation of dataset entity.
- * @export
- * @interface JsonApiDataset
- */
-export interface JsonApiDataset {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataset
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataset
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDatasetAttributes}
-     * @memberof JsonApiDataset
-     */
-    attributes?: JsonApiDatasetAttributes;
-    /**
-     *
-     * @type {JsonApiDatasetRelationships}
-     * @memberof JsonApiDataset
-     */
-    relationships?: JsonApiDatasetRelationships;
+    attributes?: JsonApiDataSourceOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributes
+ * @interface JsonApiDataSourceOutAttributes
  */
-export interface JsonApiDatasetAttributes {
+export interface JsonApiDataSourceOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    title?: string;
+    name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    description?: string;
-    /**
-     *
-     * @type {Array<string>}
-     * @memberof JsonApiDatasetAttributes
-     */
-    tags?: Array<string>;
+    type?: JsonApiDataSourceOutAttributesTypeEnum;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    type?: JsonApiDatasetAttributesTypeEnum;
+    url?: string;
     /**
      *
-     * @type {Array<JsonApiDatasetAttributesGrain>}
-     * @memberof JsonApiDatasetAttributes
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    grain?: Array<JsonApiDatasetAttributesGrain>;
+    schema?: string;
     /**
      *
-     * @type {Array<JsonApiDatasetAttributesReferenceProperties>}
-     * @memberof JsonApiDatasetAttributes
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    referenceProperties?: Array<JsonApiDatasetAttributesReferenceProperties>;
+    username?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
+     */
+    uploadId?: string;
+    /**
+     *
+     * @type {boolean}
+     * @memberof JsonApiDataSourceOutAttributes
+     */
+    enableCaching?: boolean;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiDatasetAttributesTypeEnum {
+export enum JsonApiDataSourceOutAttributesTypeEnum {
+    POSTGRESQL = "POSTGRESQL",
+    REDSHIFT = "REDSHIFT",
+    VERTICA = "VERTICA",
+    SNOWFLAKE = "SNOWFLAKE",
+    ADS = "ADS",
+    BIGQUERY = "BIGQUERY",
+    MSSQL = "MSSQL",
+    PRESTO = "PRESTO",
+}
+
+/**
+ *
+ * @export
+ * @interface JsonApiDataSourceOutDocument
+ */
+export interface JsonApiDataSourceOutDocument {
+    /**
+     *
+     * @type {JsonApiDataSourceOut}
+     * @memberof JsonApiDataSourceOutDocument
+     */
+    data: JsonApiDataSourceOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiDataSourceOutDocument
+     */
+    links?: ObjectLinks;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiDataSourceOutList
+ */
+export interface JsonApiDataSourceOutList {
+    /**
+     *
+     * @type {Array<JsonApiDataSourceOutWithLinks>}
+     * @memberof JsonApiDataSourceOutList
+     */
+    data: Array<JsonApiDataSourceOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiDataSourceOutList
+     */
+    links?: ListLinks;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiDataSourceOutWithLinks
+ */
+export interface JsonApiDataSourceOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiDataSourceOutAttributes}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    attributes?: JsonApiDataSourceOutAttributes;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of dataset entity.
+ * @export
+ * @interface JsonApiDatasetOut
+ */
+export interface JsonApiDatasetOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiDatasetOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiDatasetOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiDatasetOutAttributes}
+     * @memberof JsonApiDatasetOut
+     */
+    attributes?: JsonApiDatasetOutAttributes;
+    /**
+     *
+     * @type {JsonApiDatasetOutRelationships}
+     * @memberof JsonApiDatasetOut
+     */
+    relationships?: JsonApiDatasetOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiDatasetOutAttributes
+ */
+export interface JsonApiDatasetOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    tags?: Array<string>;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    type?: JsonApiDatasetOutAttributesTypeEnum;
+    /**
+     *
+     * @type {Array<JsonApiDatasetOutAttributesGrain>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    grain?: Array<JsonApiDatasetOutAttributesGrain>;
+    /**
+     *
+     * @type {Array<JsonApiDatasetOutAttributesReferenceProperties>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    referenceProperties?: Array<JsonApiDatasetOutAttributesReferenceProperties>;
+}
+
+/**
+ * @export
+ * @enum {string}
+ */
+export enum JsonApiDatasetOutAttributesTypeEnum {
     NORMAL = "NORMAL",
     DATE = "DATE",
 }
@@ -1818,28 +1976,28 @@ export enum JsonApiDatasetAttributesTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributesGrain
+ * @interface JsonApiDatasetOutAttributesGrain
  */
-export interface JsonApiDatasetAttributesGrain {
+export interface JsonApiDatasetOutAttributesGrain {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributesGrain
+     * @memberof JsonApiDatasetOutAttributesGrain
      */
     id: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributesGrain
+     * @memberof JsonApiDatasetOutAttributesGrain
      */
-    type: JsonApiDatasetAttributesGrainTypeEnum;
+    type: JsonApiDatasetOutAttributesGrainTypeEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiDatasetAttributesGrainTypeEnum {
+export enum JsonApiDatasetOutAttributesGrainTypeEnum {
     Attribute = "attribute",
     Dataset = "dataset",
 }
@@ -1847,626 +2005,664 @@ export enum JsonApiDatasetAttributesGrainTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributesReferenceProperties
+ * @interface JsonApiDatasetOutAttributesReferenceProperties
  */
-export interface JsonApiDatasetAttributesReferenceProperties {
+export interface JsonApiDatasetOutAttributesReferenceProperties {
     /**
      *
      * @type {DatasetReferenceIdentifier}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     identifier: DatasetReferenceIdentifier;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     multivalue: boolean;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     sourceColumns: Array<string>;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetDocument
+ * @interface JsonApiDatasetOutDocument
  */
-export interface JsonApiDatasetDocument {
+export interface JsonApiDatasetOutDocument {
     /**
      *
-     * @type {JsonApiDataset}
-     * @memberof JsonApiDatasetDocument
+     * @type {JsonApiDatasetOut}
+     * @memberof JsonApiDatasetOutDocument
      */
-    data: JsonApiDataset;
+    data: JsonApiDatasetOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDatasetDocument
+     * @memberof JsonApiDatasetOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetDocument
+     * @type {Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutDocument
      */
     included?: Array<
-        | JsonApiSourceTableWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiFactWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiSourceTableOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiDatasetList
+ * @interface JsonApiDatasetOutList
  */
-export interface JsonApiDatasetList {
+export interface JsonApiDatasetOutList {
     /**
      *
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetList
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutList
      */
-    data: Array<JsonApiDatasetWithLinks>;
+    data: Array<JsonApiDatasetOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiDatasetList
+     * @memberof JsonApiDatasetOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetList
+     * @type {Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutList
      */
     included?: Array<
-        | JsonApiSourceTableWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiFactWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiSourceTableOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetRelationships
+ * @interface JsonApiDatasetOutRelationships
  */
-export interface JsonApiDatasetRelationships {
+export interface JsonApiDatasetOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    table?: JsonApiOrganizationRelationshipsUser;
+    table?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    facts?: JsonApiACLRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetWithLinks
+ * @interface JsonApiDatasetOutWithLinks
  */
-export interface JsonApiDatasetWithLinks {
+export interface JsonApiDatasetOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiDatasetAttributes}
-     * @memberof JsonApiDatasetWithLinks
+     * @type {JsonApiDatasetOutAttributes}
+     * @memberof JsonApiDatasetOutWithLinks
      */
-    attributes?: JsonApiDatasetAttributes;
+    attributes?: JsonApiDatasetOutAttributes;
     /**
      *
-     * @type {JsonApiDatasetRelationships}
-     * @memberof JsonApiDatasetWithLinks
+     * @type {JsonApiDatasetOutRelationships}
+     * @memberof JsonApiDatasetOutWithLinks
      */
-    relationships?: JsonApiDatasetRelationships;
+    relationships?: JsonApiDatasetOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of fact entity.
  * @export
- * @interface JsonApiFact
+ * @interface JsonApiFactOut
  */
-export interface JsonApiFact {
+export interface JsonApiFactOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFact
+     * @memberof JsonApiFactOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFact
+     * @memberof JsonApiFactOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiFactAttributes}
-     * @memberof JsonApiFact
+     * @type {JsonApiFactOutAttributes}
+     * @memberof JsonApiFactOut
      */
-    attributes?: JsonApiFactAttributes;
+    attributes?: JsonApiFactOutAttributes;
     /**
      *
-     * @type {JsonApiFactRelationships}
-     * @memberof JsonApiFact
+     * @type {JsonApiFactOutRelationships}
+     * @memberof JsonApiFactOut
      */
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiFactAttributes
+ * @interface JsonApiFactOutAttributes
  */
-export interface JsonApiFactAttributes {
+export interface JsonApiFactOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     sourceColumn?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiFactDocument
+ * @interface JsonApiFactOutDocument
  */
-export interface JsonApiFactDocument {
+export interface JsonApiFactOutDocument {
     /**
      *
-     * @type {JsonApiFact}
-     * @memberof JsonApiFactDocument
+     * @type {JsonApiFactOut}
+     * @memberof JsonApiFactOutDocument
      */
-    data: JsonApiFact;
+    data: JsonApiFactOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFactDocument
+     * @memberof JsonApiFactOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiFactDocument
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiFactOutDocument
      */
-    included?: Array<JsonApiDatasetWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiFactList
+ * @interface JsonApiFactOutList
  */
-export interface JsonApiFactList {
+export interface JsonApiFactOutList {
     /**
      *
-     * @type {Array<JsonApiFactWithLinks>}
-     * @memberof JsonApiFactList
+     * @type {Array<JsonApiFactOutWithLinks>}
+     * @memberof JsonApiFactOutList
      */
-    data: Array<JsonApiFactWithLinks>;
+    data: Array<JsonApiFactOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiFactList
+     * @memberof JsonApiFactOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiFactList
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiFactOutList
      */
-    included?: Array<JsonApiDatasetWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiFactRelationships
+ * @interface JsonApiFactOutRelationships
  */
-export interface JsonApiFactRelationships {
+export interface JsonApiFactOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiFactRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiFactOutRelationships
      */
-    dataset?: JsonApiOrganizationRelationshipsUser;
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiFactWithLinks
+ * @interface JsonApiFactOutWithLinks
  */
-export interface JsonApiFactWithLinks {
+export interface JsonApiFactOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiFactAttributes}
-     * @memberof JsonApiFactWithLinks
+     * @type {JsonApiFactOutAttributes}
+     * @memberof JsonApiFactOutWithLinks
      */
-    attributes?: JsonApiFactAttributes;
+    attributes?: JsonApiFactOutAttributes;
     /**
      *
-     * @type {JsonApiFactRelationships}
-     * @memberof JsonApiFactWithLinks
+     * @type {JsonApiFactOutRelationships}
+     * @memberof JsonApiFactOutWithLinks
      */
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of filterContext entity.
  * @export
- * @interface JsonApiFilterContext
+ * @interface JsonApiFilterContextIn
  */
-export interface JsonApiFilterContext {
+export interface JsonApiFilterContextIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFilterContext
+     * @memberof JsonApiFilterContextIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFilterContext
+     * @memberof JsonApiFilterContextIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiFilterContext
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiFilterContextIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiFilterContextRelationships}
-     * @memberof JsonApiFilterContext
-     */
-    relationships?: JsonApiFilterContextRelationships;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextDocument
+ * @interface JsonApiFilterContextInDocument
  */
-export interface JsonApiFilterContextDocument {
+export interface JsonApiFilterContextInDocument {
     /**
      *
-     * @type {JsonApiFilterContext}
-     * @memberof JsonApiFilterContextDocument
+     * @type {JsonApiFilterContextIn}
+     * @memberof JsonApiFilterContextInDocument
      */
-    data: JsonApiFilterContext;
+    data: JsonApiFilterContextIn;
+}
+/**
+ * JSON:API representation of filterContext entity.
+ * @export
+ * @interface JsonApiFilterContextOut
+ */
+export interface JsonApiFilterContextOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiFilterContextOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiFilterContextOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiFilterContextOut
+     */
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    /**
+     *
+     * @type {JsonApiFilterContextOutRelationships}
+     * @memberof JsonApiFilterContextOut
+     */
+    relationships?: JsonApiFilterContextOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiFilterContextOutDocument
+ */
+export interface JsonApiFilterContextOutDocument {
+    /**
+     *
+     * @type {JsonApiFilterContextOut}
+     * @memberof JsonApiFilterContextOutDocument
+     */
+    data: JsonApiFilterContextOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFilterContextDocument
+     * @memberof JsonApiFilterContextOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiFilterContextDocument
+     * @type {Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiFilterContextOutDocument
      */
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiFilterContextList
+ * @interface JsonApiFilterContextOutList
  */
-export interface JsonApiFilterContextList {
+export interface JsonApiFilterContextOutList {
     /**
      *
-     * @type {Array<JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiFilterContextList
+     * @type {Array<JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiFilterContextOutList
      */
-    data: Array<JsonApiFilterContextWithLinks>;
+    data: Array<JsonApiFilterContextOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiFilterContextList
+     * @memberof JsonApiFilterContextOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiFilterContextList
+     * @type {Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiFilterContextOutList
      */
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextRelationships
+ * @interface JsonApiFilterContextOutRelationships
  */
-export interface JsonApiFilterContextRelationships {
+export interface JsonApiFilterContextOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextWithLinks
+ * @interface JsonApiFilterContextOutWithLinks
  */
-export interface JsonApiFilterContextWithLinks {
+export interface JsonApiFilterContextOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiFilterContextWithLinks
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiFilterContextOutWithLinks
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     /**
      *
-     * @type {JsonApiFilterContextRelationships}
-     * @memberof JsonApiFilterContextWithLinks
+     * @type {JsonApiFilterContextOutRelationships}
+     * @memberof JsonApiFilterContextOutWithLinks
      */
-    relationships?: JsonApiFilterContextRelationships;
+    relationships?: JsonApiFilterContextOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of label entity.
  * @export
- * @interface JsonApiLabel
+ * @interface JsonApiLabelOut
  */
-export interface JsonApiLabel {
+export interface JsonApiLabelOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiLabel
+     * @memberof JsonApiLabelOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiLabel
+     * @memberof JsonApiLabelOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiLabelAttributes}
-     * @memberof JsonApiLabel
+     * @type {JsonApiLabelOutAttributes}
+     * @memberof JsonApiLabelOut
      */
-    attributes?: JsonApiLabelAttributes;
+    attributes?: JsonApiLabelOutAttributes;
     /**
      *
-     * @type {JsonApiLabelRelationships}
-     * @memberof JsonApiLabel
+     * @type {JsonApiLabelOutRelationships}
+     * @memberof JsonApiLabelOut
      */
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelAttributes
+ * @interface JsonApiLabelOutAttributes
  */
-export interface JsonApiLabelAttributes {
+export interface JsonApiLabelOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     primary?: boolean;
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     sourceColumn?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelDocument
+ * @interface JsonApiLabelOutDocument
  */
-export interface JsonApiLabelDocument {
+export interface JsonApiLabelOutDocument {
     /**
      *
-     * @type {JsonApiLabel}
-     * @memberof JsonApiLabelDocument
+     * @type {JsonApiLabelOut}
+     * @memberof JsonApiLabelOutDocument
      */
-    data: JsonApiLabel;
+    data: JsonApiLabelOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiLabelDocument
+     * @memberof JsonApiLabelOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiLabelDocument
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiLabelOutDocument
      */
-    included?: Array<JsonApiAttributeWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiLabelList
+ * @interface JsonApiLabelOutList
  */
-export interface JsonApiLabelList {
+export interface JsonApiLabelOutList {
     /**
      *
-     * @type {Array<JsonApiLabelWithLinks>}
-     * @memberof JsonApiLabelList
+     * @type {Array<JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiLabelOutList
      */
-    data: Array<JsonApiLabelWithLinks>;
+    data: Array<JsonApiLabelOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiLabelList
+     * @memberof JsonApiLabelOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiLabelList
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiLabelOutList
      */
-    included?: Array<JsonApiAttributeWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelRelationships
+ * @interface JsonApiLabelOutRelationships
  */
-export interface JsonApiLabelRelationships {
+export interface JsonApiLabelOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiLabelRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiLabelOutRelationships
      */
-    attribute?: JsonApiOrganizationRelationshipsUser;
+    attribute?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelWithLinks
+ * @interface JsonApiLabelOutWithLinks
  */
-export interface JsonApiLabelWithLinks {
+export interface JsonApiLabelOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiLabelAttributes}
-     * @memberof JsonApiLabelWithLinks
+     * @type {JsonApiLabelOutAttributes}
+     * @memberof JsonApiLabelOutWithLinks
      */
-    attributes?: JsonApiLabelAttributes;
+    attributes?: JsonApiLabelOutAttributes;
     /**
      *
-     * @type {JsonApiLabelRelationships}
-     * @memberof JsonApiLabelWithLinks
+     * @type {JsonApiLabelOutRelationships}
+     * @memberof JsonApiLabelOutWithLinks
      */
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -2492,484 +2688,635 @@ export interface JsonApiLinkage {
 /**
  * JSON:API representation of metric entity.
  * @export
- * @interface JsonApiMetric
+ * @interface JsonApiMetricIn
  */
-export interface JsonApiMetric {
+export interface JsonApiMetricIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiMetric
+     * @memberof JsonApiMetricIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiMetric
+     * @memberof JsonApiMetricIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiMetricAttributes}
-     * @memberof JsonApiMetric
+     * @type {JsonApiMetricOutAttributes}
+     * @memberof JsonApiMetricIn
      */
-    attributes?: JsonApiMetricAttributes;
-    /**
-     *
-     * @type {JsonApiMetricRelationships}
-     * @memberof JsonApiMetric
-     */
-    relationships?: JsonApiMetricRelationships;
+    attributes?: JsonApiMetricOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricAttributes
+ * @interface JsonApiMetricInDocument
  */
-export interface JsonApiMetricAttributes {
+export interface JsonApiMetricInDocument {
+    /**
+     *
+     * @type {JsonApiMetricIn}
+     * @memberof JsonApiMetricInDocument
+     */
+    data: JsonApiMetricIn;
+}
+/**
+ * JSON:API representation of metric entity.
+ * @export
+ * @interface JsonApiMetricOut
+ */
+export interface JsonApiMetricOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiMetricOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiMetricOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiMetricOutAttributes}
+     * @memberof JsonApiMetricOut
+     */
+    attributes?: JsonApiMetricOutAttributes;
+    /**
+     *
+     * @type {JsonApiMetricOutRelationships}
+     * @memberof JsonApiMetricOut
+     */
+    relationships?: JsonApiMetricOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiMetricOutAttributes
+ */
+export interface JsonApiMetricOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricOutAttributes
      */
     tags?: Array<string>;
     /**
      *
-     * @type {JsonApiMetricAttributesContent}
-     * @memberof JsonApiMetricAttributes
+     * @type {JsonApiMetricOutAttributesContent}
+     * @memberof JsonApiMetricOutAttributes
      */
-    content?: JsonApiMetricAttributesContent;
+    content?: JsonApiMetricOutAttributesContent;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricAttributesContent
+ * @interface JsonApiMetricOutAttributesContent
  */
-export interface JsonApiMetricAttributesContent {
+export interface JsonApiMetricOutAttributesContent {
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributesContent
+     * @memberof JsonApiMetricOutAttributesContent
      */
     format?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributesContent
+     * @memberof JsonApiMetricOutAttributesContent
      */
     maql?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricDocument
+ * @interface JsonApiMetricOutDocument
  */
-export interface JsonApiMetricDocument {
+export interface JsonApiMetricOutDocument {
     /**
      *
-     * @type {JsonApiMetric}
-     * @memberof JsonApiMetricDocument
+     * @type {JsonApiMetricOut}
+     * @memberof JsonApiMetricOutDocument
      */
-    data: JsonApiMetric;
+    data: JsonApiMetricOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiMetricDocument
+     * @memberof JsonApiMetricOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricDocument
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutDocument
      */
     included?: Array<
-        JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiMetricList
+ * @interface JsonApiMetricOutList
  */
-export interface JsonApiMetricList {
+export interface JsonApiMetricOutList {
     /**
      *
-     * @type {Array<JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricList
+     * @type {Array<JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutList
      */
-    data: Array<JsonApiMetricWithLinks>;
+    data: Array<JsonApiMetricOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiMetricList
+     * @memberof JsonApiMetricOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricList
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutList
      */
     included?: Array<
-        JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricRelationships
+ * @interface JsonApiMetricOutRelationships
  */
-export interface JsonApiMetricRelationships {
+export interface JsonApiMetricOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
      */
-    facts?: JsonApiACLRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
      */
-    metrics?: JsonApiACLRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricWithLinks
+ * @interface JsonApiMetricOutWithLinks
  */
-export interface JsonApiMetricWithLinks {
+export interface JsonApiMetricOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiMetricAttributes}
-     * @memberof JsonApiMetricWithLinks
+     * @type {JsonApiMetricOutAttributes}
+     * @memberof JsonApiMetricOutWithLinks
      */
-    attributes?: JsonApiMetricAttributes;
+    attributes?: JsonApiMetricOutAttributes;
     /**
      *
-     * @type {JsonApiMetricRelationships}
-     * @memberof JsonApiMetricWithLinks
+     * @type {JsonApiMetricOutRelationships}
+     * @memberof JsonApiMetricOutWithLinks
      */
-    relationships?: JsonApiMetricRelationships;
+    relationships?: JsonApiMetricOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of modelModule entity.
  * @export
- * @interface JsonApiModelModule
+ * @interface JsonApiModelModuleIn
  */
-export interface JsonApiModelModule {
+export interface JsonApiModelModuleIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     attributes?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiModelModuleDocument
+ * @interface JsonApiModelModuleInDocument
  */
-export interface JsonApiModelModuleDocument {
+export interface JsonApiModelModuleInDocument {
     /**
      *
-     * @type {JsonApiModelModule}
-     * @memberof JsonApiModelModuleDocument
+     * @type {JsonApiModelModuleIn}
+     * @memberof JsonApiModelModuleInDocument
      */
-    data: JsonApiModelModule;
+    data: JsonApiModelModuleIn;
+}
+/**
+ * JSON:API representation of modelModule entity.
+ * @export
+ * @interface JsonApiModelModuleOut
+ */
+export interface JsonApiModelModuleOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiModelModuleOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiModelModuleOut
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiModelModuleOut
+     */
+    attributes?: object;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiModelModuleOutDocument
+ */
+export interface JsonApiModelModuleOutDocument {
+    /**
+     *
+     * @type {JsonApiModelModuleOut}
+     * @memberof JsonApiModelModuleOutDocument
+     */
+    data: JsonApiModelModuleOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiModelModuleDocument
+     * @memberof JsonApiModelModuleOutDocument
      */
     links?: ObjectLinks;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiModelModuleList
+ * @interface JsonApiModelModuleOutList
  */
-export interface JsonApiModelModuleList {
+export interface JsonApiModelModuleOutList {
     /**
      *
-     * @type {Array<JsonApiModelModuleWithLinks>}
-     * @memberof JsonApiModelModuleList
+     * @type {Array<JsonApiModelModuleOutWithLinks>}
+     * @memberof JsonApiModelModuleOutList
      */
-    data: Array<JsonApiModelModuleWithLinks>;
+    data: Array<JsonApiModelModuleOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiModelModuleList
+     * @memberof JsonApiModelModuleOutList
      */
     links?: ListLinks;
 }
 /**
  *
  * @export
- * @interface JsonApiModelModuleWithLinks
+ * @interface JsonApiModelModuleOutWithLinks
  */
-export interface JsonApiModelModuleWithLinks {
+export interface JsonApiModelModuleOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     attributes?: object;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of organization entity.
  * @export
- * @interface JsonApiOrganization
+ * @interface JsonApiOrganizationIn
  */
-export interface JsonApiOrganization {
+export interface JsonApiOrganizationIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiOrganization
+     * @memberof JsonApiOrganizationIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiOrganization
+     * @memberof JsonApiOrganizationIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiOrganizationAttributes}
-     * @memberof JsonApiOrganization
+     * @type {JsonApiOrganizationInAttributes}
+     * @memberof JsonApiOrganizationIn
      */
-    attributes?: JsonApiOrganizationAttributes;
-    /**
-     *
-     * @type {JsonApiOrganizationRelationships}
-     * @memberof JsonApiOrganization
-     */
-    relationships?: JsonApiOrganizationRelationships;
+    attributes?: JsonApiOrganizationInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationAttributes
+ * @interface JsonApiOrganizationInAttributes
  */
-export interface JsonApiOrganizationAttributes {
+export interface JsonApiOrganizationInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     hostname?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthIssuerLocation?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthClientId?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthClientSecret?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationDocument
+ * @interface JsonApiOrganizationInDocument
  */
-export interface JsonApiOrganizationDocument {
+export interface JsonApiOrganizationInDocument {
     /**
      *
-     * @type {JsonApiOrganization}
-     * @memberof JsonApiOrganizationDocument
+     * @type {JsonApiOrganizationIn}
+     * @memberof JsonApiOrganizationInDocument
      */
-    data: JsonApiOrganization;
+    data: JsonApiOrganizationIn;
+}
+/**
+ * JSON:API representation of organization entity.
+ * @export
+ * @interface JsonApiOrganizationOut
+ */
+export interface JsonApiOrganizationOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiOrganizationOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiOrganizationOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiOrganizationOutAttributes}
+     * @memberof JsonApiOrganizationOut
+     */
+    attributes?: JsonApiOrganizationOutAttributes;
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationships}
+     * @memberof JsonApiOrganizationOut
+     */
+    relationships?: JsonApiOrganizationOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiOrganizationOutAttributes
+ */
+export interface JsonApiOrganizationOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    name?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    hostname?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    oauthIssuerLocation?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    oauthClientId?: string;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiOrganizationOutDocument
+ */
+export interface JsonApiOrganizationOutDocument {
+    /**
+     *
+     * @type {JsonApiOrganizationOut}
+     * @memberof JsonApiOrganizationOutDocument
+     */
+    data: JsonApiOrganizationOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiOrganizationDocument
+     * @memberof JsonApiOrganizationOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiOrganizationDocument
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiOrganizationOutDocument
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiOrganizationList
+ * @interface JsonApiOrganizationOutList
  */
-export interface JsonApiOrganizationList {
+export interface JsonApiOrganizationOutList {
     /**
      *
-     * @type {Array<JsonApiOrganizationWithLinks>}
-     * @memberof JsonApiOrganizationList
+     * @type {Array<JsonApiOrganizationOutWithLinks>}
+     * @memberof JsonApiOrganizationOutList
      */
-    data: Array<JsonApiOrganizationWithLinks>;
+    data: Array<JsonApiOrganizationOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiOrganizationList
+     * @memberof JsonApiOrganizationOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiOrganizationList
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiOrganizationOutList
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationRelationships
+ * @interface JsonApiOrganizationOutRelationships
  */
-export interface JsonApiOrganizationRelationships {
+export interface JsonApiOrganizationOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiOrganizationRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiOrganizationOutRelationships
      */
-    user?: JsonApiOrganizationRelationshipsUser;
+    user?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiOrganizationRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiOrganizationOutRelationships
      */
-    userGroup?: JsonApiOrganizationRelationshipsUser;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationRelationshipsUser
+ * @interface JsonApiOrganizationOutRelationshipsUser
  */
-export interface JsonApiOrganizationRelationshipsUser {
+export interface JsonApiOrganizationOutRelationshipsUser {
     /**
      *
      * @type {JsonApiRelToOne}
-     * @memberof JsonApiOrganizationRelationshipsUser
+     * @memberof JsonApiOrganizationOutRelationshipsUser
      */
     data?: JsonApiRelToOne | null;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationWithLinks
+ * @interface JsonApiOrganizationOutWithLinks
  */
-export interface JsonApiOrganizationWithLinks {
+export interface JsonApiOrganizationOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiOrganizationAttributes}
-     * @memberof JsonApiOrganizationWithLinks
+     * @type {JsonApiOrganizationOutAttributes}
+     * @memberof JsonApiOrganizationOutWithLinks
      */
-    attributes?: JsonApiOrganizationAttributes;
+    attributes?: JsonApiOrganizationOutAttributes;
     /**
      *
-     * @type {JsonApiOrganizationRelationships}
-     * @memberof JsonApiOrganizationWithLinks
+     * @type {JsonApiOrganizationOutRelationships}
+     * @memberof JsonApiOrganizationOutWithLinks
      */
-    relationships?: JsonApiOrganizationRelationships;
+    relationships?: JsonApiOrganizationOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -2982,78 +3329,78 @@ export type JsonApiRelToOne = JsonApiLinkage;
 /**
  * A source table
  * @export
- * @interface JsonApiSourceTable
+ * @interface JsonApiSourceTableOut
  */
-export interface JsonApiSourceTable {
+export interface JsonApiSourceTableOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTable
+     * @memberof JsonApiSourceTableOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTable
+     * @memberof JsonApiSourceTableOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiSourceTableAttributes}
-     * @memberof JsonApiSourceTable
+     * @type {JsonApiSourceTableOutAttributes}
+     * @memberof JsonApiSourceTableOut
      */
-    attributes?: JsonApiSourceTableAttributes;
+    attributes?: JsonApiSourceTableOutAttributes;
     /**
      *
-     * @type {JsonApiSourceTableRelationships}
-     * @memberof JsonApiSourceTable
+     * @type {JsonApiSourceTableOutRelationships}
+     * @memberof JsonApiSourceTableOut
      */
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableAttributes
+ * @interface JsonApiSourceTableOutAttributes
  */
-export interface JsonApiSourceTableAttributes {
+export interface JsonApiSourceTableOutAttributes {
     /**
-     *
+     * Path to table.
      * @type {Array<string>}
-     * @memberof JsonApiSourceTableAttributes
+     * @memberof JsonApiSourceTableOutAttributes
      */
     path?: Array<string>;
     /**
      *
-     * @type {Array<JsonApiSourceTableAttributesColumns>}
-     * @memberof JsonApiSourceTableAttributes
+     * @type {Array<JsonApiSourceTableOutAttributesColumns>}
+     * @memberof JsonApiSourceTableOutAttributes
      */
-    columns?: Array<JsonApiSourceTableAttributesColumns>;
+    columns?: Array<JsonApiSourceTableOutAttributesColumns>;
 }
 /**
  * A source table column
  * @export
- * @interface JsonApiSourceTableAttributesColumns
+ * @interface JsonApiSourceTableOutAttributesColumns
  */
-export interface JsonApiSourceTableAttributesColumns {
+export interface JsonApiSourceTableOutAttributesColumns {
     /**
      *
      * @type {string}
-     * @memberof JsonApiSourceTableAttributesColumns
+     * @memberof JsonApiSourceTableOutAttributesColumns
      */
     name: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiSourceTableAttributesColumns
+     * @memberof JsonApiSourceTableOutAttributesColumns
      */
-    dataType: JsonApiSourceTableAttributesColumnsDataTypeEnum;
+    dataType: JsonApiSourceTableOutAttributesColumnsDataTypeEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
+export enum JsonApiSourceTableOutAttributesColumnsDataTypeEnum {
     INT = "INT",
     STRING = "STRING",
     DATE = "DATE",
@@ -3065,818 +3412,1344 @@ export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiSourceTableDocument
+ * @interface JsonApiSourceTableOutDocument
  */
-export interface JsonApiSourceTableDocument {
+export interface JsonApiSourceTableOutDocument {
     /**
      *
-     * @type {JsonApiSourceTable}
-     * @memberof JsonApiSourceTableDocument
+     * @type {JsonApiSourceTableOut}
+     * @memberof JsonApiSourceTableOutDocument
      */
-    data: JsonApiSourceTable;
+    data: JsonApiSourceTableOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTableDocument
+     * @memberof JsonApiSourceTableOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTableDocument
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTableOutDocument
      */
-    included?: Array<JsonApiSourceTablesWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiSourceTableList
+ * @interface JsonApiSourceTableOutList
  */
-export interface JsonApiSourceTableList {
+export interface JsonApiSourceTableOutList {
     /**
      *
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTableList
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTableOutList
      */
-    data: Array<JsonApiSourceTableWithLinks>;
+    data: Array<JsonApiSourceTableOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiSourceTableList
+     * @memberof JsonApiSourceTableOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTableList
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTableOutList
      */
-    included?: Array<JsonApiSourceTablesWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableRelationships
+ * @interface JsonApiSourceTableOutRelationships
  */
-export interface JsonApiSourceTableRelationships {
+export interface JsonApiSourceTableOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiSourceTableRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiSourceTableOutRelationships
      */
-    source?: JsonApiOrganizationRelationshipsUser;
+    source?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableWithLinks
+ * @interface JsonApiSourceTableOutWithLinks
  */
-export interface JsonApiSourceTableWithLinks {
+export interface JsonApiSourceTableOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiSourceTableAttributes}
-     * @memberof JsonApiSourceTableWithLinks
+     * @type {JsonApiSourceTableOutAttributes}
+     * @memberof JsonApiSourceTableOutWithLinks
      */
-    attributes?: JsonApiSourceTableAttributes;
+    attributes?: JsonApiSourceTableOutAttributes;
     /**
      *
-     * @type {JsonApiSourceTableRelationships}
-     * @memberof JsonApiSourceTableWithLinks
+     * @type {JsonApiSourceTableOutRelationships}
+     * @memberof JsonApiSourceTableOutWithLinks
      */
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * A defined data source for analytics data
  * @export
- * @interface JsonApiSourceTables
+ * @interface JsonApiSourceTablesOut
  */
-export interface JsonApiSourceTables {
+export interface JsonApiSourceTablesOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     attributes?: object;
     /**
      *
-     * @type {JsonApiSourceTablesRelationships}
-     * @memberof JsonApiSourceTables
+     * @type {JsonApiSourceTablesOutRelationships}
+     * @memberof JsonApiSourceTablesOut
      */
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesDocument
+ * @interface JsonApiSourceTablesOutDocument
  */
-export interface JsonApiSourceTablesDocument {
+export interface JsonApiSourceTablesOutDocument {
     /**
      *
-     * @type {JsonApiSourceTables}
-     * @memberof JsonApiSourceTablesDocument
+     * @type {JsonApiSourceTablesOut}
+     * @memberof JsonApiSourceTablesOutDocument
      */
-    data: JsonApiSourceTables;
+    data: JsonApiSourceTablesOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTablesDocument
+     * @memberof JsonApiSourceTablesOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTablesDocument
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutDocument
      */
-    included?: Array<JsonApiSourceTableWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiSourceTablesList
+ * @interface JsonApiSourceTablesOutList
  */
-export interface JsonApiSourceTablesList {
+export interface JsonApiSourceTablesOutList {
     /**
      *
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTablesList
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutList
      */
-    data: Array<JsonApiSourceTablesWithLinks>;
+    data: Array<JsonApiSourceTablesOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiSourceTablesList
+     * @memberof JsonApiSourceTablesOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTablesList
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutList
      */
-    included?: Array<JsonApiSourceTableWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesRelationships
+ * @interface JsonApiSourceTablesOutRelationships
  */
-export interface JsonApiSourceTablesRelationships {
+export interface JsonApiSourceTablesOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiSourceTablesRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiSourceTablesOutRelationships
      */
-    tables?: JsonApiACLRelationshipsUsers;
+    tables?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesWithLinks
+ * @interface JsonApiSourceTablesOutWithLinks
  */
-export interface JsonApiSourceTablesWithLinks {
+export interface JsonApiSourceTablesOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     attributes?: object;
     /**
      *
-     * @type {JsonApiSourceTablesRelationships}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @type {JsonApiSourceTablesOutRelationships}
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of userGroup entity.
+ * @export
+ * @interface JsonApiUserGroupIn
+ */
+export interface JsonApiUserGroupIn {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupIn
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupIn
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupIn
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupIn
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupInDocument
+ */
+export interface JsonApiUserGroupInDocument {
+    /**
+     *
+     * @type {JsonApiUserGroupIn}
+     * @memberof JsonApiUserGroupInDocument
+     */
+    data: JsonApiUserGroupIn;
+}
+/**
+ * JSON:API representation of userGroup entity.
+ * @export
+ * @interface JsonApiUserGroupOut
+ */
+export interface JsonApiUserGroupOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupOut
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupOut
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupOut
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutDocument
+ */
+export interface JsonApiUserGroupOutDocument {
+    /**
+     *
+     * @type {JsonApiUserGroupOut}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    data: JsonApiUserGroupOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiUserGroupOutList
+ */
+export interface JsonApiUserGroupOutList {
+    /**
+     *
+     * @type {Array<JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiUserGroupOutList
+     */
+    data: Array<JsonApiUserGroupOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiUserGroupOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserGroupOutList
+     */
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutRelationships
+ */
+export interface JsonApiUserGroupOutRelationships {
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiUserGroupOutRelationships
+     */
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiUserGroupOutRelationships
+     */
+    acls?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutWithLinks
+ */
+export interface JsonApiUserGroupOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiUserGroupOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of user entity.
  * @export
- * @interface JsonApiUser
+ * @interface JsonApiUserIn
  */
-export interface JsonApiUser {
+export interface JsonApiUserIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiUser
+     * @memberof JsonApiUserIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiUser
+     * @memberof JsonApiUserIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiUserAttributes}
-     * @memberof JsonApiUser
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserIn
      */
-    attributes?: JsonApiUserAttributes;
+    attributes?: JsonApiUserOutAttributes;
     /**
      *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUser
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserIn
      */
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiUserAttributes
+ * @interface JsonApiUserInDocument
  */
-export interface JsonApiUserAttributes {
+export interface JsonApiUserInDocument {
+    /**
+     *
+     * @type {JsonApiUserIn}
+     * @memberof JsonApiUserInDocument
+     */
+    data: JsonApiUserIn;
+}
+/**
+ * JSON:API representation of user entity.
+ * @export
+ * @interface JsonApiUserOut
+ */
+export interface JsonApiUserOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserOut
+     */
+    attributes?: JsonApiUserOutAttributes;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserOut
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserOutAttributes
+ */
+export interface JsonApiUserOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiUserAttributes
+     * @memberof JsonApiUserOutAttributes
      */
     authenticationId?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiUserDocument
+ * @interface JsonApiUserOutDocument
  */
-export interface JsonApiUserDocument {
+export interface JsonApiUserOutDocument {
     /**
      *
-     * @type {JsonApiUser}
-     * @memberof JsonApiUserDocument
+     * @type {JsonApiUserOut}
+     * @memberof JsonApiUserOutDocument
      */
-    data: JsonApiUser;
+    data: JsonApiUserOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiUserDocument
+     * @memberof JsonApiUserOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserDocument
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserOutDocument
      */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-}
-/**
- * JSON:API representation of userGroup entity.
- * @export
- * @interface JsonApiUserGroup
- */
-export interface JsonApiUserGroup {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiUserGroup
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiUserGroup
-     */
-    type: string;
-    /**
-     *
-     * @type {object}
-     * @memberof JsonApiUserGroup
-     */
-    attributes?: object;
-    /**
-     *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserGroup
-     */
-    relationships?: JsonApiUserGroupRelationships;
-}
-/**
- *
- * @export
- * @interface JsonApiUserGroupDocument
- */
-export interface JsonApiUserGroupDocument {
-    /**
-     *
-     * @type {JsonApiUserGroup}
-     * @memberof JsonApiUserGroupDocument
-     */
-    data: JsonApiUserGroup;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiUserGroupDocument
-     */
-    links?: ObjectLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserGroupDocument
-     */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiUserGroupList
+ * @interface JsonApiUserOutList
  */
-export interface JsonApiUserGroupList {
+export interface JsonApiUserOutList {
     /**
      *
-     * @type {Array<JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiUserGroupList
+     * @type {Array<JsonApiUserOutWithLinks>}
+     * @memberof JsonApiUserOutList
      */
-    data: Array<JsonApiUserGroupWithLinks>;
+    data: Array<JsonApiUserOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiUserGroupList
+     * @memberof JsonApiUserOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserGroupList
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserOutList
      */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiUserGroupRelationships
+ * @interface JsonApiUserOutWithLinks
  */
-export interface JsonApiUserGroupRelationships {
-    /**
-     *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiUserGroupRelationships
-     */
-    userGroup?: JsonApiOrganizationRelationshipsUser;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiUserGroupRelationships
-     */
-    acls?: JsonApiACLRelationshipsUsers;
-}
-/**
- *
- * @export
- * @interface JsonApiUserGroupWithLinks
- */
-export interface JsonApiUserGroupWithLinks {
+export interface JsonApiUserOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiUserGroupWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiUserGroupWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {object}
-     * @memberof JsonApiUserGroupWithLinks
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserOutWithLinks
      */
-    attributes?: object;
+    attributes?: JsonApiUserOutAttributes;
     /**
      *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserGroupWithLinks
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserOutWithLinks
      */
-    relationships?: JsonApiUserGroupRelationships;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiUserGroupWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * A JSON:API document with a list of resources
- * @export
- * @interface JsonApiUserList
- */
-export interface JsonApiUserList {
-    /**
-     *
-     * @type {Array<JsonApiUserWithLinks>}
-     * @memberof JsonApiUserList
-     */
-    data: Array<JsonApiUserWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiUserList
-     */
-    links?: ListLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserList
-     */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-}
-/**
- *
- * @export
- * @interface JsonApiUserWithLinks
- */
-export interface JsonApiUserWithLinks {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiUserWithLinks
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiUserWithLinks
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiUserAttributes}
-     * @memberof JsonApiUserWithLinks
-     */
-    attributes?: JsonApiUserAttributes;
-    /**
-     *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserWithLinks
-     */
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiUserWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of visualizationObject entity.
  * @export
- * @interface JsonApiVisualizationObject
+ * @interface JsonApiVisualizationObjectIn
  */
-export interface JsonApiVisualizationObject {
+export interface JsonApiVisualizationObjectIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiVisualizationObject
+     * @memberof JsonApiVisualizationObjectIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiVisualizationObject
+     * @memberof JsonApiVisualizationObjectIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiVisualizationObject
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiVisualizationObjectIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiVisualizationObjectRelationships}
-     * @memberof JsonApiVisualizationObject
-     */
-    relationships?: JsonApiVisualizationObjectRelationships;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectDocument
+ * @interface JsonApiVisualizationObjectInDocument
  */
-export interface JsonApiVisualizationObjectDocument {
+export interface JsonApiVisualizationObjectInDocument {
     /**
      *
-     * @type {JsonApiVisualizationObject}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @type {JsonApiVisualizationObjectIn}
+     * @memberof JsonApiVisualizationObjectInDocument
      */
-    data: JsonApiVisualizationObject;
+    data: JsonApiVisualizationObjectIn;
+}
+/**
+ * JSON:API representation of visualizationObject entity.
+ * @export
+ * @interface JsonApiVisualizationObjectOut
+ */
+export interface JsonApiVisualizationObjectOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
+    /**
+     *
+     * @type {JsonApiVisualizationObjectOutRelationships}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    relationships?: JsonApiVisualizationObjectOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiVisualizationObjectOutDocument
+ */
+export interface JsonApiVisualizationObjectOutDocument {
+    /**
+     *
+     * @type {JsonApiVisualizationObjectOut}
+     * @memberof JsonApiVisualizationObjectOutDocument
+     */
+    data: JsonApiVisualizationObjectOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @memberof JsonApiVisualizationObjectOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutDocument
      */
     included?: Array<
-        | JsonApiFactWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiAnalyticalDashboardWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiAnalyticalDashboardOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiVisualizationObjectList
+ * @interface JsonApiVisualizationObjectOutList
  */
-export interface JsonApiVisualizationObjectList {
+export interface JsonApiVisualizationObjectOutList {
     /**
      *
-     * @type {Array<JsonApiVisualizationObjectWithLinks>}
-     * @memberof JsonApiVisualizationObjectList
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutList
      */
-    data: Array<JsonApiVisualizationObjectWithLinks>;
+    data: Array<JsonApiVisualizationObjectOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiVisualizationObjectList
+     * @memberof JsonApiVisualizationObjectOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiVisualizationObjectList
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutList
      */
     included?: Array<
-        | JsonApiFactWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiAnalyticalDashboardWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiAnalyticalDashboardOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectRelationships
+ * @interface JsonApiVisualizationObjectOutRelationships
  */
-export interface JsonApiVisualizationObjectRelationships {
+export interface JsonApiVisualizationObjectOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    facts?: JsonApiACLRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    metrics?: JsonApiACLRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    analyticalDashboards?: JsonApiACLRelationshipsUsers;
+    analyticalDashboards?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectWithLinks
+ * @interface JsonApiVisualizationObjectOutWithLinks
  */
-export interface JsonApiVisualizationObjectWithLinks {
+export interface JsonApiVisualizationObjectOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @type {JsonApiAnalyticalDashboardOutAttributes}
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardOutAttributes;
     /**
      *
-     * @type {JsonApiVisualizationObjectRelationships}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @type {JsonApiVisualizationObjectOutRelationships}
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of workspaceDataFilter entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterIn
+ */
+export interface JsonApiWorkspaceDataFilterIn {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterInDocument
+ */
+export interface JsonApiWorkspaceDataFilterInDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterIn}
+     * @memberof JsonApiWorkspaceDataFilterInDocument
+     */
+    data: JsonApiWorkspaceDataFilterIn;
+}
+/**
+ * JSON:API representation of workspaceDataFilter entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOut
+ */
+export interface JsonApiWorkspaceDataFilterOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutAttributes
+ */
+export interface JsonApiWorkspaceDataFilterOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutAttributes
+     */
+    columnName?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutAttributes
+     */
+    dataSourceName?: string;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutDocument
+ */
+export interface JsonApiWorkspaceDataFilterOutDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOut}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    data: JsonApiWorkspaceDataFilterOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutList
+ */
+export interface JsonApiWorkspaceDataFilterOutList {
+    /**
+     *
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    data: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutRelationships
+ */
+export interface JsonApiWorkspaceDataFilterOutRelationships {
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiWorkspaceDataFilterOutRelationships
+     */
+    workspaceDataFilterSettings?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutWithLinks
+ */
+export interface JsonApiWorkspaceDataFilterOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    attributes?: JsonApiWorkspaceDataFilterOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    relationships?: JsonApiWorkspaceDataFilterOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of workspaceDataFilterSetting entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOut
+ */
+export interface JsonApiWorkspaceDataFilterSettingOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutAttributes
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    filterValues?: Array<string>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutDocument
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOut}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    data: JsonApiWorkspaceDataFilterSettingOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutList
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutList {
+    /**
+     *
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    data: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutRelationships
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutRelationships {
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutRelationships
+     */
+    workspaceDataFilter?: JsonApiOrganizationOutRelationshipsUser;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutWithLinks
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of workspace entity.
  * @export
- * @interface JsonApiWorkspace
+ * @interface JsonApiWorkspaceIn
  */
-export interface JsonApiWorkspace {
+export interface JsonApiWorkspaceIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiWorkspace
+     * @memberof JsonApiWorkspaceIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiWorkspace
+     * @memberof JsonApiWorkspaceIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiWorkspaceAttributes}
-     * @memberof JsonApiWorkspace
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceIn
      */
-    attributes?: JsonApiWorkspaceAttributes;
-    /**
-     *
-     * @type {JsonApiWorkspaceRelationships}
-     * @memberof JsonApiWorkspace
-     */
-    relationships?: JsonApiWorkspaceRelationships;
+    attributes?: JsonApiWorkspaceOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceAttributes
+ * @interface JsonApiWorkspaceInDocument
  */
-export interface JsonApiWorkspaceAttributes {
+export interface JsonApiWorkspaceInDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceIn}
+     * @memberof JsonApiWorkspaceInDocument
+     */
+    data: JsonApiWorkspaceIn;
+}
+/**
+ * JSON:API representation of workspace entity.
+ * @export
+ * @interface JsonApiWorkspaceOut
+ */
+export interface JsonApiWorkspaceOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceOut
+     */
+    attributes?: JsonApiWorkspaceOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceOutRelationships}
+     * @memberof JsonApiWorkspaceOut
+     */
+    relationships?: JsonApiWorkspaceOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceOutAttributes
+ */
+export interface JsonApiWorkspaceOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiWorkspaceAttributes
+     * @memberof JsonApiWorkspaceOutAttributes
      */
     name?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceDocument
+ * @interface JsonApiWorkspaceOutDocument
  */
-export interface JsonApiWorkspaceDocument {
+export interface JsonApiWorkspaceOutDocument {
     /**
      *
-     * @type {JsonApiWorkspace}
-     * @memberof JsonApiWorkspaceDocument
+     * @type {JsonApiWorkspaceOut}
+     * @memberof JsonApiWorkspaceOutDocument
      */
-    data: JsonApiWorkspace;
+    data: JsonApiWorkspaceOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiWorkspaceDocument
+     * @memberof JsonApiWorkspaceOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceDocument
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutDocument
      */
-    included?: Array<JsonApiWorkspaceWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiWorkspaceList
+ * @interface JsonApiWorkspaceOutList
  */
-export interface JsonApiWorkspaceList {
+export interface JsonApiWorkspaceOutList {
     /**
      *
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceList
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutList
      */
-    data: Array<JsonApiWorkspaceWithLinks>;
+    data: Array<JsonApiWorkspaceOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiWorkspaceList
+     * @memberof JsonApiWorkspaceOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceList
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutList
      */
-    included?: Array<JsonApiWorkspaceWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceRelationships
+ * @interface JsonApiWorkspaceOutRelationships
  */
-export interface JsonApiWorkspaceRelationships {
+export interface JsonApiWorkspaceOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiWorkspaceRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiWorkspaceOutRelationships
      */
-    workspace?: JsonApiOrganizationRelationshipsUser;
+    workspace?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceWithLinks
+ * @interface JsonApiWorkspaceOutWithLinks
  */
-export interface JsonApiWorkspaceWithLinks {
+export interface JsonApiWorkspaceOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiWorkspaceAttributes}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
-    attributes?: JsonApiWorkspaceAttributes;
+    attributes?: JsonApiWorkspaceOutAttributes;
     /**
      *
-     * @type {JsonApiWorkspaceRelationships}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @type {JsonApiWorkspaceOutRelationships}
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -3967,7 +4840,7 @@ export enum ReferenceIdentifierTypeEnum {
 }
 
 /**
- *
+ * Store filter into this workspace. Empty if it is part of layout of workspaces.
  * @export
  * @interface WorkspaceIdentifier
  */
@@ -4117,6 +4990,34 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(params: {}, options: any = {}): RequestArgs {
+            const {} = params;
+            const localVarPath = `/api/layout/workspaceDataFilters`;
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4161,8 +5062,8 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4400,6 +5301,57 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { declarativeWorkspaceDataFilters } = params;
+            // verify required parameter 'declarativeWorkspaceDataFilters' is not null or undefined
+            if (declarativeWorkspaceDataFilters === null || declarativeWorkspaceDataFilters === undefined) {
+                throw new RequiredError(
+                    "declarativeWorkspaceDataFilters",
+                    "Required parameter declarativeWorkspaceDataFilters was null or undefined when calling setWorkspaceDataFiltersLayout.",
+                );
+            }
+            const localVarPath = `/api/layout/workspaceDataFilters`;
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof declarativeWorkspaceDataFilters !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      declarativeWorkspaceDataFilters !== undefined ? declarativeWorkspaceDataFilters : {},
+                  )
+                : declarativeWorkspaceDataFilters || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4527,6 +5479,27 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(
+            params: {},
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DeclarativeWorkspaceDataFilters> {
+            const localVarAxiosArgs = DeclarativeLayoutControllerApiAxiosParamCreator(
+                configuration,
+            ).getWorkspaceDataFiltersLayout(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4551,8 +5524,8 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4671,6 +5644,30 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
+            const localVarAxiosArgs = DeclarativeLayoutControllerApiAxiosParamCreator(
+                configuration,
+            ).setWorkspaceDataFiltersLayout(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4756,6 +5753,21 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(
+            params: {},
+            options?: any,
+        ): AxiosPromise<DeclarativeWorkspaceDataFilters> {
+            return DeclarativeLayoutControllerApiFp(configuration).getWorkspaceDataFiltersLayout(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4774,8 +5786,8 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4858,6 +5870,24 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options?: any,
+        ): AxiosPromise<void> {
+            return DeclarativeLayoutControllerApiFp(configuration).setWorkspaceDataFiltersLayout(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4924,6 +5954,15 @@ export interface DeclarativeLayoutControllerApiInterface {
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
 
     /**
+     * Retrieve all workspaces and related workspace data filters (and their settings / values).
+     * @summary Get workspace data filters for all workspaces
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApiInterface
+     */
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
+
+    /**
      * Retrieve current model of the workspace in declarative form.
      * @summary Get workspace layout
      * @param {string} workspaceId
@@ -4939,8 +5978,8 @@ export interface DeclarativeLayoutControllerApiInterface {
     ): AxiosPromise<DeclarativeWorkspaceModel>;
 
     /**
-     * Retrieve layout of workspaces, including a hierarchy and models.
-     * @summary Get all workspaces layout
+     * Sets complete layout of workspaces, their hierarchy, models.
+     * @summary Set all workspaces layout
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DeclarativeLayoutControllerApiInterface
@@ -5006,6 +6045,21 @@ export interface DeclarativeLayoutControllerApiInterface {
      * @memberof DeclarativeLayoutControllerApiInterface
      */
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+
+    /**
+     * Sets workspace data filters in all workspaces in entire organization.
+     * @summary Set all workspace data filters
+     * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApiInterface
+     */
+    setWorkspaceDataFiltersLayout(
+        params: {
+            declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+        },
+        options?: any,
+    ): AxiosPromise<void>;
 
     /**
      * Sets complete layout of workspaces, their hierarchy, models.
@@ -5086,6 +6140,20 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
+     * Retrieve all workspaces and related workspace data filters (and their settings / values).
+     * @summary Get workspace data filters for all workspaces
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApi
+     */
+    public getWorkspaceDataFiltersLayout(params: {}, options?: any) {
+        return DeclarativeLayoutControllerApiFp(this.configuration).getWorkspaceDataFiltersLayout(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
      * Retrieve current model of the workspace in declarative form.
      * @summary Get workspace layout
      * @param {string} workspaceId
@@ -5106,8 +6174,8 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
-     * Retrieve layout of workspaces, including a hierarchy and models.
-     * @summary Get all workspaces layout
+     * Sets complete layout of workspaces, their hierarchy, models.
+     * @summary Set all workspaces layout
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DeclarativeLayoutControllerApi
@@ -5200,6 +6268,26 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
+     * Sets workspace data filters in all workspaces in entire organization.
+     * @summary Set all workspace data filters
+     * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApi
+     */
+    public setWorkspaceDataFiltersLayout(
+        params: {
+            declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+        },
+        options?: any,
+    ) {
+        return DeclarativeLayoutControllerApiFp(this.configuration).setWorkspaceDataFiltersLayout(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
      * Sets complete layout of workspaces, their hierarchy, models.
      * @summary Set all workspaces layout
      * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -5247,7 +6335,7 @@ export const NotificationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter dataSourceId was null or undefined when calling registerUploadNotification.",
                 );
             }
-            const localVarPath = `/api/dataSources/{dataSourceId}/uploadNotification`.replace(
+            const localVarPath = `/api/actions/dataSources/{dataSourceId}/uploadNotification`.replace(
                 `{${"dataSourceId"}}`,
                 encodeURIComponent(String(dataSourceId)),
             );
@@ -5607,451 +6695,10 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
     return {
         /**
          *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAcls1(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityAcls1.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/acls/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataSources(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityDataSources.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/dataSources/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityModelModules(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityModelModules.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/modelModules/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityOrganizations(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityOrganizations.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/organizations/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUserGroups(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityUserGroups.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/userGroups/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUsers(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityUsers.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/users/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityWorkspaces(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling getEntityWorkspaces.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/workspaces/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getOrganizationUsers11(params: {}, options: any = {}): RequestArgs {
+        getOrganizationUsers(params: {}, options: any = {}): RequestArgs {
             const {} = params;
             const localVarPath = `/api/entities/organization`;
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
@@ -6073,566 +6720,6 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                 options: localVarRequestOptions,
             };
         },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAcls1(
-            params: {
-                id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiACLDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityAcls1.",
-                );
-            }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling updateEntityAcls1.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/acls/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataSources(
-            params: {
-                id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiDataSourceDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityDataSources.",
-                );
-            }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling updateEntityDataSources.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/dataSources/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityModelModules(
-            params: {
-                id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiModelModuleDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityModelModules.",
-                );
-            }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling updateEntityModelModules.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/modelModules/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityOrganizations(
-            params: {
-                id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiOrganizationDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityOrganizations.",
-                );
-            }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling updateEntityOrganizations.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/organizations/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUserGroups(
-            params: {
-                id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiUserGroupDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityUserGroups.",
-                );
-            }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling updateEntityUserGroups.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/userGroups/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUsers(
-            params: {
-                id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiUserDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityUsers.",
-                );
-            }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling updateEntityUsers.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/users/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityWorkspaces(
-            params: {
-                id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { id, jsonApiWorkspaceDocument, variableParam, include } = params;
-            // verify required parameter 'id' is not null or undefined
-            if (id === null || id === undefined) {
-                throw new RequiredError(
-                    "id",
-                    "Required parameter id was null or undefined when calling updateEntityWorkspaces.",
-                );
-            }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling updateEntityWorkspaces.",
-                );
-            }
-            const localVarPath = `/api/entities/admin/workspaces/{id}`.replace(
-                `{${"id"}}`,
-                encodeURIComponent(String(id)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
     };
 };
 
@@ -6644,419 +6731,27 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
     return {
         /**
          *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAcls1(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityAcls1(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataSources(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityDataSources(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityModelModules(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityModelModules(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityOrganizations(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityOrganizations(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUserGroups(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityUserGroups(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUsers(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityUsers(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityWorkspaces(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityWorkspaces(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getOrganizationUsers11(
+        getOrganizationUsers(
             params: {},
             options: any = {},
         ): (
             axios?: AxiosInstance,
             basePath?: string,
         ) => AxiosPromise<
-            | JsonApiDataSourceDocument
-            | JsonApiACLDocument
-            | JsonApiModelModuleDocument
-            | JsonApiOrganizationDocument
-            | JsonApiUserGroupDocument
-            | JsonApiUserDocument
-            | JsonApiWorkspaceDocument
+            | JsonApiDataSourceOutDocument
+            | JsonApiACLOutDocument
+            | JsonApiModelModuleOutDocument
+            | JsonApiOrganizationOutDocument
+            | JsonApiUserGroupOutDocument
+            | JsonApiUserOutDocument
+            | JsonApiWorkspaceOutDocument
         > {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
-            ).getOrganizationUsers11(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAcls1(
-            params: {
-                id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityAcls1(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataSources(
-            params: {
-                id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityDataSources(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityModelModules(
-            params: {
-                id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityModelModules(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityOrganizations(
-            params: {
-                id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityOrganizations(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUserGroups(
-            params: {
-                id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityUserGroups(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUsers(
-            params: {
-                id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityUsers(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityWorkspaces(
-            params: {
-                id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
-            const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityWorkspaces(params, options);
+            ).getOrganizationUsers(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -7080,330 +6775,22 @@ export const OrganizationControllerApiFactory = function (
     return {
         /**
          *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityAcls1(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityAcls1(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataSources(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityDataSources(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityModelModules(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityModelModules(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityOrganizations(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityOrganizations(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUserGroups(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityUserGroups(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityUsers(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityUsers(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityWorkspaces(
-            params: {
-                id: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
-            return OrganizationControllerApiFp(configuration).getEntityWorkspaces(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getOrganizationUsers11(
+        getOrganizationUsers(
             params: {},
             options?: any,
         ): AxiosPromise<
-            | JsonApiDataSourceDocument
-            | JsonApiACLDocument
-            | JsonApiModelModuleDocument
-            | JsonApiOrganizationDocument
-            | JsonApiUserGroupDocument
-            | JsonApiUserDocument
-            | JsonApiWorkspaceDocument
+            | JsonApiDataSourceOutDocument
+            | JsonApiACLOutDocument
+            | JsonApiModelModuleOutDocument
+            | JsonApiOrganizationOutDocument
+            | JsonApiUserGroupOutDocument
+            | JsonApiUserOutDocument
+            | JsonApiWorkspaceOutDocument
         > {
-            return OrganizationControllerApiFp(configuration).getOrganizationUsers11(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityAcls1(
-            params: {
-                id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityAcls1(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataSources(
-            params: {
-                id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityDataSources(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityModelModules(
-            params: {
-                id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityModelModules(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityOrganizations(
-            params: {
-                id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityOrganizations(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUserGroups(
-            params: {
-                id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityUserGroups(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUsers(
-            params: {
-                id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityUsers(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityWorkspaces(
-            params: {
-                id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
-            return OrganizationControllerApiFp(configuration).updateEntityWorkspaces(params, options)(
+            return OrganizationControllerApiFp(configuration).getOrganizationUsers(params, options)(
                 axios,
                 basePath,
             );
@@ -7419,288 +6806,22 @@ export const OrganizationControllerApiFactory = function (
 export interface OrganizationControllerApiInterface {
     /**
      *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationControllerApiInterface
      */
-    getEntityAcls1(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityDataSources(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityModelModules(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityOrganizations(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityUserGroups(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityUsers(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getEntityWorkspaces(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
-
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    getOrganizationUsers11(
+    getOrganizationUsers(
         params: {},
         options?: any,
     ): AxiosPromise<
-        | JsonApiDataSourceDocument
-        | JsonApiACLDocument
-        | JsonApiModelModuleDocument
-        | JsonApiOrganizationDocument
-        | JsonApiUserGroupDocument
-        | JsonApiUserDocument
-        | JsonApiWorkspaceDocument
+        | JsonApiDataSourceOutDocument
+        | JsonApiACLOutDocument
+        | JsonApiModelModuleOutDocument
+        | JsonApiOrganizationOutDocument
+        | JsonApiUserGroupOutDocument
+        | JsonApiUserOutDocument
+        | JsonApiWorkspaceOutDocument
     >;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityAcls1(
-        params: {
-            id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityDataSources(
-        params: {
-            id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityModelModules(
-        params: {
-            id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityOrganizations(
-        params: {
-            id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityUserGroups(
-        params: {
-            id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityUsers(
-        params: {
-            id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApiInterface
-     */
-    updateEntityWorkspaces(
-        params: {
-            id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
 }
 
 /**
@@ -7712,348 +6833,12 @@ export interface OrganizationControllerApiInterface {
 export class OrganizationControllerApi extends BaseAPI implements OrganizationControllerApiInterface {
     /**
      *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationControllerApi
      */
-    public getEntityAcls1(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityAcls1(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityDataSources(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityDataSources(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityModelModules(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityModelModules(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityOrganizations(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityOrganizations(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityUserGroups(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityUserGroups(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityUsers(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityUsers(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getEntityWorkspaces(
-        params: {
-            id: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).getEntityWorkspaces(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public getOrganizationUsers11(params: {}, options?: any) {
-        return OrganizationControllerApiFp(this.configuration).getOrganizationUsers11(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityAcls1(
-        params: {
-            id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityAcls1(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityDataSources(
-        params: {
-            id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityDataSources(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityModelModules(
-        params: {
-            id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityModelModules(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityOrganizations(
-        params: {
-            id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityOrganizations(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityUserGroups(
-        params: {
-            id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityUserGroups(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityUsers(
-        params: {
-            id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityUsers(params, options)(
-            this.axios,
-            this.basePath,
-        );
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationControllerApi
-     */
-    public updateEntityWorkspaces(
-        params: {
-            id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationControllerApiFp(this.configuration).updateEntityWorkspaces(params, options)(
+    public getOrganizationUsers(params: {}, options?: any) {
+        return OrganizationControllerApiFp(this.configuration).getOrganizationUsers(params, options)(
             this.axios,
             this.basePath,
         );
@@ -8069,18 +6854,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiACLDocument } = params;
+            const { workspaceId, jsonApiACLInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8088,11 +6873,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityAcls.",
                 );
             }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling createChildEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createChildEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/acls`.replace(
@@ -8115,11 +6900,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8129,18 +6914,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiDataSourceDocument } = params;
+            const { workspaceId, jsonApiDataSourceInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8148,11 +6933,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityDataSources.",
                 );
             }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling createChildEntityDataSources.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createChildEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/dataSources`.replace(
@@ -8175,11 +6960,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8189,18 +6974,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiModelModuleDocument } = params;
+            const { workspaceId, jsonApiModelModuleInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8208,11 +6993,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityModelModules.",
                 );
             }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling createChildEntityModelModules.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createChildEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/modelModules`.replace(
@@ -8235,11 +7020,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8249,18 +7036,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiOrganizationDocument } = params;
+            const { workspaceId, jsonApiOrganizationInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8268,11 +7055,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityOrganizations.",
                 );
             }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling createChildEntityOrganizations.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createChildEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/organizations`.replace(
@@ -8295,11 +7082,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8309,18 +7098,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiUserGroupDocument } = params;
+            const { workspaceId, jsonApiUserGroupInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8328,11 +7117,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityUserGroups.",
                 );
             }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling createChildEntityUserGroups.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createChildEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/userGroups`.replace(
@@ -8355,11 +7144,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8369,18 +7158,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiUserDocument } = params;
+            const { workspaceId, jsonApiUserInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8388,11 +7177,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityUsers.",
                 );
             }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling createChildEntityUsers.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createChildEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/users`.replace(
@@ -8415,11 +7204,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8429,18 +7218,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiWorkspaceDocument } = params;
+            const { workspaceId, jsonApiWorkspaceInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8448,11 +7237,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityWorkspaces.",
                 );
             }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling createChildEntityWorkspaces.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createChildEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/workspaces`.replace(
@@ -8475,11 +7264,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8488,7 +7277,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8496,18 +7285,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiACLDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            const { jsonApiACLInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling createEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/acls`;
@@ -8543,11 +7332,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8556,7 +7345,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8564,18 +7353,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiDataSourceDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            const { jsonApiDataSourceInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling createEntityDataSources.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/dataSources`;
@@ -8611,11 +7400,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8624,7 +7413,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8632,18 +7421,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiModelModuleDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            const { jsonApiModelModuleInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling createEntityModelModules.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/modelModules`;
@@ -8679,11 +7468,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8692,7 +7483,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8700,18 +7491,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiOrganizationDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            const { jsonApiOrganizationInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling createEntityOrganizations.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/organizations`;
@@ -8747,11 +7538,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8760,7 +7553,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8768,18 +7561,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiUserGroupDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            const { jsonApiUserGroupInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling createEntityUserGroups.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/userGroups`;
@@ -8815,11 +7608,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8828,7 +7621,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8836,18 +7629,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiUserDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            const { jsonApiUserInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling createEntityUsers.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/users`;
@@ -8883,11 +7676,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8896,7 +7689,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8904,18 +7697,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiWorkspaceDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            const { jsonApiWorkspaceInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling createEntityWorkspaces.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces`;
@@ -8951,11 +7744,491 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiACLInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/acls`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiACLInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiDataSourceInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/dataSources`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiDataSourceInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiModelModuleInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/modelModules`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiModelModuleInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiOrganizationInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/organizations`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiOrganizationInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiUserGroupInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/userGroups`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiUserGroupInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiUserInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/users`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiUserInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiWorkspaceInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/workspaces`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -9943,7 +9216,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDataSources1(
+        getEntityDataSources(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -9956,7 +9229,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityDataSources1.",
+                    "Required parameter id was null or undefined when calling getEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/dataSources/{id}`.replace(
@@ -10006,7 +9279,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityModelModules1(
+        getEntityModelModules(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -10019,7 +9292,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityModelModules1.",
+                    "Required parameter id was null or undefined when calling getEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/modelModules/{id}`.replace(
@@ -10069,7 +9342,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityOrganizations1(
+        getEntityOrganizations(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -10082,7 +9355,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityOrganizations1.",
+                    "Required parameter id was null or undefined when calling getEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/organizations/{id}`.replace(
@@ -10132,7 +9405,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUserGroups1(
+        getEntityUserGroups(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -10145,7 +9418,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityUserGroups1.",
+                    "Required parameter id was null or undefined when calling getEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/userGroups/{id}`.replace(
@@ -10195,7 +9468,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUsers1(
+        getEntityUsers(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -10208,7 +9481,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityUsers1.",
+                    "Required parameter id was null or undefined when calling getEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/users/{id}`.replace(
@@ -10258,7 +9531,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityWorkspaces1(
+        getEntityWorkspaces(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
@@ -10271,7 +9544,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling getEntityWorkspaces1.",
+                    "Required parameter id was null or undefined when calling getEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{id}`.replace(
@@ -10316,7 +9589,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10325,13 +9598,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiACLDocument, variableParam, include } = params;
+            const { id, jsonApiACLInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10339,11 +9612,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityAcls.",
                 );
             }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling updateEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling updateEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/acls/{id}`.replace(
@@ -10382,11 +9655,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10396,34 +9669,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityDataSources1(
+        updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiDataSourceDocument, variableParam, include } = params;
+            const { id, jsonApiDataSourceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityDataSources1.",
+                    "Required parameter id was null or undefined when calling updateEntityDataSources.",
                 );
             }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling updateEntityDataSources1.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling updateEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/dataSources/{id}`.replace(
@@ -10462,11 +9735,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10476,34 +9749,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityModelModules1(
+        updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiModelModuleDocument, variableParam, include } = params;
+            const { id, jsonApiModelModuleInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityModelModules1.",
+                    "Required parameter id was null or undefined when calling updateEntityModelModules.",
                 );
             }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling updateEntityModelModules1.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling updateEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/modelModules/{id}`.replace(
@@ -10542,11 +9815,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10556,34 +9831,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityOrganizations1(
+        updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiOrganizationDocument, variableParam, include } = params;
+            const { id, jsonApiOrganizationInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityOrganizations1.",
+                    "Required parameter id was null or undefined when calling updateEntityOrganizations.",
                 );
             }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling updateEntityOrganizations1.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling updateEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/organizations/{id}`.replace(
@@ -10622,11 +9897,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10636,34 +9913,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityUserGroups1(
+        updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserGroupDocument, variableParam, include } = params;
+            const { id, jsonApiUserGroupInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityUserGroups1.",
+                    "Required parameter id was null or undefined when calling updateEntityUserGroups.",
                 );
             }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling updateEntityUserGroups1.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling updateEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/userGroups/{id}`.replace(
@@ -10702,11 +9979,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10716,34 +9993,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityUsers1(
+        updateEntityUsers(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserDocument, variableParam, include } = params;
+            const { id, jsonApiUserInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityUsers1.",
+                    "Required parameter id was null or undefined when calling updateEntityUsers.",
                 );
             }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling updateEntityUsers1.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling updateEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/users/{id}`.replace(
@@ -10782,11 +10059,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10796,34 +10073,34 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityWorkspaces1(
+        updateEntityWorkspaces(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiWorkspaceDocument, variableParam, include } = params;
+            const { id, jsonApiWorkspaceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
                     "id",
-                    "Required parameter id was null or undefined when calling updateEntityWorkspaces1.",
+                    "Required parameter id was null or undefined when calling updateEntityWorkspaces.",
                 );
             }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling updateEntityWorkspaces1.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling updateEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{id}`.replace(
@@ -10862,11 +10139,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10885,17 +10162,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityAcls(params, options);
@@ -10910,17 +10187,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityDataSources(params, options);
@@ -10935,17 +10212,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityModelModules(params, options);
@@ -10960,17 +10237,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityOrganizations(params, options);
@@ -10985,17 +10262,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityUserGroups(params, options);
@@ -11010,17 +10287,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityUsers(params, options);
@@ -11035,17 +10312,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityWorkspaces(params, options);
@@ -11059,7 +10336,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11067,12 +10344,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityAcls(params, options);
@@ -11086,7 +10363,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11094,12 +10371,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityDataSources(params, options);
@@ -11113,7 +10390,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11121,12 +10398,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityModelModules(params, options);
@@ -11140,7 +10417,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11148,12 +10425,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityOrganizations(params, options);
@@ -11167,7 +10444,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11175,12 +10452,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityUserGroups(params, options);
@@ -11194,7 +10471,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11202,12 +10479,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityUsers(params, options);
@@ -11221,7 +10498,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11229,15 +10506,204 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityWorkspaces(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityAcls(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityDataSources(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityModelModules(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityOrganizations(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUserGroups(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUsers(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11440,7 +10906,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesAcls(params, options);
@@ -11471,7 +10937,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesDataSources(params, options);
@@ -11502,7 +10968,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesModelModules(params, options);
@@ -11533,7 +10999,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesOrganizations(params, options);
@@ -11564,7 +11030,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesUserGroups(params, options);
@@ -11595,7 +11061,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesUsers(params, options);
@@ -11626,7 +11092,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesWorkspaces(params, options);
@@ -11653,7 +11119,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAcls(params, options);
@@ -11673,17 +11139,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDataSources1(
+        getEntityDataSources(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityDataSources1(params, options);
+            ).getEntityDataSources(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11700,17 +11166,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityModelModules1(
+        getEntityModelModules(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityModelModules1(params, options);
+            ).getEntityModelModules(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11727,17 +11193,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityOrganizations1(
+        getEntityOrganizations(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityOrganizations1(params, options);
+            ).getEntityOrganizations(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11754,17 +11220,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUserGroups1(
+        getEntityUserGroups(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityUserGroups1(params, options);
+            ).getEntityUserGroups(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11781,17 +11247,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUsers1(
+        getEntityUsers(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityUsers1(params, options);
+            ).getEntityUsers(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11808,17 +11274,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityWorkspaces1(
+        getEntityWorkspaces(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).getEntityWorkspaces1(params, options);
+            ).getEntityWorkspaces(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11830,7 +11296,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11839,12 +11305,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityAcls(params, options);
@@ -11859,24 +11325,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityDataSources1(
+        updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityDataSources1(params, options);
+            ).updateEntityDataSources(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11888,24 +11354,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityModelModules1(
+        updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityModelModules1(params, options);
+            ).updateEntityModelModules(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11917,24 +11383,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityOrganizations1(
+        updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityOrganizations1(params, options);
+            ).updateEntityOrganizations(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11946,24 +11412,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityUserGroups1(
+        updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityUserGroups1(params, options);
+            ).updateEntityUserGroups(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11975,24 +11441,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityUsers1(
+        updateEntityUsers(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityUsers1(params, options);
+            ).updateEntityUsers(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -12004,24 +11470,24 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityWorkspaces1(
+        updateEntityWorkspaces(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
-            ).updateEntityWorkspaces1(params, options);
+            ).updateEntityWorkspaces(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -12046,17 +11512,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12065,17 +11531,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityDataSources(
                 params,
                 options,
@@ -12084,17 +11550,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityModelModules(
                 params,
                 options,
@@ -12103,17 +11569,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityOrganizations(
                 params,
                 options,
@@ -12122,17 +11588,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityUserGroups(
                 params,
                 options,
@@ -12141,17 +11607,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -12160,17 +11626,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityWorkspaces(
                 params,
                 options,
@@ -12178,7 +11644,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12186,12 +11652,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12199,7 +11665,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12207,12 +11673,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityDataSources(params, options)(
                 axios,
                 basePath,
@@ -12220,7 +11686,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12228,12 +11694,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityModelModules(params, options)(
                 axios,
                 basePath,
@@ -12241,7 +11707,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12249,12 +11715,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityOrganizations(params, options)(
                 axios,
                 basePath,
@@ -12262,7 +11728,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12270,12 +11736,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityUserGroups(params, options)(
                 axios,
                 basePath,
@@ -12283,7 +11749,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12291,12 +11757,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -12304,7 +11770,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12312,16 +11778,157 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityWorkspaces(params, options)(
                 axios,
                 basePath,
             );
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiACLOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).createWorkspaceDataFilterSettingEntityAcls(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityDataSources(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityModelModules(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityOrganizations(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUserGroups(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiUserOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUsers(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options)(axios, basePath);
         },
         /**
          *
@@ -12475,7 +12082,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLList> {
+        ): AxiosPromise<JsonApiACLOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesAcls(params, options)(
                 axios,
                 basePath,
@@ -12500,7 +12107,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceList> {
+        ): AxiosPromise<JsonApiDataSourceOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesDataSources(params, options)(
                 axios,
                 basePath,
@@ -12525,7 +12132,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleList> {
+        ): AxiosPromise<JsonApiModelModuleOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesModelModules(
                 params,
                 options,
@@ -12550,7 +12157,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationList> {
+        ): AxiosPromise<JsonApiOrganizationOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesOrganizations(
                 params,
                 options,
@@ -12575,7 +12182,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupList> {
+        ): AxiosPromise<JsonApiUserGroupOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesUserGroups(params, options)(
                 axios,
                 basePath,
@@ -12600,7 +12207,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserList> {
+        ): AxiosPromise<JsonApiUserOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesUsers(params, options)(
                 axios,
                 basePath,
@@ -12625,7 +12232,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceList> {
+        ): AxiosPromise<JsonApiWorkspaceOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesWorkspaces(params, options)(
                 axios,
                 basePath,
@@ -12646,7 +12253,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12660,15 +12267,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityDataSources1(
+        getEntityDataSources(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityDataSources1(params, options)(
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityDataSources(params, options)(
                 axios,
                 basePath,
             );
@@ -12681,15 +12288,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityModelModules1(
+        getEntityModelModules(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityModelModules1(params, options)(
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityModelModules(params, options)(
                 axios,
                 basePath,
             );
@@ -12702,15 +12309,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityOrganizations1(
+        getEntityOrganizations(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityOrganizations1(params, options)(
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityOrganizations(params, options)(
                 axios,
                 basePath,
             );
@@ -12723,15 +12330,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUserGroups1(
+        getEntityUserGroups(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityUserGroups1(params, options)(
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityUserGroups(params, options)(
                 axios,
                 basePath,
             );
@@ -12744,15 +12351,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityUsers1(
+        getEntityUsers(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityUsers1(params, options)(
+        ): AxiosPromise<JsonApiUserOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityUsers(params, options)(
                 axios,
                 basePath,
             );
@@ -12765,15 +12372,15 @@ export const OrganizationModelControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getEntityWorkspaces1(
+        getEntityWorkspaces(
             params: {
                 id: string;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
-            return OrganizationModelControllerApiFp(configuration).getEntityWorkspaces1(params, options)(
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).getEntityWorkspaces(params, options)(
                 axios,
                 basePath,
             );
@@ -12781,7 +12388,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12790,12 +12397,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12804,22 +12411,22 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityDataSources1(
+        updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityDataSources1(params, options)(
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityDataSources(params, options)(
                 axios,
                 basePath,
             );
@@ -12827,22 +12434,22 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityModelModules1(
+        updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityModelModules1(params, options)(
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityModelModules(params, options)(
                 axios,
                 basePath,
             );
@@ -12850,45 +12457,22 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityOrganizations1(
+        updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityOrganizations1(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityUserGroups1(
-            params: {
-                id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityUserGroups1(params, options)(
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityOrganizations(params, options)(
                 axios,
                 basePath,
             );
@@ -12896,22 +12480,22 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityUsers1(
+        updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityUsers1(params, options)(
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityUserGroups(params, options)(
                 axios,
                 basePath,
             );
@@ -12919,22 +12503,45 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEntityWorkspaces1(
+        updateEntityUsers(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
-            return OrganizationModelControllerApiFp(configuration).updateEntityWorkspaces1(params, options)(
+        ): AxiosPromise<JsonApiUserOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityUsers(params, options)(
+                axios,
+                basePath,
+            );
+        },
+        /**
+         *
+         * @param {string} id
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaces(
+            params: {
+                id: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).updateEntityWorkspaces(params, options)(
                 axios,
                 basePath,
             );
@@ -12951,7 +12558,7 @@ export interface OrganizationModelControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12959,15 +12566,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityAcls(
         params: {
             workspaceId: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12975,15 +12582,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityDataSources(
         params: {
             workspaceId: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12991,15 +12598,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityModelModules(
         params: {
             workspaceId: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13007,15 +12614,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityOrganizations(
         params: {
             workspaceId: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13023,15 +12630,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityUserGroups(
         params: {
             workspaceId: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13039,15 +12646,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityUsers(
         params: {
             workspaceId: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13055,14 +12662,14 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityWorkspaces(
         params: {
             workspaceId: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13071,16 +12678,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityAcls(
         params: {
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13089,16 +12696,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityDataSources(
         params: {
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13107,16 +12714,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityModelModules(
         params: {
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13125,16 +12732,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityOrganizations(
         params: {
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13143,16 +12750,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityUserGroups(
         params: {
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13161,16 +12768,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityUsers(
         params: {
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13179,12 +12786,138 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityWorkspaces(
         params: {
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityAcls(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiACLInDocument: JsonApiACLInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiACLOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityDataSources(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityModelModules(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityOrganizations(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityUserGroups(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityUsers(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserInDocument: JsonApiUserInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiUserOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityWorkspaces(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
@@ -13318,7 +13051,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLList>;
+    ): AxiosPromise<JsonApiACLOutList>;
 
     /**
      *
@@ -13340,7 +13073,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceList>;
+    ): AxiosPromise<JsonApiDataSourceOutList>;
 
     /**
      *
@@ -13362,7 +13095,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleList>;
+    ): AxiosPromise<JsonApiModelModuleOutList>;
 
     /**
      *
@@ -13384,7 +13117,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationList>;
+    ): AxiosPromise<JsonApiOrganizationOutList>;
 
     /**
      *
@@ -13406,7 +13139,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupList>;
+    ): AxiosPromise<JsonApiUserGroupOutList>;
 
     /**
      *
@@ -13428,7 +13161,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserList>;
+    ): AxiosPromise<JsonApiUserOutList>;
 
     /**
      *
@@ -13450,7 +13183,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceList>;
+    ): AxiosPromise<JsonApiWorkspaceOutList>;
 
     /**
      *
@@ -13468,7 +13201,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
@@ -13479,14 +13212,14 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityDataSources1(
+    getEntityDataSources(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
@@ -13497,14 +13230,14 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityModelModules1(
+    getEntityModelModules(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
@@ -13515,14 +13248,14 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityOrganizations1(
+    getEntityOrganizations(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
@@ -13533,14 +13266,14 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityUserGroups1(
+    getEntityUserGroups(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
@@ -13551,14 +13284,14 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityUsers1(
+    getEntityUsers(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
@@ -13569,19 +13302,19 @@ export interface OrganizationModelControllerApiInterface {
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    getEntityWorkspaces1(
+    getEntityWorkspaces(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13591,132 +13324,132 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityAcls(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityDataSources1(
+    updateEntityDataSources(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityModelModules1(
+    updateEntityModelModules(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityOrganizations1(
+    updateEntityOrganizations(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityUserGroups1(
+    updateEntityUserGroups(
         params: {
             id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityUsers1(
+    updateEntityUsers(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
      */
-    updateEntityWorkspaces1(
+    updateEntityWorkspaces(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 /**
@@ -13730,7 +13463,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13738,7 +13471,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityAcls(
         params: {
             workspaceId: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
         },
         options?: any,
     ) {
@@ -13751,7 +13484,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13759,7 +13492,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityDataSources(
         params: {
             workspaceId: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         },
         options?: any,
     ) {
@@ -13772,7 +13505,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13780,7 +13513,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityModelModules(
         params: {
             workspaceId: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         },
         options?: any,
     ) {
@@ -13793,7 +13526,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13801,7 +13534,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityOrganizations(
         params: {
             workspaceId: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         },
         options?: any,
     ) {
@@ -13814,7 +13547,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13822,7 +13555,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityUserGroups(
         params: {
             workspaceId: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         },
         options?: any,
     ) {
@@ -13835,7 +13568,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13843,7 +13576,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityUsers(
         params: {
             workspaceId: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
         },
         options?: any,
     ) {
@@ -13856,7 +13589,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13864,7 +13597,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityWorkspaces(
         params: {
             workspaceId: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         },
         options?: any,
     ) {
@@ -13876,7 +13609,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13885,7 +13618,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityAcls(
         params: {
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13899,7 +13632,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13908,7 +13641,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityDataSources(
         params: {
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13922,7 +13655,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13931,7 +13664,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityModelModules(
         params: {
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13945,7 +13678,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13954,7 +13687,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityOrganizations(
         params: {
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13968,7 +13701,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13977,7 +13710,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityUserGroups(
         params: {
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13991,7 +13724,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14000,7 +13733,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityUsers(
         params: {
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14014,7 +13747,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14023,7 +13756,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityWorkspaces(
         params: {
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14033,6 +13766,160 @@ export class OrganizationModelControllerApi extends BaseAPI
             this.axios,
             this.basePath,
         );
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityAcls(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiACLInDocument: JsonApiACLInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityAcls(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityDataSources(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityDataSources(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityModelModules(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityModelModules(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityOrganizations(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityOrganizations(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityUserGroups(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityUserGroups(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityUsers(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserInDocument: JsonApiUserInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityUsers(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityWorkspaces(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options)(this.axios, this.basePath);
     }
 
     /**
@@ -14403,7 +14290,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityDataSources1(
+    public getEntityDataSources(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14411,7 +14298,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityDataSources1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityDataSources(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14426,7 +14313,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityModelModules1(
+    public getEntityModelModules(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14434,7 +14321,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityModelModules1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityModelModules(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14449,7 +14336,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityOrganizations1(
+    public getEntityOrganizations(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14457,7 +14344,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityOrganizations1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityOrganizations(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14472,7 +14359,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityUserGroups1(
+    public getEntityUserGroups(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14480,7 +14367,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityUserGroups1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityUserGroups(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14495,7 +14382,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityUsers1(
+    public getEntityUsers(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14503,7 +14390,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityUsers1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityUsers(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14518,7 +14405,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public getEntityWorkspaces1(
+    public getEntityWorkspaces(
         params: {
             id: string;
             variableParam?: { [key: string]: object };
@@ -14526,7 +14413,7 @@ export class OrganizationModelControllerApi extends BaseAPI
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).getEntityWorkspaces1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).getEntityWorkspaces(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14535,7 +14422,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14545,7 +14432,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityAcls(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14560,23 +14447,23 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public updateEntityDataSources1(
+    public updateEntityDataSources(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityDataSources1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityDataSources(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14585,23 +14472,48 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public updateEntityModelModules1(
+    public updateEntityModelModules(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityModelModules1(
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityModelModules(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
+    /**
+     *
+     * @param {string} id
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public updateEntityOrganizations(
+        params: {
+            id: string;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityOrganizations(
             params,
             options,
         )(this.axios, this.basePath);
@@ -14610,48 +14522,23 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public updateEntityOrganizations1(
+    public updateEntityUserGroups(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityOrganizations1(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof OrganizationModelControllerApi
-     */
-    public updateEntityUserGroups1(
-        params: {
-            id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityUserGroups1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityUserGroups(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14660,23 +14547,23 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public updateEntityUsers1(
+    public updateEntityUsers(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityUsers1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityUsers(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14685,23 +14572,23 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
      */
-    public updateEntityWorkspaces1(
+    public updateEntityWorkspaces(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
-        return OrganizationModelControllerApiFp(this.configuration).updateEntityWorkspaces1(params, options)(
+        return OrganizationModelControllerApiFp(this.configuration).updateEntityWorkspaces(params, options)(
             this.axios,
             this.basePath,
         );
@@ -14717,7 +14604,7 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -14726,13 +14613,13 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { userId, jsonApiApiTokenDocument, variableParam, include } = params;
+            const { userId, jsonApiApiTokenInDocument, variableParam, include } = params;
             // verify required parameter 'userId' is not null or undefined
             if (userId === null || userId === undefined) {
                 throw new RequiredError(
@@ -14740,11 +14627,11 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
                     "Required parameter userId was null or undefined when calling createEntityApiTokens.",
                 );
             }
-            // verify required parameter 'jsonApiApiTokenDocument' is not null or undefined
-            if (jsonApiApiTokenDocument === null || jsonApiApiTokenDocument === undefined) {
+            // verify required parameter 'jsonApiApiTokenInDocument' is not null or undefined
+            if (jsonApiApiTokenInDocument === null || jsonApiApiTokenInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiApiTokenDocument",
-                    "Required parameter jsonApiApiTokenDocument was null or undefined when calling createEntityApiTokens.",
+                    "jsonApiApiTokenInDocument",
+                    "Required parameter jsonApiApiTokenInDocument was null or undefined when calling createEntityApiTokens.",
                 );
             }
             const localVarPath = `/api/entities/users/{userId}/apiTokens`.replace(
@@ -14783,11 +14670,11 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiApiTokenDocument !== "string" ||
+                typeof jsonApiApiTokenInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiApiTokenDocument !== undefined ? jsonApiApiTokenDocument : {})
-                : jsonApiApiTokenDocument || "";
+                ? JSON.stringify(jsonApiApiTokenInDocument !== undefined ? jsonApiApiTokenInDocument : {})
+                : jsonApiApiTokenInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15053,7 +14940,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15062,12 +14949,12 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityApiTokens(params, options);
@@ -15127,7 +15014,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutList> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesApiTokens(params, options);
@@ -15162,7 +15049,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityApiTokens(params, options);
@@ -15190,7 +15077,7 @@ export const UserModelControllerApiFactory = function (
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15199,12 +15086,12 @@ export const UserModelControllerApiFactory = function (
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenDocument> {
+        ): AxiosPromise<JsonApiApiTokenOutDocument> {
             return UserModelControllerApiFp(configuration).createEntityApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15252,7 +15139,7 @@ export const UserModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenList> {
+        ): AxiosPromise<JsonApiApiTokenOutList> {
             return UserModelControllerApiFp(configuration).getAllEntitiesApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15281,7 +15168,7 @@ export const UserModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenDocument> {
+        ): AxiosPromise<JsonApiApiTokenOutDocument> {
             return UserModelControllerApiFp(configuration).getEntityApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15299,7 +15186,7 @@ export interface UserModelControllerApiInterface {
     /**
      *
      * @param {string} userId
-     * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+     * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -15309,12 +15196,12 @@ export interface UserModelControllerApiInterface {
     createEntityApiTokens(
         params: {
             userId: string;
-            jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+            jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenDocument>;
+    ): AxiosPromise<JsonApiApiTokenOutDocument>;
 
     /**
      *
@@ -15356,7 +15243,7 @@ export interface UserModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenList>;
+    ): AxiosPromise<JsonApiApiTokenOutList>;
 
     /**
      *
@@ -15382,7 +15269,7 @@ export interface UserModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenDocument>;
+    ): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 /**
@@ -15395,7 +15282,7 @@ export class UserModelControllerApi extends BaseAPI implements UserModelControll
     /**
      *
      * @param {string} userId
-     * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+     * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -15405,7 +15292,7 @@ export class UserModelControllerApi extends BaseAPI implements UserModelControll
     public createEntityApiTokens(
         params: {
             userId: string;
-            jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+            jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -15510,7 +15397,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15519,13 +15406,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiAnalyticalDashboardDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiAnalyticalDashboardInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15533,14 +15420,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityAnalyticalDashboards.",
                 );
             }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
+            // verify required parameter 'jsonApiAnalyticalDashboardInDocument' is not null or undefined
             if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
+                jsonApiAnalyticalDashboardInDocument === null ||
+                jsonApiAnalyticalDashboardInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling createEntityAnalyticalDashboards.",
+                    "jsonApiAnalyticalDashboardInDocument",
+                    "Required parameter jsonApiAnalyticalDashboardInDocument was null or undefined when calling createEntityAnalyticalDashboards.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards`.replace(
@@ -15579,15 +15466,15 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
+                typeof jsonApiAnalyticalDashboardInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
+                      jsonApiAnalyticalDashboardInDocument !== undefined
+                          ? jsonApiAnalyticalDashboardInDocument
                           : {},
                   )
-                : jsonApiAnalyticalDashboardDocument || "";
+                : jsonApiAnalyticalDashboardInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15597,89 +15484,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiDataDiscriminatorDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'jsonApiDataDiscriminatorDocument' is not null or undefined
-            if (jsonApiDataDiscriminatorDocument === null || jsonApiDataDiscriminatorDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiDataDiscriminatorDocument",
-                    "Required parameter jsonApiDataDiscriminatorDocument was null or undefined when calling createEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiDataDiscriminatorDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiDataDiscriminatorDocument !== undefined ? jsonApiDataDiscriminatorDocument : {},
-                  )
-                : jsonApiDataDiscriminatorDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15688,13 +15493,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiFilterContextDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiFilterContextInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15702,11 +15507,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityFilterContexts.",
                 );
             }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
+            // verify required parameter 'jsonApiFilterContextInDocument' is not null or undefined
+            if (jsonApiFilterContextInDocument === null || jsonApiFilterContextInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling createEntityFilterContexts.",
+                    "jsonApiFilterContextInDocument",
+                    "Required parameter jsonApiFilterContextInDocument was null or undefined when calling createEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/filterContexts`.replace(
@@ -15745,13 +15550,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
+                typeof jsonApiFilterContextInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
+                      jsonApiFilterContextInDocument !== undefined ? jsonApiFilterContextInDocument : {},
                   )
-                : jsonApiFilterContextDocument || "";
+                : jsonApiFilterContextInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15761,7 +15566,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15770,13 +15575,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiMetricDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiMetricInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15784,11 +15589,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityMetrics.",
                 );
             }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
+            // verify required parameter 'jsonApiMetricInDocument' is not null or undefined
+            if (jsonApiMetricInDocument === null || jsonApiMetricInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling createEntityMetrics.",
+                    "jsonApiMetricInDocument",
+                    "Required parameter jsonApiMetricInDocument was null or undefined when calling createEntityMetrics.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/metrics`.replace(
@@ -15827,11 +15632,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
+                typeof jsonApiMetricInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
+                ? JSON.stringify(jsonApiMetricInDocument !== undefined ? jsonApiMetricInDocument : {})
+                : jsonApiMetricInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15841,7 +15646,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15850,13 +15655,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiVisualizationObjectDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiVisualizationObjectInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15864,14 +15669,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityVisualizationObjects.",
                 );
             }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
+            // verify required parameter 'jsonApiVisualizationObjectInDocument' is not null or undefined
             if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
+                jsonApiVisualizationObjectInDocument === null ||
+                jsonApiVisualizationObjectInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling createEntityVisualizationObjects.",
+                    "jsonApiVisualizationObjectInDocument",
+                    "Required parameter jsonApiVisualizationObjectInDocument was null or undefined when calling createEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/visualizationObjects`.replace(
@@ -15910,15 +15715,102 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
+                typeof jsonApiVisualizationObjectInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
+                      jsonApiVisualizationObjectInDocument !== undefined
+                          ? jsonApiVisualizationObjectInDocument
                           : {},
                   )
-                : jsonApiVisualizationObjectDocument || "";
+                : jsonApiVisualizationObjectInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, jsonApiWorkspaceDataFilterInDocument, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceDataFilterInDocument' is not null or undefined
+            if (
+                jsonApiWorkspaceDataFilterInDocument === null ||
+                jsonApiWorkspaceDataFilterInDocument === undefined
+            ) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceDataFilterInDocument",
+                    "Required parameter jsonApiWorkspaceDataFilterInDocument was null or undefined when calling createEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceDataFilterInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiWorkspaceDataFilterInDocument !== undefined
+                          ? jsonApiWorkspaceDataFilterInDocument
+                          : {},
+                  )
+                : jsonApiWorkspaceDataFilterInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15957,67 +15849,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
                 .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
                 .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
@@ -16233,6 +16064,67 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling deleteEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -16350,95 +16242,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/attributes`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -17212,6 +17015,184 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, variableParam, include, page, size, sort } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntitiesWorkspaceDataFilterSettings.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            if (page !== undefined) {
+                if (typeof page === "object") {
+                    addFlattenedObjectTo(page, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["page"] = page;
+                }
+            }
+
+            if (size !== undefined) {
+                if (typeof size === "object") {
+                    addFlattenedObjectTo(size, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["size"] = size;
+                }
+            }
+
+            if (sort) {
+                localVarQueryParameter["sort"] = sort;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, variableParam, include, page, size, sort } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntitiesWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            if (page !== undefined) {
+                if (typeof page === "object") {
+                    addFlattenedObjectTo(page, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["page"] = page;
+                }
+            }
+
+            if (size !== undefined) {
+                if (typeof size === "object") {
+                    addFlattenedObjectTo(size, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["size"] = size;
+                }
+            }
+
+            if (sort) {
+                localVarQueryParameter["sort"] = sort;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
@@ -17314,77 +17295,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/attributes/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
                 .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
                 .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
@@ -17994,7 +17904,149 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntityWorkspaceDataFilterSettings.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling getEntityWorkspaceDataFilterSettings.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling getEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18004,7 +18056,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
@@ -18013,7 +18065,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             const {
                 workspaceId,
                 objectId,
-                jsonApiAnalyticalDashboardDocument,
+                jsonApiAnalyticalDashboardInDocument,
                 variableParam,
                 include,
             } = params;
@@ -18031,14 +18083,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
+            // verify required parameter 'jsonApiAnalyticalDashboardInDocument' is not null or undefined
             if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
+                jsonApiAnalyticalDashboardInDocument === null ||
+                jsonApiAnalyticalDashboardInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
+                    "jsonApiAnalyticalDashboardInDocument",
+                    "Required parameter jsonApiAnalyticalDashboardInDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards/{objectId}`
@@ -18076,15 +18128,15 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
+                typeof jsonApiAnalyticalDashboardInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
+                      jsonApiAnalyticalDashboardInDocument !== undefined
+                          ? jsonApiAnalyticalDashboardInDocument
                           : {},
                   )
-                : jsonApiAnalyticalDashboardDocument || "";
+                : jsonApiAnalyticalDashboardInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18095,103 +18147,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const {
-                workspaceId,
-                objectId,
-                jsonApiDataDiscriminatorDocument,
-                variableParam,
-                include,
-            } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'jsonApiDataDiscriminatorDocument' is not null or undefined
-            if (jsonApiDataDiscriminatorDocument === null || jsonApiDataDiscriminatorDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiDataDiscriminatorDocument",
-                    "Required parameter jsonApiDataDiscriminatorDocument was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiDataDiscriminatorDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiDataDiscriminatorDocument !== undefined ? jsonApiDataDiscriminatorDocument : {},
-                  )
-                : jsonApiDataDiscriminatorDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18201,13 +18157,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, objectId, jsonApiFilterContextDocument, variableParam, include } = params;
+            const { workspaceId, objectId, jsonApiFilterContextInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -18222,11 +18178,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
+            // verify required parameter 'jsonApiFilterContextInDocument' is not null or undefined
+            if (jsonApiFilterContextInDocument === null || jsonApiFilterContextInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling updateEntityFilterContexts.",
+                    "jsonApiFilterContextInDocument",
+                    "Required parameter jsonApiFilterContextInDocument was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/filterContexts/{objectId}`
@@ -18264,13 +18220,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
+                typeof jsonApiFilterContextInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
+                      jsonApiFilterContextInDocument !== undefined ? jsonApiFilterContextInDocument : {},
                   )
-                : jsonApiFilterContextDocument || "";
+                : jsonApiFilterContextInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18281,7 +18237,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18291,13 +18247,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, objectId, jsonApiMetricDocument, variableParam, include } = params;
+            const { workspaceId, objectId, jsonApiMetricInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -18312,11 +18268,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityMetrics.",
                 );
             }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
+            // verify required parameter 'jsonApiMetricInDocument' is not null or undefined
+            if (jsonApiMetricInDocument === null || jsonApiMetricInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling updateEntityMetrics.",
+                    "jsonApiMetricInDocument",
+                    "Required parameter jsonApiMetricInDocument was null or undefined when calling updateEntityMetrics.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/metrics/{objectId}`
@@ -18354,11 +18310,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
+                typeof jsonApiMetricInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
+                ? JSON.stringify(jsonApiMetricInDocument !== undefined ? jsonApiMetricInDocument : {})
+                : jsonApiMetricInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18369,7 +18325,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18379,7 +18335,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
@@ -18388,7 +18344,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             const {
                 workspaceId,
                 objectId,
-                jsonApiVisualizationObjectDocument,
+                jsonApiVisualizationObjectInDocument,
                 variableParam,
                 include,
             } = params;
@@ -18406,14 +18362,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
+            // verify required parameter 'jsonApiVisualizationObjectInDocument' is not null or undefined
             if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
+                jsonApiVisualizationObjectInDocument === null ||
+                jsonApiVisualizationObjectInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling updateEntityVisualizationObjects.",
+                    "jsonApiVisualizationObjectInDocument",
+                    "Required parameter jsonApiVisualizationObjectInDocument was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/visualizationObjects/{objectId}`
@@ -18451,15 +18407,116 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
+                typeof jsonApiVisualizationObjectInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
+                      jsonApiVisualizationObjectInDocument !== undefined
+                          ? jsonApiVisualizationObjectInDocument
                           : {},
                   )
-                : jsonApiVisualizationObjectDocument || "";
+                : jsonApiVisualizationObjectInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const {
+                workspaceId,
+                objectId,
+                jsonApiWorkspaceDataFilterInDocument,
+                variableParam,
+                include,
+            } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceDataFilterInDocument' is not null or undefined
+            if (
+                jsonApiWorkspaceDataFilterInDocument === null ||
+                jsonApiWorkspaceDataFilterInDocument === undefined
+            ) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceDataFilterInDocument",
+                    "Required parameter jsonApiWorkspaceDataFilterInDocument was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceDataFilterInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiWorkspaceDataFilterInDocument !== undefined
+                          ? jsonApiWorkspaceDataFilterInDocument
+                          : {},
+                  )
+                : jsonApiWorkspaceDataFilterInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18478,7 +18535,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18487,12 +18544,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityAnalyticalDashboards(params, options);
@@ -18507,36 +18564,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityDataDiscriminators(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18545,12 +18573,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityFilterContexts(params, options);
@@ -18565,7 +18593,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18574,12 +18602,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityMetrics(params, options);
@@ -18594,7 +18622,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18603,15 +18631,44 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).createEntityWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18639,33 +18696,6 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).deleteEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18758,6 +18788,33 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).deleteEntityWorkspaceDataFilters(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -18776,7 +18833,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesAnalyticalDashboards(params, options);
@@ -18809,43 +18866,10 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorList> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18875,7 +18899,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesDatasets(params, options);
@@ -18908,7 +18932,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesFacts(params, options);
@@ -18941,7 +18965,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesFilterContexts(params, options);
@@ -18974,7 +18998,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesLabels(params, options);
@@ -19007,7 +19031,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesMetrics(params, options);
@@ -19040,7 +19064,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesSources(params, options);
@@ -19073,7 +19097,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesTables(params, options);
@@ -19106,10 +19130,79 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): (
+            axios?: AxiosInstance,
+            basePath?: string,
+        ) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntitiesWorkspaceDataFilterSettings(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutList> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntitiesWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19135,7 +19228,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAnalyticalDashboards(params, options);
@@ -19164,39 +19257,10 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19222,7 +19286,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityDatasets(params, options);
@@ -19251,7 +19315,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityFacts(params, options);
@@ -19280,7 +19344,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityFilterContexts(params, options);
@@ -19309,7 +19373,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityLabels(params, options);
@@ -19338,7 +19402,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityMetrics(params, options);
@@ -19367,7 +19431,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitySources(params, options);
@@ -19396,7 +19460,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityTables(params, options);
@@ -19425,7 +19489,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityVisualizationObjects(params, options);
@@ -19441,7 +19505,68 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (
+            axios?: AxiosInstance,
+            basePath?: string,
+        ) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntityWorkspaceDataFilterSettings(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntityWorkspaceDataFilters(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19451,12 +19576,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityAnalyticalDashboards(params, options);
@@ -19472,38 +19597,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityDataDiscriminators(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19513,12 +19607,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityFilterContexts(params, options);
@@ -19534,7 +19628,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19544,12 +19638,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityMetrics(params, options);
@@ -19565,7 +19659,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19575,15 +19669,46 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).updateEntityWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19608,7 +19733,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19617,12 +19742,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityAnalyticalDashboards(
                 params,
                 options,
@@ -19631,30 +19756,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19663,12 +19765,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -19677,7 +19779,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19686,12 +19788,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -19700,7 +19802,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19709,13 +19811,36 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).createEntityWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -19737,27 +19862,6 @@ export const WorkspaceObjectControllerApiFactory = function (
             options?: any,
         ): AxiosPromise<void> {
             return WorkspaceObjectControllerApiFp(configuration).deleteEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityDataDiscriminators(
                 params,
                 options,
             )(axios, basePath);
@@ -19828,6 +19932,27 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options?: any,
+        ): AxiosPromise<void> {
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityWorkspaceDataFilters(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -19846,7 +19971,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardList> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesAnalyticalDashboards(
                 params,
                 options,
@@ -19873,38 +19998,11 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAttributeList> {
+        ): AxiosPromise<JsonApiAttributeOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesAttributes(params, options)(
                 axios,
                 basePath,
             );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
         },
         /**
          *
@@ -19927,7 +20025,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDatasetList> {
+        ): AxiosPromise<JsonApiDatasetOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesDatasets(params, options)(
                 axios,
                 basePath,
@@ -19954,7 +20052,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFactList> {
+        ): AxiosPromise<JsonApiFactOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesFacts(params, options)(
                 axios,
                 basePath,
@@ -19981,7 +20079,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextList> {
+        ): AxiosPromise<JsonApiFilterContextOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20008,7 +20106,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiLabelList> {
+        ): AxiosPromise<JsonApiLabelOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesLabels(params, options)(
                 axios,
                 basePath,
@@ -20035,7 +20133,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricList> {
+        ): AxiosPromise<JsonApiMetricOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesMetrics(params, options)(
                 axios,
                 basePath,
@@ -20062,7 +20160,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTablesList> {
+        ): AxiosPromise<JsonApiSourceTablesOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesSources(params, options)(
                 axios,
                 basePath,
@@ -20089,7 +20187,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTableList> {
+        ): AxiosPromise<JsonApiSourceTableOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesTables(params, options)(
                 axios,
                 basePath,
@@ -20116,8 +20214,62 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectList> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesWorkspaceDataFilterSettings(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutList> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -20139,7 +20291,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityAnalyticalDashboards(
                 params,
                 options,
@@ -20162,31 +20314,8 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAttributeDocument> {
+        ): AxiosPromise<JsonApiAttributeOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityAttributes(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityDataDiscriminators(params, options)(
                 axios,
                 basePath,
             );
@@ -20208,7 +20337,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDatasetDocument> {
+        ): AxiosPromise<JsonApiDatasetOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityDatasets(params, options)(
                 axios,
                 basePath,
@@ -20231,7 +20360,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFactDocument> {
+        ): AxiosPromise<JsonApiFactOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityFacts(params, options)(
                 axios,
                 basePath,
@@ -20254,7 +20383,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20277,7 +20406,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiLabelDocument> {
+        ): AxiosPromise<JsonApiLabelOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityLabels(params, options)(
                 axios,
                 basePath,
@@ -20300,7 +20429,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -20323,7 +20452,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTablesDocument> {
+        ): AxiosPromise<JsonApiSourceTablesOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitySources(params, options)(
                 axios,
                 basePath,
@@ -20346,7 +20475,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTableDocument> {
+        ): AxiosPromise<JsonApiSourceTableOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityTables(params, options)(
                 axios,
                 basePath,
@@ -20369,7 +20498,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityVisualizationObjects(
                 params,
                 options,
@@ -20379,7 +20508,53 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntityWorkspaceDataFilterSettings(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntityWorkspaceDataFilters(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20389,12 +20564,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityAnalyticalDashboards(
                 params,
                 options,
@@ -20404,32 +20579,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20439,12 +20589,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20454,7 +20604,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20464,12 +20614,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -20479,7 +20629,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20489,13 +20639,38 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -20512,7 +20687,7 @@ export interface WorkspaceObjectControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20522,37 +20697,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    createEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20562,17 +20717,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityFilterContexts(
         params: {
             workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20582,17 +20737,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityMetrics(
         params: {
             workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20602,12 +20757,32 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityVisualizationObjects(
         params: {
             workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    createEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 
     /**
      *
@@ -20619,24 +20794,6 @@ export interface WorkspaceObjectControllerApiInterface {
      * @memberof WorkspaceObjectControllerApiInterface
      */
     deleteEntityAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    deleteEntityDataDiscriminators(
         params: {
             workspaceId: string;
             objectId: string;
@@ -20702,6 +20859,24 @@ export interface WorkspaceObjectControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    deleteEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+        },
+        options?: any,
+    ): AxiosPromise<void>;
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {number} [page] Zero-based page index (0..N)
@@ -20721,7 +20896,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
 
     /**
      *
@@ -20745,31 +20920,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAttributeList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    getEntitiesDataDiscriminators(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorList>;
+    ): AxiosPromise<JsonApiAttributeOutList>;
 
     /**
      *
@@ -20793,7 +20944,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDatasetList>;
+    ): AxiosPromise<JsonApiDatasetOutList>;
 
     /**
      *
@@ -20817,7 +20968,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFactList>;
+    ): AxiosPromise<JsonApiFactOutList>;
 
     /**
      *
@@ -20841,7 +20992,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextList>;
+    ): AxiosPromise<JsonApiFilterContextOutList>;
 
     /**
      *
@@ -20865,7 +21016,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiLabelList>;
+    ): AxiosPromise<JsonApiLabelOutList>;
 
     /**
      *
@@ -20889,7 +21040,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricList>;
+    ): AxiosPromise<JsonApiMetricOutList>;
 
     /**
      *
@@ -20913,7 +21064,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTablesList>;
+    ): AxiosPromise<JsonApiSourceTablesOutList>;
 
     /**
      *
@@ -20937,7 +21088,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTableList>;
+    ): AxiosPromise<JsonApiSourceTableOutList>;
 
     /**
      *
@@ -20961,7 +21112,55 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectList>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutList>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntitiesWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntitiesWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
 
     /**
      *
@@ -20981,7 +21180,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
@@ -21001,27 +21200,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAttributeDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    getEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    ): AxiosPromise<JsonApiAttributeOutDocument>;
 
     /**
      *
@@ -21041,7 +21220,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDatasetDocument>;
+    ): AxiosPromise<JsonApiDatasetOutDocument>;
 
     /**
      *
@@ -21061,7 +21240,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFactDocument>;
+    ): AxiosPromise<JsonApiFactOutDocument>;
 
     /**
      *
@@ -21081,7 +21260,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
@@ -21101,7 +21280,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiLabelDocument>;
+    ): AxiosPromise<JsonApiLabelOutDocument>;
 
     /**
      *
@@ -21121,7 +21300,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
@@ -21141,7 +21320,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTablesDocument>;
+    ): AxiosPromise<JsonApiSourceTablesOutDocument>;
 
     /**
      *
@@ -21161,7 +21340,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTableDocument>;
+    ): AxiosPromise<JsonApiSourceTableOutDocument>;
 
     /**
      *
@@ -21181,13 +21360,53 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntityWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21198,40 +21417,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    updateEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21242,18 +21439,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21264,18 +21461,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21286,12 +21483,34 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    updateEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 /**
@@ -21304,7 +21523,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21314,7 +21533,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21329,32 +21548,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public createEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21364,7 +21558,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityFilterContexts(
         params: {
             workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21379,7 +21573,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21389,7 +21583,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityMetrics(
         params: {
             workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21404,7 +21598,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21414,13 +21608,38 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityVisualizationObjects(
         params: {
             workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).createEntityVisualizationObjects(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public createEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityWorkspaceDataFilters(
             params,
             options,
         )(this.axios, this.basePath);
@@ -21444,29 +21663,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public deleteEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityDataDiscriminators(
             params,
             options,
         )(this.axios, this.basePath);
@@ -21544,6 +21740,29 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public deleteEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {number} [page] Zero-based page index (0..N)
@@ -21597,35 +21816,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
             this.axios,
             this.basePath,
         );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public getEntitiesDataDiscriminators(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
     }
 
     /**
@@ -21863,6 +22053,64 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntitiesWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesWorkspaceDataFilterSettings(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntitiesWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {string} objectId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
@@ -21908,31 +22156,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
             this.axios,
             this.basePath,
         );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public getEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
     }
 
     /**
@@ -22139,7 +22362,57 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntityWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityWorkspaceDataFilterSettings(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22150,7 +22423,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22166,34 +22439,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public updateEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22204,7 +22450,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22220,7 +22466,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22231,7 +22477,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22247,7 +22493,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22258,13 +22504,40 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).updateEntityVisualizationObjects(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public updateEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityWorkspaceDataFilters(
             params,
             options,
         )(this.axios, this.basePath);

--- a/libs/api-client-tiger/src/generated/metadata-json-api/base.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/base.ts
@@ -1,5 +1,3 @@
-// (C) 2021 GoodData Corporation
-
 /* eslint-disable */
 /**
  * OpenAPI definition
@@ -18,7 +16,7 @@ import { Configuration } from "./configuration";
 // @ts-ignore
 import globalAxios, { AxiosPromise, AxiosInstance } from "axios";
 
-export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
+export const BASE_PATH = "http://localhost:3000".replace(/\/+$/, "");
 
 /**
  *

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -330,32 +330,6 @@
                 }
             }
         },
-        "/api/dataSources/{dataSourceId}/uploadNotification": {
-            "post": {
-                "tags": ["notification-controller"],
-                "summary": "Register an upload notification",
-                "description": "Notification sets up all reports to be computed again with new data.",
-                "operationId": "registerUploadNotification_1",
-                "parameters": [
-                    {
-                        "name": "dataSourceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "An upload notification has been successfully registered."
-                    },
-                    "404": {
-                        "description": "Data source with given name does not exist."
-                    }
-                }
-            }
-        },
         "/api/options": {
             "get": {
                 "tags": ["options-controller"],
@@ -647,692 +621,6 @@
                 }
             }
         },
-        "/api/entities/admin/acls/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@Acls_1",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@Acls_1",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/dataSources/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@DataSources",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@DataSources",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/modelModules/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@ModelModules",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@ModelModules",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/organizations/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@Organizations",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@Organizations",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/userGroups/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@UserGroups",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@UserGroups",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/users/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@Users",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@Users",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/entities/admin/workspaces/{id}": {
-            "get": {
-                "tags": ["organization-controller"],
-                "operationId": "getEntity@Workspaces",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["organization-controller"],
-                "operationId": "updateEntity@Workspaces",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application/vnd.gooddata.api+json": {
-                            "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
-                            }
-                        }
-                    },
-                    "required": true
-                },
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/entities/dataSources": {
             "get": {
                 "tags": ["organization-model-controller"],
@@ -1445,7 +733,7 @@
         "/api/entities/dataSources/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@DataSources_1",
+                "operationId": "getEntity@DataSources",
                 "parameters": [
                     {
                         "name": "id",
@@ -1488,7 +776,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@DataSources_1",
+                "operationId": "updateEntity@DataSources",
                 "parameters": [
                     {
                         "name": "id",
@@ -1680,7 +968,7 @@
         "/api/entities/modelModules/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@ModelModules_1",
+                "operationId": "getEntity@ModelModules",
                 "parameters": [
                     {
                         "name": "id",
@@ -1723,7 +1011,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@ModelModules_1",
+                "operationId": "updateEntity@ModelModules",
                 "parameters": [
                     {
                         "name": "id",
@@ -1806,7 +1094,7 @@
         "/api/entities/organization": {
             "get": {
                 "tags": ["organization-controller"],
-                "operationId": "getOrganization@Users_1_1",
+                "operationId": "getOrganization@Users",
                 "responses": {
                     "200": {
                         "description": "Request successfully processed",
@@ -1955,7 +1243,7 @@
         "/api/entities/organizations/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@Organizations_1",
+                "operationId": "getEntity@Organizations",
                 "parameters": [
                     {
                         "name": "id",
@@ -1998,7 +1286,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@Organizations_1",
+                "operationId": "updateEntity@Organizations",
                 "parameters": [
                     {
                         "name": "id",
@@ -2190,7 +1478,7 @@
         "/api/entities/userGroups/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@UserGroups_1",
+                "operationId": "getEntity@UserGroups",
                 "parameters": [
                     {
                         "name": "id",
@@ -2233,7 +1521,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@UserGroups_1",
+                "operationId": "updateEntity@UserGroups",
                 "parameters": [
                     {
                         "name": "id",
@@ -2425,7 +1713,7 @@
         "/api/entities/users/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@Users_1",
+                "operationId": "getEntity@Users",
                 "parameters": [
                     {
                         "name": "id",
@@ -2468,7 +1756,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@Users_1",
+                "operationId": "updateEntity@Users",
                 "parameters": [
                     {
                         "name": "id",
@@ -2903,7 +2191,7 @@
         "/api/entities/workspaces/{id}": {
             "get": {
                 "tags": ["organization-model-controller"],
-                "operationId": "getEntity@Workspaces_1",
+                "operationId": "getEntity@Workspaces",
                 "parameters": [
                     {
                         "name": "id",
@@ -2946,7 +2234,7 @@
             },
             "put": {
                 "tags": ["organization-model-controller"],
-                "operationId": "updateEntity@Workspaces_1",
+                "operationId": "updateEntity@Workspaces",
                 "parameters": [
                     {
                         "name": "id",

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -18,12 +18,12 @@
         "/api/layout/workspaces": {
             "get": {
                 "tags": ["declarative-layout-controller"],
-                "summary": "Get all workspaces layout",
-                "description": "Retrieve layout of workspaces, including a hierarchy and models.",
+                "summary": "Set all workspaces layout",
+                "description": "Sets complete layout of workspaces, their hierarchy, models.",
                 "operationId": "getWorkspacesLayout",
                 "responses": {
-                    "200": {
-                        "description": "Retrieved all workspaces layout.",
+                    "204": {
+                        "description": "All workspaces layout set.",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -239,6 +239,47 @@
                 }
             }
         },
+        "/api/layout/workspaceDataFilters": {
+            "get": {
+                "tags": ["declarative-layout-controller"],
+                "summary": "Get workspace data filters for all workspaces",
+                "description": "Retrieve all workspaces and related workspace data filters (and their settings / values).",
+                "operationId": "getWorkspaceDataFiltersLayout",
+                "responses": {
+                    "200": {
+                        "description": "Retrieved all workspace data filters.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilters"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": ["declarative-layout-controller"],
+                "summary": "Set all workspace data filters",
+                "description": "Sets workspace data filters in all workspaces in entire organization.",
+                "operationId": "setWorkspaceDataFiltersLayout",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilters"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "All workspace data filters set."
+                    }
+                }
+            }
+        },
         "/api/layout/organization": {
             "get": {
                 "tags": ["declarative-layout-controller"],
@@ -263,12 +304,38 @@
                 }
             }
         },
-        "/api/dataSources/{dataSourceId}/uploadNotification": {
+        "/api/actions/dataSources/{dataSourceId}/uploadNotification": {
             "post": {
                 "tags": ["notification-controller"],
                 "summary": "Register an upload notification",
                 "description": "Notification sets up all reports to be computed again with new data.",
                 "operationId": "registerUploadNotification",
+                "parameters": [
+                    {
+                        "name": "dataSourceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "An upload notification has been successfully registered."
+                    },
+                    "404": {
+                        "description": "Data source with given name does not exist."
+                    }
+                }
+            }
+        },
+        "/api/dataSources/{dataSourceId}/uploadNotification": {
+            "post": {
+                "tags": ["notification-controller"],
+                "summary": "Register an upload notification",
+                "description": "Notification sets up all reports to be computed again with new data.",
+                "operationId": "registerUploadNotification_1",
                 "parameters": [
                     {
                         "name": "dataSourceId",
@@ -402,7 +469,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLList"
+                                    "$ref": "#/components/schemas/JsonApiACLOutList"
                                 }
                             }
                         }
@@ -434,7 +501,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -446,7 +513,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -491,7 +558,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -532,7 +599,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -544,7 +611,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -617,7 +684,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -658,7 +725,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -670,7 +737,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -715,7 +782,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -756,7 +823,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -768,7 +835,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -813,7 +880,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -854,7 +921,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -866,7 +933,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -911,7 +978,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -952,7 +1019,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -964,7 +1031,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1009,7 +1076,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -1050,7 +1117,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -1062,7 +1129,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -1107,7 +1174,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -1148,7 +1215,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -1160,7 +1227,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -1205,7 +1272,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -1246,7 +1313,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -1258,7 +1325,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -1323,7 +1390,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceList"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutList"
                                 }
                             }
                         }
@@ -1355,7 +1422,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -1367,7 +1434,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1412,7 +1479,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1453,7 +1520,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -1465,7 +1532,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1558,7 +1625,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleList"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutList"
                                 }
                             }
                         }
@@ -1590,7 +1657,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -1602,7 +1669,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1647,7 +1714,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1688,7 +1755,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -1700,7 +1767,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1748,25 +1815,25 @@
                                 "schema": {
                                     "oneOf": [
                                         {
-                                            "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                            "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiACLDocument"
+                                            "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                            "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                            "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                            "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiUserDocument"
+                                            "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                            "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                         }
                                     ]
                                 }
@@ -1833,7 +1900,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationList"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutList"
                                 }
                             }
                         }
@@ -1865,7 +1932,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -1877,7 +1944,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1922,7 +1989,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1963,7 +2030,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -1975,7 +2042,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -2068,7 +2135,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupList"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutList"
                                 }
                             }
                         }
@@ -2100,7 +2167,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -2112,7 +2179,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2157,7 +2224,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2198,7 +2265,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -2210,7 +2277,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2303,7 +2370,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserList"
+                                    "$ref": "#/components/schemas/JsonApiUserOutList"
                                 }
                             }
                         }
@@ -2335,7 +2402,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -2347,7 +2414,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2392,7 +2459,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2433,7 +2500,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -2445,7 +2512,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2546,7 +2613,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenList"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutList"
                                 }
                             }
                         }
@@ -2586,7 +2653,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                "$ref": "#/components/schemas/JsonApiApiTokenInDocument"
                             }
                         }
                     },
@@ -2598,7 +2665,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutDocument"
                                 }
                             }
                         }
@@ -2680,7 +2747,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutDocument"
                                 }
                             }
                         }
@@ -2781,7 +2848,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceList"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutList"
                                 }
                             }
                         }
@@ -2813,7 +2880,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -2825,7 +2892,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -2870,7 +2937,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -2911,7 +2978,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -2923,7 +2990,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -3024,7 +3091,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardList"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutList"
                                 }
                             }
                         }
@@ -3064,7 +3131,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardInDocument"
                             }
                         }
                     },
@@ -3076,7 +3143,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3128,7 +3195,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3176,7 +3243,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardInDocument"
                             }
                         }
                     },
@@ -3188,7 +3255,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3296,7 +3363,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeList"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutList"
                                 }
                             }
                         }
@@ -3348,7 +3415,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeDocument"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutDocument"
                                 }
                             }
                         }
@@ -3374,7 +3441,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -3386,7 +3453,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -3412,7 +3479,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -3424,7 +3491,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -3450,7 +3517,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -3462,7 +3529,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -3488,7 +3555,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -3500,7 +3567,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -3526,7 +3593,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -3538,7 +3605,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -3564,7 +3631,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -3576,7 +3643,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -3602,7 +3669,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -3614,7 +3681,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -3622,81 +3689,10 @@
                 }
             }
         },
-        "/api/entities/workspaces/{workspaceId}/dataDiscriminators": {
-            "get": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@DataDiscriminators",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/acls": {
             "post": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@DataDiscriminators",
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Acls",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3707,19 +3703,11 @@
                         }
                     },
                     {
-                        "name": "variableParam",
-                        "in": "query",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
+                            "type": "string"
                         }
                     }
                 ],
@@ -3727,7 +3715,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -3739,7 +3727,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -3747,10 +3735,10 @@
                 }
             }
         },
-        "/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}": {
-            "get": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@DataDiscriminators",
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/dataSources": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@DataSources",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3761,77 +3749,11 @@
                         }
                     },
                     {
-                        "name": "objectId",
+                        "name": "childWorkspaceId",
                         "in": "path",
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@DataDiscriminators",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "objectId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
                         }
                     }
                 ],
@@ -3839,28 +3761,30 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
                     "required": true
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "Request successfully processed",
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
                     }
                 }
-            },
-            "delete": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@DataDiscriminators",
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/modelModules": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@ModelModules",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3871,7 +3795,45 @@
                         }
                     },
                     {
-                        "name": "objectId",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/organizations": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Organizations",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
                         "in": "path",
                         "required": true,
                         "schema": {
@@ -3879,17 +3841,172 @@
                         }
                     },
                     {
-                        "name": "variableParam",
-                        "in": "query",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "type": "string"
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/userGroups": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@UserGroups",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/users": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Users",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/workspaces": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Workspaces",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3959,7 +4076,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetList"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutList"
                                 }
                             }
                         }
@@ -4011,7 +4128,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetDocument"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutDocument"
                                 }
                             }
                         }
@@ -4084,7 +4201,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactList"
+                                    "$ref": "#/components/schemas/JsonApiFactOutList"
                                 }
                             }
                         }
@@ -4136,7 +4253,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactDocument"
+                                    "$ref": "#/components/schemas/JsonApiFactOutDocument"
                                 }
                             }
                         }
@@ -4209,7 +4326,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextList"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutList"
                                 }
                             }
                         }
@@ -4249,7 +4366,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                "$ref": "#/components/schemas/JsonApiFilterContextInDocument"
                             }
                         }
                     },
@@ -4261,7 +4378,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4313,7 +4430,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4361,7 +4478,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                "$ref": "#/components/schemas/JsonApiFilterContextInDocument"
                             }
                         }
                     },
@@ -4373,7 +4490,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4481,7 +4598,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelList"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutList"
                                 }
                             }
                         }
@@ -4533,7 +4650,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelDocument"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutDocument"
                                 }
                             }
                         }
@@ -4606,7 +4723,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricList"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutList"
                                 }
                             }
                         }
@@ -4646,7 +4763,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                "$ref": "#/components/schemas/JsonApiMetricInDocument"
                             }
                         }
                     },
@@ -4658,7 +4775,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4710,7 +4827,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4758,7 +4875,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                "$ref": "#/components/schemas/JsonApiMetricInDocument"
                             }
                         }
                     },
@@ -4770,7 +4887,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4878,7 +4995,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesList"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutList"
                                 }
                             }
                         }
@@ -4930,7 +5047,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesDocument"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutDocument"
                                 }
                             }
                         }
@@ -5003,7 +5120,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableList"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutList"
                                 }
                             }
                         }
@@ -5055,7 +5172,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableDocument"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutDocument"
                                 }
                             }
                         }
@@ -5128,7 +5245,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectList"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutList"
                                 }
                             }
                         }
@@ -5168,7 +5285,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                "$ref": "#/components/schemas/JsonApiVisualizationObjectInDocument"
                             }
                         }
                     },
@@ -5180,7 +5297,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5232,7 +5349,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5280,7 +5397,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                "$ref": "#/components/schemas/JsonApiVisualizationObjectInDocument"
                             }
                         }
                     },
@@ -5292,7 +5409,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5302,6 +5419,403 @@
             "delete": {
                 "tags": ["workspace-object-controller"],
                 "operationId": "deleteEntity@VisualizationObjects",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntities@WorkspaceDataFilterSettings",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Zero-based page index (0..N)",
+                        "schema": {
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The size of the page to be returned",
+                        "schema": {
+                            "type": "integer",
+                            "default": "20"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutList"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings/{objectId}": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntity@WorkspaceDataFilterSettings",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilters": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntities@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Zero-based page index (0..N)",
+                        "schema": {
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The size of the page to be returned",
+                        "schema": {
+                            "type": "integer",
+                            "default": "20"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutList"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "createEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "updateEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "deleteEntity@WorkspaceDataFilters",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5442,38 +5956,6 @@
                     }
                 },
                 "description": "A table column."
-            },
-            "DeclarativeDataDiscriminator": {
-                "required": ["columnName", "dataSourceName", "id", "title"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Data Discriminator ID. This ID is further used to refer to this instance of DD.",
-                        "example": "country_id"
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "Data Discriminator title.",
-                        "example": "Country ID"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Data Discriminator description.",
-                        "example": "ID of country"
-                    },
-                    "columnName": {
-                        "type": "string",
-                        "description": "Data Discriminator column name. Data are filtered using this physical column.",
-                        "example": "country_id"
-                    },
-                    "dataSourceName": {
-                        "type": "string",
-                        "description": "Data source name (ID). Data Discriminator must always be connected to single data source.",
-                        "example": "sampleDataSource"
-                    }
-                },
-                "description": "Data discriminators serving the discrimination of what data users can see in workspaces."
             },
             "DeclarativeDataSource": {
                 "required": ["name", "tables"],
@@ -5775,9 +6257,10 @@
                     "path": {
                         "type": "array",
                         "description": "Path to table.",
-                        "example": "table_schema.table_name",
+                        "example": ["table_schema", "table_name"],
                         "items": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "table_name"
                         }
                     },
                     "columns": {
@@ -5832,8 +6315,85 @@
                     }
                 }
             },
+            "DeclarativeWorkspaceDataFilter": {
+                "required": ["columnName", "dataSourceName", "id", "title", "workspaceDataFilterSettings"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Workspace Data Filters ID. This ID is further used to refer to this instance.",
+                        "example": "country_id"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Workspace Data Filters title.",
+                        "example": "Country ID"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Workspace Data Filters description.",
+                        "example": "ID of country"
+                    },
+                    "columnName": {
+                        "type": "string",
+                        "description": "Workspace Data Filters column name. Data are filtered using this physical column.",
+                        "example": "country_id"
+                    },
+                    "dataSourceName": {
+                        "type": "string",
+                        "description": "Data source name (ID). Workspace Data Filters must always be connected to single data source.",
+                        "example": "sampleDataSource"
+                    },
+                    "workspaceDataFilterSettings": {
+                        "type": "array",
+                        "description": "Filter settings specifying values of filters valid for the workspace.",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilterSetting"
+                        }
+                    },
+                    "workspace": {
+                        "$ref": "#/components/schemas/WorkspaceIdentifier"
+                    }
+                },
+                "description": "Workspace Data Filters serving the filtering of what data users can see in workspaces."
+            },
+            "DeclarativeWorkspaceDataFilterSetting": {
+                "required": ["filterValues", "id", "title", "workspace"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Workspace Data Filters ID. This ID is further used to refer to this instance.",
+                        "example": "country_id_setting"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Workspace Data Filters setting title.",
+                        "example": "Country ID setting"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Workspace Data Filters setting description.",
+                        "example": "ID of country setting"
+                    },
+                    "filterValues": {
+                        "type": "array",
+                        "description": "Only those rows are returned, where columnName from filter matches those values.",
+                        "example": ["US"],
+                        "items": {
+                            "type": "string",
+                            "description": "Only those rows are returned, where columnName from filter matches those values.",
+                            "example": "[\"US\"]"
+                        }
+                    },
+                    "workspace": {
+                        "$ref": "#/components/schemas/WorkspaceIdentifier"
+                    }
+                },
+                "description": "Workspace Data Filters serving the filtering of what data users can see in workspaces."
+            },
             "DeclarativeWorkspaceModel": {
-                "required": ["analytics", "dataDiscriminators", "ldm", "pdm"],
+                "required": ["analytics", "ldm", "pdm"],
                 "type": "object",
                 "properties": {
                     "ldm": {
@@ -5844,23 +6404,23 @@
                     },
                     "analytics": {
                         "$ref": "#/components/schemas/DeclarativeAnalyticsLayer"
-                    },
-                    "dataDiscriminators": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeclarativeDataDiscriminator"
-                        }
                     }
                 }
             },
             "DeclarativeWorkspaces": {
-                "required": ["workspaces"],
+                "required": ["workspaceDataFilters", "workspaces"],
                 "type": "object",
                 "properties": {
                     "workspaces": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/DeclarativeWorkspace"
+                        }
+                    },
+                    "workspaceDataFilters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilter"
                         }
                     }
                 }
@@ -5933,7 +6493,9 @@
                         "type": "string",
                         "enum": ["workspace"]
                     }
-                }
+                },
+                "description": "Store filter into this workspace. Empty if it is part of layout of workspaces.",
+                "example": "{ id: demo, type: workspace }"
             },
             "DeclarativeModel": {
                 "required": ["ldm", "pdm"],
@@ -5957,6 +6519,18 @@
                     }
                 },
                 "description": "Entities describing users' view on data."
+            },
+            "DeclarativeWorkspaceDataFilters": {
+                "required": ["workspaceDataFilters"],
+                "type": "object",
+                "properties": {
+                    "workspaceDataFilters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilter"
+                        }
+                    }
+                }
             },
             "ObjectLinks": {
                 "required": ["self"],
@@ -6022,12 +6596,65 @@
                 },
                 "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
             },
-            "JsonApiACLDocument": {
+            "JsonApiApiTokenOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiApiTokenOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiACL"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiApiTokenOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiApiTokenOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "bearerToken": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
+            },
+            "JsonApiACLOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiACLOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6039,17 +6666,17 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiACL": {
+            "JsonApiACLOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6105,19 +6732,19 @@
                 },
                 "description": "JSON:API representation of acl entity."
             },
-            "JsonApiDataSourceDocument": {
+            "JsonApiDataSourceOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataSource"
+                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
                     }
                 }
             },
-            "JsonApiDataSource": {
+            "JsonApiDataSourceOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6160,9 +6787,6 @@
                             "username": {
                                 "type": "string"
                             },
-                            "password": {
-                                "type": "string"
-                            },
                             "uploadId": {
                                 "type": "string"
                             },
@@ -6174,19 +6798,19 @@
                 },
                 "description": "JSON:API representation of dataSource entity."
             },
-            "JsonApiModelModuleDocument": {
+            "JsonApiModelModuleOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiModelModule"
+                        "$ref": "#/components/schemas/JsonApiModelModuleOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
                     }
                 }
             },
-            "JsonApiModelModule": {
+            "JsonApiModelModuleOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6207,12 +6831,12 @@
                 },
                 "description": "JSON:API representation of modelModule entity."
             },
-            "JsonApiOrganizationDocument": {
+            "JsonApiOrganizationOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganization"
+                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6224,17 +6848,17 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiOrganization": {
+            "JsonApiOrganizationOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6263,9 +6887,6 @@
                             },
                             "oauthClientId": {
                                 "type": "string"
-                            },
-                            "oauthClientSecret": {
-                                "type": "string"
                             }
                         }
                     },
@@ -6293,12 +6914,12 @@
                 },
                 "description": "JSON:API representation of organization entity."
             },
-            "JsonApiUserGroupDocument": {
+            "JsonApiUserGroupOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiUserGroup"
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6310,17 +6931,17 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiUserGroup": {
+            "JsonApiUserGroupOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6362,12 +6983,12 @@
                 },
                 "description": "JSON:API representation of userGroup entity."
             },
-            "JsonApiUserDocument": {
+            "JsonApiUserOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiUser"
+                        "$ref": "#/components/schemas/JsonApiUserOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6379,17 +7000,17 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiUser": {
+            "JsonApiUserOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6436,12 +7057,12 @@
                 },
                 "description": "JSON:API representation of user entity."
             },
-            "JsonApiWorkspaceDocument": {
+            "JsonApiWorkspaceOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspace"
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6453,14 +7074,14 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiWorkspace": {
+            "JsonApiWorkspaceOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6499,15 +7120,29 @@
                 },
                 "description": "JSON:API representation of workspace entity."
             },
-            "JsonApiAttributeDocument": {
+            "JsonApiAttributeOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiAttributeOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiAttributeOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiAttribute"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6516,17 +7151,18 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiAttribute": {
+            "JsonApiAttributeOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6602,15 +7238,29 @@
                 },
                 "description": "JSON:API representation of attribute entity."
             },
-            "JsonApiDatasetDocument": {
+            "JsonApiDatasetOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiDatasetOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiDatasetOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataset"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6619,23 +7269,24 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiDataset": {
+            "JsonApiDatasetOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6761,15 +7412,29 @@
                     }
                 }
             },
-            "JsonApiFactDocument": {
+            "JsonApiFactOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiFactOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiFactOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiFact"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6778,14 +7443,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiFact": {
+            "JsonApiFactOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6836,15 +7502,29 @@
                 },
                 "description": "JSON:API representation of fact entity."
             },
-            "JsonApiLabelDocument": {
+            "JsonApiLabelOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiLabelOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiLabelOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiLabel"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6853,14 +7533,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiLabel": {
+            "JsonApiLabelOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6914,15 +7595,29 @@
                 },
                 "description": "JSON:API representation of label entity."
             },
-            "JsonApiSourceTablesDocument": {
+            "JsonApiSourceTablesOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiSourceTablesOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiSourceTablesOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiSourceTables"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6931,14 +7626,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiSourceTables": {
+            "JsonApiSourceTablesOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6972,15 +7668,29 @@
                 },
                 "description": "A defined data source for analytics data"
             },
-            "JsonApiSourceTableDocument": {
+            "JsonApiSourceTableOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiSourceTableOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiSourceTableOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiSourceTable"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6989,14 +7699,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiSourceTable": {
+            "JsonApiSourceTableOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7016,8 +7727,11 @@
                         "properties": {
                             "path": {
                                 "type": "array",
+                                "description": "Path to table.",
+                                "example": ["table_schema", "table_name"],
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "example": "table_name"
                                 }
                             },
                             "columns": {
@@ -7062,15 +7776,29 @@
                 },
                 "description": "A source table"
             },
-            "JsonApiAnalyticalDashboardDocument": {
+            "JsonApiAnalyticalDashboardOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiAnalyticalDashboardOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboard"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -7079,26 +7807,27 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiAnalyticalDashboard": {
+            "JsonApiAnalyticalDashboardOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7189,15 +7918,29 @@
                 },
                 "description": "JSON:API representation of analyticalDashboard entity."
             },
-            "JsonApiFilterContextDocument": {
+            "JsonApiFilterContextOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiFilterContextOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiFilterContextOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiFilterContext"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -7206,20 +7949,21 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiFilterContext": {
+            "JsonApiFilterContextOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7294,15 +8038,29 @@
                 },
                 "description": "JSON:API representation of filterContext entity."
             },
-            "JsonApiMetricDocument": {
+            "JsonApiMetricOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiMetricOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiMetricOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiMetric"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -7311,23 +8069,24 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiMetric": {
+            "JsonApiMetricOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7410,15 +8169,29 @@
                 },
                 "description": "JSON:API representation of metric entity."
             },
-            "JsonApiVisualizationObjectDocument": {
+            "JsonApiVisualizationObjectOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiVisualizationObjectOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObject"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -7427,29 +8200,30 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiVisualizationObject": {
+            "JsonApiVisualizationObjectOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7548,19 +8322,46 @@
                 },
                 "description": "JSON:API representation of visualizationObject entity."
             },
-            "JsonApiDataDiscriminatorDocument": {
+            "JsonApiWorkspaceDataFilterSettingOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceDataFilterSettingOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataDiscriminator"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                                }
+                            ]
+                        }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiDataDiscriminator": {
+            "JsonApiWorkspaceDataFilterSettingOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7573,7 +8374,94 @@
                     "type": {
                         "type": "string",
                         "description": "Object type",
-                        "example": "dataDiscriminator"
+                        "example": "workspaceDataFilterSetting"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "filterValues": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspaceDataFilter": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspaceDataFilterSetting entity."
+            },
+            "JsonApiWorkspaceDataFilterOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceDataFilterOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiWorkspaceDataFilterOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspaceDataFilter"
                     },
                     "attributes": {
                         "type": "object",
@@ -7591,21 +8479,46 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspaceDataFilterSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
-                "description": "JSON:API representation of dataDiscriminator entity."
+                "description": "JSON:API representation of workspaceDataFilter entity."
             },
-            "JsonApiACLWithLinks": {
+            "JsonApiApiTokenOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiACLOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiACL"
+                        "$ref": "#/components/schemas/JsonApiACLOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiACLList": {
+            "JsonApiACLOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7613,7 +8526,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiACLWithLinks"
+                            "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
                         }
                     },
                     "links": {
@@ -7626,10 +8539,10 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 }
                             ]
                         }
@@ -7637,17 +8550,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiDataSourceWithLinks": {
+            "JsonApiDataSourceOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiDataSource"
+                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiDataSourceList": {
+            "JsonApiDataSourceOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7655,7 +8568,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiDataSourceWithLinks"
+                            "$ref": "#/components/schemas/JsonApiDataSourceOutWithLinks"
                         }
                     },
                     "links": {
@@ -7664,17 +8577,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiModelModuleWithLinks": {
+            "JsonApiModelModuleOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiModelModule"
+                        "$ref": "#/components/schemas/JsonApiModelModuleOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiModelModuleList": {
+            "JsonApiModelModuleOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7682,7 +8595,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiModelModuleWithLinks"
+                            "$ref": "#/components/schemas/JsonApiModelModuleOutWithLinks"
                         }
                     },
                     "links": {
@@ -7691,17 +8604,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiOrganizationWithLinks": {
+            "JsonApiOrganizationOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiOrganization"
+                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiOrganizationList": {
+            "JsonApiOrganizationOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7709,7 +8622,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiOrganizationWithLinks"
+                            "$ref": "#/components/schemas/JsonApiOrganizationOutWithLinks"
                         }
                     },
                     "links": {
@@ -7722,10 +8635,10 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 }
                             ]
                         }
@@ -7733,17 +8646,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiUserGroupWithLinks": {
+            "JsonApiUserGroupOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiUserGroup"
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiUserGroupList": {
+            "JsonApiUserGroupOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7751,7 +8664,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                         }
                     },
                     "links": {
@@ -7764,10 +8677,10 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
                                 }
                             ]
                         }
@@ -7775,17 +8688,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiUserWithLinks": {
+            "JsonApiUserOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiUser"
+                        "$ref": "#/components/schemas/JsonApiUserOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiUserList": {
+            "JsonApiUserOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7793,7 +8706,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                            "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                         }
                     },
                     "links": {
@@ -7806,10 +8719,10 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
                                 }
                             ]
                         }
@@ -7817,17 +8730,17 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiWorkspaceWithLinks": {
+            "JsonApiWorkspaceOutWithLinks": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/JsonApiWorkspace"
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
                     },
                     {
                         "$ref": "#/components/schemas/ObjectLinksContainer"
                     }
                 ]
             },
-            "JsonApiWorkspaceList": {
+            "JsonApiWorkspaceOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
@@ -7835,7 +8748,7 @@
                         "uniqueItems": true,
                         "type": "array",
                         "items": {
-                            "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
+                            "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
                         }
                     },
                     "links": {
@@ -7848,7 +8761,7 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
                                 }
                             ]
                         }
@@ -7856,34 +8769,366 @@
                 },
                 "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiApiTokenWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiApiToken"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiApiTokenList": {
+            "JsonApiACLInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiApiTokenWithLinks"
+                        "$ref": "#/components/schemas/JsonApiACLIn"
+                    }
+                }
+            },
+            "JsonApiACLIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "acl"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "access": {
+                                "type": "string",
+                                "enum": ["FULL_ACCESS"]
+                            },
+                            "priority": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "control": {
+                                "type": "string",
+                                "enum": ["ALLOW", "DENY"]
+                            }
                         }
                     },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "users": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "userGroups": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
                     }
                 },
-                "description": "A JSON:API document with a list of resources"
+                "description": "JSON:API representation of acl entity."
             },
-            "JsonApiApiToken": {
+            "JsonApiDataSourceInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDataSourceIn"
+                    }
+                }
+            },
+            "JsonApiDataSourceIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dataSource"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "POSTGRESQL",
+                                    "REDSHIFT",
+                                    "VERTICA",
+                                    "SNOWFLAKE",
+                                    "ADS",
+                                    "BIGQUERY",
+                                    "MSSQL",
+                                    "PRESTO"
+                                ]
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "schema": {
+                                "type": "string"
+                            },
+                            "username": {
+                                "type": "string"
+                            },
+                            "password": {
+                                "type": "string"
+                            },
+                            "uploadId": {
+                                "type": "string"
+                            },
+                            "enableCaching": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of dataSource entity."
+            },
+            "JsonApiModelModuleInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiModelModuleIn"
+                    }
+                }
+            },
+            "JsonApiModelModuleIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "modelModule"
+                    },
+                    "attributes": {
+                        "type": "object"
+                    }
+                },
+                "description": "JSON:API representation of modelModule entity."
+            },
+            "JsonApiOrganizationInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationIn"
+                    }
+                }
+            },
+            "JsonApiOrganizationIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organization"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "hostname": {
+                                "type": "string"
+                            },
+                            "oauthIssuerLocation": {
+                                "type": "string"
+                            },
+                            "oauthClientId": {
+                                "type": "string"
+                            },
+                            "oauthClientSecret": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of organization entity."
+            },
+            "JsonApiUserGroupInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserGroupIn"
+                    }
+                }
+            },
+            "JsonApiUserGroupIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userGroup"
+                    },
+                    "attributes": {
+                        "type": "object"
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            },
+                            "acls": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userGroup entity."
+            },
+            "JsonApiUserInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserIn"
+                    }
+                }
+            },
+            "JsonApiUserIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "user"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "authenticationId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            },
+                            "acls": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of user entity."
+            },
+            "JsonApiWorkspaceInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceIn"
+                    }
+                }
+            },
+            "JsonApiWorkspaceIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspace"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspace entity."
+            },
+            "JsonApiApiTokenInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
+                    }
+                }
+            },
+            "JsonApiApiTokenIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7899,496 +9144,627 @@
                         "example": "apiToken"
                     },
                     "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "bearerToken": {
-                                "type": "string"
-                            }
-                        }
+                        "type": "object"
                     }
                 },
                 "description": "JSON:API representation of apiToken entity."
             },
-            "JsonApiAttributeWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiAttribute"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiAttributeList": {
+            "JsonApiAnalyticalDashboardInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                        }
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardIn"
+                    }
+                }
+            },
+            "JsonApiAnalyticalDashboardIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
                     },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "analyticalDashboard"
                     },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
                                 }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiDatasetWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiDataset"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiDatasetList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
                                 }
-                            ]
+                            }
                         }
                     }
                 },
-                "description": "A JSON:API document with a list of resources"
+                "description": "JSON:API representation of analyticalDashboard entity."
             },
-            "JsonApiFactWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiFact"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiFactList": {
+            "JsonApiAnalyticalDashboardOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiLabelWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiLabel"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiLabelList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiSourceTablesWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiSourceTables"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiSourceTablesList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiSourceTableWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiSourceTable"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiSourceTableList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiAnalyticalDashboardWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboard"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiAnalyticalDashboardList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiFilterContextWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiFilterContext"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiFilterContextList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiMetricWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiMetric"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiMetricList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiVisualizationObjectWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObject"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiVisualizationObjectList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiDataDiscriminatorWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiDataDiscriminator"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiDataDiscriminatorList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiDataDiscriminatorWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiApiTokenDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiToken"
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiFilterContextInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFilterContextIn"
+                    }
+                }
+            },
+            "JsonApiFilterContextIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "filterContext"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of filterContext entity."
+            },
+            "JsonApiFilterContextOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFilterContextOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiMetricInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiMetricIn"
+                    }
+                }
+            },
+            "JsonApiMetricIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "metric"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "properties": {
+                                    "format": {
+                                        "type": "string"
+                                    },
+                                    "maql": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of metric entity."
+            },
+            "JsonApiMetricOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiMetricOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiVisualizationObjectInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectIn"
+                    }
+                }
+            },
+            "JsonApiVisualizationObjectIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "visualizationObject"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of visualizationObject entity."
+            },
+            "JsonApiVisualizationObjectOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterIn"
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspaceDataFilter"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "columnName": {
+                                "type": "string"
+                            },
+                            "dataSourceName": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspaceDataFilterSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspaceDataFilter entity."
+            },
+            "JsonApiWorkspaceDataFilterOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiAttributeOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiAttributeOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiDatasetOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDatasetOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiFactOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFactOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiLabelOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiLabelOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiSourceTablesOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiSourceTablesOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiSourceTableOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiSourceTableOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterSettingOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                                }
+                            ]
+                        }
                     }
                 }
             }


### PR DESCRIPTION
There is a manual change in the metadata JSON to avoid `_1` naming of methods (relates to duplication of methods between organization-controller and organization-model-controller) plus fixing `typeGuards.js`.
