### PR TITLE
RELATED: NAS-34 - Mention applink in docs + small usability tweak in the tool

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -280,6 +280,13 @@ This will make sure that the SDK8 files in your app are from your local SDK8 ver
 > not change the case. A webpack build of the target application may then fail with `Module not found: Error: [CaseSensitivePathsPlugin]`
 > because imports are for the new file name while the node_modules contains the old file names.
 
+#### Using `applink` tool
+
+Applink can make your life easier by watching for source code changes, automatically rebuilding the impacted packages and syncing
+their artifacts into the target application's `node_modules` similar to what you would be doing manually with `rsync`.
+
+To learn more about it check out the [tools/applink/README.md](../tools/applink/README.md).
+
 ## CI jobs and gating
 
 Every pull-request can be merged by adding `merge` label. This triggers test scripts and once they pass, the pull-request is automatically merged. All related scripts run in docker, see `./common/scripts/ci/` for individual scripts being run on jenkins slaves.

--- a/tools/applink/src/devConsole/ui/ui.ts
+++ b/tools/applink/src/devConsole/ui/ui.ts
@@ -1,8 +1,8 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import blessed from "blessed";
 import { AppLog } from "./appLog";
 import { PackageList } from "./packageList";
-import { appLogWarn, getTerminalSize } from "./utils";
+import { appLogInfo, appLogWarn, getTerminalSize } from "./utils";
 import { AppMenu, AppMenuItem } from "./appMenu";
 import {
     autobuildToggled,
@@ -41,6 +41,10 @@ export class TerminalUi implements IEventListener {
         this.menu = this.createApplicationMenu();
 
         this.screen.render();
+
+        appLogInfo(
+            "Hint: it is also possible use non-F-keys to trigger menu functions. You can use just the respective number instead or 'q' for quit.",
+        );
     }
 
     public static init(eventBus: EventBus = GlobalEventBus): TerminalUi {
@@ -151,7 +155,7 @@ export class TerminalUi implements IEventListener {
             {
                 name: "Log Toggle",
                 keyName: "F2",
-                registerKeys: ["f2"],
+                registerKeys: ["f2", "2"],
                 registerCb: () => {
                     this.log.toggleExpand();
 
@@ -171,7 +175,7 @@ export class TerminalUi implements IEventListener {
                     }
                 },
                 keyName: "F3",
-                registerKeys: ["f3"],
+                registerKeys: ["f3", "3"],
                 registerCb: (item: AppMenuItem) => {
                     item.itemState = !item.itemState;
                     this.eventBus.post(autobuildToggled(item.itemState));
@@ -181,7 +185,7 @@ export class TerminalUi implements IEventListener {
             {
                 name: "BuildOne",
                 keyName: "F7",
-                registerKeys: ["f7"],
+                registerKeys: ["f7", "7"],
                 registerCb: () => {
                     if (!this.selectedPackages.length) {
                         return;
@@ -198,7 +202,7 @@ export class TerminalUi implements IEventListener {
             {
                 name: "BuildDeps",
                 keyName: "F8",
-                registerKeys: ["f8"],
+                registerKeys: ["f8", "8"],
                 registerCb: () => {
                     if (!this.selectedPackages.length) {
                         return;
@@ -214,7 +218,7 @@ export class TerminalUi implements IEventListener {
             {
                 name: "BuildAll",
                 keyName: "F9",
-                registerKeys: ["f9"],
+                registerKeys: ["f9", "9"],
                 registerCb: () => {
                     // fire package change for all packages. these form transitive closure so it is ok to
                     // mark changes as independent (means less initial processing for scheduler).
@@ -229,7 +233,7 @@ export class TerminalUi implements IEventListener {
             {
                 name: "Quit",
                 keyName: "F10",
-                registerKeys: ["f10"],
+                registerKeys: ["f10", "0", "q"],
                 registerCb: () => {
                     process.exit(0);
                 },


### PR DESCRIPTION
- Updated contributing guide
- Made applink to also support non-F-keys to start menu commands


JIRA: NAS-34

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
