### PR TITLE
RELATED: RAIL-3064 use measure names from execution response on tiger

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -53,6 +53,12 @@ export interface AFM {
 
 // @public
 export class AfmControllerApi extends LabelElementsBaseApi implements AfmControllerApiInterface {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -63,6 +69,12 @@ export class AfmControllerApi extends LabelElementsBaseApi implements AfmControl
 
 // @public
 export const AfmControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean | undefined;
+        timestamp?: string | undefined;
+    }, options?: any): LabelElementsRequestArgs;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -73,6 +85,12 @@ export const AfmControllerApiAxiosParamCreator: (configuration?: LabelElementsCo
 
 // @public
 export const AfmControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -83,6 +101,12 @@ export const AfmControllerApiFactory: (configuration?: LabelElementsConfiguratio
 
 // @public
 export const AfmControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -93,6 +117,12 @@ export const AfmControllerApiFp: (configuration?: LabelElementsConfiguration | u
 
 // @public
 export interface AfmControllerApiInterface {
+    computeReport(params: {
+        workspaceId: string;
+        afmExecution: AfmExecution;
+        skipCache?: boolean;
+        timestamp?: string;
+    }, options?: any): AxiosPromise<AfmExecutionResponse>;
     processAfmRequest(params: {
         workspaceId: string;
         afmExecution: AfmExecution;
@@ -381,15 +411,6 @@ export enum DeclarativeColumnDataTypeEnum {
 }
 
 // @public
-export interface DeclarativeDataDiscriminator {
-    columnName: string;
-    dataSourceName: string;
-    description?: string;
-    id: string;
-    title: string;
-}
-
-// @public
 export interface DeclarativeDataset {
     attributes: Array<DeclarativeAttribute>;
     description?: string;
@@ -484,6 +505,7 @@ export class DeclarativeLayoutControllerApi extends MetadataBaseApi implements D
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -501,6 +523,9 @@ export class DeclarativeLayoutControllerApi extends MetadataBaseApi implements D
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -515,6 +540,7 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator: (configuration?: M
         workspaceId: string;
     }, options?: any): MetadataRequestArgs;
     getOrganizationLayout(params: {}, options?: any): MetadataRequestArgs;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): MetadataRequestArgs;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): MetadataRequestArgs;
@@ -532,6 +558,9 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator: (configuration?: M
         declarativeModel: DeclarativeModel;
     }, options?: any): MetadataRequestArgs;
     setOrganizationLayout(params: {}, options?: any): MetadataRequestArgs;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): MetadataRequestArgs;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): MetadataRequestArgs;
@@ -546,6 +575,7 @@ export const DeclarativeLayoutControllerApiFactory: (configuration?: MetadataCon
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -563,6 +593,9 @@ export const DeclarativeLayoutControllerApiFactory: (configuration?: MetadataCon
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -577,6 +610,7 @@ export const DeclarativeLayoutControllerApiFp: (configuration?: MetadataConfigur
         workspaceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<DeclarativeWorkspaceModel>;
@@ -594,6 +628,9 @@ export const DeclarativeLayoutControllerApiFp: (configuration?: MetadataConfigur
         declarativeModel: DeclarativeModel;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
@@ -608,6 +645,7 @@ export interface DeclarativeLayoutControllerApiInterface {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeModel>;
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
     getWorkspaceLayout(params: {
         workspaceId: string;
     }, options?: any): AxiosPromise<DeclarativeWorkspaceModel>;
@@ -625,6 +663,9 @@ export interface DeclarativeLayoutControllerApiInterface {
         declarativeModel: DeclarativeModel;
     }, options?: any): AxiosPromise<void>;
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+    setWorkspaceDataFiltersLayout(params: {
+        declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+    }, options?: any): AxiosPromise<void>;
     setWorkspacesLayout(params: {
         declarativeWorkspaces: DeclarativeWorkspaces;
     }, options?: any): AxiosPromise<void>;
@@ -686,15 +727,40 @@ export interface DeclarativeWorkspace {
 }
 
 // @public
+export interface DeclarativeWorkspaceDataFilter {
+    columnName: string;
+    dataSourceName: string;
+    description?: string;
+    id: string;
+    title: string;
+    workspace?: WorkspaceIdentifier;
+    workspaceDataFilterSettings: Array<DeclarativeWorkspaceDataFilterSetting>;
+}
+
+// @public
+export interface DeclarativeWorkspaceDataFilters {
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
+}
+
+// @public
+export interface DeclarativeWorkspaceDataFilterSetting {
+    description?: string;
+    filterValues: Array<string>;
+    id: string;
+    title: string;
+    workspace: WorkspaceIdentifier;
+}
+
+// @public
 export interface DeclarativeWorkspaceModel {
     analytics: DeclarativeAnalyticsLayer;
-    dataDiscriminators: Array<DeclarativeDataDiscriminator>;
     ldm: DeclarativeLdm;
     pdm: DeclarativePdm;
 }
 
 // @public
 export interface DeclarativeWorkspaces {
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
     workspaces: Array<DeclarativeWorkspace>;
 }
 
@@ -737,6 +803,17 @@ export { Element_2 as Element }
 
 // @public
 export class ElementsControllerApi extends LabelElementsBaseApi implements ElementsControllerApiInterface {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -752,6 +829,17 @@ export class ElementsControllerApi extends LabelElementsBaseApi implements Eleme
 
 // @public
 export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC" | undefined;
+        includeTotalWithoutFilters?: boolean | undefined;
+        complementFilter?: boolean | undefined;
+        patternFilter?: string | undefined;
+        offset?: number | undefined;
+        limit?: number | undefined;
+        skipCache?: boolean | undefined;
+    }, options?: any): LabelElementsRequestArgs;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -767,6 +855,17 @@ export const ElementsControllerApiAxiosParamCreator: (configuration?: LabelEleme
 
 // @public
 export const ElementsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -782,6 +881,17 @@ export const ElementsControllerApiFactory: (configuration?: LabelElementsConfigu
 
 // @public
 export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -797,6 +907,17 @@ export const ElementsControllerApiFp: (configuration?: LabelElementsConfiguratio
 
 // @public
 export interface ElementsControllerApiInterface {
+    computeLabelElements(params: {
+        workspaceId: string;
+        label: string;
+        sortOrder?: "ASC" | "DESC";
+        includeTotalWithoutFilters?: boolean;
+        complementFilter?: boolean;
+        patternFilter?: string;
+        offset?: number;
+        limit?: number;
+        skipCache?: boolean;
+    }, options?: any): AxiosPromise<ElementsResponse>;
     processElementsRequest(params: {
         workspaceId: string;
         label: string;
@@ -984,7 +1105,7 @@ export interface InlineMeasureDefinitionInline {
 export function isAttributeHeader(header: ResultDimensionHeader): header is AttributeHeader;
 
 // @public (undocumented)
-export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContext;
+export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn;
 
 // @public (undocumented)
 export const isObjectIdentifier: (value: unknown) => value is ObjectIdentifier;
@@ -993,7 +1114,7 @@ export const isObjectIdentifier: (value: unknown) => value is ObjectIdentifier;
 export function isResultAttributeHeader(header: ExecutionResultHeader): header is AttributeExecutionResultHeader;
 
 // @public (undocumented)
-export function isVisualizationObjectsItem(visualizationObject: unknown): visualizationObject is JsonApiVisualizationObject;
+export function isVisualizationObjectsItem(visualizationObject: unknown): visualizationObject is JsonApiVisualizationObjectIn;
 
 // @public (undocumented)
 export interface ITigerClient {
@@ -1018,28 +1139,41 @@ export interface ITigerClient {
 export const JSON_API_HEADER_VALUE = "application/vnd.gooddata.api+json";
 
 // @public
-export interface JsonApiACL {
-    attributes?: JsonApiACLAttributes;
+export interface JsonApiACLIn {
+    attributes?: JsonApiACLOutAttributes;
     id: string;
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiACLAttributes {
-    access?: JsonApiACLAttributesAccessEnum;
-    control?: JsonApiACLAttributesControlEnum;
+export interface JsonApiACLInDocument {
+    data: JsonApiACLIn;
+}
+
+// @public
+export interface JsonApiACLOut {
+    attributes?: JsonApiACLOutAttributes;
+    id: string;
+    relationships?: JsonApiACLOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiACLOutAttributes {
+    access?: JsonApiACLOutAttributesAccessEnum;
+    control?: JsonApiACLOutAttributesControlEnum;
     priority?: number;
 }
 
 // @public
-export enum JsonApiACLAttributesAccessEnum {
+export enum JsonApiACLOutAttributesAccessEnum {
     // (undocumented)
     FULLACCESS = "FULL_ACCESS"
 }
 
 // @public
-export enum JsonApiACLAttributesControlEnum {
+export enum JsonApiACLOutAttributesControlEnum {
     // (undocumented)
     ALLOW = "ALLOW",
     // (undocumented)
@@ -1047,49 +1181,48 @@ export enum JsonApiACLAttributesControlEnum {
 }
 
 // @public
-export interface JsonApiACLDocument {
-    data: JsonApiACL;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiACLOutDocument {
+    data: JsonApiACLOut;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiACLList {
-    data: Array<JsonApiACLWithLinks>;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiACLOutList {
+    data: Array<JsonApiACLOutWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiACLRelationships {
-    userGroups?: JsonApiACLRelationshipsUsers;
-    users?: JsonApiACLRelationshipsUsers;
+export interface JsonApiACLOutRelationships {
+    userGroups?: JsonApiACLOutRelationshipsUsers;
+    users?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiACLRelationshipsUsers {
+export interface JsonApiACLOutRelationshipsUsers {
     data?: Array<JsonApiLinkage>;
 }
 
 // @public
-export interface JsonApiACLWithLinks {
-    attributes?: JsonApiACLAttributes;
+export interface JsonApiACLOutWithLinks {
+    attributes?: JsonApiACLOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboard {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiAnalyticalDashboardIn {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     id: string;
-    relationships?: JsonApiAnalyticalDashboardRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardAttributes {
+export interface JsonApiAnalyticalDashboardInAttributes {
     content?: object;
     description?: string;
     tags?: Array<string>;
@@ -1097,87 +1230,112 @@ export interface JsonApiAnalyticalDashboardAttributes {
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardDocument {
-    data: JsonApiAnalyticalDashboard;
-    included?: Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>;
+export interface JsonApiAnalyticalDashboardInDocument {
+    data: JsonApiAnalyticalDashboardIn;
+}
+
+// @public
+export interface JsonApiAnalyticalDashboardOut {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    id: string;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiAnalyticalDashboardOutDocument {
+    data: JsonApiAnalyticalDashboardOut;
+    included?: Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardList {
-    data: Array<JsonApiAnalyticalDashboardWithLinks>;
-    included?: Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>;
+export interface JsonApiAnalyticalDashboardOutList {
+    data: Array<JsonApiAnalyticalDashboardOutWithLinks>;
+    included?: Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardRelationships {
-    datasets?: JsonApiACLRelationshipsUsers;
-    filterContexts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
-    visualizationObjects?: JsonApiACLRelationshipsUsers;
+export interface JsonApiAnalyticalDashboardOutRelationships {
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    filterContexts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
+    visualizationObjects?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiAnalyticalDashboardWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiAnalyticalDashboardOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiApiToken {
-    attributes?: JsonApiApiTokenAttributes;
+export interface JsonApiApiTokenIn {
+    attributes?: object;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiApiTokenAttributes {
+export interface JsonApiApiTokenInDocument {
+    data: JsonApiApiTokenIn;
+}
+
+// @public
+export interface JsonApiApiTokenOut {
+    attributes?: JsonApiApiTokenOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiApiTokenOutAttributes {
     bearerToken?: string;
 }
 
 // @public
-export interface JsonApiApiTokenDocument {
-    data: JsonApiApiToken;
+export interface JsonApiApiTokenOutDocument {
+    data: JsonApiApiTokenOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiApiTokenList {
-    data: Array<JsonApiApiTokenWithLinks>;
+export interface JsonApiApiTokenOutList {
+    data: Array<JsonApiApiTokenOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiApiTokenWithLinks {
-    attributes?: JsonApiApiTokenAttributes;
+export interface JsonApiApiTokenOutWithLinks {
+    attributes?: JsonApiApiTokenOutAttributes;
     id: string;
     links?: ObjectLinks;
     type: string;
 }
 
 // @public
-export interface JsonApiAttribute {
-    attributes?: JsonApiAttributeAttributes;
+export interface JsonApiAttributeOut {
+    attributes?: JsonApiAttributeOutAttributes;
     id: string;
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiAttributeAttributes {
+export interface JsonApiAttributeOutAttributes {
     description?: string;
-    granularity?: JsonApiAttributeAttributesGranularityEnum;
+    granularity?: JsonApiAttributeOutAttributesGranularityEnum;
     tags?: Array<string>;
     title?: string;
 }
 
 // @public
-export enum JsonApiAttributeAttributesGranularityEnum {
+export enum JsonApiAttributeOutAttributesGranularityEnum {
     // (undocumented)
     DAY = "DAY",
     // (undocumented)
@@ -1211,95 +1369,60 @@ export enum JsonApiAttributeAttributesGranularityEnum {
 }
 
 // @public
-export interface JsonApiAttributeDocument {
-    data: JsonApiAttribute;
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiAttributeOutDocument {
+    data: JsonApiAttributeOut;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiAttributeList {
-    data: Array<JsonApiAttributeWithLinks>;
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiAttributeOutList {
+    data: Array<JsonApiAttributeOutWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiAttributeRelationships {
-    dataset?: JsonApiOrganizationRelationshipsUser;
-    labels?: JsonApiACLRelationshipsUsers;
+export interface JsonApiAttributeOutRelationships {
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiAttributeWithLinks {
-    attributes?: JsonApiAttributeAttributes;
+export interface JsonApiAttributeOutWithLinks {
+    attributes?: JsonApiAttributeOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataDiscriminator {
-    attributes?: JsonApiDataDiscriminatorAttributes;
+export interface JsonApiDatasetOut {
+    attributes?: JsonApiDatasetOutAttributes;
     id: string;
+    relationships?: JsonApiDatasetOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataDiscriminatorAttributes {
-    columnName?: string;
-    dataSourceName?: string;
+export interface JsonApiDatasetOutAttributes {
     description?: string;
-    title?: string;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorDocument {
-    data: JsonApiDataDiscriminator;
-    links?: ObjectLinks;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorList {
-    data: Array<JsonApiDataDiscriminatorWithLinks>;
-    links?: ListLinks;
-}
-
-// @public
-export interface JsonApiDataDiscriminatorWithLinks {
-    attributes?: JsonApiDataDiscriminatorAttributes;
-    id: string;
-    links?: ObjectLinks;
-    type: string;
-}
-
-// @public
-export interface JsonApiDataset {
-    attributes?: JsonApiDatasetAttributes;
-    id: string;
-    relationships?: JsonApiDatasetRelationships;
-    type: string;
-}
-
-// @public
-export interface JsonApiDatasetAttributes {
-    description?: string;
-    grain?: Array<JsonApiDatasetAttributesGrain>;
-    referenceProperties?: Array<JsonApiDatasetAttributesReferenceProperties>;
+    grain?: Array<JsonApiDatasetOutAttributesGrain>;
+    referenceProperties?: Array<JsonApiDatasetOutAttributesReferenceProperties>;
     tags?: Array<string>;
     title?: string;
-    type?: JsonApiDatasetAttributesTypeEnum;
+    type?: JsonApiDatasetOutAttributesTypeEnum;
 }
 
 // @public
-export interface JsonApiDatasetAttributesGrain {
+export interface JsonApiDatasetOutAttributesGrain {
     id: string;
-    type: JsonApiDatasetAttributesGrainTypeEnum;
+    type: JsonApiDatasetOutAttributesGrainTypeEnum;
 }
 
 // @public
-export enum JsonApiDatasetAttributesGrainTypeEnum {
+export enum JsonApiDatasetOutAttributesGrainTypeEnum {
     // (undocumented)
     Attribute = "attribute",
     // (undocumented)
@@ -1307,14 +1430,14 @@ export enum JsonApiDatasetAttributesGrainTypeEnum {
 }
 
 // @public
-export interface JsonApiDatasetAttributesReferenceProperties {
+export interface JsonApiDatasetOutAttributesReferenceProperties {
     identifier: DatasetReferenceIdentifier;
     multivalue: boolean;
     sourceColumns: Array<string>;
 }
 
 // @public
-export enum JsonApiDatasetAttributesTypeEnum {
+export enum JsonApiDatasetOutAttributesTypeEnum {
     // (undocumented)
     DATE = "DATE",
     // (undocumented)
@@ -1322,57 +1445,57 @@ export enum JsonApiDatasetAttributesTypeEnum {
 }
 
 // @public
-export interface JsonApiDatasetDocument {
-    data: JsonApiDataset;
-    included?: Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiDatasetOutDocument {
+    data: JsonApiDatasetOut;
+    included?: Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiDatasetList {
-    data: Array<JsonApiDatasetWithLinks>;
-    included?: Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiDatasetOutList {
+    data: Array<JsonApiDatasetOutWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiDatasetRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    table?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiDatasetOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    table?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiDatasetWithLinks {
-    attributes?: JsonApiDatasetAttributes;
+export interface JsonApiDatasetOutWithLinks {
+    attributes?: JsonApiDatasetOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiDatasetRelationships;
+    relationships?: JsonApiDatasetOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiDataSource {
-    attributes?: JsonApiDataSourceAttributes;
+export interface JsonApiDataSourceIn {
+    attributes?: JsonApiDataSourceInAttributes;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiDataSourceAttributes {
+export interface JsonApiDataSourceInAttributes {
     enableCaching?: boolean;
     name?: string;
     password?: string;
     schema?: string;
-    type?: JsonApiDataSourceAttributesTypeEnum;
+    type?: JsonApiDataSourceInAttributesTypeEnum;
     uploadId?: string;
     url?: string;
     username?: string;
 }
 
 // @public
-export enum JsonApiDataSourceAttributesTypeEnum {
+export enum JsonApiDataSourceInAttributesTypeEnum {
     // (undocumented)
     ADS = "ADS",
     // (undocumented)
@@ -1392,35 +1515,78 @@ export enum JsonApiDataSourceAttributesTypeEnum {
 }
 
 // @public
-export interface JsonApiDataSourceDocument {
-    data: JsonApiDataSource;
+export interface JsonApiDataSourceInDocument {
+    data: JsonApiDataSourceIn;
+}
+
+// @public
+export interface JsonApiDataSourceOut {
+    attributes?: JsonApiDataSourceOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiDataSourceOutAttributes {
+    enableCaching?: boolean;
+    name?: string;
+    schema?: string;
+    type?: JsonApiDataSourceOutAttributesTypeEnum;
+    uploadId?: string;
+    url?: string;
+    username?: string;
+}
+
+// @public
+export enum JsonApiDataSourceOutAttributesTypeEnum {
+    // (undocumented)
+    ADS = "ADS",
+    // (undocumented)
+    BIGQUERY = "BIGQUERY",
+    // (undocumented)
+    MSSQL = "MSSQL",
+    // (undocumented)
+    POSTGRESQL = "POSTGRESQL",
+    // (undocumented)
+    PRESTO = "PRESTO",
+    // (undocumented)
+    REDSHIFT = "REDSHIFT",
+    // (undocumented)
+    SNOWFLAKE = "SNOWFLAKE",
+    // (undocumented)
+    VERTICA = "VERTICA"
+}
+
+// @public
+export interface JsonApiDataSourceOutDocument {
+    data: JsonApiDataSourceOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiDataSourceList {
-    data: Array<JsonApiDataSourceWithLinks>;
+export interface JsonApiDataSourceOutList {
+    data: Array<JsonApiDataSourceOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiDataSourceWithLinks {
-    attributes?: JsonApiDataSourceAttributes;
+export interface JsonApiDataSourceOutWithLinks {
+    attributes?: JsonApiDataSourceOutAttributes;
     id: string;
     links?: ObjectLinks;
     type: string;
 }
 
 // @public
-export interface JsonApiFact {
-    attributes?: JsonApiFactAttributes;
+export interface JsonApiFactOut {
+    attributes?: JsonApiFactOutAttributes;
     id: string;
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFactAttributes {
+export interface JsonApiFactOutAttributes {
     description?: string;
     sourceColumn?: string;
     tags?: Array<string>;
@@ -1428,68 +1594,80 @@ export interface JsonApiFactAttributes {
 }
 
 // @public
-export interface JsonApiFactDocument {
-    data: JsonApiFact;
-    included?: Array<JsonApiDatasetWithLinks>;
+export interface JsonApiFactOutDocument {
+    data: JsonApiFactOut;
+    included?: Array<JsonApiDatasetOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiFactList {
-    data: Array<JsonApiFactWithLinks>;
-    included?: Array<JsonApiDatasetWithLinks>;
+export interface JsonApiFactOutList {
+    data: Array<JsonApiFactOutWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiFactRelationships {
-    dataset?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiFactOutRelationships {
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiFactWithLinks {
-    attributes?: JsonApiFactAttributes;
+export interface JsonApiFactOutWithLinks {
+    attributes?: JsonApiFactOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFilterContext {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiFilterContextIn {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     id: string;
-    relationships?: JsonApiFilterContextRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiFilterContextDocument {
-    data: JsonApiFilterContext;
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiFilterContextInDocument {
+    data: JsonApiFilterContextIn;
+}
+
+// @public
+export interface JsonApiFilterContextOut {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    id: string;
+    relationships?: JsonApiFilterContextOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiFilterContextOutDocument {
+    data: JsonApiFilterContextOut;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiFilterContextList {
-    data: Array<JsonApiFilterContextWithLinks>;
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+export interface JsonApiFilterContextOutList {
+    data: Array<JsonApiFilterContextOutWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiFilterContextRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
+export interface JsonApiFilterContextOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiFilterContextWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiFilterContextOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiFilterContextRelationships;
+    relationships?: JsonApiFilterContextOutRelationships;
     type: string;
 }
 
@@ -1500,15 +1678,15 @@ export const jsonApiHeaders: {
 };
 
 // @public
-export interface JsonApiLabel {
-    attributes?: JsonApiLabelAttributes;
+export interface JsonApiLabelOut {
+    attributes?: JsonApiLabelOutAttributes;
     id: string;
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiLabelAttributes {
+export interface JsonApiLabelOutAttributes {
     description?: string;
     primary?: boolean;
     sourceColumn?: string;
@@ -1517,30 +1695,30 @@ export interface JsonApiLabelAttributes {
 }
 
 // @public
-export interface JsonApiLabelDocument {
-    data: JsonApiLabel;
-    included?: Array<JsonApiAttributeWithLinks>;
+export interface JsonApiLabelOutDocument {
+    data: JsonApiLabelOut;
+    included?: Array<JsonApiAttributeOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiLabelList {
-    data: Array<JsonApiLabelWithLinks>;
-    included?: Array<JsonApiAttributeWithLinks>;
+export interface JsonApiLabelOutList {
+    data: Array<JsonApiLabelOutWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiLabelRelationships {
-    attribute?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiLabelOutRelationships {
+    attribute?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiLabelWithLinks {
-    attributes?: JsonApiLabelAttributes;
+export interface JsonApiLabelOutWithLinks {
+    attributes?: JsonApiLabelOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     type: string;
 }
 
@@ -1551,79 +1729,103 @@ export interface JsonApiLinkage {
 }
 
 // @public
-export interface JsonApiMetric {
-    attributes?: JsonApiMetricAttributes;
+export interface JsonApiMetricIn {
+    attributes?: JsonApiMetricInAttributes;
     id: string;
-    relationships?: JsonApiMetricRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiMetricAttributes {
-    content?: JsonApiMetricAttributesContent;
+export interface JsonApiMetricInAttributes {
+    content?: JsonApiMetricInAttributesContent;
     description?: string;
     tags?: Array<string>;
     title?: string;
 }
 
 // @public
-export interface JsonApiMetricAttributesContent {
+export interface JsonApiMetricInAttributesContent {
     format?: string;
     maql?: string;
 }
 
 // @public
-export interface JsonApiMetricDocument {
-    data: JsonApiMetric;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>;
-    links?: ObjectLinks;
+export interface JsonApiMetricInDocument {
+    data: JsonApiMetricIn;
 }
 
 // @public
-export interface JsonApiMetricList {
-    data: Array<JsonApiMetricWithLinks>;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>;
-    links?: ListLinks;
-}
-
-// @public
-export interface JsonApiMetricRelationships {
-    attributes?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
-}
-
-// @public
-export interface JsonApiMetricWithLinks {
-    attributes?: JsonApiMetricAttributes;
+export interface JsonApiMetricOut {
+    attributes?: JsonApiMetricInAttributes;
     id: string;
-    links?: ObjectLinks;
-    relationships?: JsonApiMetricRelationships;
+    relationships?: JsonApiMetricOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiModelModule {
+export interface JsonApiMetricOutDocument {
+    data: JsonApiMetricOut;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiMetricOutList {
+    data: Array<JsonApiMetricOutWithLinks>;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>;
+    links?: ListLinks;
+}
+
+// @public
+export interface JsonApiMetricOutRelationships {
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
+}
+
+// @public
+export interface JsonApiMetricOutWithLinks {
+    attributes?: JsonApiMetricInAttributes;
+    id: string;
+    links?: ObjectLinks;
+    relationships?: JsonApiMetricOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiModelModuleIn {
     attributes?: object;
     id: string;
     type: string;
 }
 
 // @public
-export interface JsonApiModelModuleDocument {
-    data: JsonApiModelModule;
+export interface JsonApiModelModuleInDocument {
+    data: JsonApiModelModuleIn;
+}
+
+// @public
+export interface JsonApiModelModuleOut {
+    attributes?: object;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiModelModuleOutDocument {
+    data: JsonApiModelModuleOut;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiModelModuleList {
-    data: Array<JsonApiModelModuleWithLinks>;
+export interface JsonApiModelModuleOutList {
+    data: Array<JsonApiModelModuleOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiModelModuleWithLinks {
+export interface JsonApiModelModuleOutWithLinks {
     attributes?: object;
     id: string;
     links?: ObjectLinks;
@@ -1631,15 +1833,14 @@ export interface JsonApiModelModuleWithLinks {
 }
 
 // @public
-export interface JsonApiOrganization {
-    attributes?: JsonApiOrganizationAttributes;
+export interface JsonApiOrganizationIn {
+    attributes?: JsonApiOrganizationInAttributes;
     id: string;
-    relationships?: JsonApiOrganizationRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiOrganizationAttributes {
+export interface JsonApiOrganizationInAttributes {
     hostname?: string;
     name?: string;
     oauthClientId?: string;
@@ -1648,36 +1849,57 @@ export interface JsonApiOrganizationAttributes {
 }
 
 // @public
-export interface JsonApiOrganizationDocument {
-    data: JsonApiOrganization;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiOrganizationInDocument {
+    data: JsonApiOrganizationIn;
+}
+
+// @public
+export interface JsonApiOrganizationOut {
+    attributes?: JsonApiOrganizationOutAttributes;
+    id: string;
+    relationships?: JsonApiOrganizationOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiOrganizationOutAttributes {
+    hostname?: string;
+    name?: string;
+    oauthClientId?: string;
+    oauthIssuerLocation?: string;
+}
+
+// @public
+export interface JsonApiOrganizationOutDocument {
+    data: JsonApiOrganizationOut;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiOrganizationList {
-    data: Array<JsonApiOrganizationWithLinks>;
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+export interface JsonApiOrganizationOutList {
+    data: Array<JsonApiOrganizationOutWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiOrganizationRelationships {
-    user?: JsonApiOrganizationRelationshipsUser;
-    userGroup?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiOrganizationOutRelationships {
+    user?: JsonApiOrganizationOutRelationshipsUser;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiOrganizationRelationshipsUser {
+export interface JsonApiOrganizationOutRelationshipsUser {
     data?: JsonApiRelToOne | null;
 }
 
 // @public
-export interface JsonApiOrganizationWithLinks {
-    attributes?: JsonApiOrganizationAttributes;
+export interface JsonApiOrganizationOutWithLinks {
+    attributes?: JsonApiOrganizationOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiOrganizationRelationships;
+    relationships?: JsonApiOrganizationOutRelationships;
     type: string;
 }
 
@@ -1685,27 +1907,27 @@ export interface JsonApiOrganizationWithLinks {
 export type JsonApiRelToOne = JsonApiLinkage;
 
 // @public
-export interface JsonApiSourceTable {
-    attributes?: JsonApiSourceTableAttributes;
+export interface JsonApiSourceTableOut {
+    attributes?: JsonApiSourceTableOutAttributes;
     id: string;
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTableAttributes {
-    columns?: Array<JsonApiSourceTableAttributesColumns>;
+export interface JsonApiSourceTableOutAttributes {
+    columns?: Array<JsonApiSourceTableOutAttributesColumns>;
     path?: Array<string>;
 }
 
 // @public
-export interface JsonApiSourceTableAttributesColumns {
-    dataType: JsonApiSourceTableAttributesColumnsDataTypeEnum;
+export interface JsonApiSourceTableOutAttributesColumns {
+    dataType: JsonApiSourceTableOutAttributesColumnsDataTypeEnum;
     name: string;
 }
 
 // @public
-export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
+export enum JsonApiSourceTableOutAttributesColumnsDataTypeEnum {
     // (undocumented)
     BOOLEAN = "BOOLEAN",
     // (undocumented)
@@ -1721,221 +1943,371 @@ export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
 }
 
 // @public
-export interface JsonApiSourceTableDocument {
-    data: JsonApiSourceTable;
-    included?: Array<JsonApiSourceTablesWithLinks>;
+export interface JsonApiSourceTableOutDocument {
+    data: JsonApiSourceTableOut;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiSourceTableList {
-    data: Array<JsonApiSourceTableWithLinks>;
-    included?: Array<JsonApiSourceTablesWithLinks>;
+export interface JsonApiSourceTableOutList {
+    data: Array<JsonApiSourceTableOutWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiSourceTableRelationships {
-    source?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiSourceTableOutRelationships {
+    source?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiSourceTables {
-    attributes?: object;
+export interface JsonApiSourceTableOutWithLinks {
+    attributes?: JsonApiSourceTableOutAttributes;
     id: string;
-    relationships?: JsonApiSourceTablesRelationships;
+    links?: ObjectLinks;
+    relationships?: JsonApiSourceTableOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTablesDocument {
-    data: JsonApiSourceTables;
-    included?: Array<JsonApiSourceTableWithLinks>;
+export interface JsonApiSourceTablesOut {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiSourceTablesOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiSourceTablesOutDocument {
+    data: JsonApiSourceTablesOut;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiSourceTablesList {
-    data: Array<JsonApiSourceTablesWithLinks>;
-    included?: Array<JsonApiSourceTableWithLinks>;
+export interface JsonApiSourceTablesOutList {
+    data: Array<JsonApiSourceTablesOutWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiSourceTablesRelationships {
-    tables?: JsonApiACLRelationshipsUsers;
+export interface JsonApiSourceTablesOutRelationships {
+    tables?: JsonApiACLOutRelationshipsUsers;
 }
 
 // @public
-export interface JsonApiSourceTablesWithLinks {
+export interface JsonApiSourceTablesOutWithLinks {
     attributes?: object;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiSourceTableWithLinks {
-    attributes?: JsonApiSourceTableAttributes;
+export interface JsonApiUserGroupIn {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserGroupInDocument {
+    data: JsonApiUserGroupIn;
+}
+
+// @public
+export interface JsonApiUserGroupOut {
+    attributes?: object;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserGroupOutDocument {
+    data: JsonApiUserGroupOut;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiUserGroupOutList {
+    data: Array<JsonApiUserGroupOutWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+    links?: ListLinks;
+}
+
+// @public
+export interface JsonApiUserGroupOutRelationships {
+    acls?: JsonApiACLOutRelationshipsUsers;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
+}
+
+// @public
+export interface JsonApiUserGroupOutWithLinks {
+    attributes?: object;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUser {
-    attributes?: JsonApiUserAttributes;
+export interface JsonApiUserIn {
+    attributes?: JsonApiUserOutAttributes;
     id: string;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUserAttributes {
+export interface JsonApiUserInDocument {
+    data: JsonApiUserIn;
+}
+
+// @public
+export interface JsonApiUserOut {
+    attributes?: JsonApiUserOutAttributes;
+    id: string;
+    relationships?: JsonApiUserGroupOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiUserOutAttributes {
     authenticationId?: string;
 }
 
 // @public
-export interface JsonApiUserDocument {
-    data: JsonApiUser;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiUserOutDocument {
+    data: JsonApiUserOut;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiUserGroup {
-    attributes?: object;
-    id: string;
-    relationships?: JsonApiUserGroupRelationships;
-    type: string;
-}
-
-// @public
-export interface JsonApiUserGroupDocument {
-    data: JsonApiUserGroup;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-    links?: ObjectLinks;
-}
-
-// @public
-export interface JsonApiUserGroupList {
-    data: Array<JsonApiUserGroupWithLinks>;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiUserOutList {
+    data: Array<JsonApiUserOutWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiUserGroupRelationships {
-    acls?: JsonApiACLRelationshipsUsers;
-    userGroup?: JsonApiOrganizationRelationshipsUser;
-}
-
-// @public
-export interface JsonApiUserGroupWithLinks {
-    attributes?: object;
+export interface JsonApiUserOutWithLinks {
+    attributes?: JsonApiUserOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiUserList {
-    data: Array<JsonApiUserWithLinks>;
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+export interface JsonApiVisualizationObjectIn {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiVisualizationObjectInDocument {
+    data: JsonApiVisualizationObjectIn;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOut {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    id: string;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutDocument {
+    data: JsonApiVisualizationObjectOut;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutList {
+    data: Array<JsonApiVisualizationObjectOutWithLinks>;
+    included?: Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiUserWithLinks {
-    attributes?: JsonApiUserAttributes;
+export interface JsonApiVisualizationObjectOutRelationships {
+    analyticalDashboards?: JsonApiACLOutRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
+}
+
+// @public
+export interface JsonApiVisualizationObjectOutWithLinks {
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiVisualizationObject {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiWorkspaceDataFilterIn {
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
     id: string;
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiVisualizationObjectDocument {
-    data: JsonApiVisualizationObject;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiWorkspaceDataFilterInAttributes {
+    columnName?: string;
+    dataSourceName?: string;
+    description?: string;
+    title?: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterInDocument {
+    data: JsonApiWorkspaceDataFilterIn;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterInRelationships {
+    workspaceDataFilterSettings?: JsonApiACLOutRelationshipsUsers;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterOut {
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
+    id: string;
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterOutDocument {
+    data: JsonApiWorkspaceDataFilterOut;
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiVisualizationObjectList {
-    data: Array<JsonApiVisualizationObjectWithLinks>;
-    included?: Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>;
+export interface JsonApiWorkspaceDataFilterOutList {
+    data: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiVisualizationObjectRelationships {
-    analyticalDashboards?: JsonApiACLRelationshipsUsers;
-    attributes?: JsonApiACLRelationshipsUsers;
-    datasets?: JsonApiACLRelationshipsUsers;
-    facts?: JsonApiACLRelationshipsUsers;
-    labels?: JsonApiACLRelationshipsUsers;
-    metrics?: JsonApiACLRelationshipsUsers;
-}
-
-// @public
-export interface JsonApiVisualizationObjectWithLinks {
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+export interface JsonApiWorkspaceDataFilterOutWithLinks {
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiWorkspace {
-    attributes?: JsonApiWorkspaceAttributes;
+export interface JsonApiWorkspaceDataFilterSettingOut {
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
     id: string;
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
     type: string;
 }
 
 // @public
-export interface JsonApiWorkspaceAttributes {
+export interface JsonApiWorkspaceDataFilterSettingOutAttributes {
+    description?: string;
+    filterValues?: Array<string>;
+    title?: string;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutDocument {
+    data: JsonApiWorkspaceDataFilterSettingOut;
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    links?: ObjectLinks;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutList {
+    data: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    links?: ListLinks;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutRelationships {
+    workspaceDataFilter?: JsonApiOrganizationOutRelationshipsUser;
+}
+
+// @public
+export interface JsonApiWorkspaceDataFilterSettingOutWithLinks {
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    id: string;
+    links?: ObjectLinks;
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceIn {
+    attributes?: JsonApiWorkspaceOutAttributes;
+    id: string;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceInDocument {
+    data: JsonApiWorkspaceIn;
+}
+
+// @public
+export interface JsonApiWorkspaceOut {
+    attributes?: JsonApiWorkspaceOutAttributes;
+    id: string;
+    relationships?: JsonApiWorkspaceOutRelationships;
+    type: string;
+}
+
+// @public
+export interface JsonApiWorkspaceOutAttributes {
     name?: string;
 }
 
 // @public
-export interface JsonApiWorkspaceDocument {
-    data: JsonApiWorkspace;
-    included?: Array<JsonApiWorkspaceWithLinks>;
+export interface JsonApiWorkspaceOutDocument {
+    data: JsonApiWorkspaceOut;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
     links?: ObjectLinks;
 }
 
 // @public
-export interface JsonApiWorkspaceList {
-    data: Array<JsonApiWorkspaceWithLinks>;
-    included?: Array<JsonApiWorkspaceWithLinks>;
+export interface JsonApiWorkspaceOutList {
+    data: Array<JsonApiWorkspaceOutWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
     links?: ListLinks;
 }
 
 // @public
-export interface JsonApiWorkspaceRelationships {
-    workspace?: JsonApiOrganizationRelationshipsUser;
+export interface JsonApiWorkspaceOutRelationships {
+    workspace?: JsonApiOrganizationOutRelationshipsUser;
 }
 
 // @public
-export interface JsonApiWorkspaceWithLinks {
-    attributes?: JsonApiWorkspaceAttributes;
+export interface JsonApiWorkspaceOutWithLinks {
+    attributes?: JsonApiWorkspaceOutAttributes;
     id: string;
     links?: ObjectLinks;
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceOutRelationships;
     type: string;
 }
 
@@ -2028,6 +2400,7 @@ export interface MeasureHeaderItem {
 export interface MeasureHeaderItemMeasureHeaderItem {
     format?: string;
     localIdentifier: string;
+    name?: string;
 }
 
 // @public
@@ -2103,7 +2476,7 @@ export type MetadataGetEntitiesParams = {
 };
 
 // @internal
-export type MetadataGetEntitiesResult = JsonApiVisualizationObjectList | JsonApiAnalyticalDashboardList | JsonApiDatasetList | JsonApiAttributeList | JsonApiLabelList | JsonApiMetricList | JsonApiFactList | JsonApiFilterContextList;
+export type MetadataGetEntitiesResult = JsonApiVisualizationObjectOutList | JsonApiAnalyticalDashboardOutList | JsonApiDatasetOutList | JsonApiAttributeOutList | JsonApiLabelOutList | JsonApiMetricOutList | JsonApiFactOutList | JsonApiFilterContextOutList;
 
 // @public
 export interface MetadataRequestArgs {
@@ -2146,11 +2519,17 @@ export class NotificationControllerApi extends MetadataBaseApi implements Notifi
     registerUploadNotification(params: {
         dataSourceId: string;
     }, options?: any): AxiosPromise<void>;
+    registerUploadNotification1(params: {
+        dataSourceId: string;
+    }, options?: any): AxiosPromise<void>;
 }
 
 // @public
 export const NotificationControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     registerUploadNotification(params: {
+        dataSourceId: string;
+    }, options?: any): MetadataRequestArgs;
+    registerUploadNotification1(params: {
         dataSourceId: string;
     }, options?: any): MetadataRequestArgs;
 };
@@ -2160,6 +2539,9 @@ export const NotificationControllerApiFactory: (configuration?: MetadataConfigur
     registerUploadNotification(params: {
         dataSourceId: string;
     }, options?: any): AxiosPromise<void>;
+    registerUploadNotification1(params: {
+        dataSourceId: string;
+    }, options?: any): AxiosPromise<void>;
 };
 
 // @public
@@ -2167,11 +2549,17 @@ export const NotificationControllerApiFp: (configuration?: MetadataConfiguration
     registerUploadNotification(params: {
         dataSourceId: string;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    registerUploadNotification1(params: {
+        dataSourceId: string;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
 };
 
 // @public
 export interface NotificationControllerApiInterface {
     registerUploadNotification(params: {
+        dataSourceId: string;
+    }, options?: any): AxiosPromise<void>;
+    registerUploadNotification1(params: {
         dataSourceId: string;
     }, options?: any): AxiosPromise<void>;
 }
@@ -2236,7 +2624,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     getEntityDataSources(params: {
         id: string;
@@ -2244,7 +2632,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     getEntityModelModules(params: {
         id: string;
@@ -2252,7 +2640,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     getEntityOrganizations(params: {
         id: string;
@@ -2260,7 +2648,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     getEntityUserGroups(params: {
         id: string;
@@ -2268,7 +2656,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     getEntityUsers(params: {
         id: string;
@@ -2276,7 +2664,7 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     getEntityWorkspaces(params: {
         id: string;
@@ -2284,72 +2672,72 @@ export class OrganizationControllerApi extends MetadataBaseApi implements Organi
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiACLDocument | JsonApiDataSourceDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserDocument | JsonApiUserGroupDocument | JsonApiWorkspaceDocument>;
+    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiACLOutDocument | JsonApiDataSourceOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls1(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @public
@@ -2406,7 +2794,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     getOrganizationUsers11(params: {}, options?: any): MetadataRequestArgs;
     updateEntityAcls1(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2414,7 +2802,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2422,7 +2810,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2430,7 +2818,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2438,7 +2826,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2446,7 +2834,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2454,7 +2842,7 @@ export const OrganizationControllerApiAxiosParamCreator: (configuration?: Metada
     }, options?: any): MetadataRequestArgs;
     updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -2470,106 +2858,106 @@ export const OrganizationControllerApiFactory: (configuration?: MetadataConfigur
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
     updateEntityAcls1(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
@@ -2580,106 +2968,106 @@ export const OrganizationControllerApiFp: (configuration?: MetadataConfiguration
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     getEntityDataSources(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     getEntityModelModules(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     getEntityOrganizations(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     getEntityUserGroups(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     getEntityUsers(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     getEntityWorkspaces(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
-    getOrganizationUsers11(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
+    getOrganizationUsers11(params: {}, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
     updateEntityAcls1(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
@@ -2691,7 +3079,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     getEntityDataSources(params: {
         id: string;
@@ -2699,7 +3087,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     getEntityModelModules(params: {
         id: string;
@@ -2707,7 +3095,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     getEntityOrganizations(params: {
         id: string;
@@ -2715,7 +3103,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     getEntityUserGroups(params: {
         id: string;
@@ -2723,7 +3111,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     getEntityUsers(params: {
         id: string;
@@ -2731,7 +3119,7 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     getEntityWorkspaces(params: {
         id: string;
@@ -2739,72 +3127,72 @@ export interface OrganizationControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
-    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceDocument | JsonApiACLDocument | JsonApiModelModuleDocument | JsonApiOrganizationDocument | JsonApiUserGroupDocument | JsonApiUserDocument | JsonApiWorkspaceDocument>;
+    getOrganizationUsers11(params: {}, options?: any): AxiosPromise<JsonApiDataSourceOutDocument | JsonApiACLOutDocument | JsonApiModelModuleOutDocument | JsonApiOrganizationOutDocument | JsonApiUserGroupOutDocument | JsonApiUserOutDocument | JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls1(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     updateEntityDataSources(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     updateEntityModelModules(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     updateEntityOrganizations(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     updateEntityUserGroups(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     updateEntityUsers(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     updateEntityWorkspaces(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @internal
@@ -2823,101 +3211,143 @@ export type OrganizationGetEntitiesOptions = {
 };
 
 // @internal
-export type OrganizationGetEntitiesResult = JsonApiACLList | JsonApiOrganizationList | JsonApiUserList | JsonApiUserGroupList | JsonApiWorkspaceList;
+export type OrganizationGetEntitiesResult = JsonApiACLOutList | JsonApiOrganizationOutList | JsonApiUserOutList | JsonApiUserGroupOutList | JsonApiWorkspaceOutList;
 
 // @public
 export class OrganizationModelControllerApi extends MetadataBaseApi implements OrganizationModelControllerApiInterface {
     // (undocumented)
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     deleteEntityAcls(params: {
         id: string;
@@ -2976,7 +3406,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     // (undocumented)
     getAllEntitiesDataSources(params: {
         variableParam?: {
@@ -2986,7 +3416,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     // (undocumented)
     getAllEntitiesModelModules(params: {
         variableParam?: {
@@ -2996,7 +3426,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     // (undocumented)
     getAllEntitiesOrganizations(params: {
         variableParam?: {
@@ -3006,7 +3436,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     // (undocumented)
     getAllEntitiesUserGroups(params: {
         variableParam?: {
@@ -3016,7 +3446,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     // (undocumented)
     getAllEntitiesUsers(params: {
         variableParam?: {
@@ -3026,7 +3456,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     // (undocumented)
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
@@ -3036,7 +3466,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     // (undocumented)
     getEntityAcls(params: {
         id: string;
@@ -3044,7 +3474,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     getEntityDataSources1(params: {
         id: string;
@@ -3052,7 +3482,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     getEntityModelModules1(params: {
         id: string;
@@ -3060,7 +3490,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     getEntityOrganizations1(params: {
         id: string;
@@ -3068,7 +3498,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     getEntityUserGroups1(params: {
         id: string;
@@ -3076,7 +3506,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     getEntityUsers1(params: {
         id: string;
@@ -3084,7 +3514,7 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     getEntityWorkspaces1(params: {
         id: string;
@@ -3092,150 +3522,185 @@ export class OrganizationModelControllerApi extends MetadataBaseApi implements O
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     updateEntityDataSources1(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     updateEntityModelModules1(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     updateEntityOrganizations1(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     updateEntityUserGroups1(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     updateEntityUsers1(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     updateEntityWorkspaces1(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @public
 export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
     }, options?: any): MetadataRequestArgs;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
     }, options?: any): MetadataRequestArgs;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): MetadataRequestArgs;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
     }, options?: any): MetadataRequestArgs;
     deleteEntityAcls(params: {
         id: string;
@@ -3393,7 +3858,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3401,7 +3866,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityDataSources1(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3409,7 +3874,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityModelModules1(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3417,7 +3882,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityOrganizations1(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3425,7 +3890,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityUserGroups1(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3433,7 +3898,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityUsers1(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3441,7 +3906,7 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
     }, options?: any): MetadataRequestArgs;
     updateEntityWorkspaces1(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -3453,81 +3918,116 @@ export const OrganizationModelControllerApiAxiosParamCreator: (configuration?: M
 export const OrganizationModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     deleteEntityAcls(params: {
         id: string;
         variableParam?: {
@@ -3578,7 +4078,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     getAllEntitiesDataSources(params: {
         variableParam?: {
             [key: string]: object;
@@ -3587,7 +4087,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     getAllEntitiesModelModules(params: {
         variableParam?: {
             [key: string]: object;
@@ -3596,7 +4096,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     getAllEntitiesOrganizations(params: {
         variableParam?: {
             [key: string]: object;
@@ -3605,7 +4105,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     getAllEntitiesUserGroups(params: {
         variableParam?: {
             [key: string]: object;
@@ -3614,7 +4114,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     getAllEntitiesUsers(params: {
         variableParam?: {
             [key: string]: object;
@@ -3623,7 +4123,7 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
             [key: string]: object;
@@ -3632,193 +4132,228 @@ export const OrganizationModelControllerApiFactory: (configuration?: MetadataCon
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     getEntityAcls(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     getEntityDataSources1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     getEntityModelModules1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     getEntityOrganizations1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     getEntityUserGroups1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     getEntityUsers1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     getEntityWorkspaces1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     updateEntityDataSources1(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     updateEntityModelModules1(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     updateEntityOrganizations1(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     updateEntityUserGroups1(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     updateEntityUsers1(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     updateEntityWorkspaces1(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
 export const OrganizationModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     deleteEntityAcls(params: {
         id: string;
         variableParam?: {
@@ -3869,7 +4404,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutList>;
     getAllEntitiesDataSources(params: {
         variableParam?: {
             [key: string]: object;
@@ -3878,7 +4413,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutList>;
     getAllEntitiesModelModules(params: {
         variableParam?: {
             [key: string]: object;
@@ -3887,7 +4422,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutList>;
     getAllEntitiesOrganizations(params: {
         variableParam?: {
             [key: string]: object;
@@ -3896,7 +4431,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutList>;
     getAllEntitiesUserGroups(params: {
         variableParam?: {
             [key: string]: object;
@@ -3905,7 +4440,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutList>;
     getAllEntitiesUsers(params: {
         variableParam?: {
             [key: string]: object;
@@ -3914,7 +4449,7 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutList>;
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
             [key: string]: object;
@@ -3923,112 +4458,112 @@ export const OrganizationModelControllerApiFp: (configuration?: MetadataConfigur
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutList>;
     getEntityAcls(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     getEntityDataSources1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     getEntityModelModules1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     getEntityOrganizations1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     getEntityUserGroups1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     getEntityUsers1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     getEntityWorkspaces1(params: {
         id: string;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiACLOutDocument>;
     updateEntityDataSources1(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataSourceOutDocument>;
     updateEntityModelModules1(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiModelModuleOutDocument>;
     updateEntityOrganizations1(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiOrganizationOutDocument>;
     updateEntityUserGroups1(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserGroupOutDocument>;
     updateEntityUsers1(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiUserOutDocument>;
     updateEntityWorkspaces1(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceOutDocument>;
 };
 
 // @public
@@ -4036,94 +4571,136 @@ export interface OrganizationModelControllerApiInterface {
     // (undocumented)
     createChildEntityAcls(params: {
         workspaceId: string;
-        jsonApiACLDocument: JsonApiACLDocument;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createChildEntityDataSources(params: {
         workspaceId: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createChildEntityModelModules(params: {
         workspaceId: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createChildEntityOrganizations(params: {
         workspaceId: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createChildEntityUserGroups(params: {
         workspaceId: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createChildEntityUsers(params: {
         workspaceId: string;
-        jsonApiUserDocument: JsonApiUserDocument;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createChildEntityWorkspaces(params: {
         workspaceId: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     createEntityAcls(params: {
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     createEntityDataSources(params: {
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     createEntityModelModules(params: {
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     createEntityOrganizations(params: {
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     createEntityUserGroups(params: {
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     createEntityUsers(params: {
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     createEntityWorkspaces(params: {
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityAcls(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiACLInDocument: JsonApiACLInDocument;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityDataSources(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityModelModules(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityOrganizations(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUserGroups(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityUsers(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiUserInDocument: JsonApiUserInDocument;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
+    // (undocumented)
+    createWorkspaceDataFilterSettingEntityWorkspaces(params: {
+        workspaceId: string;
+        childWorkspaceId: string;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     deleteEntityAcls(params: {
         id: string;
@@ -4182,7 +4759,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiACLList>;
+    }, options?: any): AxiosPromise<JsonApiACLOutList>;
     // (undocumented)
     getAllEntitiesDataSources(params: {
         variableParam?: {
@@ -4192,7 +4769,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataSourceList>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutList>;
     // (undocumented)
     getAllEntitiesModelModules(params: {
         variableParam?: {
@@ -4202,7 +4779,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiModelModuleList>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutList>;
     // (undocumented)
     getAllEntitiesOrganizations(params: {
         variableParam?: {
@@ -4212,7 +4789,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiOrganizationList>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutList>;
     // (undocumented)
     getAllEntitiesUserGroups(params: {
         variableParam?: {
@@ -4222,7 +4799,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserGroupList>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutList>;
     // (undocumented)
     getAllEntitiesUsers(params: {
         variableParam?: {
@@ -4232,7 +4809,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiUserList>;
+    }, options?: any): AxiosPromise<JsonApiUserOutList>;
     // (undocumented)
     getAllEntitiesWorkspaces(params: {
         variableParam?: {
@@ -4242,7 +4819,7 @@ export interface OrganizationModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceList>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutList>;
     // (undocumented)
     getEntityAcls(params: {
         id: string;
@@ -4250,7 +4827,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     getEntityDataSources1(params: {
         id: string;
@@ -4258,7 +4835,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     getEntityModelModules1(params: {
         id: string;
@@ -4266,7 +4843,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     getEntityOrganizations1(params: {
         id: string;
@@ -4274,7 +4851,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     getEntityUserGroups1(params: {
         id: string;
@@ -4282,7 +4859,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     getEntityUsers1(params: {
         id: string;
@@ -4290,7 +4867,7 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     getEntityWorkspaces1(params: {
         id: string;
@@ -4298,70 +4875,70 @@ export interface OrganizationModelControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
     // (undocumented)
     updateEntityAcls(params: {
         id: string;
-        jsonApiACLDocument: JsonApiACLDocument;
+        jsonApiACLInDocument: JsonApiACLInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiACLDocument>;
+    }, options?: any): AxiosPromise<JsonApiACLOutDocument>;
     // (undocumented)
     updateEntityDataSources1(params: {
         id: string;
-        jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+        jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataSourceDocument>;
+    }, options?: any): AxiosPromise<JsonApiDataSourceOutDocument>;
     // (undocumented)
     updateEntityModelModules1(params: {
         id: string;
-        jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+        jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiModelModuleDocument>;
+    }, options?: any): AxiosPromise<JsonApiModelModuleOutDocument>;
     // (undocumented)
     updateEntityOrganizations1(params: {
         id: string;
-        jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+        jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiOrganizationDocument>;
+    }, options?: any): AxiosPromise<JsonApiOrganizationOutDocument>;
     // (undocumented)
     updateEntityUserGroups1(params: {
         id: string;
-        jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+        jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserGroupDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserGroupOutDocument>;
     // (undocumented)
     updateEntityUsers1(params: {
         id: string;
-        jsonApiUserDocument: JsonApiUserDocument;
+        jsonApiUserInDocument: JsonApiUserInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiUserDocument>;
+    }, options?: any): AxiosPromise<JsonApiUserOutDocument>;
     // (undocumented)
     updateEntityWorkspaces1(params: {
         id: string;
-        jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+        jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiWorkspaceDocument>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 // @internal
@@ -4614,11 +5191,23 @@ export class ResultControllerApi extends LabelElementsBaseApi implements ResultC
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
 }
 
 // @public
 export const ResultControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
     getResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: number[] | undefined;
+        limit?: number[] | undefined;
+    }, options?: any): LabelElementsRequestArgs;
+    retrieveResult(params: {
         workspaceId: string;
         resultId: string;
         offset?: number[] | undefined;
@@ -4634,6 +5223,12 @@ export const ResultControllerApiFactory: (configuration?: LabelElementsConfigura
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
 };
 
 // @public
@@ -4644,11 +5239,23 @@ export const ResultControllerApiFp: (configuration?: LabelElementsConfiguration 
         offset?: Array<number>;
         limit?: Array<number>;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<ExecutionResult>;
 };
 
 // @public
 export interface ResultControllerApiInterface {
     getResult(params: {
+        workspaceId: string;
+        resultId: string;
+        offset?: Array<number>;
+        limit?: Array<number>;
+    }, options?: any): AxiosPromise<ExecutionResult>;
+    retrieveResult(params: {
         workspaceId: string;
         resultId: string;
         offset?: Array<number>;
@@ -4780,12 +5387,12 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
     // (undocumented)
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     // (undocumented)
     deleteEntityApiTokens(params: {
         userId: string;
@@ -4804,7 +5411,7 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     // (undocumented)
     getEntityApiTokens(params: {
         userId: string;
@@ -4816,14 +5423,14 @@ export class UserModelControllerApi extends MetadataBaseApi implements UserModel
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 // @public
 export const UserModelControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -4863,12 +5470,12 @@ export const UserModelControllerApiAxiosParamCreator: (configuration?: MetadataC
 export const UserModelControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     deleteEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4885,7 +5492,7 @@ export const UserModelControllerApiFactory: (configuration?: MetadataConfigurati
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4896,19 +5503,19 @@ export const UserModelControllerApiFactory: (configuration?: MetadataConfigurati
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 };
 
 // @public
 export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutDocument>;
     deleteEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4925,7 +5532,7 @@ export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | 
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutList>;
     getEntityApiTokens(params: {
         userId: string;
         id: string;
@@ -4936,7 +5543,7 @@ export const UserModelControllerApiFp: (configuration?: MetadataConfiguration | 
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiApiTokenOutDocument>;
 };
 
 // @public
@@ -4944,12 +5551,12 @@ export interface UserModelControllerApiInterface {
     // (undocumented)
     createEntityApiTokens(params: {
         userId: string;
-        jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+        jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
     // (undocumented)
     deleteEntityApiTokens(params: {
         userId: string;
@@ -4968,7 +5575,7 @@ export interface UserModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenList>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutList>;
     // (undocumented)
     getEntityApiTokens(params: {
         userId: string;
@@ -4980,11 +5587,15 @@ export interface UserModelControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiApiTokenDocument>;
+    }, options?: any): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 // @public
 export class ValidObjectsControllerApi extends LabelElementsBaseApi implements ValidObjectsControllerApiInterface {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -4993,6 +5604,10 @@ export class ValidObjectsControllerApi extends LabelElementsBaseApi implements V
 
 // @public
 export const ValidObjectsControllerApiAxiosParamCreator: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): LabelElementsRequestArgs;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -5001,6 +5616,10 @@ export const ValidObjectsControllerApiAxiosParamCreator: (configuration?: LabelE
 
 // @public
 export const ValidObjectsControllerApiFactory: (configuration?: LabelElementsConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -5009,6 +5628,10 @@ export const ValidObjectsControllerApiFactory: (configuration?: LabelElementsCon
 
 // @public
 export const ValidObjectsControllerApiFp: (configuration?: LabelElementsConfiguration | undefined) => {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -5017,6 +5640,10 @@ export const ValidObjectsControllerApiFp: (configuration?: LabelElementsConfigur
 
 // @public
 export interface ValidObjectsControllerApiInterface {
+    computeValidObjects(params: {
+        workspaceId: string;
+        afmValidObjectsQuery: AfmValidObjectsQuery;
+    }, options?: any): AxiosPromise<AfmValidObjectsResponse>;
     processAfmValidObjectsQuery(params: {
         workspaceId: string;
         afmValidObjectsQuery: AfmValidObjectsQuery;
@@ -5118,58 +5745,50 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
     // (undocumented)
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         };
-    }, options?: any): AxiosPromise<void>;
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     // (undocumented)
-    deleteEntityDataDiscriminators(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5201,6 +5820,14 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+    }, options?: any): AxiosPromise<void>;
+    // (undocumented)
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5210,7 +5837,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     // (undocumented)
     getEntitiesAttributes(params: {
         workspaceId: string;
@@ -5221,18 +5848,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     // (undocumented)
     getEntitiesDatasets(params: {
         workspaceId: string;
@@ -5243,7 +5859,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     // (undocumented)
     getEntitiesFacts(params: {
         workspaceId: string;
@@ -5254,7 +5870,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     // (undocumented)
     getEntitiesFilterContexts(params: {
         workspaceId: string;
@@ -5265,7 +5881,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     // (undocumented)
     getEntitiesLabels(params: {
         workspaceId: string;
@@ -5276,7 +5892,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     // (undocumented)
     getEntitiesMetrics(params: {
         workspaceId: string;
@@ -5287,7 +5903,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     // (undocumented)
     getEntitiesSources(params: {
         workspaceId: string;
@@ -5298,7 +5914,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     // (undocumented)
     getEntitiesTables(params: {
         workspaceId: string;
@@ -5309,7 +5925,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     // (undocumented)
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
@@ -5320,7 +5936,29 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
     // (undocumented)
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
@@ -5329,7 +5967,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     getEntityAttributes(params: {
         workspaceId: string;
@@ -5338,16 +5976,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     // (undocumented)
     getEntityDatasets(params: {
         workspaceId: string;
@@ -5356,7 +5985,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     // (undocumented)
     getEntityFacts(params: {
         workspaceId: string;
@@ -5365,7 +5994,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     // (undocumented)
     getEntityFilterContexts(params: {
         workspaceId: string;
@@ -5374,7 +6003,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     getEntityLabels(params: {
         workspaceId: string;
@@ -5383,7 +6012,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     // (undocumented)
     getEntityMetrics(params: {
         workspaceId: string;
@@ -5392,7 +6021,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     getEntitySources(params: {
         workspaceId: string;
@@ -5401,7 +6030,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     // (undocumented)
     getEntityTables(params: {
         workspaceId: string;
@@ -5410,7 +6039,7 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     // (undocumented)
     getEntityVisualizationObjects(params: {
         workspaceId: string;
@@ -5419,72 +6048,82 @@ export class WorkspaceObjectControllerApi extends MetadataBaseApi implements Wor
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
     // (undocumented)
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 // @public
 export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: MetadataConfiguration | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5492,7 +6131,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5500,7 +6139,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5508,20 +6147,21 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     }, options?: any): MetadataRequestArgs;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    createEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     deleteEntityAnalyticalDashboards(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-    }, options?: any): MetadataRequestArgs;
-    deleteEntityDataDiscriminators(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5549,6 +6189,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
             [key: string]: object;
         } | undefined;
     }, options?: any): MetadataRequestArgs;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): MetadataRequestArgs;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5560,16 +6207,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
     getEntitiesAttributes(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntitiesDataDiscriminators(params: {
         workspaceId: string;
         variableParam?: {
             [key: string]: object;
@@ -5659,6 +6296,26 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         size?: number | undefined;
         sort?: string[] | undefined;
     }, options?: any): MetadataRequestArgs;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): MetadataRequestArgs;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): MetadataRequestArgs;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -5668,14 +6325,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
     getEntityAttributes(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): MetadataRequestArgs;
-    getEntityDataDiscriminators(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5747,19 +6396,26 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityAnalyticalDashboards(params: {
+    getEntityWorkspaceDataFilterSettings(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
     }, options?: any): MetadataRequestArgs;
-    updateEntityDataDiscriminators(params: {
+    getEntityWorkspaceDataFilters(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    updateEntityAnalyticalDashboards(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5768,7 +6424,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5777,7 +6433,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5786,7 +6442,16 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): MetadataRequestArgs;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
@@ -5798,52 +6463,45 @@ export const WorkspaceObjectControllerApiAxiosParamCreator: (configuration?: Met
 export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfiguration | undefined, basePath?: string | undefined, axios?: AxiosInstance | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
-    }, options?: any): AxiosPromise<void>;
-    deleteEntityDataDiscriminators(params: {
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -5871,6 +6529,13 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
     }, options?: any): AxiosPromise<void>;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): AxiosPromise<void>;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -5880,7 +6545,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
@@ -5890,17 +6555,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
@@ -5910,7 +6565,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
@@ -5920,7 +6575,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
@@ -5930,7 +6585,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
@@ -5940,7 +6595,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
@@ -5950,7 +6605,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
@@ -5960,7 +6615,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
@@ -5970,7 +6625,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
@@ -5980,7 +6635,27 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -5988,7 +6663,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
@@ -5996,15 +6671,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
@@ -6012,7 +6679,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
@@ -6020,7 +6687,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
@@ -6028,7 +6695,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
@@ -6036,7 +6703,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
@@ -6044,7 +6711,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     getEntitySources(params: {
         workspaceId: string;
         objectId: string;
@@ -6052,7 +6719,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     getEntityTables(params: {
         workspaceId: string;
         objectId: string;
@@ -6060,7 +6727,7 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
@@ -6068,104 +6735,113 @@ export const WorkspaceObjectControllerApiFactory: (configuration?: MetadataConfi
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 };
 
 // @public
 export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfiguration | undefined) => {
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
-    deleteEntityAnalyticalDashboards(params: {
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
-    deleteEntityDataDiscriminators(params: {
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6193,6 +6869,13 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
     }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<void>;
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -6202,7 +6885,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     getEntitiesAttributes(params: {
         workspaceId: string;
         variableParam?: {
@@ -6212,17 +6895,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeList>;
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-        page?: number | undefined;
-        size?: number | undefined;
-        sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeOutList>;
     getEntitiesDatasets(params: {
         workspaceId: string;
         variableParam?: {
@@ -6232,7 +6905,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetOutList>;
     getEntitiesFacts(params: {
         workspaceId: string;
         variableParam?: {
@@ -6242,7 +6915,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactOutList>;
     getEntitiesFilterContexts(params: {
         workspaceId: string;
         variableParam?: {
@@ -6252,7 +6925,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutList>;
     getEntitiesLabels(params: {
         workspaceId: string;
         variableParam?: {
@@ -6262,7 +6935,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelOutList>;
     getEntitiesMetrics(params: {
         workspaceId: string;
         variableParam?: {
@@ -6272,7 +6945,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutList>;
     getEntitiesSources(params: {
         workspaceId: string;
         variableParam?: {
@@ -6282,7 +6955,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesOutList>;
     getEntitiesTables(params: {
         workspaceId: string;
         variableParam?: {
@@ -6292,7 +6965,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableOutList>;
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
         variableParam?: {
@@ -6302,7 +6975,27 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
         page?: number | undefined;
         size?: number | undefined;
         sort?: string[] | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutList>;
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+        page?: number | undefined;
+        size?: number | undefined;
+        sort?: string[] | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
@@ -6310,7 +7003,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     getEntityAttributes(params: {
         workspaceId: string;
         objectId: string;
@@ -6318,15 +7011,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeDocument>;
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAttributeOutDocument>;
     getEntityDatasets(params: {
         workspaceId: string;
         objectId: string;
@@ -6334,7 +7019,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDatasetOutDocument>;
     getEntityFacts(params: {
         workspaceId: string;
         objectId: string;
@@ -6342,7 +7027,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFactOutDocument>;
     getEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
@@ -6350,7 +7035,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     getEntityLabels(params: {
         workspaceId: string;
         objectId: string;
@@ -6358,7 +7043,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiLabelOutDocument>;
     getEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
@@ -6366,7 +7051,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     getEntitySources(params: {
         workspaceId: string;
         objectId: string;
@@ -6374,7 +7059,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTablesOutDocument>;
     getEntityTables(params: {
         workspaceId: string;
         objectId: string;
@@ -6382,7 +7067,7 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiSourceTableOutDocument>;
     getEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
@@ -6390,52 +7075,68 @@ export const WorkspaceObjectControllerApiFp: (configuration?: MetadataConfigurat
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        } | undefined;
-        include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiFilterContextOutDocument>;
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiMetricOutDocument>;
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         } | undefined;
         include?: object | undefined;
-    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        } | undefined;
+        include?: object | undefined;
+    }, options?: any): (axios?: AxiosInstance | undefined, basePath?: string | undefined) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 };
 
 // @public
@@ -6443,58 +7144,50 @@ export interface WorkspaceObjectControllerApiInterface {
     // (undocumented)
     createEntityAnalyticalDashboards(params: {
         workspaceId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    createEntityDataDiscriminators(params: {
-        workspaceId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     createEntityFilterContexts(params: {
         workspaceId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     createEntityMetrics(params: {
         workspaceId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     createEntityVisualizationObjects(params: {
         workspaceId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
     // (undocumented)
-    deleteEntityAnalyticalDashboards(params: {
+    createEntityWorkspaceDataFilters(params: {
         workspaceId: string;
-        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
         variableParam?: {
             [key: string]: object;
         };
-    }, options?: any): AxiosPromise<void>;
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
     // (undocumented)
-    deleteEntityDataDiscriminators(params: {
+    deleteEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
         variableParam?: {
@@ -6526,6 +7219,14 @@ export interface WorkspaceObjectControllerApiInterface {
         };
     }, options?: any): AxiosPromise<void>;
     // (undocumented)
+    deleteEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+    }, options?: any): AxiosPromise<void>;
+    // (undocumented)
     getEntitiesAnalyticalDashboards(params: {
         workspaceId: string;
         variableParam?: {
@@ -6535,7 +7236,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
     // (undocumented)
     getEntitiesAttributes(params: {
         workspaceId: string;
@@ -6546,18 +7247,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiAttributeList>;
-    // (undocumented)
-    getEntitiesDataDiscriminators(params: {
-        workspaceId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-        page?: number;
-        size?: number;
-        sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorList>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutList>;
     // (undocumented)
     getEntitiesDatasets(params: {
         workspaceId: string;
@@ -6568,7 +7258,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiDatasetList>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutList>;
     // (undocumented)
     getEntitiesFacts(params: {
         workspaceId: string;
@@ -6579,7 +7269,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFactList>;
+    }, options?: any): AxiosPromise<JsonApiFactOutList>;
     // (undocumented)
     getEntitiesFilterContexts(params: {
         workspaceId: string;
@@ -6590,7 +7280,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiFilterContextList>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutList>;
     // (undocumented)
     getEntitiesLabels(params: {
         workspaceId: string;
@@ -6601,7 +7291,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiLabelList>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutList>;
     // (undocumented)
     getEntitiesMetrics(params: {
         workspaceId: string;
@@ -6612,7 +7302,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiMetricList>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutList>;
     // (undocumented)
     getEntitiesSources(params: {
         workspaceId: string;
@@ -6623,7 +7313,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutList>;
     // (undocumented)
     getEntitiesTables(params: {
         workspaceId: string;
@@ -6634,7 +7324,7 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiSourceTableList>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutList>;
     // (undocumented)
     getEntitiesVisualizationObjects(params: {
         workspaceId: string;
@@ -6645,7 +7335,29 @@ export interface WorkspaceObjectControllerApiInterface {
         page?: number;
         size?: number;
         sort?: Array<string>;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectList>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilters(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
+    // (undocumented)
+    getEntitiesWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+        page?: number;
+        size?: number;
+        sort?: Array<string>;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
     // (undocumented)
     getEntityAnalyticalDashboards(params: {
         workspaceId: string;
@@ -6654,7 +7366,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     getEntityAttributes(params: {
         workspaceId: string;
@@ -6663,16 +7375,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAttributeDocument>;
-    // (undocumented)
-    getEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAttributeOutDocument>;
     // (undocumented)
     getEntityDatasets(params: {
         workspaceId: string;
@@ -6681,7 +7384,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiDatasetDocument>;
+    }, options?: any): AxiosPromise<JsonApiDatasetOutDocument>;
     // (undocumented)
     getEntityFacts(params: {
         workspaceId: string;
@@ -6690,7 +7393,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFactDocument>;
+    }, options?: any): AxiosPromise<JsonApiFactOutDocument>;
     // (undocumented)
     getEntityFilterContexts(params: {
         workspaceId: string;
@@ -6699,7 +7402,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     getEntityLabels(params: {
         workspaceId: string;
@@ -6708,7 +7411,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiLabelDocument>;
+    }, options?: any): AxiosPromise<JsonApiLabelOutDocument>;
     // (undocumented)
     getEntityMetrics(params: {
         workspaceId: string;
@@ -6717,7 +7420,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     getEntitySources(params: {
         workspaceId: string;
@@ -6726,7 +7429,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTablesDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTablesOutDocument>;
     // (undocumented)
     getEntityTables(params: {
         workspaceId: string;
@@ -6735,7 +7438,7 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiSourceTableDocument>;
+    }, options?: any): AxiosPromise<JsonApiSourceTableOutDocument>;
     // (undocumented)
     getEntityVisualizationObjects(params: {
         workspaceId: string;
@@ -6744,57 +7447,75 @@ export interface WorkspaceObjectControllerApiInterface {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+    // (undocumented)
+    getEntityWorkspaceDataFilterSettings(params: {
+        workspaceId: string;
+        objectId: string;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
     // (undocumented)
     updateEntityAnalyticalDashboards(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+        jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
-    // (undocumented)
-    updateEntityDataDiscriminators(params: {
-        workspaceId: string;
-        objectId: string;
-        jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-        variableParam?: {
-            [key: string]: object;
-        };
-        include?: object;
-    }, options?: any): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    }, options?: any): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
     // (undocumented)
     updateEntityFilterContexts(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+        jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiFilterContextDocument>;
+    }, options?: any): AxiosPromise<JsonApiFilterContextOutDocument>;
     // (undocumented)
     updateEntityMetrics(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiMetricDocument: JsonApiMetricDocument;
+        jsonApiMetricInDocument: JsonApiMetricInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiMetricDocument>;
+    }, options?: any): AxiosPromise<JsonApiMetricOutDocument>;
     // (undocumented)
     updateEntityVisualizationObjects(params: {
         workspaceId: string;
         objectId: string;
-        jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+        jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
         variableParam?: {
             [key: string]: object;
         };
         include?: object;
-    }, options?: any): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    }, options?: any): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+    // (undocumented)
+    updateEntityWorkspaceDataFilters(params: {
+        workspaceId: string;
+        objectId: string;
+        jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+        variableParam?: {
+            [key: string]: object;
+        };
+        include?: object;
+    }, options?: any): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 

--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -1125,6 +1125,8 @@ export interface ITigerClient {
     // (undocumented)
     execution: ReturnType<typeof tigerExecutionClientFactory>;
     // (undocumented)
+    executionResult: ReturnType<typeof tigerExecutionResultClientFactory>;
+    // (undocumented)
     labelElements: ReturnType<typeof tigerLabelElementsClientFactory>;
     // (undocumented)
     organizationObjects: ReturnType<typeof tigerOrganizationObjectsClientFactory>;
@@ -5351,10 +5353,10 @@ export const tigerClientFactory: (axios: AxiosInstance) => ITigerClient;
 export const tigerDeclarativeLayoutClientFactory: (axios: AxiosInstance) => DeclarativeLayoutControllerApiInterface;
 
 // @public
-export const tigerExecutionClientFactory: (axios: AxiosInstance) => {
-    executeAfm: (workspaceId: string, execution: AfmExecution) => Promise<AfmExecutionResponse>;
-    executionResult: (workspaceId: string, resultId: string, offset?: number[] | undefined, size?: number[] | undefined) => Promise<ExecutionResult>;
-};
+export const tigerExecutionClientFactory: (axios: AxiosInstance) => AfmControllerApiInterface;
+
+// @public
+export const tigerExecutionResultClientFactory: (axios: AxiosInstance) => ResultControllerApiInterface;
 
 // @public (undocumented)
 export const tigerLabelElementsClientFactory: (axios: AxiosInstance) => ElementsControllerApiInterface;

--- a/libs/api-client-tiger/src/client.ts
+++ b/libs/api-client-tiger/src/client.ts
@@ -1,5 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import { tigerExecutionClientFactory } from "./execution";
+import { tigerExecutionResultClientFactory } from "./executionResult";
 import {
     LabelElementsConfiguration,
     LabelElementsConfigurationParameters,
@@ -23,6 +24,7 @@ import { tigerDeclarativeLayoutClientFactory } from "./layout";
 export {
     tigerWorkspaceObjectsClientFactory,
     tigerExecutionClientFactory,
+    tigerExecutionResultClientFactory,
     tigerLabelElementsClientFactory,
     tigerValidObjectsClientFactory,
     tigerOrganizationObjectsClientFactory,
@@ -41,6 +43,7 @@ export interface ITigerClient {
     axios: AxiosInstance;
     workspaceObjects: ReturnType<typeof tigerWorkspaceObjectsClientFactory>;
     execution: ReturnType<typeof tigerExecutionClientFactory>;
+    executionResult: ReturnType<typeof tigerExecutionResultClientFactory>;
     labelElements: ReturnType<typeof tigerLabelElementsClientFactory>;
     validObjects: ReturnType<typeof tigerValidObjectsClientFactory>;
     organizationObjects: ReturnType<typeof tigerOrganizationObjectsClientFactory>;
@@ -62,6 +65,7 @@ export interface ITigerClient {
  */
 export const tigerClientFactory = (axios: AxiosInstance): ITigerClient => {
     const execution = tigerExecutionClientFactory(axios);
+    const executionResult = tigerExecutionResultClientFactory(axios);
     const labelElements = tigerLabelElementsClientFactory(axios);
     const workspaceObjects = tigerWorkspaceObjectsClientFactory(axios);
     const validObjects = tigerValidObjectsClientFactory(axios);
@@ -71,6 +75,7 @@ export const tigerClientFactory = (axios: AxiosInstance): ITigerClient => {
     return {
         axios,
         execution,
+        executionResult,
         labelElements,
         workspaceObjects,
         validObjects,

--- a/libs/api-client-tiger/src/execution.ts
+++ b/libs/api-client-tiger/src/execution.ts
@@ -1,64 +1,10 @@
-// (C) 2019-2020 GoodData Corporation
-
-import { AxiosInstance, AxiosResponse } from "axios";
-import { AfmExecution, AfmExecutionResponse, ExecutionResult } from "./generated/afm-rest-api";
+// (C) 2019-2021 GoodData Corporation
+import { AxiosInstance } from "axios";
+import { AfmControllerApi, AfmControllerApiInterface } from "./generated/afm-rest-api";
 
 /**
  * Tiger execution client factory
  *
  */
-export const tigerExecutionClientFactory = (
-    axios: AxiosInstance,
-): {
-    executeAfm: (workspaceId: string, execution: AfmExecution) => Promise<AfmExecutionResponse>;
-    executionResult: (
-        workspaceId: string,
-        resultId: string,
-        offset?: number[] | undefined,
-        size?: number[] | undefined,
-    ) => Promise<ExecutionResult>;
-} => {
-    /**
-     * Starts a new AFM execution.
-     *
-     * @param workspaceId workspace identifier
-     * @param execution - execution to send as-is in request body
-     * @public
-     */
-    const executeAfm = (workspaceId: string, execution: AfmExecution): Promise<AfmExecutionResponse> => {
-        return axios
-            .post(`/api/workspaces/${workspaceId}/afm`, execution)
-            .then((res: AxiosResponse<AfmExecutionResponse>) => {
-                return res.data;
-            });
-    };
-
-    /**
-     * Retrieves result of execution. All calculated data is returned, no paging yet.
-     *
-     * @param workspaceId workspace identifier
-     * @param resultId - ID of AFM execution result
-     * @param offset
-     * @param size
-     * @public
-     */
-    const executionResult = (
-        workspaceId: string,
-        resultId: string,
-        offset?: number[],
-        size?: number[],
-    ): Promise<ExecutionResult> => {
-        const params = { limit: size && size.join(","), offset: offset && offset.join(",") };
-
-        return axios
-            .get(`/api/workspaces/${workspaceId}/result/${resultId}`, { params })
-            .then((res: AxiosResponse<ExecutionResult>) => {
-                return res.data;
-            });
-    };
-
-    return {
-        executeAfm,
-        executionResult,
-    };
-};
+export const tigerExecutionClientFactory = (axios: AxiosInstance): AfmControllerApiInterface =>
+    new AfmControllerApi({}, "", axios);

--- a/libs/api-client-tiger/src/executionResult.ts
+++ b/libs/api-client-tiger/src/executionResult.ts
@@ -1,0 +1,10 @@
+// (C) 2019-2021 GoodData Corporation
+import { AxiosInstance } from "axios";
+import { ResultControllerApi, ResultControllerApiInterface } from "./generated/afm-rest-api";
+
+/**
+ * Tiger execution result client factory
+ *
+ */
+export const tigerExecutionResultClientFactory = (axios: AxiosInstance): ResultControllerApiInterface =>
+    new ResultControllerApi({}, "", axios);

--- a/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
@@ -7,7 +7,7 @@ import {
     ObjectIdentifier,
     ResultDimension,
 } from "../generated/afm-rest-api";
-import { JsonApiFilterContext, JsonApiVisualizationObject } from "../generated/metadata-json-api";
+import { JsonApiFilterContextIn, JsonApiVisualizationObjectIn } from "../generated/metadata-json-api";
 
 export type ResultDimensionHeader = ResultDimension["headers"][number];
 
@@ -30,10 +30,10 @@ export function isResultAttributeHeader(
 
 export function isVisualizationObjectsItem(
     visualizationObject: unknown,
-): visualizationObject is JsonApiVisualizationObject {
-    return (visualizationObject as JsonApiVisualizationObject).type === "visualizationObject";
+): visualizationObject is JsonApiVisualizationObjectIn {
+    return (visualizationObject as JsonApiVisualizationObjectIn).type === "visualizationObject";
 }
 
-export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContext {
-    return (filterContext as JsonApiFilterContext).type === "filterContext";
+export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn {
+    return (filterContext as JsonApiFilterContextIn).type === "filterContext";
 }

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -1196,6 +1196,12 @@ export interface MeasureHeaderItemMeasureHeaderItem {
      * @memberof MeasureHeaderItemMeasureHeaderItem
      */
     format?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof MeasureHeaderItemMeasureHeaderItem
+     */
+    name?: string;
 }
 /**
  *
@@ -2018,6 +2024,79 @@ export const AfmControllerApiAxiosParamCreator = function (configuration?: Confi
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, afmExecution, skipCache, timestamp } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeReport.",
+                );
+            }
+            // verify required parameter 'afmExecution' is not null or undefined
+            if (afmExecution === null || afmExecution === undefined) {
+                throw new RequiredError(
+                    "afmExecution",
+                    "Required parameter afmExecution was null or undefined when calling computeReport.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/afm/execute`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (skipCache !== undefined && skipCache !== null) {
+                localVarHeaderParameter["skip-cache"] = String(JSON.stringify(skipCache));
+            }
+
+            if (timestamp !== undefined && timestamp !== null) {
+                localVarHeaderParameter["timestamp"] = String(timestamp);
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof afmExecution !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(afmExecution !== undefined ? afmExecution : {})
+                : afmExecution || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2100,6 +2179,37 @@ export const AfmControllerApiFp = function (configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmExecutionResponse> {
+            const localVarAxiosArgs = AfmControllerApiAxiosParamCreator(configuration).computeReport(
+                params,
+                options,
+            );
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2144,6 +2254,27 @@ export const AfmControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeReport(
+            params: {
+                workspaceId: string;
+                afmExecution: AfmExecution;
+                skipCache?: boolean;
+                timestamp?: string;
+            },
+            options?: any,
+        ): AxiosPromise<AfmExecutionResponse> {
+            return AfmControllerApiFp(configuration).computeReport(params, options)(axios, basePath);
+        },
+        /**
+         * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+         * @summary Executes analytical request and returns link to the result
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmExecution} afmExecution
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {string} [timestamp]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmRequest(
             params: {
                 workspaceId: string;
@@ -2164,6 +2295,27 @@ export const AfmControllerApiFactory = function (
  * @interface AfmControllerApi
  */
 export interface AfmControllerApiInterface {
+    /**
+     * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+     * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmExecution} afmExecution
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {string} [timestamp]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AfmControllerApiInterface
+     */
+    computeReport(
+        params: {
+            workspaceId: string;
+            afmExecution: AfmExecution;
+            skipCache?: boolean;
+            timestamp?: string;
+        },
+        options?: any,
+    ): AxiosPromise<AfmExecutionResponse>;
+
     /**
      * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
      * @summary Executes analytical request and returns link to the result
@@ -2204,6 +2356,32 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
      * @throws {RequiredError}
      * @memberof AfmControllerApi
      */
+    public computeReport(
+        params: {
+            workspaceId: string;
+            afmExecution: AfmExecution;
+            skipCache?: boolean;
+            timestamp?: string;
+        },
+        options?: any,
+    ) {
+        return AfmControllerApiFp(this.configuration).computeReport(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
+    /**
+     * AFM is a combination of attributes, measures and filters that describe a query you want to execute.
+     * @summary Executes analytical request and returns link to the result
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmExecution} afmExecution
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {string} [timestamp]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AfmControllerApi
+     */
     public processAfmRequest(
         params: {
             workspaceId: string;
@@ -2226,6 +2404,143 @@ export class AfmControllerApi extends BaseAPI implements AfmControllerApiInterfa
  */
 export const ElementsControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const {
+                workspaceId,
+                label,
+                sortOrder,
+                includeTotalWithoutFilters,
+                complementFilter,
+                patternFilter,
+                offset,
+                limit,
+                skipCache,
+            } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeLabelElements.",
+                );
+            }
+            // verify required parameter 'label' is not null or undefined
+            if (label === null || label === undefined) {
+                throw new RequiredError(
+                    "label",
+                    "Required parameter label was null or undefined when calling computeLabelElements.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/collectLabelElements`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (label !== undefined) {
+                if (typeof label === "object") {
+                    addFlattenedObjectTo(label, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["label"] = label;
+                }
+            }
+
+            if (sortOrder !== undefined) {
+                if (typeof sortOrder === "object") {
+                    addFlattenedObjectTo(sortOrder, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["sortOrder"] = sortOrder;
+                }
+            }
+
+            if (includeTotalWithoutFilters !== undefined) {
+                if (typeof includeTotalWithoutFilters === "object") {
+                    addFlattenedObjectTo(includeTotalWithoutFilters, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["includeTotalWithoutFilters"] = includeTotalWithoutFilters;
+                }
+            }
+
+            if (complementFilter !== undefined) {
+                if (typeof complementFilter === "object") {
+                    addFlattenedObjectTo(complementFilter, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["complementFilter"] = complementFilter;
+                }
+            }
+
+            if (patternFilter !== undefined) {
+                if (typeof patternFilter === "object") {
+                    addFlattenedObjectTo(patternFilter, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["patternFilter"] = patternFilter;
+                }
+            }
+
+            if (offset !== undefined) {
+                if (typeof offset === "object") {
+                    addFlattenedObjectTo(offset, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["offset"] = offset;
+                }
+            }
+
+            if (limit !== undefined) {
+                if (typeof limit === "object") {
+                    addFlattenedObjectTo(limit, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["limit"] = limit;
+                }
+            }
+
+            if (skipCache !== undefined && skipCache !== null) {
+                localVarHeaderParameter["skip-cache"] = String(JSON.stringify(skipCache));
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
@@ -2387,6 +2702,46 @@ export const ElementsControllerApiFp = function (configuration?: Configuration) 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ElementsResponse> {
+            const localVarAxiosArgs = ElementsControllerApiAxiosParamCreator(
+                configuration,
+            ).computeLabelElements(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processElementsRequest(
             params: {
                 workspaceId: string;
@@ -2425,6 +2780,40 @@ export const ElementsControllerApiFactory = function (
     axios?: AxiosInstance,
 ) {
     return {
+        /**
+         * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+         * @summary Listing of label values.
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} label Requested label.
+         * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+         * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+         * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+         * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+         * @param {number} [offset] Request page with this offset.
+         * @param {number} [limit] Return only this number of items.
+         * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeLabelElements(
+            params: {
+                workspaceId: string;
+                label: string;
+                sortOrder?: "ASC" | "DESC";
+                includeTotalWithoutFilters?: boolean;
+                complementFilter?: boolean;
+                patternFilter?: string;
+                offset?: number;
+                limit?: number;
+                skipCache?: boolean;
+            },
+            options?: any,
+        ): AxiosPromise<ElementsResponse> {
+            return ElementsControllerApiFp(configuration).computeLabelElements(params, options)(
+                axios,
+                basePath,
+            );
+        },
         /**
          * Returns paged list of elements (values) of given label satisfying given filtering criteria.
          * @summary Listing of label values.
@@ -2484,6 +2873,37 @@ export interface ElementsControllerApiInterface {
      * @throws {RequiredError}
      * @memberof ElementsControllerApiInterface
      */
+    computeLabelElements(
+        params: {
+            workspaceId: string;
+            label: string;
+            sortOrder?: "ASC" | "DESC";
+            includeTotalWithoutFilters?: boolean;
+            complementFilter?: boolean;
+            patternFilter?: string;
+            offset?: number;
+            limit?: number;
+            skipCache?: boolean;
+        },
+        options?: any,
+    ): AxiosPromise<ElementsResponse>;
+
+    /**
+     * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+     * @summary Listing of label values.
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} label Requested label.
+     * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+     * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+     * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+     * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+     * @param {number} [offset] Request page with this offset.
+     * @param {number} [limit] Return only this number of items.
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ElementsControllerApiInterface
+     */
     processElementsRequest(
         params: {
             workspaceId: string;
@@ -2507,6 +2927,42 @@ export interface ElementsControllerApiInterface {
  * @extends {BaseAPI}
  */
 export class ElementsControllerApi extends BaseAPI implements ElementsControllerApiInterface {
+    /**
+     * Returns paged list of elements (values) of given label satisfying given filtering criteria.
+     * @summary Listing of label values.
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} label Requested label.
+     * @param {'ASC' | 'DESC'} [sortOrder] Sort order of returned items. Items are sorted by &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title.
+     * @param {boolean} [includeTotalWithoutFilters] Specify if &#x60;&#x60;&#x60;totalCountWithoutFilters&#x60;&#x60;&#x60; should be returned.
+     * @param {boolean} [complementFilter] Inverse filter: * &#x60;&#x60;&#x60;false&#x60;&#x60;&#x60; - return items matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60; * &#x60;&#x60;&#x60;true&#x60;&#x60;&#x60; - return items not matching &#x60;&#x60;&#x60;patternFilter&#x60;&#x60;&#x60;
+     * @param {string} [patternFilter] Return only items, whose &#x60;&#x60;&#x60;label&#x60;&#x60;&#x60; title case insensitively contains &#x60;&#x60;&#x60;filter&#x60;&#x60;&#x60; as substring.
+     * @param {number} [offset] Request page with this offset.
+     * @param {number} [limit] Return only this number of items.
+     * @param {boolean} [skipCache] Ignore all caches during execution of current request.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ElementsControllerApi
+     */
+    public computeLabelElements(
+        params: {
+            workspaceId: string;
+            label: string;
+            sortOrder?: "ASC" | "DESC";
+            includeTotalWithoutFilters?: boolean;
+            complementFilter?: boolean;
+            patternFilter?: string;
+            offset?: number;
+            limit?: number;
+            skipCache?: boolean;
+        },
+        options?: any,
+    ) {
+        return ElementsControllerApiFp(this.configuration).computeLabelElements(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
     /**
      * Returns paged list of elements (values) of given label satisfying given filtering criteria.
      * @summary Listing of label values.
@@ -2614,6 +3070,70 @@ export const ResultControllerApiAxiosParamCreator = function (configuration?: Co
                 options: localVarRequestOptions,
             };
         },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, resultId, offset, limit } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling retrieveResult.",
+                );
+            }
+            // verify required parameter 'resultId' is not null or undefined
+            if (resultId === null || resultId === undefined) {
+                throw new RequiredError(
+                    "resultId",
+                    "Required parameter resultId was null or undefined when calling retrieveResult.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/afm/execute/result/{resultId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"resultId"}}`, encodeURIComponent(String(resultId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (offset) {
+                localVarQueryParameter["offset"] = offset;
+            }
+
+            if (limit) {
+                localVarQueryParameter["limit"] = limit;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
     };
 };
 
@@ -2643,6 +3163,37 @@ export const ResultControllerApiFp = function (configuration?: Configuration) {
             options: any = {},
         ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ExecutionResult> {
             const localVarAxiosArgs = ResultControllerApiAxiosParamCreator(configuration).getResult(
+                params,
+                options,
+            );
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<ExecutionResult> {
+            const localVarAxiosArgs = ResultControllerApiAxiosParamCreator(configuration).retrieveResult(
                 params,
                 options,
             );
@@ -2688,6 +3239,27 @@ export const ResultControllerApiFactory = function (
         ): AxiosPromise<ExecutionResult> {
             return ResultControllerApiFp(configuration).getResult(params, options)(axios, basePath);
         },
+        /**
+         * Gets a single execution result.
+         * @summary Get a single execution result
+         * @param {string} workspaceId Workspace identifier
+         * @param {string} resultId Result ID
+         * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+         * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        retrieveResult(
+            params: {
+                workspaceId: string;
+                resultId: string;
+                offset?: Array<number>;
+                limit?: Array<number>;
+            },
+            options?: any,
+        ): AxiosPromise<ExecutionResult> {
+            return ResultControllerApiFp(configuration).retrieveResult(params, options)(axios, basePath);
+        },
     };
 };
 
@@ -2709,6 +3281,27 @@ export interface ResultControllerApiInterface {
      * @memberof ResultControllerApiInterface
      */
     getResult(
+        params: {
+            workspaceId: string;
+            resultId: string;
+            offset?: Array<number>;
+            limit?: Array<number>;
+        },
+        options?: any,
+    ): AxiosPromise<ExecutionResult>;
+
+    /**
+     * Gets a single execution result.
+     * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} resultId Result ID
+     * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+     * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ResultControllerApiInterface
+     */
+    retrieveResult(
         params: {
             workspaceId: string;
             resultId: string;
@@ -2751,6 +3344,32 @@ export class ResultControllerApi extends BaseAPI implements ResultControllerApiI
             this.basePath,
         );
     }
+
+    /**
+     * Gets a single execution result.
+     * @summary Get a single execution result
+     * @param {string} workspaceId Workspace identifier
+     * @param {string} resultId Result ID
+     * @param {Array<number>} [offset] Request page with these offsets. Format is offset&#x3D;1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.
+     * @param {Array<number>} [limit] Return only this number of items. Format is limit&#x3D;1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ResultControllerApi
+     */
+    public retrieveResult(
+        params: {
+            workspaceId: string;
+            resultId: string;
+            offset?: Array<number>;
+            limit?: Array<number>;
+        },
+        options?: any,
+    ) {
+        return ResultControllerApiFp(this.configuration).retrieveResult(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
 }
 
 /**
@@ -2759,6 +3378,67 @@ export class ResultControllerApi extends BaseAPI implements ResultControllerApiI
  */
 export const ValidObjectsControllerApiAxiosParamCreator = function (configuration?: Configuration) {
     return {
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, afmValidObjectsQuery } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling computeValidObjects.",
+                );
+            }
+            // verify required parameter 'afmValidObjectsQuery' is not null or undefined
+            if (afmValidObjectsQuery === null || afmValidObjectsQuery === undefined) {
+                throw new RequiredError(
+                    "afmValidObjectsQuery",
+                    "Required parameter afmValidObjectsQuery was null or undefined when calling computeValidObjects.",
+                );
+            }
+            const localVarPath = `/api/actions/workspaces/{workspaceId}/execution/afm/computeValidObjects`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof afmValidObjectsQuery !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(afmValidObjectsQuery !== undefined ? afmValidObjectsQuery : {})
+                : afmValidObjectsQuery || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
         /**
          * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
          * @summary Valid objects
@@ -2837,6 +3517,32 @@ export const ValidObjectsControllerApiFp = function (configuration?: Configurati
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<AfmValidObjectsResponse> {
+            const localVarAxiosArgs = ValidObjectsControllerApiAxiosParamCreator(
+                configuration,
+            ).computeValidObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmValidObjectsQuery(
             params: {
                 workspaceId: string;
@@ -2876,6 +3582,26 @@ export const ValidObjectsControllerApiFactory = function (
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
+        computeValidObjects(
+            params: {
+                workspaceId: string;
+                afmValidObjectsQuery: AfmValidObjectsQuery;
+            },
+            options?: any,
+        ): AxiosPromise<AfmValidObjectsResponse> {
+            return ValidObjectsControllerApiFp(configuration).computeValidObjects(params, options)(
+                axios,
+                basePath,
+            );
+        },
+        /**
+         * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+         * @summary Valid objects
+         * @param {string} workspaceId Workspace identifier
+         * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
         processAfmValidObjectsQuery(
             params: {
                 workspaceId: string;
@@ -2906,6 +3632,23 @@ export interface ValidObjectsControllerApiInterface {
      * @throws {RequiredError}
      * @memberof ValidObjectsControllerApiInterface
      */
+    computeValidObjects(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ): AxiosPromise<AfmValidObjectsResponse>;
+
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApiInterface
+     */
     processAfmValidObjectsQuery(
         params: {
             workspaceId: string;
@@ -2922,6 +3665,28 @@ export interface ValidObjectsControllerApiInterface {
  * @extends {BaseAPI}
  */
 export class ValidObjectsControllerApi extends BaseAPI implements ValidObjectsControllerApiInterface {
+    /**
+     * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
+     * @summary Valid objects
+     * @param {string} workspaceId Workspace identifier
+     * @param {AfmValidObjectsQuery} afmValidObjectsQuery
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof ValidObjectsControllerApi
+     */
+    public computeValidObjects(
+        params: {
+            workspaceId: string;
+            afmValidObjectsQuery: AfmValidObjectsQuery;
+        },
+        options?: any,
+    ) {
+        return ValidObjectsControllerApiFp(this.configuration).computeValidObjects(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
     /**
      * Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.
      * @summary Valid objects

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -11,6 +11,321 @@
         }
     ],
     "paths": {
+        "/api/actions/workspaces/{workspaceId}/execution/afm/execute": {
+            "post": {
+                "tags": ["afm-controller"],
+                "summary": "Executes analytical request and returns link to the result",
+                "description": "AFM is a combination of attributes, measures and filters that describe a query you want to execute.",
+                "operationId": "computeReport",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "skip-cache",
+                        "in": "header",
+                        "description": "Ignore all caches during execution of current request.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "timestamp",
+                        "in": "header",
+                        "required": false,
+                        "example": "2020-06-03T10:15:30+01:00",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AfmExecution"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "AFM Execution response with links to the result and server-enhanced dimensions from the original request.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AfmExecutionResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/execution/afm/computeValidObjects": {
+            "post": {
+                "tags": ["validObjects-controller"],
+                "summary": "Valid objects",
+                "description": "Returns list containing attributes, facts, or measures, which can be added to given AFM while still keeping it computable.",
+                "operationId": "computeValidObjects",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AfmValidObjectsQuery"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "List of attributes, facts and measures valid with respect to given AFM.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AfmValidObjectsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/execution/collectLabelElements": {
+            "get": {
+                "tags": ["elements-controller"],
+                "summary": "Listing of label values.",
+                "description": "Returns paged list of elements (values) of given label satisfying given filtering criteria.",
+                "operationId": "computeLabelElements",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "label",
+                        "in": "query",
+                        "description": "Requested label.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "sortOrder",
+                        "in": "query",
+                        "description": "Sort order of returned items.\nItems are sorted by ```label``` title.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["ASC", "DESC"],
+                            "default": "ASC"
+                        }
+                    },
+                    {
+                        "name": "includeTotalWithoutFilters",
+                        "in": "query",
+                        "description": "Specify if ```totalCountWithoutFilters``` should be returned.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "complementFilter",
+                        "in": "query",
+                        "description": "Inverse filter:\n* ```false``` - return items matching ```patternFilter```\n* ```true``` - return items not matching ```patternFilter```",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "patternFilter",
+                        "in": "query",
+                        "description": "Return only items, whose ```label``` title case insensitively contains ```filter``` as substring.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Request page with this offset.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 0
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Return only this number of items.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 1000
+                        }
+                    },
+                    {
+                        "name": "skip-cache",
+                        "description": "Ignore all caches during execution of current request.",
+                        "in": "header",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of label values.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ElementsResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/actions/workspaces/{workspaceId}/execution/afm/execute/result/{resultId}": {
+            "get": {
+                "tags": ["result-controller"],
+                "summary": "Get a single execution result",
+                "description": "Gets a single execution result.",
+                "operationId": "retrieveResult",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "description": "Workspace identifier",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9._-]+"
+                        }
+                    },
+                    {
+                        "name": "resultId",
+                        "in": "path",
+                        "description": "Result ID",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "example": "a9b28f9dc55f37ea9f4a5fb0c76895923591e781"
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Request page with these offsets. Format is offset=1,2,3,... - one offset for each dimensions in ResultSpec from originating AFM.",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "default": []
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "Return only this number of items. Format is limit=1,2,3,... - one limit for each dimensions in ResultSpec from originating AFM.",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "default": []
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Execution result was found and returned.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ExecutionResult"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Limit and/or offset query parameters (paging) were invalid.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Execution result was not found.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "The result processing has failed unexpectedly.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/workspaces/{workspaceId}/afm": {
             "post": {
                 "tags": ["afm-controller"],
@@ -406,7 +721,8 @@
                 "type": "object",
                 "properties": {
                     "localIdentifier": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9_\\-.]+$"
                     },
                     "displayForm": {
                         "$ref": "#/components/schemas/ObjectIdentifier"
@@ -1050,6 +1366,7 @@
                 "properties": {
                     "localIdentifier": {
                         "type": "string",
+                        "pattern": "^[a-zA-Z0-9_\\-.]+$",
                         "example": "sampleAutoGenerated0123_ID"
                     },
                     "definition": {
@@ -1321,6 +1638,9 @@
                                 "type": "string"
                             },
                             "format": {
+                                "type": "string"
+                            },
+                            "name": {
                                 "type": "string"
                             }
                         }

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -198,43 +198,6 @@ export enum DeclarativeColumnDataTypeEnum {
 }
 
 /**
- * Data discriminators serving the discrimination of what data users can see in workspaces.
- * @export
- * @interface DeclarativeDataDiscriminator
- */
-export interface DeclarativeDataDiscriminator {
-    /**
-     * Data Discriminator ID. This ID is further used to refer to this instance of DD.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    id: string;
-    /**
-     * Data Discriminator title.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    title: string;
-    /**
-     * Data Discriminator description.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    description?: string;
-    /**
-     * Data Discriminator column name. Data are filtered using this physical column.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    columnName: string;
-    /**
-     * Data source name (ID). Data Discriminator must always be connected to single data source.
-     * @type {string}
-     * @memberof DeclarativeDataDiscriminator
-     */
-    dataSourceName: string;
-}
-/**
  * A data source.
  * @export
  * @interface DeclarativeDataSource
@@ -662,6 +625,105 @@ export interface DeclarativeWorkspace {
     parent?: WorkspaceIdentifier;
 }
 /**
+ * Workspace Data Filters serving the filtering of what data users can see in workspaces.
+ * @export
+ * @interface DeclarativeWorkspaceDataFilter
+ */
+export interface DeclarativeWorkspaceDataFilter {
+    /**
+     * Workspace Data Filters ID. This ID is further used to refer to this instance.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    id: string;
+    /**
+     * Workspace Data Filters title.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    title: string;
+    /**
+     * Workspace Data Filters description.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    description?: string;
+    /**
+     * Workspace Data Filters column name. Data are filtered using this physical column.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    columnName: string;
+    /**
+     * Data source name (ID). Workspace Data Filters must always be connected to single data source.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    dataSourceName: string;
+    /**
+     * Filter settings specifying values of filters valid for the workspace.
+     * @type {Array<DeclarativeWorkspaceDataFilterSetting>}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    workspaceDataFilterSettings: Array<DeclarativeWorkspaceDataFilterSetting>;
+    /**
+     *
+     * @type {WorkspaceIdentifier}
+     * @memberof DeclarativeWorkspaceDataFilter
+     */
+    workspace?: WorkspaceIdentifier;
+}
+/**
+ * Workspace Data Filters serving the filtering of what data users can see in workspaces.
+ * @export
+ * @interface DeclarativeWorkspaceDataFilterSetting
+ */
+export interface DeclarativeWorkspaceDataFilterSetting {
+    /**
+     * Workspace Data Filters ID. This ID is further used to refer to this instance.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    id: string;
+    /**
+     * Workspace Data Filters setting title.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    title: string;
+    /**
+     * Workspace Data Filters setting description.
+     * @type {string}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    description?: string;
+    /**
+     * Only those rows are returned, where columnName from filter matches those values.
+     * @type {Array<string>}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    filterValues: Array<string>;
+    /**
+     *
+     * @type {WorkspaceIdentifier}
+     * @memberof DeclarativeWorkspaceDataFilterSetting
+     */
+    workspace: WorkspaceIdentifier;
+}
+/**
+ *
+ * @export
+ * @interface DeclarativeWorkspaceDataFilters
+ */
+export interface DeclarativeWorkspaceDataFilters {
+    /**
+     *
+     * @type {Array<DeclarativeWorkspaceDataFilter>}
+     * @memberof DeclarativeWorkspaceDataFilters
+     */
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
+}
+/**
  *
  * @export
  * @interface DeclarativeWorkspaceModel
@@ -685,12 +747,6 @@ export interface DeclarativeWorkspaceModel {
      * @memberof DeclarativeWorkspaceModel
      */
     analytics: DeclarativeAnalyticsLayer;
-    /**
-     *
-     * @type {Array<DeclarativeDataDiscriminator>}
-     * @memberof DeclarativeWorkspaceModel
-     */
-    dataDiscriminators: Array<DeclarativeDataDiscriminator>;
 }
 /**
  *
@@ -704,6 +760,12 @@ export interface DeclarativeWorkspaces {
      * @memberof DeclarativeWorkspaces
      */
     workspaces: Array<DeclarativeWorkspace>;
+    /**
+     *
+     * @type {Array<DeclarativeWorkspaceDataFilter>}
+     * @memberof DeclarativeWorkspaces
+     */
+    workspaceDataFilters: Array<DeclarativeWorkspaceDataFilter>;
 }
 /**
  * A grain identifier.
@@ -756,72 +818,116 @@ export interface GranularitiesFormatting {
 /**
  * JSON:API representation of acl entity.
  * @export
- * @interface JsonApiACL
+ * @interface JsonApiACLIn
  */
-export interface JsonApiACL {
+export interface JsonApiACLIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiACL
+     * @memberof JsonApiACLIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiACL
+     * @memberof JsonApiACLIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiACLAttributes}
-     * @memberof JsonApiACL
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLIn
      */
-    attributes?: JsonApiACLAttributes;
+    attributes?: JsonApiACLOutAttributes;
     /**
      *
-     * @type {JsonApiACLRelationships}
-     * @memberof JsonApiACL
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLIn
      */
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiACLAttributes
+ * @interface JsonApiACLInDocument
  */
-export interface JsonApiACLAttributes {
+export interface JsonApiACLInDocument {
+    /**
+     *
+     * @type {JsonApiACLIn}
+     * @memberof JsonApiACLInDocument
+     */
+    data: JsonApiACLIn;
+}
+/**
+ * JSON:API representation of acl entity.
+ * @export
+ * @interface JsonApiACLOut
+ */
+export interface JsonApiACLOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiACLOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiACLOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLOut
+     */
+    attributes?: JsonApiACLOutAttributes;
+    /**
+     *
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLOut
+     */
+    relationships?: JsonApiACLOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiACLOutAttributes
+ */
+export interface JsonApiACLOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
-    access?: JsonApiACLAttributesAccessEnum;
+    access?: JsonApiACLOutAttributesAccessEnum;
     /**
      *
      * @type {number}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
     priority?: number;
     /**
      *
      * @type {string}
-     * @memberof JsonApiACLAttributes
+     * @memberof JsonApiACLOutAttributes
      */
-    control?: JsonApiACLAttributesControlEnum;
+    control?: JsonApiACLOutAttributesControlEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiACLAttributesAccessEnum {
+export enum JsonApiACLOutAttributesAccessEnum {
     FULLACCESS = "FULL_ACCESS",
 }
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiACLAttributesControlEnum {
+export enum JsonApiACLOutAttributesControlEnum {
     ALLOW = "ALLOW",
     DENY = "DENY",
 }
@@ -829,495 +935,571 @@ export enum JsonApiACLAttributesControlEnum {
 /**
  *
  * @export
- * @interface JsonApiACLDocument
+ * @interface JsonApiACLOutDocument
  */
-export interface JsonApiACLDocument {
+export interface JsonApiACLOutDocument {
     /**
      *
-     * @type {JsonApiACL}
-     * @memberof JsonApiACLDocument
+     * @type {JsonApiACLOut}
+     * @memberof JsonApiACLOutDocument
      */
-    data: JsonApiACL;
+    data: JsonApiACLOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiACLDocument
+     * @memberof JsonApiACLOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiACLDocument
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiACLOutDocument
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiACLList
+ * @interface JsonApiACLOutList
  */
-export interface JsonApiACLList {
+export interface JsonApiACLOutList {
     /**
      *
-     * @type {Array<JsonApiACLWithLinks>}
-     * @memberof JsonApiACLList
+     * @type {Array<JsonApiACLOutWithLinks>}
+     * @memberof JsonApiACLOutList
      */
-    data: Array<JsonApiACLWithLinks>;
+    data: Array<JsonApiACLOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiACLList
+     * @memberof JsonApiACLOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiACLList
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiACLOutList
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiACLRelationships
+ * @interface JsonApiACLOutRelationships
  */
-export interface JsonApiACLRelationships {
+export interface JsonApiACLOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiACLRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiACLOutRelationships
      */
-    users?: JsonApiACLRelationshipsUsers;
+    users?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiACLRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiACLOutRelationships
      */
-    userGroups?: JsonApiACLRelationshipsUsers;
+    userGroups?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiACLRelationshipsUsers
+ * @interface JsonApiACLOutRelationshipsUsers
  */
-export interface JsonApiACLRelationshipsUsers {
+export interface JsonApiACLOutRelationshipsUsers {
     /**
      *
      * @type {Array<JsonApiLinkage>}
-     * @memberof JsonApiACLRelationshipsUsers
+     * @memberof JsonApiACLOutRelationshipsUsers
      */
     data?: Array<JsonApiLinkage>;
 }
 /**
  *
  * @export
- * @interface JsonApiACLWithLinks
+ * @interface JsonApiACLOutWithLinks
  */
-export interface JsonApiACLWithLinks {
+export interface JsonApiACLOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiACLAttributes}
-     * @memberof JsonApiACLWithLinks
+     * @type {JsonApiACLOutAttributes}
+     * @memberof JsonApiACLOutWithLinks
      */
-    attributes?: JsonApiACLAttributes;
+    attributes?: JsonApiACLOutAttributes;
     /**
      *
-     * @type {JsonApiACLRelationships}
-     * @memberof JsonApiACLWithLinks
+     * @type {JsonApiACLOutRelationships}
+     * @memberof JsonApiACLOutWithLinks
      */
-    relationships?: JsonApiACLRelationships;
+    relationships?: JsonApiACLOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiACLWithLinks
+     * @memberof JsonApiACLOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of analyticalDashboard entity.
  * @export
- * @interface JsonApiAnalyticalDashboard
+ * @interface JsonApiAnalyticalDashboardIn
  */
-export interface JsonApiAnalyticalDashboard {
+export interface JsonApiAnalyticalDashboardIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboard
+     * @memberof JsonApiAnalyticalDashboardIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboard
+     * @memberof JsonApiAnalyticalDashboardIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiAnalyticalDashboard
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiAnalyticalDashboardIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiAnalyticalDashboardRelationships}
-     * @memberof JsonApiAnalyticalDashboard
-     */
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardAttributes
+ * @interface JsonApiAnalyticalDashboardInAttributes
  */
-export interface JsonApiAnalyticalDashboardAttributes {
+export interface JsonApiAnalyticalDashboardInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardInAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardInAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardInAttributes
      */
     tags?: Array<string>;
     /**
      * Free-form JSON content.
      * @type {object}
-     * @memberof JsonApiAnalyticalDashboardAttributes
+     * @memberof JsonApiAnalyticalDashboardInAttributes
      */
     content?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiAnalyticalDashboardDocument
+ * @interface JsonApiAnalyticalDashboardInDocument
  */
-export interface JsonApiAnalyticalDashboardDocument {
+export interface JsonApiAnalyticalDashboardInDocument {
     /**
      *
-     * @type {JsonApiAnalyticalDashboard}
-     * @memberof JsonApiAnalyticalDashboardDocument
+     * @type {JsonApiAnalyticalDashboardIn}
+     * @memberof JsonApiAnalyticalDashboardInDocument
      */
-    data: JsonApiAnalyticalDashboard;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiAnalyticalDashboardDocument
-     */
-    links?: ObjectLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardDocument
-     */
-    included?: Array<
-        | JsonApiVisualizationObjectWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiDatasetWithLinks
-        | JsonApiFilterContextWithLinks
-    >;
+    data: JsonApiAnalyticalDashboardIn;
 }
 /**
- * A JSON:API document with a list of resources
+ * JSON:API representation of analyticalDashboard entity.
  * @export
- * @interface JsonApiAnalyticalDashboardList
+ * @interface JsonApiAnalyticalDashboardOut
  */
-export interface JsonApiAnalyticalDashboardList {
-    /**
-     *
-     * @type {Array<JsonApiAnalyticalDashboardWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardList
-     */
-    data: Array<JsonApiAnalyticalDashboardWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiAnalyticalDashboardList
-     */
-    links?: ListLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiVisualizationObjectWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiDatasetWithLinks | JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiAnalyticalDashboardList
-     */
-    included?: Array<
-        | JsonApiVisualizationObjectWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiDatasetWithLinks
-        | JsonApiFilterContextWithLinks
-    >;
-}
-/**
- *
- * @export
- * @interface JsonApiAnalyticalDashboardRelationships
- */
-export interface JsonApiAnalyticalDashboardRelationships {
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
-     */
-    visualizationObjects?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
-     */
-    labels?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
-     */
-    metrics?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
-     */
-    datasets?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAnalyticalDashboardRelationships
-     */
-    filterContexts?: JsonApiACLRelationshipsUsers;
-}
-/**
- *
- * @export
- * @interface JsonApiAnalyticalDashboardWithLinks
- */
-export interface JsonApiAnalyticalDashboardWithLinks {
+export interface JsonApiAnalyticalDashboardOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiAnalyticalDashboardOut
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardRelationships}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @type {JsonApiAnalyticalDashboardOutRelationships}
+     * @memberof JsonApiAnalyticalDashboardOut
      */
-    relationships?: JsonApiAnalyticalDashboardRelationships;
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiAnalyticalDashboardOutDocument
+ */
+export interface JsonApiAnalyticalDashboardOutDocument {
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOut}
+     * @memberof JsonApiAnalyticalDashboardOutDocument
+     */
+    data: JsonApiAnalyticalDashboardOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiAnalyticalDashboardWithLinks
+     * @memberof JsonApiAnalyticalDashboardOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutDocument
+     */
+    included?: Array<
+        | JsonApiVisualizationObjectOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiDatasetOutWithLinks
+        | JsonApiFilterContextOutWithLinks
+    >;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiAnalyticalDashboardOutList
+ */
+export interface JsonApiAnalyticalDashboardOutList {
+    /**
+     *
+     * @type {Array<JsonApiAnalyticalDashboardOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutList
+     */
+    data: Array<JsonApiAnalyticalDashboardOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiAnalyticalDashboardOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiAnalyticalDashboardOutList
+     */
+    included?: Array<
+        | JsonApiVisualizationObjectOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiDatasetOutWithLinks
+        | JsonApiFilterContextOutWithLinks
+    >;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiAnalyticalDashboardOutRelationships
+ */
+export interface JsonApiAnalyticalDashboardOutRelationships {
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
+     */
+    visualizationObjects?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
+     */
+    labels?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
+     */
+    metrics?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
+     */
+    datasets?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAnalyticalDashboardOutRelationships
+     */
+    filterContexts?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiAnalyticalDashboardOutWithLinks
+ */
+export interface JsonApiAnalyticalDashboardOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
+     */
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardOutRelationships}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
+     */
+    relationships?: JsonApiAnalyticalDashboardOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiAnalyticalDashboardOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of apiToken entity.
  * @export
- * @interface JsonApiApiToken
+ * @interface JsonApiApiTokenIn
  */
-export interface JsonApiApiToken {
+export interface JsonApiApiTokenIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiApiToken
+     * @memberof JsonApiApiTokenIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiApiToken
+     * @memberof JsonApiApiTokenIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiApiTokenAttributes}
-     * @memberof JsonApiApiToken
+     * @type {object}
+     * @memberof JsonApiApiTokenIn
      */
-    attributes?: JsonApiApiTokenAttributes;
+    attributes?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenAttributes
+ * @interface JsonApiApiTokenInDocument
  */
-export interface JsonApiApiTokenAttributes {
+export interface JsonApiApiTokenInDocument {
+    /**
+     *
+     * @type {JsonApiApiTokenIn}
+     * @memberof JsonApiApiTokenInDocument
+     */
+    data: JsonApiApiTokenIn;
+}
+/**
+ * JSON:API representation of apiToken entity.
+ * @export
+ * @interface JsonApiApiTokenOut
+ */
+export interface JsonApiApiTokenOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiApiTokenOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiApiTokenOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiApiTokenOutAttributes}
+     * @memberof JsonApiApiTokenOut
+     */
+    attributes?: JsonApiApiTokenOutAttributes;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiApiTokenOutAttributes
+ */
+export interface JsonApiApiTokenOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiApiTokenAttributes
+     * @memberof JsonApiApiTokenOutAttributes
      */
     bearerToken?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenDocument
+ * @interface JsonApiApiTokenOutDocument
  */
-export interface JsonApiApiTokenDocument {
+export interface JsonApiApiTokenOutDocument {
     /**
      *
-     * @type {JsonApiApiToken}
-     * @memberof JsonApiApiTokenDocument
+     * @type {JsonApiApiTokenOut}
+     * @memberof JsonApiApiTokenOutDocument
      */
-    data: JsonApiApiToken;
+    data: JsonApiApiTokenOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiApiTokenDocument
+     * @memberof JsonApiApiTokenOutDocument
      */
     links?: ObjectLinks;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiApiTokenList
+ * @interface JsonApiApiTokenOutList
  */
-export interface JsonApiApiTokenList {
+export interface JsonApiApiTokenOutList {
     /**
      *
-     * @type {Array<JsonApiApiTokenWithLinks>}
-     * @memberof JsonApiApiTokenList
+     * @type {Array<JsonApiApiTokenOutWithLinks>}
+     * @memberof JsonApiApiTokenOutList
      */
-    data: Array<JsonApiApiTokenWithLinks>;
+    data: Array<JsonApiApiTokenOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiApiTokenList
+     * @memberof JsonApiApiTokenOutList
      */
     links?: ListLinks;
 }
 /**
  *
  * @export
- * @interface JsonApiApiTokenWithLinks
+ * @interface JsonApiApiTokenOutWithLinks
  */
-export interface JsonApiApiTokenWithLinks {
+export interface JsonApiApiTokenOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiApiTokenAttributes}
-     * @memberof JsonApiApiTokenWithLinks
+     * @type {JsonApiApiTokenOutAttributes}
+     * @memberof JsonApiApiTokenOutWithLinks
      */
-    attributes?: JsonApiApiTokenAttributes;
+    attributes?: JsonApiApiTokenOutAttributes;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiApiTokenWithLinks
+     * @memberof JsonApiApiTokenOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of attribute entity.
  * @export
- * @interface JsonApiAttribute
+ * @interface JsonApiAttributeOut
  */
-export interface JsonApiAttribute {
+export interface JsonApiAttributeOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAttribute
+     * @memberof JsonApiAttributeOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAttribute
+     * @memberof JsonApiAttributeOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiAttributeAttributes}
-     * @memberof JsonApiAttribute
+     * @type {JsonApiAttributeOutAttributes}
+     * @memberof JsonApiAttributeOut
      */
-    attributes?: JsonApiAttributeAttributes;
+    attributes?: JsonApiAttributeOutAttributes;
     /**
      *
-     * @type {JsonApiAttributeRelationships}
-     * @memberof JsonApiAttribute
+     * @type {JsonApiAttributeOutRelationships}
+     * @memberof JsonApiAttributeOut
      */
-    relationships?: JsonApiAttributeRelationships;
+    relationships?: JsonApiAttributeOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeAttributes
+ * @interface JsonApiAttributeOutAttributes
  */
-export interface JsonApiAttributeAttributes {
+export interface JsonApiAttributeOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {string}
-     * @memberof JsonApiAttributeAttributes
+     * @memberof JsonApiAttributeOutAttributes
      */
-    granularity?: JsonApiAttributeAttributesGranularityEnum;
+    granularity?: JsonApiAttributeOutAttributesGranularityEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiAttributeAttributesGranularityEnum {
+export enum JsonApiAttributeOutAttributesGranularityEnum {
     MINUTE = "MINUTE",
     HOUR = "HOUR",
     DAY = "DAY",
@@ -1338,311 +1520,186 @@ export enum JsonApiAttributeAttributesGranularityEnum {
 /**
  *
  * @export
- * @interface JsonApiAttributeDocument
+ * @interface JsonApiAttributeOutDocument
  */
-export interface JsonApiAttributeDocument {
+export interface JsonApiAttributeOutDocument {
     /**
      *
-     * @type {JsonApiAttribute}
-     * @memberof JsonApiAttributeDocument
+     * @type {JsonApiAttributeOut}
+     * @memberof JsonApiAttributeOutDocument
      */
-    data: JsonApiAttribute;
+    data: JsonApiAttributeOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiAttributeDocument
+     * @memberof JsonApiAttributeOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiAttributeDocument
+     * @type {Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiAttributeOutDocument
      */
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiAttributeList
+ * @interface JsonApiAttributeOutList
  */
-export interface JsonApiAttributeList {
+export interface JsonApiAttributeOutList {
     /**
      *
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiAttributeList
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiAttributeOutList
      */
-    data: Array<JsonApiAttributeWithLinks>;
+    data: Array<JsonApiAttributeOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiAttributeList
+     * @memberof JsonApiAttributeOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiAttributeList
+     * @type {Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiAttributeOutList
      */
-    included?: Array<JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeRelationships
+ * @interface JsonApiAttributeOutRelationships
  */
-export interface JsonApiAttributeRelationships {
+export interface JsonApiAttributeOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiAttributeRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiAttributeOutRelationships
      */
-    dataset?: JsonApiOrganizationRelationshipsUser;
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiAttributeRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiAttributeOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiAttributeWithLinks
+ * @interface JsonApiAttributeOutWithLinks
  */
-export interface JsonApiAttributeWithLinks {
+export interface JsonApiAttributeOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiAttributeWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiAttributeWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAttributeAttributes}
-     * @memberof JsonApiAttributeWithLinks
+     * @type {JsonApiAttributeOutAttributes}
+     * @memberof JsonApiAttributeOutWithLinks
      */
-    attributes?: JsonApiAttributeAttributes;
+    attributes?: JsonApiAttributeOutAttributes;
     /**
      *
-     * @type {JsonApiAttributeRelationships}
-     * @memberof JsonApiAttributeWithLinks
+     * @type {JsonApiAttributeOutRelationships}
+     * @memberof JsonApiAttributeOutWithLinks
      */
-    relationships?: JsonApiAttributeRelationships;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiAttributeWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * JSON:API representation of dataDiscriminator entity.
- * @export
- * @interface JsonApiDataDiscriminator
- */
-export interface JsonApiDataDiscriminator {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataDiscriminator
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataDiscriminator
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDataDiscriminatorAttributes}
-     * @memberof JsonApiDataDiscriminator
-     */
-    attributes?: JsonApiDataDiscriminatorAttributes;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorAttributes
- */
-export interface JsonApiDataDiscriminatorAttributes {
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    title?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    description?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    columnName?: string;
-    /**
-     *
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorAttributes
-     */
-    dataSourceName?: string;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorDocument
- */
-export interface JsonApiDataDiscriminatorDocument {
-    /**
-     *
-     * @type {JsonApiDataDiscriminator}
-     * @memberof JsonApiDataDiscriminatorDocument
-     */
-    data: JsonApiDataDiscriminator;
+    relationships?: JsonApiAttributeOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDataDiscriminatorDocument
-     */
-    links?: ObjectLinks;
-}
-/**
- * A JSON:API document with a list of resources
- * @export
- * @interface JsonApiDataDiscriminatorList
- */
-export interface JsonApiDataDiscriminatorList {
-    /**
-     *
-     * @type {Array<JsonApiDataDiscriminatorWithLinks>}
-     * @memberof JsonApiDataDiscriminatorList
-     */
-    data: Array<JsonApiDataDiscriminatorWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiDataDiscriminatorList
-     */
-    links?: ListLinks;
-}
-/**
- *
- * @export
- * @interface JsonApiDataDiscriminatorWithLinks
- */
-export interface JsonApiDataDiscriminatorWithLinks {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDataDiscriminatorAttributes}
-     * @memberof JsonApiDataDiscriminatorWithLinks
-     */
-    attributes?: JsonApiDataDiscriminatorAttributes;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataDiscriminatorWithLinks
+     * @memberof JsonApiAttributeOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of dataSource entity.
  * @export
- * @interface JsonApiDataSource
+ * @interface JsonApiDataSourceIn
  */
-export interface JsonApiDataSource {
+export interface JsonApiDataSourceIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDataSource
+     * @memberof JsonApiDataSourceIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDataSource
+     * @memberof JsonApiDataSourceIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiDataSourceAttributes}
-     * @memberof JsonApiDataSource
+     * @type {JsonApiDataSourceInAttributes}
+     * @memberof JsonApiDataSourceIn
      */
-    attributes?: JsonApiDataSourceAttributes;
+    attributes?: JsonApiDataSourceInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiDataSourceAttributes
+ * @interface JsonApiDataSourceInAttributes
  */
-export interface JsonApiDataSourceAttributes {
+export interface JsonApiDataSourceInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
-    type?: JsonApiDataSourceAttributesTypeEnum;
+    type?: JsonApiDataSourceInAttributesTypeEnum;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     url?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     schema?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     username?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     password?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     uploadId?: string;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiDataSourceAttributes
+     * @memberof JsonApiDataSourceInAttributes
      */
     enableCaching?: boolean;
 }
@@ -1651,7 +1708,7 @@ export interface JsonApiDataSourceAttributes {
  * @export
  * @enum {string}
  */
-export enum JsonApiDataSourceAttributesTypeEnum {
+export enum JsonApiDataSourceInAttributesTypeEnum {
     POSTGRESQL = "POSTGRESQL",
     REDSHIFT = "REDSHIFT",
     VERTICA = "VERTICA",
@@ -1665,152 +1722,255 @@ export enum JsonApiDataSourceAttributesTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDataSourceDocument
+ * @interface JsonApiDataSourceInDocument
  */
-export interface JsonApiDataSourceDocument {
+export interface JsonApiDataSourceInDocument {
     /**
      *
-     * @type {JsonApiDataSource}
-     * @memberof JsonApiDataSourceDocument
+     * @type {JsonApiDataSourceIn}
+     * @memberof JsonApiDataSourceInDocument
      */
-    data: JsonApiDataSource;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataSourceDocument
-     */
-    links?: ObjectLinks;
+    data: JsonApiDataSourceIn;
 }
 /**
- * A JSON:API document with a list of resources
+ * JSON:API representation of dataSource entity.
  * @export
- * @interface JsonApiDataSourceList
+ * @interface JsonApiDataSourceOut
  */
-export interface JsonApiDataSourceList {
-    /**
-     *
-     * @type {Array<JsonApiDataSourceWithLinks>}
-     * @memberof JsonApiDataSourceList
-     */
-    data: Array<JsonApiDataSourceWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiDataSourceList
-     */
-    links?: ListLinks;
-}
-/**
- *
- * @export
- * @interface JsonApiDataSourceWithLinks
- */
-export interface JsonApiDataSourceWithLinks {
+export interface JsonApiDataSourceOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDataSourceWithLinks
+     * @memberof JsonApiDataSourceOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDataSourceWithLinks
+     * @memberof JsonApiDataSourceOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiDataSourceAttributes}
-     * @memberof JsonApiDataSourceWithLinks
+     * @type {JsonApiDataSourceOutAttributes}
+     * @memberof JsonApiDataSourceOut
      */
-    attributes?: JsonApiDataSourceAttributes;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiDataSourceWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * JSON:API representation of dataset entity.
- * @export
- * @interface JsonApiDataset
- */
-export interface JsonApiDataset {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiDataset
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiDataset
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiDatasetAttributes}
-     * @memberof JsonApiDataset
-     */
-    attributes?: JsonApiDatasetAttributes;
-    /**
-     *
-     * @type {JsonApiDatasetRelationships}
-     * @memberof JsonApiDataset
-     */
-    relationships?: JsonApiDatasetRelationships;
+    attributes?: JsonApiDataSourceOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributes
+ * @interface JsonApiDataSourceOutAttributes
  */
-export interface JsonApiDatasetAttributes {
+export interface JsonApiDataSourceOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    title?: string;
+    name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    description?: string;
-    /**
-     *
-     * @type {Array<string>}
-     * @memberof JsonApiDatasetAttributes
-     */
-    tags?: Array<string>;
+    type?: JsonApiDataSourceOutAttributesTypeEnum;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributes
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    type?: JsonApiDatasetAttributesTypeEnum;
+    url?: string;
     /**
      *
-     * @type {Array<JsonApiDatasetAttributesGrain>}
-     * @memberof JsonApiDatasetAttributes
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    grain?: Array<JsonApiDatasetAttributesGrain>;
+    schema?: string;
     /**
      *
-     * @type {Array<JsonApiDatasetAttributesReferenceProperties>}
-     * @memberof JsonApiDatasetAttributes
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
      */
-    referenceProperties?: Array<JsonApiDatasetAttributesReferenceProperties>;
+    username?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDataSourceOutAttributes
+     */
+    uploadId?: string;
+    /**
+     *
+     * @type {boolean}
+     * @memberof JsonApiDataSourceOutAttributes
+     */
+    enableCaching?: boolean;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiDatasetAttributesTypeEnum {
+export enum JsonApiDataSourceOutAttributesTypeEnum {
+    POSTGRESQL = "POSTGRESQL",
+    REDSHIFT = "REDSHIFT",
+    VERTICA = "VERTICA",
+    SNOWFLAKE = "SNOWFLAKE",
+    ADS = "ADS",
+    BIGQUERY = "BIGQUERY",
+    MSSQL = "MSSQL",
+    PRESTO = "PRESTO",
+}
+
+/**
+ *
+ * @export
+ * @interface JsonApiDataSourceOutDocument
+ */
+export interface JsonApiDataSourceOutDocument {
+    /**
+     *
+     * @type {JsonApiDataSourceOut}
+     * @memberof JsonApiDataSourceOutDocument
+     */
+    data: JsonApiDataSourceOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiDataSourceOutDocument
+     */
+    links?: ObjectLinks;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiDataSourceOutList
+ */
+export interface JsonApiDataSourceOutList {
+    /**
+     *
+     * @type {Array<JsonApiDataSourceOutWithLinks>}
+     * @memberof JsonApiDataSourceOutList
+     */
+    data: Array<JsonApiDataSourceOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiDataSourceOutList
+     */
+    links?: ListLinks;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiDataSourceOutWithLinks
+ */
+export interface JsonApiDataSourceOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiDataSourceOutAttributes}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    attributes?: JsonApiDataSourceOutAttributes;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiDataSourceOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of dataset entity.
+ * @export
+ * @interface JsonApiDatasetOut
+ */
+export interface JsonApiDatasetOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiDatasetOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiDatasetOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiDatasetOutAttributes}
+     * @memberof JsonApiDatasetOut
+     */
+    attributes?: JsonApiDatasetOutAttributes;
+    /**
+     *
+     * @type {JsonApiDatasetOutRelationships}
+     * @memberof JsonApiDatasetOut
+     */
+    relationships?: JsonApiDatasetOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiDatasetOutAttributes
+ */
+export interface JsonApiDatasetOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    tags?: Array<string>;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    type?: JsonApiDatasetOutAttributesTypeEnum;
+    /**
+     *
+     * @type {Array<JsonApiDatasetOutAttributesGrain>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    grain?: Array<JsonApiDatasetOutAttributesGrain>;
+    /**
+     *
+     * @type {Array<JsonApiDatasetOutAttributesReferenceProperties>}
+     * @memberof JsonApiDatasetOutAttributes
+     */
+    referenceProperties?: Array<JsonApiDatasetOutAttributesReferenceProperties>;
+}
+
+/**
+ * @export
+ * @enum {string}
+ */
+export enum JsonApiDatasetOutAttributesTypeEnum {
     NORMAL = "NORMAL",
     DATE = "DATE",
 }
@@ -1818,28 +1978,28 @@ export enum JsonApiDatasetAttributesTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributesGrain
+ * @interface JsonApiDatasetOutAttributesGrain
  */
-export interface JsonApiDatasetAttributesGrain {
+export interface JsonApiDatasetOutAttributesGrain {
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributesGrain
+     * @memberof JsonApiDatasetOutAttributesGrain
      */
     id: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiDatasetAttributesGrain
+     * @memberof JsonApiDatasetOutAttributesGrain
      */
-    type: JsonApiDatasetAttributesGrainTypeEnum;
+    type: JsonApiDatasetOutAttributesGrainTypeEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiDatasetAttributesGrainTypeEnum {
+export enum JsonApiDatasetOutAttributesGrainTypeEnum {
     Attribute = "attribute",
     Dataset = "dataset",
 }
@@ -1847,626 +2007,664 @@ export enum JsonApiDatasetAttributesGrainTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiDatasetAttributesReferenceProperties
+ * @interface JsonApiDatasetOutAttributesReferenceProperties
  */
-export interface JsonApiDatasetAttributesReferenceProperties {
+export interface JsonApiDatasetOutAttributesReferenceProperties {
     /**
      *
      * @type {DatasetReferenceIdentifier}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     identifier: DatasetReferenceIdentifier;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     multivalue: boolean;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiDatasetAttributesReferenceProperties
+     * @memberof JsonApiDatasetOutAttributesReferenceProperties
      */
     sourceColumns: Array<string>;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetDocument
+ * @interface JsonApiDatasetOutDocument
  */
-export interface JsonApiDatasetDocument {
+export interface JsonApiDatasetOutDocument {
     /**
      *
-     * @type {JsonApiDataset}
-     * @memberof JsonApiDatasetDocument
+     * @type {JsonApiDatasetOut}
+     * @memberof JsonApiDatasetOutDocument
      */
-    data: JsonApiDataset;
+    data: JsonApiDatasetOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDatasetDocument
+     * @memberof JsonApiDatasetOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetDocument
+     * @type {Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutDocument
      */
     included?: Array<
-        | JsonApiSourceTableWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiFactWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiSourceTableOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiDatasetList
+ * @interface JsonApiDatasetOutList
  */
-export interface JsonApiDatasetList {
+export interface JsonApiDatasetOutList {
     /**
      *
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetList
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutList
      */
-    data: Array<JsonApiDatasetWithLinks>;
+    data: Array<JsonApiDatasetOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiDatasetList
+     * @memberof JsonApiDatasetOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks | JsonApiAttributeWithLinks | JsonApiFactWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiDatasetList
+     * @type {Array<JsonApiSourceTableOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiFactOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiDatasetOutList
      */
     included?: Array<
-        | JsonApiSourceTableWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiFactWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiSourceTableOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetRelationships
+ * @interface JsonApiDatasetOutRelationships
  */
-export interface JsonApiDatasetRelationships {
+export interface JsonApiDatasetOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    table?: JsonApiOrganizationRelationshipsUser;
+    table?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    facts?: JsonApiACLRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiDatasetRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiDatasetOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiDatasetWithLinks
+ * @interface JsonApiDatasetOutWithLinks
  */
-export interface JsonApiDatasetWithLinks {
+export interface JsonApiDatasetOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiDatasetAttributes}
-     * @memberof JsonApiDatasetWithLinks
+     * @type {JsonApiDatasetOutAttributes}
+     * @memberof JsonApiDatasetOutWithLinks
      */
-    attributes?: JsonApiDatasetAttributes;
+    attributes?: JsonApiDatasetOutAttributes;
     /**
      *
-     * @type {JsonApiDatasetRelationships}
-     * @memberof JsonApiDatasetWithLinks
+     * @type {JsonApiDatasetOutRelationships}
+     * @memberof JsonApiDatasetOutWithLinks
      */
-    relationships?: JsonApiDatasetRelationships;
+    relationships?: JsonApiDatasetOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiDatasetWithLinks
+     * @memberof JsonApiDatasetOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of fact entity.
  * @export
- * @interface JsonApiFact
+ * @interface JsonApiFactOut
  */
-export interface JsonApiFact {
+export interface JsonApiFactOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFact
+     * @memberof JsonApiFactOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFact
+     * @memberof JsonApiFactOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiFactAttributes}
-     * @memberof JsonApiFact
+     * @type {JsonApiFactOutAttributes}
+     * @memberof JsonApiFactOut
      */
-    attributes?: JsonApiFactAttributes;
+    attributes?: JsonApiFactOutAttributes;
     /**
      *
-     * @type {JsonApiFactRelationships}
-     * @memberof JsonApiFact
+     * @type {JsonApiFactOutRelationships}
+     * @memberof JsonApiFactOut
      */
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiFactAttributes
+ * @interface JsonApiFactOutAttributes
  */
-export interface JsonApiFactAttributes {
+export interface JsonApiFactOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {string}
-     * @memberof JsonApiFactAttributes
+     * @memberof JsonApiFactOutAttributes
      */
     sourceColumn?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiFactDocument
+ * @interface JsonApiFactOutDocument
  */
-export interface JsonApiFactDocument {
+export interface JsonApiFactOutDocument {
     /**
      *
-     * @type {JsonApiFact}
-     * @memberof JsonApiFactDocument
+     * @type {JsonApiFactOut}
+     * @memberof JsonApiFactOutDocument
      */
-    data: JsonApiFact;
+    data: JsonApiFactOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFactDocument
+     * @memberof JsonApiFactOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiFactDocument
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiFactOutDocument
      */
-    included?: Array<JsonApiDatasetWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiFactList
+ * @interface JsonApiFactOutList
  */
-export interface JsonApiFactList {
+export interface JsonApiFactOutList {
     /**
      *
-     * @type {Array<JsonApiFactWithLinks>}
-     * @memberof JsonApiFactList
+     * @type {Array<JsonApiFactOutWithLinks>}
+     * @memberof JsonApiFactOutList
      */
-    data: Array<JsonApiFactWithLinks>;
+    data: Array<JsonApiFactOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiFactList
+     * @memberof JsonApiFactOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiDatasetWithLinks>}
-     * @memberof JsonApiFactList
+     * @type {Array<JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiFactOutList
      */
-    included?: Array<JsonApiDatasetWithLinks>;
+    included?: Array<JsonApiDatasetOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiFactRelationships
+ * @interface JsonApiFactOutRelationships
  */
-export interface JsonApiFactRelationships {
+export interface JsonApiFactOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiFactRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiFactOutRelationships
      */
-    dataset?: JsonApiOrganizationRelationshipsUser;
+    dataset?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiFactWithLinks
+ * @interface JsonApiFactOutWithLinks
  */
-export interface JsonApiFactWithLinks {
+export interface JsonApiFactOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiFactAttributes}
-     * @memberof JsonApiFactWithLinks
+     * @type {JsonApiFactOutAttributes}
+     * @memberof JsonApiFactOutWithLinks
      */
-    attributes?: JsonApiFactAttributes;
+    attributes?: JsonApiFactOutAttributes;
     /**
      *
-     * @type {JsonApiFactRelationships}
-     * @memberof JsonApiFactWithLinks
+     * @type {JsonApiFactOutRelationships}
+     * @memberof JsonApiFactOutWithLinks
      */
-    relationships?: JsonApiFactRelationships;
+    relationships?: JsonApiFactOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFactWithLinks
+     * @memberof JsonApiFactOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of filterContext entity.
  * @export
- * @interface JsonApiFilterContext
+ * @interface JsonApiFilterContextIn
  */
-export interface JsonApiFilterContext {
+export interface JsonApiFilterContextIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFilterContext
+     * @memberof JsonApiFilterContextIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFilterContext
+     * @memberof JsonApiFilterContextIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiFilterContext
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiFilterContextIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiFilterContextRelationships}
-     * @memberof JsonApiFilterContext
-     */
-    relationships?: JsonApiFilterContextRelationships;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextDocument
+ * @interface JsonApiFilterContextInDocument
  */
-export interface JsonApiFilterContextDocument {
+export interface JsonApiFilterContextInDocument {
     /**
      *
-     * @type {JsonApiFilterContext}
-     * @memberof JsonApiFilterContextDocument
+     * @type {JsonApiFilterContextIn}
+     * @memberof JsonApiFilterContextInDocument
      */
-    data: JsonApiFilterContext;
+    data: JsonApiFilterContextIn;
+}
+/**
+ * JSON:API representation of filterContext entity.
+ * @export
+ * @interface JsonApiFilterContextOut
+ */
+export interface JsonApiFilterContextOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiFilterContextOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiFilterContextOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiFilterContextOut
+     */
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    /**
+     *
+     * @type {JsonApiFilterContextOutRelationships}
+     * @memberof JsonApiFilterContextOut
+     */
+    relationships?: JsonApiFilterContextOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiFilterContextOutDocument
+ */
+export interface JsonApiFilterContextOutDocument {
+    /**
+     *
+     * @type {JsonApiFilterContextOut}
+     * @memberof JsonApiFilterContextOutDocument
+     */
+    data: JsonApiFilterContextOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFilterContextDocument
+     * @memberof JsonApiFilterContextOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiFilterContextDocument
+     * @type {Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiFilterContextOutDocument
      */
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiFilterContextList
+ * @interface JsonApiFilterContextOutList
  */
-export interface JsonApiFilterContextList {
+export interface JsonApiFilterContextOutList {
     /**
      *
-     * @type {Array<JsonApiFilterContextWithLinks>}
-     * @memberof JsonApiFilterContextList
+     * @type {Array<JsonApiFilterContextOutWithLinks>}
+     * @memberof JsonApiFilterContextOutList
      */
-    data: Array<JsonApiFilterContextWithLinks>;
+    data: Array<JsonApiFilterContextOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiFilterContextList
+     * @memberof JsonApiFilterContextOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>}
-     * @memberof JsonApiFilterContextList
+     * @type {Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiFilterContextOutList
      */
-    included?: Array<JsonApiAttributeWithLinks | JsonApiDatasetWithLinks | JsonApiLabelWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks | JsonApiDatasetOutWithLinks | JsonApiLabelOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextRelationships
+ * @interface JsonApiFilterContextOutRelationships
  */
-export interface JsonApiFilterContextRelationships {
+export interface JsonApiFilterContextOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiFilterContextRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiFilterContextOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiFilterContextWithLinks
+ * @interface JsonApiFilterContextOutWithLinks
  */
-export interface JsonApiFilterContextWithLinks {
+export interface JsonApiFilterContextOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiFilterContextWithLinks
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiFilterContextOutWithLinks
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     /**
      *
-     * @type {JsonApiFilterContextRelationships}
-     * @memberof JsonApiFilterContextWithLinks
+     * @type {JsonApiFilterContextOutRelationships}
+     * @memberof JsonApiFilterContextOutWithLinks
      */
-    relationships?: JsonApiFilterContextRelationships;
+    relationships?: JsonApiFilterContextOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiFilterContextWithLinks
+     * @memberof JsonApiFilterContextOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of label entity.
  * @export
- * @interface JsonApiLabel
+ * @interface JsonApiLabelOut
  */
-export interface JsonApiLabel {
+export interface JsonApiLabelOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiLabel
+     * @memberof JsonApiLabelOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiLabel
+     * @memberof JsonApiLabelOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiLabelAttributes}
-     * @memberof JsonApiLabel
+     * @type {JsonApiLabelOutAttributes}
+     * @memberof JsonApiLabelOut
      */
-    attributes?: JsonApiLabelAttributes;
+    attributes?: JsonApiLabelOutAttributes;
     /**
      *
-     * @type {JsonApiLabelRelationships}
-     * @memberof JsonApiLabel
+     * @type {JsonApiLabelOutRelationships}
+     * @memberof JsonApiLabelOut
      */
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelAttributes
+ * @interface JsonApiLabelOutAttributes
  */
-export interface JsonApiLabelAttributes {
+export interface JsonApiLabelOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     tags?: Array<string>;
     /**
      *
      * @type {boolean}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     primary?: boolean;
     /**
      *
      * @type {string}
-     * @memberof JsonApiLabelAttributes
+     * @memberof JsonApiLabelOutAttributes
      */
     sourceColumn?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelDocument
+ * @interface JsonApiLabelOutDocument
  */
-export interface JsonApiLabelDocument {
+export interface JsonApiLabelOutDocument {
     /**
      *
-     * @type {JsonApiLabel}
-     * @memberof JsonApiLabelDocument
+     * @type {JsonApiLabelOut}
+     * @memberof JsonApiLabelOutDocument
      */
-    data: JsonApiLabel;
+    data: JsonApiLabelOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiLabelDocument
+     * @memberof JsonApiLabelOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiLabelDocument
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiLabelOutDocument
      */
-    included?: Array<JsonApiAttributeWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiLabelList
+ * @interface JsonApiLabelOutList
  */
-export interface JsonApiLabelList {
+export interface JsonApiLabelOutList {
     /**
      *
-     * @type {Array<JsonApiLabelWithLinks>}
-     * @memberof JsonApiLabelList
+     * @type {Array<JsonApiLabelOutWithLinks>}
+     * @memberof JsonApiLabelOutList
      */
-    data: Array<JsonApiLabelWithLinks>;
+    data: Array<JsonApiLabelOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiLabelList
+     * @memberof JsonApiLabelOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiAttributeWithLinks>}
-     * @memberof JsonApiLabelList
+     * @type {Array<JsonApiAttributeOutWithLinks>}
+     * @memberof JsonApiLabelOutList
      */
-    included?: Array<JsonApiAttributeWithLinks>;
+    included?: Array<JsonApiAttributeOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelRelationships
+ * @interface JsonApiLabelOutRelationships
  */
-export interface JsonApiLabelRelationships {
+export interface JsonApiLabelOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiLabelRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiLabelOutRelationships
      */
-    attribute?: JsonApiOrganizationRelationshipsUser;
+    attribute?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiLabelWithLinks
+ * @interface JsonApiLabelOutWithLinks
  */
-export interface JsonApiLabelWithLinks {
+export interface JsonApiLabelOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiLabelAttributes}
-     * @memberof JsonApiLabelWithLinks
+     * @type {JsonApiLabelOutAttributes}
+     * @memberof JsonApiLabelOutWithLinks
      */
-    attributes?: JsonApiLabelAttributes;
+    attributes?: JsonApiLabelOutAttributes;
     /**
      *
-     * @type {JsonApiLabelRelationships}
-     * @memberof JsonApiLabelWithLinks
+     * @type {JsonApiLabelOutRelationships}
+     * @memberof JsonApiLabelOutWithLinks
      */
-    relationships?: JsonApiLabelRelationships;
+    relationships?: JsonApiLabelOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiLabelWithLinks
+     * @memberof JsonApiLabelOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -2492,484 +2690,635 @@ export interface JsonApiLinkage {
 /**
  * JSON:API representation of metric entity.
  * @export
- * @interface JsonApiMetric
+ * @interface JsonApiMetricIn
  */
-export interface JsonApiMetric {
+export interface JsonApiMetricIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiMetric
+     * @memberof JsonApiMetricIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiMetric
+     * @memberof JsonApiMetricIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiMetricAttributes}
-     * @memberof JsonApiMetric
+     * @type {JsonApiMetricInAttributes}
+     * @memberof JsonApiMetricIn
      */
-    attributes?: JsonApiMetricAttributes;
-    /**
-     *
-     * @type {JsonApiMetricRelationships}
-     * @memberof JsonApiMetric
-     */
-    relationships?: JsonApiMetricRelationships;
+    attributes?: JsonApiMetricInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricAttributes
+ * @interface JsonApiMetricInAttributes
  */
-export interface JsonApiMetricAttributes {
+export interface JsonApiMetricInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricInAttributes
      */
     title?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricInAttributes
      */
     description?: string;
     /**
      *
      * @type {Array<string>}
-     * @memberof JsonApiMetricAttributes
+     * @memberof JsonApiMetricInAttributes
      */
     tags?: Array<string>;
     /**
      *
-     * @type {JsonApiMetricAttributesContent}
-     * @memberof JsonApiMetricAttributes
+     * @type {JsonApiMetricInAttributesContent}
+     * @memberof JsonApiMetricInAttributes
      */
-    content?: JsonApiMetricAttributesContent;
+    content?: JsonApiMetricInAttributesContent;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricAttributesContent
+ * @interface JsonApiMetricInAttributesContent
  */
-export interface JsonApiMetricAttributesContent {
+export interface JsonApiMetricInAttributesContent {
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributesContent
+     * @memberof JsonApiMetricInAttributesContent
      */
     format?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiMetricAttributesContent
+     * @memberof JsonApiMetricInAttributesContent
      */
     maql?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiMetricDocument
+ * @interface JsonApiMetricInDocument
  */
-export interface JsonApiMetricDocument {
+export interface JsonApiMetricInDocument {
     /**
      *
-     * @type {JsonApiMetric}
-     * @memberof JsonApiMetricDocument
+     * @type {JsonApiMetricIn}
+     * @memberof JsonApiMetricInDocument
      */
-    data: JsonApiMetric;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiMetricDocument
-     */
-    links?: ObjectLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricDocument
-     */
-    included?: Array<
-        JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks
-    >;
+    data: JsonApiMetricIn;
 }
 /**
- * A JSON:API document with a list of resources
+ * JSON:API representation of metric entity.
  * @export
- * @interface JsonApiMetricList
+ * @interface JsonApiMetricOut
  */
-export interface JsonApiMetricList {
-    /**
-     *
-     * @type {Array<JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricList
-     */
-    data: Array<JsonApiMetricWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiMetricList
-     */
-    links?: ListLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks>}
-     * @memberof JsonApiMetricList
-     */
-    included?: Array<
-        JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks
-    >;
-}
-/**
- *
- * @export
- * @interface JsonApiMetricRelationships
- */
-export interface JsonApiMetricRelationships {
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
-     */
-    facts?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
-     */
-    attributes?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
-     */
-    labels?: JsonApiACLRelationshipsUsers;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiMetricRelationships
-     */
-    metrics?: JsonApiACLRelationshipsUsers;
-}
-/**
- *
- * @export
- * @interface JsonApiMetricWithLinks
- */
-export interface JsonApiMetricWithLinks {
+export interface JsonApiMetricOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiMetricAttributes}
-     * @memberof JsonApiMetricWithLinks
+     * @type {JsonApiMetricInAttributes}
+     * @memberof JsonApiMetricOut
      */
-    attributes?: JsonApiMetricAttributes;
+    attributes?: JsonApiMetricInAttributes;
     /**
      *
-     * @type {JsonApiMetricRelationships}
-     * @memberof JsonApiMetricWithLinks
+     * @type {JsonApiMetricOutRelationships}
+     * @memberof JsonApiMetricOut
      */
-    relationships?: JsonApiMetricRelationships;
+    relationships?: JsonApiMetricOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiMetricOutDocument
+ */
+export interface JsonApiMetricOutDocument {
+    /**
+     *
+     * @type {JsonApiMetricOut}
+     * @memberof JsonApiMetricOutDocument
+     */
+    data: JsonApiMetricOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiMetricWithLinks
+     * @memberof JsonApiMetricOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutDocument
+     */
+    included?: Array<
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+    >;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiMetricOutList
+ */
+export interface JsonApiMetricOutList {
+    /**
+     *
+     * @type {Array<JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutList
+     */
+    data: Array<JsonApiMetricOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiMetricOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks>}
+     * @memberof JsonApiMetricOutList
+     */
+    included?: Array<
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+    >;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiMetricOutRelationships
+ */
+export interface JsonApiMetricOutRelationships {
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
+     */
+    facts?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
+     */
+    attributes?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
+     */
+    labels?: JsonApiACLOutRelationshipsUsers;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiMetricOutRelationships
+     */
+    metrics?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiMetricOutWithLinks
+ */
+export interface JsonApiMetricOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiMetricOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiMetricOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiMetricInAttributes}
+     * @memberof JsonApiMetricOutWithLinks
+     */
+    attributes?: JsonApiMetricInAttributes;
+    /**
+     *
+     * @type {JsonApiMetricOutRelationships}
+     * @memberof JsonApiMetricOutWithLinks
+     */
+    relationships?: JsonApiMetricOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiMetricOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of modelModule entity.
  * @export
- * @interface JsonApiModelModule
+ * @interface JsonApiModelModuleIn
  */
-export interface JsonApiModelModule {
+export interface JsonApiModelModuleIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiModelModule
+     * @memberof JsonApiModelModuleIn
      */
     attributes?: object;
 }
 /**
  *
  * @export
- * @interface JsonApiModelModuleDocument
+ * @interface JsonApiModelModuleInDocument
  */
-export interface JsonApiModelModuleDocument {
+export interface JsonApiModelModuleInDocument {
     /**
      *
-     * @type {JsonApiModelModule}
-     * @memberof JsonApiModelModuleDocument
+     * @type {JsonApiModelModuleIn}
+     * @memberof JsonApiModelModuleInDocument
      */
-    data: JsonApiModelModule;
+    data: JsonApiModelModuleIn;
+}
+/**
+ * JSON:API representation of modelModule entity.
+ * @export
+ * @interface JsonApiModelModuleOut
+ */
+export interface JsonApiModelModuleOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiModelModuleOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiModelModuleOut
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiModelModuleOut
+     */
+    attributes?: object;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiModelModuleOutDocument
+ */
+export interface JsonApiModelModuleOutDocument {
+    /**
+     *
+     * @type {JsonApiModelModuleOut}
+     * @memberof JsonApiModelModuleOutDocument
+     */
+    data: JsonApiModelModuleOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiModelModuleDocument
+     * @memberof JsonApiModelModuleOutDocument
      */
     links?: ObjectLinks;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiModelModuleList
+ * @interface JsonApiModelModuleOutList
  */
-export interface JsonApiModelModuleList {
+export interface JsonApiModelModuleOutList {
     /**
      *
-     * @type {Array<JsonApiModelModuleWithLinks>}
-     * @memberof JsonApiModelModuleList
+     * @type {Array<JsonApiModelModuleOutWithLinks>}
+     * @memberof JsonApiModelModuleOutList
      */
-    data: Array<JsonApiModelModuleWithLinks>;
+    data: Array<JsonApiModelModuleOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiModelModuleList
+     * @memberof JsonApiModelModuleOutList
      */
     links?: ListLinks;
 }
 /**
  *
  * @export
- * @interface JsonApiModelModuleWithLinks
+ * @interface JsonApiModelModuleOutWithLinks
  */
-export interface JsonApiModelModuleWithLinks {
+export interface JsonApiModelModuleOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     attributes?: object;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiModelModuleWithLinks
+     * @memberof JsonApiModelModuleOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of organization entity.
  * @export
- * @interface JsonApiOrganization
+ * @interface JsonApiOrganizationIn
  */
-export interface JsonApiOrganization {
+export interface JsonApiOrganizationIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiOrganization
+     * @memberof JsonApiOrganizationIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiOrganization
+     * @memberof JsonApiOrganizationIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiOrganizationAttributes}
-     * @memberof JsonApiOrganization
+     * @type {JsonApiOrganizationInAttributes}
+     * @memberof JsonApiOrganizationIn
      */
-    attributes?: JsonApiOrganizationAttributes;
-    /**
-     *
-     * @type {JsonApiOrganizationRelationships}
-     * @memberof JsonApiOrganization
-     */
-    relationships?: JsonApiOrganizationRelationships;
+    attributes?: JsonApiOrganizationInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationAttributes
+ * @interface JsonApiOrganizationInAttributes
  */
-export interface JsonApiOrganizationAttributes {
+export interface JsonApiOrganizationInAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     name?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     hostname?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthIssuerLocation?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthClientId?: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiOrganizationAttributes
+     * @memberof JsonApiOrganizationInAttributes
      */
     oauthClientSecret?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationDocument
+ * @interface JsonApiOrganizationInDocument
  */
-export interface JsonApiOrganizationDocument {
+export interface JsonApiOrganizationInDocument {
     /**
      *
-     * @type {JsonApiOrganization}
-     * @memberof JsonApiOrganizationDocument
+     * @type {JsonApiOrganizationIn}
+     * @memberof JsonApiOrganizationInDocument
      */
-    data: JsonApiOrganization;
+    data: JsonApiOrganizationIn;
+}
+/**
+ * JSON:API representation of organization entity.
+ * @export
+ * @interface JsonApiOrganizationOut
+ */
+export interface JsonApiOrganizationOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiOrganizationOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiOrganizationOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiOrganizationOutAttributes}
+     * @memberof JsonApiOrganizationOut
+     */
+    attributes?: JsonApiOrganizationOutAttributes;
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationships}
+     * @memberof JsonApiOrganizationOut
+     */
+    relationships?: JsonApiOrganizationOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiOrganizationOutAttributes
+ */
+export interface JsonApiOrganizationOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    name?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    hostname?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    oauthIssuerLocation?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiOrganizationOutAttributes
+     */
+    oauthClientId?: string;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiOrganizationOutDocument
+ */
+export interface JsonApiOrganizationOutDocument {
+    /**
+     *
+     * @type {JsonApiOrganizationOut}
+     * @memberof JsonApiOrganizationOutDocument
+     */
+    data: JsonApiOrganizationOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiOrganizationDocument
+     * @memberof JsonApiOrganizationOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiOrganizationDocument
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiOrganizationOutDocument
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiOrganizationList
+ * @interface JsonApiOrganizationOutList
  */
-export interface JsonApiOrganizationList {
+export interface JsonApiOrganizationOutList {
     /**
      *
-     * @type {Array<JsonApiOrganizationWithLinks>}
-     * @memberof JsonApiOrganizationList
+     * @type {Array<JsonApiOrganizationOutWithLinks>}
+     * @memberof JsonApiOrganizationOutList
      */
-    data: Array<JsonApiOrganizationWithLinks>;
+    data: Array<JsonApiOrganizationOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiOrganizationList
+     * @memberof JsonApiOrganizationOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiOrganizationList
+     * @type {Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiOrganizationOutList
      */
-    included?: Array<JsonApiUserWithLinks | JsonApiUserGroupWithLinks>;
+    included?: Array<JsonApiUserOutWithLinks | JsonApiUserGroupOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationRelationships
+ * @interface JsonApiOrganizationOutRelationships
  */
-export interface JsonApiOrganizationRelationships {
+export interface JsonApiOrganizationOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiOrganizationRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiOrganizationOutRelationships
      */
-    user?: JsonApiOrganizationRelationshipsUser;
+    user?: JsonApiOrganizationOutRelationshipsUser;
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiOrganizationRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiOrganizationOutRelationships
      */
-    userGroup?: JsonApiOrganizationRelationshipsUser;
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationRelationshipsUser
+ * @interface JsonApiOrganizationOutRelationshipsUser
  */
-export interface JsonApiOrganizationRelationshipsUser {
+export interface JsonApiOrganizationOutRelationshipsUser {
     /**
      *
      * @type {JsonApiRelToOne}
-     * @memberof JsonApiOrganizationRelationshipsUser
+     * @memberof JsonApiOrganizationOutRelationshipsUser
      */
     data?: JsonApiRelToOne | null;
 }
 /**
  *
  * @export
- * @interface JsonApiOrganizationWithLinks
+ * @interface JsonApiOrganizationOutWithLinks
  */
-export interface JsonApiOrganizationWithLinks {
+export interface JsonApiOrganizationOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiOrganizationAttributes}
-     * @memberof JsonApiOrganizationWithLinks
+     * @type {JsonApiOrganizationOutAttributes}
+     * @memberof JsonApiOrganizationOutWithLinks
      */
-    attributes?: JsonApiOrganizationAttributes;
+    attributes?: JsonApiOrganizationOutAttributes;
     /**
      *
-     * @type {JsonApiOrganizationRelationships}
-     * @memberof JsonApiOrganizationWithLinks
+     * @type {JsonApiOrganizationOutRelationships}
+     * @memberof JsonApiOrganizationOutWithLinks
      */
-    relationships?: JsonApiOrganizationRelationships;
+    relationships?: JsonApiOrganizationOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiOrganizationWithLinks
+     * @memberof JsonApiOrganizationOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -2982,78 +3331,78 @@ export type JsonApiRelToOne = JsonApiLinkage;
 /**
  * A source table
  * @export
- * @interface JsonApiSourceTable
+ * @interface JsonApiSourceTableOut
  */
-export interface JsonApiSourceTable {
+export interface JsonApiSourceTableOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTable
+     * @memberof JsonApiSourceTableOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTable
+     * @memberof JsonApiSourceTableOut
      */
     type: string;
     /**
      *
-     * @type {JsonApiSourceTableAttributes}
-     * @memberof JsonApiSourceTable
+     * @type {JsonApiSourceTableOutAttributes}
+     * @memberof JsonApiSourceTableOut
      */
-    attributes?: JsonApiSourceTableAttributes;
+    attributes?: JsonApiSourceTableOutAttributes;
     /**
      *
-     * @type {JsonApiSourceTableRelationships}
-     * @memberof JsonApiSourceTable
+     * @type {JsonApiSourceTableOutRelationships}
+     * @memberof JsonApiSourceTableOut
      */
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableAttributes
+ * @interface JsonApiSourceTableOutAttributes
  */
-export interface JsonApiSourceTableAttributes {
+export interface JsonApiSourceTableOutAttributes {
     /**
-     *
+     * Path to table.
      * @type {Array<string>}
-     * @memberof JsonApiSourceTableAttributes
+     * @memberof JsonApiSourceTableOutAttributes
      */
     path?: Array<string>;
     /**
      *
-     * @type {Array<JsonApiSourceTableAttributesColumns>}
-     * @memberof JsonApiSourceTableAttributes
+     * @type {Array<JsonApiSourceTableOutAttributesColumns>}
+     * @memberof JsonApiSourceTableOutAttributes
      */
-    columns?: Array<JsonApiSourceTableAttributesColumns>;
+    columns?: Array<JsonApiSourceTableOutAttributesColumns>;
 }
 /**
  * A source table column
  * @export
- * @interface JsonApiSourceTableAttributesColumns
+ * @interface JsonApiSourceTableOutAttributesColumns
  */
-export interface JsonApiSourceTableAttributesColumns {
+export interface JsonApiSourceTableOutAttributesColumns {
     /**
      *
      * @type {string}
-     * @memberof JsonApiSourceTableAttributesColumns
+     * @memberof JsonApiSourceTableOutAttributesColumns
      */
     name: string;
     /**
      *
      * @type {string}
-     * @memberof JsonApiSourceTableAttributesColumns
+     * @memberof JsonApiSourceTableOutAttributesColumns
      */
-    dataType: JsonApiSourceTableAttributesColumnsDataTypeEnum;
+    dataType: JsonApiSourceTableOutAttributesColumnsDataTypeEnum;
 }
 
 /**
  * @export
  * @enum {string}
  */
-export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
+export enum JsonApiSourceTableOutAttributesColumnsDataTypeEnum {
     INT = "INT",
     STRING = "STRING",
     DATE = "DATE",
@@ -3065,818 +3414,1344 @@ export enum JsonApiSourceTableAttributesColumnsDataTypeEnum {
 /**
  *
  * @export
- * @interface JsonApiSourceTableDocument
+ * @interface JsonApiSourceTableOutDocument
  */
-export interface JsonApiSourceTableDocument {
+export interface JsonApiSourceTableOutDocument {
     /**
      *
-     * @type {JsonApiSourceTable}
-     * @memberof JsonApiSourceTableDocument
+     * @type {JsonApiSourceTableOut}
+     * @memberof JsonApiSourceTableOutDocument
      */
-    data: JsonApiSourceTable;
+    data: JsonApiSourceTableOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTableDocument
+     * @memberof JsonApiSourceTableOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTableDocument
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTableOutDocument
      */
-    included?: Array<JsonApiSourceTablesWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiSourceTableList
+ * @interface JsonApiSourceTableOutList
  */
-export interface JsonApiSourceTableList {
+export interface JsonApiSourceTableOutList {
     /**
      *
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTableList
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTableOutList
      */
-    data: Array<JsonApiSourceTableWithLinks>;
+    data: Array<JsonApiSourceTableOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiSourceTableList
+     * @memberof JsonApiSourceTableOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTableList
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTableOutList
      */
-    included?: Array<JsonApiSourceTablesWithLinks>;
+    included?: Array<JsonApiSourceTablesOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableRelationships
+ * @interface JsonApiSourceTableOutRelationships
  */
-export interface JsonApiSourceTableRelationships {
+export interface JsonApiSourceTableOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiSourceTableRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiSourceTableOutRelationships
      */
-    source?: JsonApiOrganizationRelationshipsUser;
+    source?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTableWithLinks
+ * @interface JsonApiSourceTableOutWithLinks
  */
-export interface JsonApiSourceTableWithLinks {
+export interface JsonApiSourceTableOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiSourceTableAttributes}
-     * @memberof JsonApiSourceTableWithLinks
+     * @type {JsonApiSourceTableOutAttributes}
+     * @memberof JsonApiSourceTableOutWithLinks
      */
-    attributes?: JsonApiSourceTableAttributes;
+    attributes?: JsonApiSourceTableOutAttributes;
     /**
      *
-     * @type {JsonApiSourceTableRelationships}
-     * @memberof JsonApiSourceTableWithLinks
+     * @type {JsonApiSourceTableOutRelationships}
+     * @memberof JsonApiSourceTableOutWithLinks
      */
-    relationships?: JsonApiSourceTableRelationships;
+    relationships?: JsonApiSourceTableOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTableWithLinks
+     * @memberof JsonApiSourceTableOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * A defined data source for analytics data
  * @export
- * @interface JsonApiSourceTables
+ * @interface JsonApiSourceTablesOut
  */
-export interface JsonApiSourceTables {
+export interface JsonApiSourceTablesOut {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiSourceTables
+     * @memberof JsonApiSourceTablesOut
      */
     attributes?: object;
     /**
      *
-     * @type {JsonApiSourceTablesRelationships}
-     * @memberof JsonApiSourceTables
+     * @type {JsonApiSourceTablesOutRelationships}
+     * @memberof JsonApiSourceTablesOut
      */
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesDocument
+ * @interface JsonApiSourceTablesOutDocument
  */
-export interface JsonApiSourceTablesDocument {
+export interface JsonApiSourceTablesOutDocument {
     /**
      *
-     * @type {JsonApiSourceTables}
-     * @memberof JsonApiSourceTablesDocument
+     * @type {JsonApiSourceTablesOut}
+     * @memberof JsonApiSourceTablesOutDocument
      */
-    data: JsonApiSourceTables;
+    data: JsonApiSourceTablesOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTablesDocument
+     * @memberof JsonApiSourceTablesOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTablesDocument
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutDocument
      */
-    included?: Array<JsonApiSourceTableWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiSourceTablesList
+ * @interface JsonApiSourceTablesOutList
  */
-export interface JsonApiSourceTablesList {
+export interface JsonApiSourceTablesOutList {
     /**
      *
-     * @type {Array<JsonApiSourceTablesWithLinks>}
-     * @memberof JsonApiSourceTablesList
+     * @type {Array<JsonApiSourceTablesOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutList
      */
-    data: Array<JsonApiSourceTablesWithLinks>;
+    data: Array<JsonApiSourceTablesOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiSourceTablesList
+     * @memberof JsonApiSourceTablesOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiSourceTableWithLinks>}
-     * @memberof JsonApiSourceTablesList
+     * @type {Array<JsonApiSourceTableOutWithLinks>}
+     * @memberof JsonApiSourceTablesOutList
      */
-    included?: Array<JsonApiSourceTableWithLinks>;
+    included?: Array<JsonApiSourceTableOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesRelationships
+ * @interface JsonApiSourceTablesOutRelationships
  */
-export interface JsonApiSourceTablesRelationships {
+export interface JsonApiSourceTablesOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiSourceTablesRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiSourceTablesOutRelationships
      */
-    tables?: JsonApiACLRelationshipsUsers;
+    tables?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiSourceTablesWithLinks
+ * @interface JsonApiSourceTablesOutWithLinks
  */
-export interface JsonApiSourceTablesWithLinks {
+export interface JsonApiSourceTablesOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     type: string;
     /**
      *
      * @type {object}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
     attributes?: object;
     /**
      *
-     * @type {JsonApiSourceTablesRelationships}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @type {JsonApiSourceTablesOutRelationships}
+     * @memberof JsonApiSourceTablesOutWithLinks
      */
-    relationships?: JsonApiSourceTablesRelationships;
+    relationships?: JsonApiSourceTablesOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiSourceTablesWithLinks
+     * @memberof JsonApiSourceTablesOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of userGroup entity.
+ * @export
+ * @interface JsonApiUserGroupIn
+ */
+export interface JsonApiUserGroupIn {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupIn
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupIn
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupIn
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupIn
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupInDocument
+ */
+export interface JsonApiUserGroupInDocument {
+    /**
+     *
+     * @type {JsonApiUserGroupIn}
+     * @memberof JsonApiUserGroupInDocument
+     */
+    data: JsonApiUserGroupIn;
+}
+/**
+ * JSON:API representation of userGroup entity.
+ * @export
+ * @interface JsonApiUserGroupOut
+ */
+export interface JsonApiUserGroupOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupOut
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupOut
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupOut
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutDocument
+ */
+export interface JsonApiUserGroupOutDocument {
+    /**
+     *
+     * @type {JsonApiUserGroupOut}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    data: JsonApiUserGroupOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserGroupOutDocument
+     */
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiUserGroupOutList
+ */
+export interface JsonApiUserGroupOutList {
+    /**
+     *
+     * @type {Array<JsonApiUserGroupOutWithLinks>}
+     * @memberof JsonApiUserGroupOutList
+     */
+    data: Array<JsonApiUserGroupOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiUserGroupOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserGroupOutList
+     */
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutRelationships
+ */
+export interface JsonApiUserGroupOutRelationships {
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiUserGroupOutRelationships
+     */
+    userGroup?: JsonApiOrganizationOutRelationshipsUser;
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiUserGroupOutRelationships
+     */
+    acls?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserGroupOutWithLinks
+ */
+export interface JsonApiUserGroupOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {object}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    attributes?: object;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserGroupOutWithLinks
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiUserGroupOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of user entity.
  * @export
- * @interface JsonApiUser
+ * @interface JsonApiUserIn
  */
-export interface JsonApiUser {
+export interface JsonApiUserIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiUser
+     * @memberof JsonApiUserIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiUser
+     * @memberof JsonApiUserIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiUserAttributes}
-     * @memberof JsonApiUser
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserIn
      */
-    attributes?: JsonApiUserAttributes;
+    attributes?: JsonApiUserOutAttributes;
     /**
      *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUser
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserIn
      */
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
 }
 /**
  *
  * @export
- * @interface JsonApiUserAttributes
+ * @interface JsonApiUserInDocument
  */
-export interface JsonApiUserAttributes {
+export interface JsonApiUserInDocument {
+    /**
+     *
+     * @type {JsonApiUserIn}
+     * @memberof JsonApiUserInDocument
+     */
+    data: JsonApiUserIn;
+}
+/**
+ * JSON:API representation of user entity.
+ * @export
+ * @interface JsonApiUserOut
+ */
+export interface JsonApiUserOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiUserOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiUserOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserOut
+     */
+    attributes?: JsonApiUserOutAttributes;
+    /**
+     *
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserOut
+     */
+    relationships?: JsonApiUserGroupOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiUserOutAttributes
+ */
+export interface JsonApiUserOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiUserAttributes
+     * @memberof JsonApiUserOutAttributes
      */
     authenticationId?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiUserDocument
+ * @interface JsonApiUserOutDocument
  */
-export interface JsonApiUserDocument {
+export interface JsonApiUserOutDocument {
     /**
      *
-     * @type {JsonApiUser}
-     * @memberof JsonApiUserDocument
+     * @type {JsonApiUserOut}
+     * @memberof JsonApiUserOutDocument
      */
-    data: JsonApiUser;
+    data: JsonApiUserOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiUserDocument
+     * @memberof JsonApiUserOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserDocument
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserOutDocument
      */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-}
-/**
- * JSON:API representation of userGroup entity.
- * @export
- * @interface JsonApiUserGroup
- */
-export interface JsonApiUserGroup {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiUserGroup
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiUserGroup
-     */
-    type: string;
-    /**
-     *
-     * @type {object}
-     * @memberof JsonApiUserGroup
-     */
-    attributes?: object;
-    /**
-     *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserGroup
-     */
-    relationships?: JsonApiUserGroupRelationships;
-}
-/**
- *
- * @export
- * @interface JsonApiUserGroupDocument
- */
-export interface JsonApiUserGroupDocument {
-    /**
-     *
-     * @type {JsonApiUserGroup}
-     * @memberof JsonApiUserGroupDocument
-     */
-    data: JsonApiUserGroup;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiUserGroupDocument
-     */
-    links?: ObjectLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserGroupDocument
-     */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiUserGroupList
+ * @interface JsonApiUserOutList
  */
-export interface JsonApiUserGroupList {
+export interface JsonApiUserOutList {
     /**
      *
-     * @type {Array<JsonApiUserGroupWithLinks>}
-     * @memberof JsonApiUserGroupList
+     * @type {Array<JsonApiUserOutWithLinks>}
+     * @memberof JsonApiUserOutList
      */
-    data: Array<JsonApiUserGroupWithLinks>;
+    data: Array<JsonApiUserOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiUserGroupList
+     * @memberof JsonApiUserOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserGroupList
+     * @type {Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>}
+     * @memberof JsonApiUserOutList
      */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
+    included?: Array<JsonApiUserGroupOutWithLinks | JsonApiACLOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiUserGroupRelationships
+ * @interface JsonApiUserOutWithLinks
  */
-export interface JsonApiUserGroupRelationships {
-    /**
-     *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiUserGroupRelationships
-     */
-    userGroup?: JsonApiOrganizationRelationshipsUser;
-    /**
-     *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiUserGroupRelationships
-     */
-    acls?: JsonApiACLRelationshipsUsers;
-}
-/**
- *
- * @export
- * @interface JsonApiUserGroupWithLinks
- */
-export interface JsonApiUserGroupWithLinks {
+export interface JsonApiUserOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiUserGroupWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiUserGroupWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {object}
-     * @memberof JsonApiUserGroupWithLinks
+     * @type {JsonApiUserOutAttributes}
+     * @memberof JsonApiUserOutWithLinks
      */
-    attributes?: object;
+    attributes?: JsonApiUserOutAttributes;
     /**
      *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserGroupWithLinks
+     * @type {JsonApiUserGroupOutRelationships}
+     * @memberof JsonApiUserOutWithLinks
      */
-    relationships?: JsonApiUserGroupRelationships;
-    /**
-     *
-     * @type {ObjectLinks}
-     * @memberof JsonApiUserGroupWithLinks
-     */
-    links?: ObjectLinks;
-}
-/**
- * A JSON:API document with a list of resources
- * @export
- * @interface JsonApiUserList
- */
-export interface JsonApiUserList {
-    /**
-     *
-     * @type {Array<JsonApiUserWithLinks>}
-     * @memberof JsonApiUserList
-     */
-    data: Array<JsonApiUserWithLinks>;
-    /**
-     *
-     * @type {ListLinks}
-     * @memberof JsonApiUserList
-     */
-    links?: ListLinks;
-    /**
-     * Included resources
-     * @type {Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>}
-     * @memberof JsonApiUserList
-     */
-    included?: Array<JsonApiUserGroupWithLinks | JsonApiACLWithLinks>;
-}
-/**
- *
- * @export
- * @interface JsonApiUserWithLinks
- */
-export interface JsonApiUserWithLinks {
-    /**
-     * API identifier of an object
-     * @type {string}
-     * @memberof JsonApiUserWithLinks
-     */
-    id: string;
-    /**
-     * Object type
-     * @type {string}
-     * @memberof JsonApiUserWithLinks
-     */
-    type: string;
-    /**
-     *
-     * @type {JsonApiUserAttributes}
-     * @memberof JsonApiUserWithLinks
-     */
-    attributes?: JsonApiUserAttributes;
-    /**
-     *
-     * @type {JsonApiUserGroupRelationships}
-     * @memberof JsonApiUserWithLinks
-     */
-    relationships?: JsonApiUserGroupRelationships;
+    relationships?: JsonApiUserGroupOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiUserWithLinks
+     * @memberof JsonApiUserOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of visualizationObject entity.
  * @export
- * @interface JsonApiVisualizationObject
+ * @interface JsonApiVisualizationObjectIn
  */
-export interface JsonApiVisualizationObject {
+export interface JsonApiVisualizationObjectIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiVisualizationObject
+     * @memberof JsonApiVisualizationObjectIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiVisualizationObject
+     * @memberof JsonApiVisualizationObjectIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiVisualizationObject
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiVisualizationObjectIn
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
-    /**
-     *
-     * @type {JsonApiVisualizationObjectRelationships}
-     * @memberof JsonApiVisualizationObject
-     */
-    relationships?: JsonApiVisualizationObjectRelationships;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectDocument
+ * @interface JsonApiVisualizationObjectInDocument
  */
-export interface JsonApiVisualizationObjectDocument {
+export interface JsonApiVisualizationObjectInDocument {
     /**
      *
-     * @type {JsonApiVisualizationObject}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @type {JsonApiVisualizationObjectIn}
+     * @memberof JsonApiVisualizationObjectInDocument
      */
-    data: JsonApiVisualizationObject;
+    data: JsonApiVisualizationObjectIn;
+}
+/**
+ * JSON:API representation of visualizationObject entity.
+ * @export
+ * @interface JsonApiVisualizationObjectOut
+ */
+export interface JsonApiVisualizationObjectOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
+    /**
+     *
+     * @type {JsonApiVisualizationObjectOutRelationships}
+     * @memberof JsonApiVisualizationObjectOut
+     */
+    relationships?: JsonApiVisualizationObjectOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiVisualizationObjectOutDocument
+ */
+export interface JsonApiVisualizationObjectOutDocument {
+    /**
+     *
+     * @type {JsonApiVisualizationObjectOut}
+     * @memberof JsonApiVisualizationObjectOutDocument
+     */
+    data: JsonApiVisualizationObjectOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @memberof JsonApiVisualizationObjectOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiVisualizationObjectDocument
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutDocument
      */
     included?: Array<
-        | JsonApiFactWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiAnalyticalDashboardWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiAnalyticalDashboardOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiVisualizationObjectList
+ * @interface JsonApiVisualizationObjectOutList
  */
-export interface JsonApiVisualizationObjectList {
+export interface JsonApiVisualizationObjectOutList {
     /**
      *
-     * @type {Array<JsonApiVisualizationObjectWithLinks>}
-     * @memberof JsonApiVisualizationObjectList
+     * @type {Array<JsonApiVisualizationObjectOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutList
      */
-    data: Array<JsonApiVisualizationObjectWithLinks>;
+    data: Array<JsonApiVisualizationObjectOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiVisualizationObjectList
+     * @memberof JsonApiVisualizationObjectOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiFactWithLinks | JsonApiAttributeWithLinks | JsonApiLabelWithLinks | JsonApiMetricWithLinks | JsonApiAnalyticalDashboardWithLinks | JsonApiDatasetWithLinks>}
-     * @memberof JsonApiVisualizationObjectList
+     * @type {Array<JsonApiFactOutWithLinks | JsonApiAttributeOutWithLinks | JsonApiLabelOutWithLinks | JsonApiMetricOutWithLinks | JsonApiAnalyticalDashboardOutWithLinks | JsonApiDatasetOutWithLinks>}
+     * @memberof JsonApiVisualizationObjectOutList
      */
     included?: Array<
-        | JsonApiFactWithLinks
-        | JsonApiAttributeWithLinks
-        | JsonApiLabelWithLinks
-        | JsonApiMetricWithLinks
-        | JsonApiAnalyticalDashboardWithLinks
-        | JsonApiDatasetWithLinks
+        | JsonApiFactOutWithLinks
+        | JsonApiAttributeOutWithLinks
+        | JsonApiLabelOutWithLinks
+        | JsonApiMetricOutWithLinks
+        | JsonApiAnalyticalDashboardOutWithLinks
+        | JsonApiDatasetOutWithLinks
     >;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectRelationships
+ * @interface JsonApiVisualizationObjectOutRelationships
  */
-export interface JsonApiVisualizationObjectRelationships {
+export interface JsonApiVisualizationObjectOutRelationships {
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    facts?: JsonApiACLRelationshipsUsers;
+    facts?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    attributes?: JsonApiACLRelationshipsUsers;
+    attributes?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    labels?: JsonApiACLRelationshipsUsers;
+    labels?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    metrics?: JsonApiACLRelationshipsUsers;
+    metrics?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    analyticalDashboards?: JsonApiACLRelationshipsUsers;
+    analyticalDashboards?: JsonApiACLOutRelationshipsUsers;
     /**
      *
-     * @type {JsonApiACLRelationshipsUsers}
-     * @memberof JsonApiVisualizationObjectRelationships
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiVisualizationObjectOutRelationships
      */
-    datasets?: JsonApiACLRelationshipsUsers;
+    datasets?: JsonApiACLOutRelationshipsUsers;
 }
 /**
  *
  * @export
- * @interface JsonApiVisualizationObjectWithLinks
+ * @interface JsonApiVisualizationObjectOutWithLinks
  */
-export interface JsonApiVisualizationObjectWithLinks {
+export interface JsonApiVisualizationObjectOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiAnalyticalDashboardAttributes}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @type {JsonApiAnalyticalDashboardInAttributes}
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
-    attributes?: JsonApiAnalyticalDashboardAttributes;
+    attributes?: JsonApiAnalyticalDashboardInAttributes;
     /**
      *
-     * @type {JsonApiVisualizationObjectRelationships}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @type {JsonApiVisualizationObjectOutRelationships}
+     * @memberof JsonApiVisualizationObjectOutWithLinks
      */
-    relationships?: JsonApiVisualizationObjectRelationships;
+    relationships?: JsonApiVisualizationObjectOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiVisualizationObjectWithLinks
+     * @memberof JsonApiVisualizationObjectOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of workspaceDataFilter entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterIn
+ */
+export interface JsonApiWorkspaceDataFilterIn {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInAttributes}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInRelationships}
+     * @memberof JsonApiWorkspaceDataFilterIn
+     */
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterInAttributes
+ */
+export interface JsonApiWorkspaceDataFilterInAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterInAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterInAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterInAttributes
+     */
+    columnName?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterInAttributes
+     */
+    dataSourceName?: string;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterInDocument
+ */
+export interface JsonApiWorkspaceDataFilterInDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterIn}
+     * @memberof JsonApiWorkspaceDataFilterInDocument
+     */
+    data: JsonApiWorkspaceDataFilterIn;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterInRelationships
+ */
+export interface JsonApiWorkspaceDataFilterInRelationships {
+    /**
+     *
+     * @type {JsonApiACLOutRelationshipsUsers}
+     * @memberof JsonApiWorkspaceDataFilterInRelationships
+     */
+    workspaceDataFilterSettings?: JsonApiACLOutRelationshipsUsers;
+}
+/**
+ * JSON:API representation of workspaceDataFilter entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOut
+ */
+export interface JsonApiWorkspaceDataFilterOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInAttributes}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInRelationships}
+     * @memberof JsonApiWorkspaceDataFilterOut
+     */
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutDocument
+ */
+export interface JsonApiWorkspaceDataFilterOutDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterOut}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    data: JsonApiWorkspaceDataFilterOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutDocument
+     */
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutList
+ */
+export interface JsonApiWorkspaceDataFilterOutList {
+    /**
+     *
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    data: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterOutList
+     */
+    included?: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterOutWithLinks
+ */
+export interface JsonApiWorkspaceDataFilterOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInAttributes}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    attributes?: JsonApiWorkspaceDataFilterInAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterInRelationships}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    relationships?: JsonApiWorkspaceDataFilterInRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterOutWithLinks
+     */
+    links?: ObjectLinks;
+}
+/**
+ * JSON:API representation of workspaceDataFilterSetting entity.
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOut
+ */
+export interface JsonApiWorkspaceDataFilterSettingOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterSettingOut
+     */
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutAttributes
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutAttributes {
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    title?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    description?: string;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutAttributes
+     */
+    filterValues?: Array<string>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutDocument
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOut}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    data: JsonApiWorkspaceDataFilterSettingOut;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    links?: ObjectLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutDocument
+     */
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+}
+/**
+ * A JSON:API document with a list of resources
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutList
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutList {
+    /**
+     *
+     * @type {Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    data: Array<JsonApiWorkspaceDataFilterSettingOutWithLinks>;
+    /**
+     *
+     * @type {ListLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    links?: ListLinks;
+    /**
+     * Included resources
+     * @type {Array<JsonApiWorkspaceDataFilterOutWithLinks>}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutList
+     */
+    included?: Array<JsonApiWorkspaceDataFilterOutWithLinks>;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutRelationships
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutRelationships {
+    /**
+     *
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutRelationships
+     */
+    workspaceDataFilter?: JsonApiOrganizationOutRelationshipsUser;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceDataFilterSettingOutWithLinks
+ */
+export interface JsonApiWorkspaceDataFilterSettingOutWithLinks {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutAttributes}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    attributes?: JsonApiWorkspaceDataFilterSettingOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceDataFilterSettingOutRelationships}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
+     */
+    relationships?: JsonApiWorkspaceDataFilterSettingOutRelationships;
+    /**
+     *
+     * @type {ObjectLinks}
+     * @memberof JsonApiWorkspaceDataFilterSettingOutWithLinks
      */
     links?: ObjectLinks;
 }
 /**
  * JSON:API representation of workspace entity.
  * @export
- * @interface JsonApiWorkspace
+ * @interface JsonApiWorkspaceIn
  */
-export interface JsonApiWorkspace {
+export interface JsonApiWorkspaceIn {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiWorkspace
+     * @memberof JsonApiWorkspaceIn
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiWorkspace
+     * @memberof JsonApiWorkspaceIn
      */
     type: string;
     /**
      *
-     * @type {JsonApiWorkspaceAttributes}
-     * @memberof JsonApiWorkspace
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceIn
      */
-    attributes?: JsonApiWorkspaceAttributes;
-    /**
-     *
-     * @type {JsonApiWorkspaceRelationships}
-     * @memberof JsonApiWorkspace
-     */
-    relationships?: JsonApiWorkspaceRelationships;
+    attributes?: JsonApiWorkspaceOutAttributes;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceAttributes
+ * @interface JsonApiWorkspaceInDocument
  */
-export interface JsonApiWorkspaceAttributes {
+export interface JsonApiWorkspaceInDocument {
+    /**
+     *
+     * @type {JsonApiWorkspaceIn}
+     * @memberof JsonApiWorkspaceInDocument
+     */
+    data: JsonApiWorkspaceIn;
+}
+/**
+ * JSON:API representation of workspace entity.
+ * @export
+ * @interface JsonApiWorkspaceOut
+ */
+export interface JsonApiWorkspaceOut {
+    /**
+     * API identifier of an object
+     * @type {string}
+     * @memberof JsonApiWorkspaceOut
+     */
+    id: string;
+    /**
+     * Object type
+     * @type {string}
+     * @memberof JsonApiWorkspaceOut
+     */
+    type: string;
+    /**
+     *
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceOut
+     */
+    attributes?: JsonApiWorkspaceOutAttributes;
+    /**
+     *
+     * @type {JsonApiWorkspaceOutRelationships}
+     * @memberof JsonApiWorkspaceOut
+     */
+    relationships?: JsonApiWorkspaceOutRelationships;
+}
+/**
+ *
+ * @export
+ * @interface JsonApiWorkspaceOutAttributes
+ */
+export interface JsonApiWorkspaceOutAttributes {
     /**
      *
      * @type {string}
-     * @memberof JsonApiWorkspaceAttributes
+     * @memberof JsonApiWorkspaceOutAttributes
      */
     name?: string;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceDocument
+ * @interface JsonApiWorkspaceOutDocument
  */
-export interface JsonApiWorkspaceDocument {
+export interface JsonApiWorkspaceOutDocument {
     /**
      *
-     * @type {JsonApiWorkspace}
-     * @memberof JsonApiWorkspaceDocument
+     * @type {JsonApiWorkspaceOut}
+     * @memberof JsonApiWorkspaceOutDocument
      */
-    data: JsonApiWorkspace;
+    data: JsonApiWorkspaceOut;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiWorkspaceDocument
+     * @memberof JsonApiWorkspaceOutDocument
      */
     links?: ObjectLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceDocument
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutDocument
      */
-    included?: Array<JsonApiWorkspaceWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
 }
 /**
  * A JSON:API document with a list of resources
  * @export
- * @interface JsonApiWorkspaceList
+ * @interface JsonApiWorkspaceOutList
  */
-export interface JsonApiWorkspaceList {
+export interface JsonApiWorkspaceOutList {
     /**
      *
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceList
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutList
      */
-    data: Array<JsonApiWorkspaceWithLinks>;
+    data: Array<JsonApiWorkspaceOutWithLinks>;
     /**
      *
      * @type {ListLinks}
-     * @memberof JsonApiWorkspaceList
+     * @memberof JsonApiWorkspaceOutList
      */
     links?: ListLinks;
     /**
      * Included resources
-     * @type {Array<JsonApiWorkspaceWithLinks>}
-     * @memberof JsonApiWorkspaceList
+     * @type {Array<JsonApiWorkspaceOutWithLinks>}
+     * @memberof JsonApiWorkspaceOutList
      */
-    included?: Array<JsonApiWorkspaceWithLinks>;
+    included?: Array<JsonApiWorkspaceOutWithLinks>;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceRelationships
+ * @interface JsonApiWorkspaceOutRelationships
  */
-export interface JsonApiWorkspaceRelationships {
+export interface JsonApiWorkspaceOutRelationships {
     /**
      *
-     * @type {JsonApiOrganizationRelationshipsUser}
-     * @memberof JsonApiWorkspaceRelationships
+     * @type {JsonApiOrganizationOutRelationshipsUser}
+     * @memberof JsonApiWorkspaceOutRelationships
      */
-    workspace?: JsonApiOrganizationRelationshipsUser;
+    workspace?: JsonApiOrganizationOutRelationshipsUser;
 }
 /**
  *
  * @export
- * @interface JsonApiWorkspaceWithLinks
+ * @interface JsonApiWorkspaceOutWithLinks
  */
-export interface JsonApiWorkspaceWithLinks {
+export interface JsonApiWorkspaceOutWithLinks {
     /**
      * API identifier of an object
      * @type {string}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     id: string;
     /**
      * Object type
      * @type {string}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     type: string;
     /**
      *
-     * @type {JsonApiWorkspaceAttributes}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @type {JsonApiWorkspaceOutAttributes}
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
-    attributes?: JsonApiWorkspaceAttributes;
+    attributes?: JsonApiWorkspaceOutAttributes;
     /**
      *
-     * @type {JsonApiWorkspaceRelationships}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @type {JsonApiWorkspaceOutRelationships}
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
-    relationships?: JsonApiWorkspaceRelationships;
+    relationships?: JsonApiWorkspaceOutRelationships;
     /**
      *
      * @type {ObjectLinks}
-     * @memberof JsonApiWorkspaceWithLinks
+     * @memberof JsonApiWorkspaceOutWithLinks
      */
     links?: ObjectLinks;
 }
@@ -3967,7 +4842,7 @@ export enum ReferenceIdentifierTypeEnum {
 }
 
 /**
- *
+ * Store filter into this workspace. Empty if it is part of layout of workspaces.
  * @export
  * @interface WorkspaceIdentifier
  */
@@ -4117,6 +4992,34 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(params: {}, options: any = {}): RequestArgs {
+            const {} = params;
+            const localVarPath = `/api/layout/workspaceDataFilters`;
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4161,8 +5064,8 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4400,6 +5303,57 @@ export const DeclarativeLayoutControllerApiAxiosParamCreator = function (configu
             };
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { declarativeWorkspaceDataFilters } = params;
+            // verify required parameter 'declarativeWorkspaceDataFilters' is not null or undefined
+            if (declarativeWorkspaceDataFilters === null || declarativeWorkspaceDataFilters === undefined) {
+                throw new RequiredError(
+                    "declarativeWorkspaceDataFilters",
+                    "Required parameter declarativeWorkspaceDataFilters was null or undefined when calling setWorkspaceDataFiltersLayout.",
+                );
+            }
+            const localVarPath = `/api/layout/workspaceDataFilters`;
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof declarativeWorkspaceDataFilters !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      declarativeWorkspaceDataFilters !== undefined ? declarativeWorkspaceDataFilters : {},
+                  )
+                : declarativeWorkspaceDataFilters || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4527,6 +5481,27 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(
+            params: {},
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<DeclarativeWorkspaceDataFilters> {
+            const localVarAxiosArgs = DeclarativeLayoutControllerApiAxiosParamCreator(
+                configuration,
+            ).getWorkspaceDataFiltersLayout(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4551,8 +5526,8 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4671,6 +5646,30 @@ export const DeclarativeLayoutControllerApiFp = function (configuration?: Config
             };
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
+            const localVarAxiosArgs = DeclarativeLayoutControllerApiAxiosParamCreator(
+                configuration,
+            ).setWorkspaceDataFiltersLayout(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4756,6 +5755,21 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
+         * Retrieve all workspaces and related workspace data filters (and their settings / values).
+         * @summary Get workspace data filters for all workspaces
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getWorkspaceDataFiltersLayout(
+            params: {},
+            options?: any,
+        ): AxiosPromise<DeclarativeWorkspaceDataFilters> {
+            return DeclarativeLayoutControllerApiFp(configuration).getWorkspaceDataFiltersLayout(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
          * Retrieve current model of the workspace in declarative form.
          * @summary Get workspace layout
          * @param {string} workspaceId
@@ -4774,8 +5788,8 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
-         * Retrieve layout of workspaces, including a hierarchy and models.
-         * @summary Get all workspaces layout
+         * Sets complete layout of workspaces, their hierarchy, models.
+         * @summary Set all workspaces layout
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -4858,6 +5872,24 @@ export const DeclarativeLayoutControllerApiFactory = function (
             );
         },
         /**
+         * Sets workspace data filters in all workspaces in entire organization.
+         * @summary Set all workspace data filters
+         * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        setWorkspaceDataFiltersLayout(
+            params: {
+                declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+            },
+            options?: any,
+        ): AxiosPromise<void> {
+            return DeclarativeLayoutControllerApiFp(configuration).setWorkspaceDataFiltersLayout(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
          * Sets complete layout of workspaces, their hierarchy, models.
          * @summary Set all workspaces layout
          * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -4924,6 +5956,15 @@ export interface DeclarativeLayoutControllerApiInterface {
     getOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
 
     /**
+     * Retrieve all workspaces and related workspace data filters (and their settings / values).
+     * @summary Get workspace data filters for all workspaces
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApiInterface
+     */
+    getWorkspaceDataFiltersLayout(params: {}, options?: any): AxiosPromise<DeclarativeWorkspaceDataFilters>;
+
+    /**
      * Retrieve current model of the workspace in declarative form.
      * @summary Get workspace layout
      * @param {string} workspaceId
@@ -4939,8 +5980,8 @@ export interface DeclarativeLayoutControllerApiInterface {
     ): AxiosPromise<DeclarativeWorkspaceModel>;
 
     /**
-     * Retrieve layout of workspaces, including a hierarchy and models.
-     * @summary Get all workspaces layout
+     * Sets complete layout of workspaces, their hierarchy, models.
+     * @summary Set all workspaces layout
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DeclarativeLayoutControllerApiInterface
@@ -5006,6 +6047,21 @@ export interface DeclarativeLayoutControllerApiInterface {
      * @memberof DeclarativeLayoutControllerApiInterface
      */
     setOrganizationLayout(params: {}, options?: any): AxiosPromise<void>;
+
+    /**
+     * Sets workspace data filters in all workspaces in entire organization.
+     * @summary Set all workspace data filters
+     * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApiInterface
+     */
+    setWorkspaceDataFiltersLayout(
+        params: {
+            declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+        },
+        options?: any,
+    ): AxiosPromise<void>;
 
     /**
      * Sets complete layout of workspaces, their hierarchy, models.
@@ -5086,6 +6142,20 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
+     * Retrieve all workspaces and related workspace data filters (and their settings / values).
+     * @summary Get workspace data filters for all workspaces
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApi
+     */
+    public getWorkspaceDataFiltersLayout(params: {}, options?: any) {
+        return DeclarativeLayoutControllerApiFp(this.configuration).getWorkspaceDataFiltersLayout(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
      * Retrieve current model of the workspace in declarative form.
      * @summary Get workspace layout
      * @param {string} workspaceId
@@ -5106,8 +6176,8 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
-     * Retrieve layout of workspaces, including a hierarchy and models.
-     * @summary Get all workspaces layout
+     * Sets complete layout of workspaces, their hierarchy, models.
+     * @summary Set all workspaces layout
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof DeclarativeLayoutControllerApi
@@ -5200,6 +6270,26 @@ export class DeclarativeLayoutControllerApi extends BaseAPI
     }
 
     /**
+     * Sets workspace data filters in all workspaces in entire organization.
+     * @summary Set all workspace data filters
+     * @param {DeclarativeWorkspaceDataFilters} declarativeWorkspaceDataFilters
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof DeclarativeLayoutControllerApi
+     */
+    public setWorkspaceDataFiltersLayout(
+        params: {
+            declarativeWorkspaceDataFilters: DeclarativeWorkspaceDataFilters;
+        },
+        options?: any,
+    ) {
+        return DeclarativeLayoutControllerApiFp(this.configuration).setWorkspaceDataFiltersLayout(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
      * Sets complete layout of workspaces, their hierarchy, models.
      * @summary Set all workspaces layout
      * @param {DeclarativeWorkspaces} declarativeWorkspaces
@@ -5245,6 +6335,50 @@ export const NotificationControllerApiAxiosParamCreator = function (configuratio
                 throw new RequiredError(
                     "dataSourceId",
                     "Required parameter dataSourceId was null or undefined when calling registerUploadNotification.",
+                );
+            }
+            const localVarPath = `/api/actions/dataSources/{dataSourceId}/uploadNotification`.replace(
+                `{${"dataSourceId"}}`,
+                encodeURIComponent(String(dataSourceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * Notification sets up all reports to be computed again with new data.
+         * @summary Register an upload notification
+         * @param {string} dataSourceId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        registerUploadNotification1(
+            params: {
+                dataSourceId: string;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { dataSourceId } = params;
+            // verify required parameter 'dataSourceId' is not null or undefined
+            if (dataSourceId === null || dataSourceId === undefined) {
+                throw new RequiredError(
+                    "dataSourceId",
+                    "Required parameter dataSourceId was null or undefined when calling registerUploadNotification1.",
                 );
             }
             const localVarPath = `/api/dataSources/{dataSourceId}/uploadNotification`.replace(
@@ -5303,6 +6437,30 @@ export const NotificationControllerApiFp = function (configuration?: Configurati
                 return axios.request(axiosRequestArgs);
             };
         },
+        /**
+         * Notification sets up all reports to be computed again with new data.
+         * @summary Register an upload notification
+         * @param {string} dataSourceId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        registerUploadNotification1(
+            params: {
+                dataSourceId: string;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
+            const localVarAxiosArgs = NotificationControllerApiAxiosParamCreator(
+                configuration,
+            ).registerUploadNotification1(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
     };
 };
 
@@ -5334,6 +6492,24 @@ export const NotificationControllerApiFactory = function (
                 basePath,
             );
         },
+        /**
+         * Notification sets up all reports to be computed again with new data.
+         * @summary Register an upload notification
+         * @param {string} dataSourceId
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        registerUploadNotification1(
+            params: {
+                dataSourceId: string;
+            },
+            options?: any,
+        ): AxiosPromise<void> {
+            return NotificationControllerApiFp(configuration).registerUploadNotification1(params, options)(
+                axios,
+                basePath,
+            );
+        },
     };
 };
 
@@ -5352,6 +6528,21 @@ export interface NotificationControllerApiInterface {
      * @memberof NotificationControllerApiInterface
      */
     registerUploadNotification(
+        params: {
+            dataSourceId: string;
+        },
+        options?: any,
+    ): AxiosPromise<void>;
+
+    /**
+     * Notification sets up all reports to be computed again with new data.
+     * @summary Register an upload notification
+     * @param {string} dataSourceId
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof NotificationControllerApiInterface
+     */
+    registerUploadNotification1(
         params: {
             dataSourceId: string;
         },
@@ -5381,6 +6572,26 @@ export class NotificationControllerApi extends BaseAPI implements NotificationCo
         options?: any,
     ) {
         return NotificationControllerApiFp(this.configuration).registerUploadNotification(params, options)(
+            this.axios,
+            this.basePath,
+        );
+    }
+
+    /**
+     * Notification sets up all reports to be computed again with new data.
+     * @summary Register an upload notification
+     * @param {string} dataSourceId
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof NotificationControllerApi
+     */
+    public registerUploadNotification1(
+        params: {
+            dataSourceId: string;
+        },
+        options?: any,
+    ) {
+        return NotificationControllerApiFp(this.configuration).registerUploadNotification1(params, options)(
             this.axios,
             this.basePath,
         );
@@ -6076,7 +7287,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6085,13 +7296,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityAcls1(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiACLDocument, variableParam, include } = params;
+            const { id, jsonApiACLInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6099,11 +7310,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityAcls1.",
                 );
             }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling updateEntityAcls1.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling updateEntityAcls1.",
                 );
             }
             const localVarPath = `/api/entities/admin/acls/{id}`.replace(
@@ -6142,11 +7353,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6156,7 +7367,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6165,13 +7376,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiDataSourceDocument, variableParam, include } = params;
+            const { id, jsonApiDataSourceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6179,11 +7390,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityDataSources.",
                 );
             }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling updateEntityDataSources.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling updateEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/admin/dataSources/{id}`.replace(
@@ -6222,11 +7433,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6236,7 +7447,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6245,13 +7456,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiModelModuleDocument, variableParam, include } = params;
+            const { id, jsonApiModelModuleInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6259,11 +7470,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityModelModules.",
                 );
             }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling updateEntityModelModules.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling updateEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/admin/modelModules/{id}`.replace(
@@ -6302,11 +7513,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6316,7 +7529,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6325,13 +7538,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiOrganizationDocument, variableParam, include } = params;
+            const { id, jsonApiOrganizationInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6339,11 +7552,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityOrganizations.",
                 );
             }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling updateEntityOrganizations.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling updateEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/admin/organizations/{id}`.replace(
@@ -6382,11 +7595,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6396,7 +7611,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6405,13 +7620,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserGroupDocument, variableParam, include } = params;
+            const { id, jsonApiUserGroupInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6419,11 +7634,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityUserGroups.",
                 );
             }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling updateEntityUserGroups.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling updateEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/admin/userGroups/{id}`.replace(
@@ -6462,11 +7677,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6476,7 +7691,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6485,13 +7700,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityUsers(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserDocument, variableParam, include } = params;
+            const { id, jsonApiUserInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6499,11 +7714,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityUsers.",
                 );
             }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling updateEntityUsers.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling updateEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/admin/users/{id}`.replace(
@@ -6542,11 +7757,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6556,7 +7771,7 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6565,13 +7780,13 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
         updateEntityWorkspaces(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiWorkspaceDocument, variableParam, include } = params;
+            const { id, jsonApiWorkspaceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -6579,11 +7794,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
                     "Required parameter id was null or undefined when calling updateEntityWorkspaces.",
                 );
             }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling updateEntityWorkspaces.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling updateEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/admin/workspaces/{id}`.replace(
@@ -6622,11 +7837,11 @@ export const OrganizationControllerApiAxiosParamCreator = function (configuratio
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -6657,7 +7872,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAcls1(params, options);
@@ -6684,7 +7899,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityDataSources(params, options);
@@ -6711,7 +7926,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityModelModules(params, options);
@@ -6738,7 +7953,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityOrganizations(params, options);
@@ -6765,7 +7980,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityUserGroups(params, options);
@@ -6792,7 +8007,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityUsers(params, options);
@@ -6819,7 +8034,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityWorkspaces(params, options);
@@ -6843,13 +8058,13 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
             axios?: AxiosInstance,
             basePath?: string,
         ) => AxiosPromise<
-            | JsonApiDataSourceDocument
-            | JsonApiACLDocument
-            | JsonApiModelModuleDocument
-            | JsonApiOrganizationDocument
-            | JsonApiUserGroupDocument
-            | JsonApiUserDocument
-            | JsonApiWorkspaceDocument
+            | JsonApiDataSourceOutDocument
+            | JsonApiACLOutDocument
+            | JsonApiModelModuleOutDocument
+            | JsonApiOrganizationOutDocument
+            | JsonApiUserGroupOutDocument
+            | JsonApiUserOutDocument
+            | JsonApiWorkspaceOutDocument
         > {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
@@ -6865,7 +8080,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6874,12 +8089,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityAcls1(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityAcls1(params, options);
@@ -6894,7 +8109,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6903,12 +8118,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityDataSources(params, options);
@@ -6923,7 +8138,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6932,12 +8147,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityModelModules(params, options);
@@ -6952,7 +8167,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6961,12 +8176,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityOrganizations(params, options);
@@ -6981,7 +8196,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -6990,12 +8205,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityUserGroups(params, options);
@@ -7010,7 +8225,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7019,12 +8234,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityUsers(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityUsers(params, options);
@@ -7039,7 +8254,7 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7048,12 +8263,12 @@ export const OrganizationControllerApiFp = function (configuration?: Configurati
         updateEntityWorkspaces(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityWorkspaces(params, options);
@@ -7093,7 +8308,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityAcls1(params, options)(
                 axios,
                 basePath,
@@ -7114,7 +8329,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityDataSources(params, options)(
                 axios,
                 basePath,
@@ -7135,7 +8350,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityModelModules(params, options)(
                 axios,
                 basePath,
@@ -7156,7 +8371,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityOrganizations(params, options)(
                 axios,
                 basePath,
@@ -7177,7 +8392,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityUserGroups(params, options)(
                 axios,
                 basePath,
@@ -7198,7 +8413,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -7219,7 +8434,7 @@ export const OrganizationControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationControllerApiFp(configuration).getEntityWorkspaces(params, options)(
                 axios,
                 basePath,
@@ -7234,13 +8449,13 @@ export const OrganizationControllerApiFactory = function (
             params: {},
             options?: any,
         ): AxiosPromise<
-            | JsonApiDataSourceDocument
-            | JsonApiACLDocument
-            | JsonApiModelModuleDocument
-            | JsonApiOrganizationDocument
-            | JsonApiUserGroupDocument
-            | JsonApiUserDocument
-            | JsonApiWorkspaceDocument
+            | JsonApiDataSourceOutDocument
+            | JsonApiACLOutDocument
+            | JsonApiModelModuleOutDocument
+            | JsonApiOrganizationOutDocument
+            | JsonApiUserGroupOutDocument
+            | JsonApiUserOutDocument
+            | JsonApiWorkspaceOutDocument
         > {
             return OrganizationControllerApiFp(configuration).getOrganizationUsers11(params, options)(
                 axios,
@@ -7250,7 +8465,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7259,12 +8474,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityAcls1(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityAcls1(params, options)(
                 axios,
                 basePath,
@@ -7273,7 +8488,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7282,12 +8497,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityDataSources(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityDataSources(params, options)(
                 axios,
                 basePath,
@@ -7296,7 +8511,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7305,12 +8520,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityModelModules(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityModelModules(params, options)(
                 axios,
                 basePath,
@@ -7319,7 +8534,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7328,12 +8543,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityOrganizations(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityOrganizations(params, options)(
                 axios,
                 basePath,
@@ -7342,7 +8557,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7351,12 +8566,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityUserGroups(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityUserGroups(params, options)(
                 axios,
                 basePath,
@@ -7365,7 +8580,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7374,12 +8589,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityUsers(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -7388,7 +8603,7 @@ export const OrganizationControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -7397,12 +8612,12 @@ export const OrganizationControllerApiFactory = function (
         updateEntityWorkspaces(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationControllerApiFp(configuration).updateEntityWorkspaces(params, options)(
                 axios,
                 basePath,
@@ -7433,7 +8648,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
@@ -7451,7 +8666,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
@@ -7469,7 +8684,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
@@ -7487,7 +8702,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
@@ -7505,7 +8720,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
@@ -7523,7 +8738,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
@@ -7541,7 +8756,7 @@ export interface OrganizationControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
@@ -7553,19 +8768,19 @@ export interface OrganizationControllerApiInterface {
         params: {},
         options?: any,
     ): AxiosPromise<
-        | JsonApiDataSourceDocument
-        | JsonApiACLDocument
-        | JsonApiModelModuleDocument
-        | JsonApiOrganizationDocument
-        | JsonApiUserGroupDocument
-        | JsonApiUserDocument
-        | JsonApiWorkspaceDocument
+        | JsonApiDataSourceOutDocument
+        | JsonApiACLOutDocument
+        | JsonApiModelModuleOutDocument
+        | JsonApiOrganizationOutDocument
+        | JsonApiUserGroupOutDocument
+        | JsonApiUserOutDocument
+        | JsonApiWorkspaceOutDocument
     >;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7575,17 +8790,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityAcls1(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7595,17 +8810,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityDataSources(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7615,17 +8830,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityModelModules(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7635,17 +8850,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityOrganizations(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7655,17 +8870,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityUserGroups(
         params: {
             id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7675,17 +8890,17 @@ export interface OrganizationControllerApiInterface {
     updateEntityUsers(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7695,12 +8910,12 @@ export interface OrganizationControllerApiInterface {
     updateEntityWorkspaces(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 /**
@@ -7887,7 +9102,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7897,7 +9112,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityAcls1(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -7912,7 +9127,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7922,7 +9137,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityDataSources(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -7937,7 +9152,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7947,7 +9162,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityModelModules(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -7962,7 +9177,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7972,7 +9187,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityOrganizations(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -7987,7 +9202,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -7997,7 +9212,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityUserGroups(
         params: {
             id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -8012,7 +9227,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -8022,7 +9237,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityUsers(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -8037,7 +9252,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -8047,7 +9262,7 @@ export class OrganizationControllerApi extends BaseAPI implements OrganizationCo
     public updateEntityWorkspaces(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -8069,18 +9284,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiACLDocument } = params;
+            const { workspaceId, jsonApiACLInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8088,11 +9303,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityAcls.",
                 );
             }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling createChildEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createChildEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/acls`.replace(
@@ -8115,11 +9330,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8129,18 +9344,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiDataSourceDocument } = params;
+            const { workspaceId, jsonApiDataSourceInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8148,11 +9363,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityDataSources.",
                 );
             }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling createChildEntityDataSources.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createChildEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/dataSources`.replace(
@@ -8175,11 +9390,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8189,18 +9404,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiModelModuleDocument } = params;
+            const { workspaceId, jsonApiModelModuleInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8208,11 +9423,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityModelModules.",
                 );
             }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling createChildEntityModelModules.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createChildEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/modelModules`.replace(
@@ -8235,11 +9450,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8249,18 +9466,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiOrganizationDocument } = params;
+            const { workspaceId, jsonApiOrganizationInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8268,11 +9485,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityOrganizations.",
                 );
             }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling createChildEntityOrganizations.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createChildEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/organizations`.replace(
@@ -8295,11 +9512,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8309,18 +9528,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiUserGroupDocument } = params;
+            const { workspaceId, jsonApiUserGroupInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8328,11 +9547,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityUserGroups.",
                 );
             }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling createChildEntityUserGroups.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createChildEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/userGroups`.replace(
@@ -8355,11 +9574,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8369,18 +9588,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiUserDocument } = params;
+            const { workspaceId, jsonApiUserInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8388,11 +9607,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityUsers.",
                 );
             }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling createChildEntityUsers.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createChildEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/users`.replace(
@@ -8415,11 +9634,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8429,18 +9648,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiWorkspaceDocument } = params;
+            const { workspaceId, jsonApiWorkspaceInDocument } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -8448,11 +9667,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter workspaceId was null or undefined when calling createChildEntityWorkspaces.",
                 );
             }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling createChildEntityWorkspaces.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createChildEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/children/workspaces`.replace(
@@ -8475,11 +9694,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8488,7 +9707,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8496,18 +9715,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiACLDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            const { jsonApiACLInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling createEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/acls`;
@@ -8543,11 +9762,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8556,7 +9775,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8564,18 +9783,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiDataSourceDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            const { jsonApiDataSourceInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling createEntityDataSources.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createEntityDataSources.",
                 );
             }
             const localVarPath = `/api/entities/dataSources`;
@@ -8611,11 +9830,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8624,7 +9843,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8632,18 +9851,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiModelModuleDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            const { jsonApiModelModuleInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling createEntityModelModules.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createEntityModelModules.",
                 );
             }
             const localVarPath = `/api/entities/modelModules`;
@@ -8679,11 +9898,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8692,7 +9913,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8700,18 +9921,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiOrganizationDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            const { jsonApiOrganizationInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling createEntityOrganizations.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createEntityOrganizations.",
                 );
             }
             const localVarPath = `/api/entities/organizations`;
@@ -8747,11 +9968,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8760,7 +9983,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8768,18 +9991,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiUserGroupDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            const { jsonApiUserGroupInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling createEntityUserGroups.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createEntityUserGroups.",
                 );
             }
             const localVarPath = `/api/entities/userGroups`;
@@ -8815,11 +10038,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8828,7 +10051,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8836,18 +10059,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiUserDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            const { jsonApiUserInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling createEntityUsers.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createEntityUsers.",
                 );
             }
             const localVarPath = `/api/entities/users`;
@@ -8883,11 +10106,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -8896,7 +10119,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -8904,18 +10127,18 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { jsonApiWorkspaceDocument, variableParam, include } = params;
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            const { jsonApiWorkspaceInDocument, variableParam, include } = params;
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling createEntityWorkspaces.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createEntityWorkspaces.",
                 );
             }
             const localVarPath = `/api/entities/workspaces`;
@@ -8951,11 +10174,491 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiACLInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityAcls.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/acls`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiACLInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiDataSourceInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityDataSources.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/dataSources`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiDataSourceInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiModelModuleInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityModelModules.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/modelModules`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiModelModuleInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiOrganizationInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityOrganizations.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/organizations`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiOrganizationInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiUserGroupInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityUserGroups.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/userGroups`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiUserGroupInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiUserInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityUsers.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/users`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiUserInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, childWorkspaceId, jsonApiWorkspaceInDocument } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            // verify required parameter 'childWorkspaceId' is not null or undefined
+            if (childWorkspaceId === null || childWorkspaceId === undefined) {
+                throw new RequiredError(
+                    "childWorkspaceId",
+                    "Required parameter childWorkspaceId was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling createWorkspaceDataFilterSettingEntityWorkspaces.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/workspaces`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"childWorkspaceId"}}`, encodeURIComponent(String(childWorkspaceId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10316,7 +12019,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10325,13 +12028,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiACLDocument, variableParam, include } = params;
+            const { id, jsonApiACLInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10339,11 +12042,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityAcls.",
                 );
             }
-            // verify required parameter 'jsonApiACLDocument' is not null or undefined
-            if (jsonApiACLDocument === null || jsonApiACLDocument === undefined) {
+            // verify required parameter 'jsonApiACLInDocument' is not null or undefined
+            if (jsonApiACLInDocument === null || jsonApiACLInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiACLDocument",
-                    "Required parameter jsonApiACLDocument was null or undefined when calling updateEntityAcls.",
+                    "jsonApiACLInDocument",
+                    "Required parameter jsonApiACLInDocument was null or undefined when calling updateEntityAcls.",
                 );
             }
             const localVarPath = `/api/entities/acls/{id}`.replace(
@@ -10382,11 +12085,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiACLDocument !== "string" ||
+                typeof jsonApiACLInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiACLDocument !== undefined ? jsonApiACLDocument : {})
-                : jsonApiACLDocument || "";
+                ? JSON.stringify(jsonApiACLInDocument !== undefined ? jsonApiACLInDocument : {})
+                : jsonApiACLInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10396,7 +12099,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10405,13 +12108,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityDataSources1(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiDataSourceDocument, variableParam, include } = params;
+            const { id, jsonApiDataSourceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10419,11 +12122,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityDataSources1.",
                 );
             }
-            // verify required parameter 'jsonApiDataSourceDocument' is not null or undefined
-            if (jsonApiDataSourceDocument === null || jsonApiDataSourceDocument === undefined) {
+            // verify required parameter 'jsonApiDataSourceInDocument' is not null or undefined
+            if (jsonApiDataSourceInDocument === null || jsonApiDataSourceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiDataSourceDocument",
-                    "Required parameter jsonApiDataSourceDocument was null or undefined when calling updateEntityDataSources1.",
+                    "jsonApiDataSourceInDocument",
+                    "Required parameter jsonApiDataSourceInDocument was null or undefined when calling updateEntityDataSources1.",
                 );
             }
             const localVarPath = `/api/entities/dataSources/{id}`.replace(
@@ -10462,11 +12165,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiDataSourceDocument !== "string" ||
+                typeof jsonApiDataSourceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiDataSourceDocument !== undefined ? jsonApiDataSourceDocument : {})
-                : jsonApiDataSourceDocument || "";
+                ? JSON.stringify(jsonApiDataSourceInDocument !== undefined ? jsonApiDataSourceInDocument : {})
+                : jsonApiDataSourceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10476,7 +12179,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10485,13 +12188,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityModelModules1(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiModelModuleDocument, variableParam, include } = params;
+            const { id, jsonApiModelModuleInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10499,11 +12202,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityModelModules1.",
                 );
             }
-            // verify required parameter 'jsonApiModelModuleDocument' is not null or undefined
-            if (jsonApiModelModuleDocument === null || jsonApiModelModuleDocument === undefined) {
+            // verify required parameter 'jsonApiModelModuleInDocument' is not null or undefined
+            if (jsonApiModelModuleInDocument === null || jsonApiModelModuleInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiModelModuleDocument",
-                    "Required parameter jsonApiModelModuleDocument was null or undefined when calling updateEntityModelModules1.",
+                    "jsonApiModelModuleInDocument",
+                    "Required parameter jsonApiModelModuleInDocument was null or undefined when calling updateEntityModelModules1.",
                 );
             }
             const localVarPath = `/api/entities/modelModules/{id}`.replace(
@@ -10542,11 +12245,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiModelModuleDocument !== "string" ||
+                typeof jsonApiModelModuleInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiModelModuleDocument !== undefined ? jsonApiModelModuleDocument : {})
-                : jsonApiModelModuleDocument || "";
+                ? JSON.stringify(
+                      jsonApiModelModuleInDocument !== undefined ? jsonApiModelModuleInDocument : {},
+                  )
+                : jsonApiModelModuleInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10556,7 +12261,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10565,13 +12270,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityOrganizations1(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiOrganizationDocument, variableParam, include } = params;
+            const { id, jsonApiOrganizationInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10579,11 +12284,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityOrganizations1.",
                 );
             }
-            // verify required parameter 'jsonApiOrganizationDocument' is not null or undefined
-            if (jsonApiOrganizationDocument === null || jsonApiOrganizationDocument === undefined) {
+            // verify required parameter 'jsonApiOrganizationInDocument' is not null or undefined
+            if (jsonApiOrganizationInDocument === null || jsonApiOrganizationInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiOrganizationDocument",
-                    "Required parameter jsonApiOrganizationDocument was null or undefined when calling updateEntityOrganizations1.",
+                    "jsonApiOrganizationInDocument",
+                    "Required parameter jsonApiOrganizationInDocument was null or undefined when calling updateEntityOrganizations1.",
                 );
             }
             const localVarPath = `/api/entities/organizations/{id}`.replace(
@@ -10622,11 +12327,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiOrganizationDocument !== "string" ||
+                typeof jsonApiOrganizationInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiOrganizationDocument !== undefined ? jsonApiOrganizationDocument : {})
-                : jsonApiOrganizationDocument || "";
+                ? JSON.stringify(
+                      jsonApiOrganizationInDocument !== undefined ? jsonApiOrganizationInDocument : {},
+                  )
+                : jsonApiOrganizationInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10636,7 +12343,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10645,13 +12352,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityUserGroups1(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserGroupDocument, variableParam, include } = params;
+            const { id, jsonApiUserGroupInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10659,11 +12366,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityUserGroups1.",
                 );
             }
-            // verify required parameter 'jsonApiUserGroupDocument' is not null or undefined
-            if (jsonApiUserGroupDocument === null || jsonApiUserGroupDocument === undefined) {
+            // verify required parameter 'jsonApiUserGroupInDocument' is not null or undefined
+            if (jsonApiUserGroupInDocument === null || jsonApiUserGroupInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserGroupDocument",
-                    "Required parameter jsonApiUserGroupDocument was null or undefined when calling updateEntityUserGroups1.",
+                    "jsonApiUserGroupInDocument",
+                    "Required parameter jsonApiUserGroupInDocument was null or undefined when calling updateEntityUserGroups1.",
                 );
             }
             const localVarPath = `/api/entities/userGroups/{id}`.replace(
@@ -10702,11 +12409,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserGroupDocument !== "string" ||
+                typeof jsonApiUserGroupInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserGroupDocument !== undefined ? jsonApiUserGroupDocument : {})
-                : jsonApiUserGroupDocument || "";
+                ? JSON.stringify(jsonApiUserGroupInDocument !== undefined ? jsonApiUserGroupInDocument : {})
+                : jsonApiUserGroupInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10716,7 +12423,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10725,13 +12432,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityUsers1(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiUserDocument, variableParam, include } = params;
+            const { id, jsonApiUserInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10739,11 +12446,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityUsers1.",
                 );
             }
-            // verify required parameter 'jsonApiUserDocument' is not null or undefined
-            if (jsonApiUserDocument === null || jsonApiUserDocument === undefined) {
+            // verify required parameter 'jsonApiUserInDocument' is not null or undefined
+            if (jsonApiUserInDocument === null || jsonApiUserInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiUserDocument",
-                    "Required parameter jsonApiUserDocument was null or undefined when calling updateEntityUsers1.",
+                    "jsonApiUserInDocument",
+                    "Required parameter jsonApiUserInDocument was null or undefined when calling updateEntityUsers1.",
                 );
             }
             const localVarPath = `/api/entities/users/{id}`.replace(
@@ -10782,11 +12489,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiUserDocument !== "string" ||
+                typeof jsonApiUserInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiUserDocument !== undefined ? jsonApiUserDocument : {})
-                : jsonApiUserDocument || "";
+                ? JSON.stringify(jsonApiUserInDocument !== undefined ? jsonApiUserInDocument : {})
+                : jsonApiUserInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10796,7 +12503,7 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -10805,13 +12512,13 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
         updateEntityWorkspaces1(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { id, jsonApiWorkspaceDocument, variableParam, include } = params;
+            const { id, jsonApiWorkspaceInDocument, variableParam, include } = params;
             // verify required parameter 'id' is not null or undefined
             if (id === null || id === undefined) {
                 throw new RequiredError(
@@ -10819,11 +12526,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
                     "Required parameter id was null or undefined when calling updateEntityWorkspaces1.",
                 );
             }
-            // verify required parameter 'jsonApiWorkspaceDocument' is not null or undefined
-            if (jsonApiWorkspaceDocument === null || jsonApiWorkspaceDocument === undefined) {
+            // verify required parameter 'jsonApiWorkspaceInDocument' is not null or undefined
+            if (jsonApiWorkspaceInDocument === null || jsonApiWorkspaceInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiWorkspaceDocument",
-                    "Required parameter jsonApiWorkspaceDocument was null or undefined when calling updateEntityWorkspaces1.",
+                    "jsonApiWorkspaceInDocument",
+                    "Required parameter jsonApiWorkspaceInDocument was null or undefined when calling updateEntityWorkspaces1.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{id}`.replace(
@@ -10862,11 +12569,11 @@ export const OrganizationModelControllerApiAxiosParamCreator = function (configu
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiWorkspaceDocument !== "string" ||
+                typeof jsonApiWorkspaceInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiWorkspaceDocument !== undefined ? jsonApiWorkspaceDocument : {})
-                : jsonApiWorkspaceDocument || "";
+                ? JSON.stringify(jsonApiWorkspaceInDocument !== undefined ? jsonApiWorkspaceInDocument : {})
+                : jsonApiWorkspaceInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -10885,17 +12592,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityAcls(params, options);
@@ -10910,17 +12617,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityDataSources(params, options);
@@ -10935,17 +12642,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityModelModules(params, options);
@@ -10960,17 +12667,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityOrganizations(params, options);
@@ -10985,17 +12692,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityUserGroups(params, options);
@@ -11010,17 +12717,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityUsers(params, options);
@@ -11035,17 +12742,17 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createChildEntityWorkspaces(params, options);
@@ -11059,7 +12766,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11067,12 +12774,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityAcls(params, options);
@@ -11086,7 +12793,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11094,12 +12801,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityDataSources(params, options);
@@ -11113,7 +12820,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11121,12 +12828,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityModelModules(params, options);
@@ -11140,7 +12847,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11148,12 +12855,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityOrganizations(params, options);
@@ -11167,7 +12874,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11175,12 +12882,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityUserGroups(params, options);
@@ -11194,7 +12901,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11202,12 +12909,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityUsers(params, options);
@@ -11221,7 +12928,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11229,15 +12936,204 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityWorkspaces(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityAcls(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityDataSources(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityModelModules(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityOrganizations(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUserGroups(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUsers(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
+            const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -11440,7 +13336,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesAcls(params, options);
@@ -11471,7 +13367,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesDataSources(params, options);
@@ -11502,7 +13398,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesModelModules(params, options);
@@ -11533,7 +13429,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesOrganizations(params, options);
@@ -11564,7 +13460,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesUserGroups(params, options);
@@ -11595,7 +13491,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesUsers(params, options);
@@ -11626,7 +13522,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutList> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesWorkspaces(params, options);
@@ -11653,7 +13549,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAcls(params, options);
@@ -11680,7 +13576,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityDataSources1(params, options);
@@ -11707,7 +13603,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityModelModules1(params, options);
@@ -11734,7 +13630,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityOrganizations1(params, options);
@@ -11761,7 +13657,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityUserGroups1(params, options);
@@ -11788,7 +13684,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityUsers1(params, options);
@@ -11815,7 +13711,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityWorkspaces1(params, options);
@@ -11830,7 +13726,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11839,12 +13735,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiACLOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityAcls(params, options);
@@ -11859,7 +13755,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11868,12 +13764,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityDataSources1(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataSourceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityDataSources1(params, options);
@@ -11888,7 +13784,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11897,12 +13793,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityModelModules1(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiModelModuleOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityModelModules1(params, options);
@@ -11917,7 +13813,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11926,12 +13822,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityOrganizations1(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiOrganizationOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityOrganizations1(params, options);
@@ -11946,7 +13842,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11955,12 +13851,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityUserGroups1(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserGroupOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityUserGroups1(params, options);
@@ -11975,7 +13871,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -11984,12 +13880,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityUsers1(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiUserOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityUsers1(params, options);
@@ -12004,7 +13900,7 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12013,12 +13909,12 @@ export const OrganizationModelControllerApiFp = function (configuration?: Config
         updateEntityWorkspaces1(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceOutDocument> {
             const localVarAxiosArgs = OrganizationModelControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityWorkspaces1(params, options);
@@ -12046,17 +13942,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityAcls(
             params: {
                 workspaceId: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12065,17 +13961,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityDataSources(
             params: {
                 workspaceId: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityDataSources(
                 params,
                 options,
@@ -12084,17 +13980,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityModelModules(
             params: {
                 workspaceId: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityModelModules(
                 params,
                 options,
@@ -12103,17 +13999,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityOrganizations(
             params: {
                 workspaceId: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityOrganizations(
                 params,
                 options,
@@ -12122,17 +14018,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUserGroups(
             params: {
                 workspaceId: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityUserGroups(
                 params,
                 options,
@@ -12141,17 +14037,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityUsers(
             params: {
                 workspaceId: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -12160,17 +14056,17 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         createChildEntityWorkspaces(
             params: {
                 workspaceId: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createChildEntityWorkspaces(
                 params,
                 options,
@@ -12178,7 +14074,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12186,12 +14082,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityAcls(
             params: {
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12199,7 +14095,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12207,12 +14103,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityDataSources(
             params: {
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityDataSources(params, options)(
                 axios,
                 basePath,
@@ -12220,7 +14116,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12228,12 +14124,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityModelModules(
             params: {
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityModelModules(params, options)(
                 axios,
                 basePath,
@@ -12241,7 +14137,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12249,12 +14145,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityOrganizations(
             params: {
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityOrganizations(params, options)(
                 axios,
                 basePath,
@@ -12262,7 +14158,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12270,12 +14166,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityUserGroups(
             params: {
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityUserGroups(params, options)(
                 axios,
                 basePath,
@@ -12283,7 +14179,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12291,12 +14187,12 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityUsers(
             params: {
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityUsers(params, options)(
                 axios,
                 basePath,
@@ -12304,7 +14200,7 @@ export const OrganizationModelControllerApiFactory = function (
         },
         /**
          *
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12312,16 +14208,157 @@ export const OrganizationModelControllerApiFactory = function (
          */
         createEntityWorkspaces(
             params: {
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).createEntityWorkspaces(params, options)(
                 axios,
                 basePath,
             );
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityAcls(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiACLInDocument: JsonApiACLInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiACLOutDocument> {
+            return OrganizationModelControllerApiFp(configuration).createWorkspaceDataFilterSettingEntityAcls(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityDataSources(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityDataSources(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityModelModules(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityModelModules(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityOrganizations(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityOrganizations(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUserGroups(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUserGroups(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityUsers(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiUserInDocument: JsonApiUserInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiUserOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityUsers(params, options)(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} childWorkspaceId
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createWorkspaceDataFilterSettingEntityWorkspaces(
+            params: {
+                workspaceId: string;
+                childWorkspaceId: string;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
+            return OrganizationModelControllerApiFp(
+                configuration,
+            ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options)(axios, basePath);
         },
         /**
          *
@@ -12475,7 +14512,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLList> {
+        ): AxiosPromise<JsonApiACLOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesAcls(params, options)(
                 axios,
                 basePath,
@@ -12500,7 +14537,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceList> {
+        ): AxiosPromise<JsonApiDataSourceOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesDataSources(params, options)(
                 axios,
                 basePath,
@@ -12525,7 +14562,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleList> {
+        ): AxiosPromise<JsonApiModelModuleOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesModelModules(
                 params,
                 options,
@@ -12550,7 +14587,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationList> {
+        ): AxiosPromise<JsonApiOrganizationOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesOrganizations(
                 params,
                 options,
@@ -12575,7 +14612,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupList> {
+        ): AxiosPromise<JsonApiUserGroupOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesUserGroups(params, options)(
                 axios,
                 basePath,
@@ -12600,7 +14637,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserList> {
+        ): AxiosPromise<JsonApiUserOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesUsers(params, options)(
                 axios,
                 basePath,
@@ -12625,7 +14662,7 @@ export const OrganizationModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceList> {
+        ): AxiosPromise<JsonApiWorkspaceOutList> {
             return OrganizationModelControllerApiFp(configuration).getAllEntitiesWorkspaces(params, options)(
                 axios,
                 basePath,
@@ -12646,7 +14683,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12667,7 +14704,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityDataSources1(params, options)(
                 axios,
                 basePath,
@@ -12688,7 +14725,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityModelModules1(params, options)(
                 axios,
                 basePath,
@@ -12709,7 +14746,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityOrganizations1(params, options)(
                 axios,
                 basePath,
@@ -12730,7 +14767,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityUserGroups1(params, options)(
                 axios,
                 basePath,
@@ -12751,7 +14788,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityUsers1(params, options)(
                 axios,
                 basePath,
@@ -12772,7 +14809,7 @@ export const OrganizationModelControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).getEntityWorkspaces1(params, options)(
                 axios,
                 basePath,
@@ -12781,7 +14818,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiACLDocument} jsonApiACLDocument
+         * @param {JsonApiACLInDocument} jsonApiACLInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12790,12 +14827,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityAcls(
             params: {
                 id: string;
-                jsonApiACLDocument: JsonApiACLDocument;
+                jsonApiACLInDocument: JsonApiACLInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiACLDocument> {
+        ): AxiosPromise<JsonApiACLOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityAcls(params, options)(
                 axios,
                 basePath,
@@ -12804,7 +14841,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+         * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12813,12 +14850,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityDataSources1(
             params: {
                 id: string;
-                jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+                jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDataSourceDocument> {
+        ): AxiosPromise<JsonApiDataSourceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityDataSources1(params, options)(
                 axios,
                 basePath,
@@ -12827,7 +14864,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+         * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12836,12 +14873,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityModelModules1(
             params: {
                 id: string;
-                jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+                jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiModelModuleDocument> {
+        ): AxiosPromise<JsonApiModelModuleOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityModelModules1(params, options)(
                 axios,
                 basePath,
@@ -12850,7 +14887,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+         * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12859,12 +14896,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityOrganizations1(
             params: {
                 id: string;
-                jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+                jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiOrganizationDocument> {
+        ): AxiosPromise<JsonApiOrganizationOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityOrganizations1(
                 params,
                 options,
@@ -12873,7 +14910,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+         * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12882,12 +14919,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityUserGroups1(
             params: {
                 id: string;
-                jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+                jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserGroupDocument> {
+        ): AxiosPromise<JsonApiUserGroupOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityUserGroups1(params, options)(
                 axios,
                 basePath,
@@ -12896,7 +14933,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiUserDocument} jsonApiUserDocument
+         * @param {JsonApiUserInDocument} jsonApiUserInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12905,12 +14942,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityUsers1(
             params: {
                 id: string;
-                jsonApiUserDocument: JsonApiUserDocument;
+                jsonApiUserInDocument: JsonApiUserInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiUserDocument> {
+        ): AxiosPromise<JsonApiUserOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityUsers1(params, options)(
                 axios,
                 basePath,
@@ -12919,7 +14956,7 @@ export const OrganizationModelControllerApiFactory = function (
         /**
          *
          * @param {string} id
-         * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+         * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -12928,12 +14965,12 @@ export const OrganizationModelControllerApiFactory = function (
         updateEntityWorkspaces1(
             params: {
                 id: string;
-                jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+                jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiWorkspaceDocument> {
+        ): AxiosPromise<JsonApiWorkspaceOutDocument> {
             return OrganizationModelControllerApiFp(configuration).updateEntityWorkspaces1(params, options)(
                 axios,
                 basePath,
@@ -12951,7 +14988,7 @@ export interface OrganizationModelControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12959,15 +14996,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityAcls(
         params: {
             workspaceId: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12975,15 +15012,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityDataSources(
         params: {
             workspaceId: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -12991,15 +15028,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityModelModules(
         params: {
             workspaceId: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13007,15 +15044,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityOrganizations(
         params: {
             workspaceId: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13023,15 +15060,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityUserGroups(
         params: {
             workspaceId: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13039,15 +15076,15 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityUsers(
         params: {
             workspaceId: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApiInterface
@@ -13055,14 +15092,14 @@ export interface OrganizationModelControllerApiInterface {
     createChildEntityWorkspaces(
         params: {
             workspaceId: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13071,16 +15108,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityAcls(
         params: {
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13089,16 +15126,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityDataSources(
         params: {
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13107,16 +15144,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityModelModules(
         params: {
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13125,16 +15162,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityOrganizations(
         params: {
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13143,16 +15180,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityUserGroups(
         params: {
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13161,16 +15198,16 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityUsers(
         params: {
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13179,12 +15216,138 @@ export interface OrganizationModelControllerApiInterface {
      */
     createEntityWorkspaces(
         params: {
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityAcls(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiACLInDocument: JsonApiACLInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiACLOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityDataSources(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityModelModules(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityOrganizations(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityUserGroups(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityUsers(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserInDocument: JsonApiUserInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiUserOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApiInterface
+     */
+    createWorkspaceDataFilterSettingEntityWorkspaces(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
@@ -13318,7 +15481,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLList>;
+    ): AxiosPromise<JsonApiACLOutList>;
 
     /**
      *
@@ -13340,7 +15503,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceList>;
+    ): AxiosPromise<JsonApiDataSourceOutList>;
 
     /**
      *
@@ -13362,7 +15525,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleList>;
+    ): AxiosPromise<JsonApiModelModuleOutList>;
 
     /**
      *
@@ -13384,7 +15547,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationList>;
+    ): AxiosPromise<JsonApiOrganizationOutList>;
 
     /**
      *
@@ -13406,7 +15569,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupList>;
+    ): AxiosPromise<JsonApiUserGroupOutList>;
 
     /**
      *
@@ -13428,7 +15591,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserList>;
+    ): AxiosPromise<JsonApiUserOutList>;
 
     /**
      *
@@ -13450,7 +15613,7 @@ export interface OrganizationModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceList>;
+    ): AxiosPromise<JsonApiWorkspaceOutList>;
 
     /**
      *
@@ -13468,7 +15631,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
@@ -13486,7 +15649,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
@@ -13504,7 +15667,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
@@ -13522,7 +15685,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
@@ -13540,7 +15703,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
@@ -13558,7 +15721,7 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
@@ -13576,12 +15739,12 @@ export interface OrganizationModelControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13591,17 +15754,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityAcls(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiACLDocument>;
+    ): AxiosPromise<JsonApiACLOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13611,17 +15774,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityDataSources1(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDataSourceDocument>;
+    ): AxiosPromise<JsonApiDataSourceOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13631,17 +15794,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityModelModules1(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiModelModuleDocument>;
+    ): AxiosPromise<JsonApiModelModuleOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13651,17 +15814,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityOrganizations1(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiOrganizationDocument>;
+    ): AxiosPromise<JsonApiOrganizationOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13671,17 +15834,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityUserGroups1(
         params: {
             id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserGroupDocument>;
+    ): AxiosPromise<JsonApiUserGroupOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13691,17 +15854,17 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityUsers1(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiUserDocument>;
+    ): AxiosPromise<JsonApiUserOutDocument>;
 
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13711,12 +15874,12 @@ export interface OrganizationModelControllerApiInterface {
     updateEntityWorkspaces1(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiWorkspaceDocument>;
+    ): AxiosPromise<JsonApiWorkspaceOutDocument>;
 }
 
 /**
@@ -13730,7 +15893,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13738,7 +15901,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityAcls(
         params: {
             workspaceId: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
         },
         options?: any,
     ) {
@@ -13751,7 +15914,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13759,7 +15922,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityDataSources(
         params: {
             workspaceId: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
         },
         options?: any,
     ) {
@@ -13772,7 +15935,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13780,7 +15943,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityModelModules(
         params: {
             workspaceId: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
         },
         options?: any,
     ) {
@@ -13793,7 +15956,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13801,7 +15964,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityOrganizations(
         params: {
             workspaceId: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
         },
         options?: any,
     ) {
@@ -13814,7 +15977,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13822,7 +15985,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityUserGroups(
         params: {
             workspaceId: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
         },
         options?: any,
     ) {
@@ -13835,7 +15998,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13843,7 +16006,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityUsers(
         params: {
             workspaceId: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
         },
         options?: any,
     ) {
@@ -13856,7 +16019,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof OrganizationModelControllerApi
@@ -13864,7 +16027,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public createChildEntityWorkspaces(
         params: {
             workspaceId: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
         },
         options?: any,
     ) {
@@ -13876,7 +16039,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13885,7 +16048,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityAcls(
         params: {
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13899,7 +16062,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13908,7 +16071,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityDataSources(
         params: {
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13922,7 +16085,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13931,7 +16094,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityModelModules(
         params: {
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13945,7 +16108,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13954,7 +16117,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityOrganizations(
         params: {
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13968,7 +16131,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -13977,7 +16140,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityUserGroups(
         params: {
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -13991,7 +16154,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14000,7 +16163,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityUsers(
         params: {
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14014,7 +16177,7 @@ export class OrganizationModelControllerApi extends BaseAPI
 
     /**
      *
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14023,7 +16186,7 @@ export class OrganizationModelControllerApi extends BaseAPI
      */
     public createEntityWorkspaces(
         params: {
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14033,6 +16196,160 @@ export class OrganizationModelControllerApi extends BaseAPI
             this.axios,
             this.basePath,
         );
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityAcls(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiACLInDocument: JsonApiACLInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityAcls(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityDataSources(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityDataSources(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityModelModules(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityModelModules(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityOrganizations(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityOrganizations(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityUserGroups(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityUserGroups(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityUsers(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiUserInDocument: JsonApiUserInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityUsers(params, options)(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} childWorkspaceId
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof OrganizationModelControllerApi
+     */
+    public createWorkspaceDataFilterSettingEntityWorkspaces(
+        params: {
+            workspaceId: string;
+            childWorkspaceId: string;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
+        },
+        options?: any,
+    ) {
+        return OrganizationModelControllerApiFp(
+            this.configuration,
+        ).createWorkspaceDataFilterSettingEntityWorkspaces(params, options)(this.axios, this.basePath);
     }
 
     /**
@@ -14535,7 +16852,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiACLDocument} jsonApiACLDocument
+     * @param {JsonApiACLInDocument} jsonApiACLInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14545,7 +16862,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityAcls(
         params: {
             id: string;
-            jsonApiACLDocument: JsonApiACLDocument;
+            jsonApiACLInDocument: JsonApiACLInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14560,7 +16877,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiDataSourceDocument} jsonApiDataSourceDocument
+     * @param {JsonApiDataSourceInDocument} jsonApiDataSourceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14570,7 +16887,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityDataSources1(
         params: {
             id: string;
-            jsonApiDataSourceDocument: JsonApiDataSourceDocument;
+            jsonApiDataSourceInDocument: JsonApiDataSourceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14585,7 +16902,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiModelModuleDocument} jsonApiModelModuleDocument
+     * @param {JsonApiModelModuleInDocument} jsonApiModelModuleInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14595,7 +16912,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityModelModules1(
         params: {
             id: string;
-            jsonApiModelModuleDocument: JsonApiModelModuleDocument;
+            jsonApiModelModuleInDocument: JsonApiModelModuleInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14610,7 +16927,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiOrganizationDocument} jsonApiOrganizationDocument
+     * @param {JsonApiOrganizationInDocument} jsonApiOrganizationInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14620,7 +16937,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityOrganizations1(
         params: {
             id: string;
-            jsonApiOrganizationDocument: JsonApiOrganizationDocument;
+            jsonApiOrganizationInDocument: JsonApiOrganizationInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14635,7 +16952,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserGroupDocument} jsonApiUserGroupDocument
+     * @param {JsonApiUserGroupInDocument} jsonApiUserGroupInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14645,7 +16962,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityUserGroups1(
         params: {
             id: string;
-            jsonApiUserGroupDocument: JsonApiUserGroupDocument;
+            jsonApiUserGroupInDocument: JsonApiUserGroupInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14660,7 +16977,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiUserDocument} jsonApiUserDocument
+     * @param {JsonApiUserInDocument} jsonApiUserInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14670,7 +16987,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityUsers1(
         params: {
             id: string;
-            jsonApiUserDocument: JsonApiUserDocument;
+            jsonApiUserInDocument: JsonApiUserInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14685,7 +17002,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     /**
      *
      * @param {string} id
-     * @param {JsonApiWorkspaceDocument} jsonApiWorkspaceDocument
+     * @param {JsonApiWorkspaceInDocument} jsonApiWorkspaceInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -14695,7 +17012,7 @@ export class OrganizationModelControllerApi extends BaseAPI
     public updateEntityWorkspaces1(
         params: {
             id: string;
-            jsonApiWorkspaceDocument: JsonApiWorkspaceDocument;
+            jsonApiWorkspaceInDocument: JsonApiWorkspaceInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -14717,7 +17034,7 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -14726,13 +17043,13 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { userId, jsonApiApiTokenDocument, variableParam, include } = params;
+            const { userId, jsonApiApiTokenInDocument, variableParam, include } = params;
             // verify required parameter 'userId' is not null or undefined
             if (userId === null || userId === undefined) {
                 throw new RequiredError(
@@ -14740,11 +17057,11 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
                     "Required parameter userId was null or undefined when calling createEntityApiTokens.",
                 );
             }
-            // verify required parameter 'jsonApiApiTokenDocument' is not null or undefined
-            if (jsonApiApiTokenDocument === null || jsonApiApiTokenDocument === undefined) {
+            // verify required parameter 'jsonApiApiTokenInDocument' is not null or undefined
+            if (jsonApiApiTokenInDocument === null || jsonApiApiTokenInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiApiTokenDocument",
-                    "Required parameter jsonApiApiTokenDocument was null or undefined when calling createEntityApiTokens.",
+                    "jsonApiApiTokenInDocument",
+                    "Required parameter jsonApiApiTokenInDocument was null or undefined when calling createEntityApiTokens.",
                 );
             }
             const localVarPath = `/api/entities/users/{userId}/apiTokens`.replace(
@@ -14783,11 +17100,11 @@ export const UserModelControllerApiAxiosParamCreator = function (configuration?:
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiApiTokenDocument !== "string" ||
+                typeof jsonApiApiTokenInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiApiTokenDocument !== undefined ? jsonApiApiTokenDocument : {})
-                : jsonApiApiTokenDocument || "";
+                ? JSON.stringify(jsonApiApiTokenInDocument !== undefined ? jsonApiApiTokenInDocument : {})
+                : jsonApiApiTokenInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15053,7 +17370,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15062,12 +17379,12 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityApiTokens(params, options);
@@ -15127,7 +17444,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutList> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).getAllEntitiesApiTokens(params, options);
@@ -15162,7 +17479,7 @@ export const UserModelControllerApiFp = function (configuration?: Configuration)
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiApiTokenOutDocument> {
             const localVarAxiosArgs = UserModelControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityApiTokens(params, options);
@@ -15190,7 +17507,7 @@ export const UserModelControllerApiFactory = function (
         /**
          *
          * @param {string} userId
-         * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+         * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15199,12 +17516,12 @@ export const UserModelControllerApiFactory = function (
         createEntityApiTokens(
             params: {
                 userId: string;
-                jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+                jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenDocument> {
+        ): AxiosPromise<JsonApiApiTokenOutDocument> {
             return UserModelControllerApiFp(configuration).createEntityApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15252,7 +17569,7 @@ export const UserModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenList> {
+        ): AxiosPromise<JsonApiApiTokenOutList> {
             return UserModelControllerApiFp(configuration).getAllEntitiesApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15281,7 +17598,7 @@ export const UserModelControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiApiTokenDocument> {
+        ): AxiosPromise<JsonApiApiTokenOutDocument> {
             return UserModelControllerApiFp(configuration).getEntityApiTokens(params, options)(
                 axios,
                 basePath,
@@ -15299,7 +17616,7 @@ export interface UserModelControllerApiInterface {
     /**
      *
      * @param {string} userId
-     * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+     * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -15309,12 +17626,12 @@ export interface UserModelControllerApiInterface {
     createEntityApiTokens(
         params: {
             userId: string;
-            jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+            jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenDocument>;
+    ): AxiosPromise<JsonApiApiTokenOutDocument>;
 
     /**
      *
@@ -15356,7 +17673,7 @@ export interface UserModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenList>;
+    ): AxiosPromise<JsonApiApiTokenOutList>;
 
     /**
      *
@@ -15382,7 +17699,7 @@ export interface UserModelControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiApiTokenDocument>;
+    ): AxiosPromise<JsonApiApiTokenOutDocument>;
 }
 
 /**
@@ -15395,7 +17712,7 @@ export class UserModelControllerApi extends BaseAPI implements UserModelControll
     /**
      *
      * @param {string} userId
-     * @param {JsonApiApiTokenDocument} jsonApiApiTokenDocument
+     * @param {JsonApiApiTokenInDocument} jsonApiApiTokenInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -15405,7 +17722,7 @@ export class UserModelControllerApi extends BaseAPI implements UserModelControll
     public createEntityApiTokens(
         params: {
             userId: string;
-            jsonApiApiTokenDocument: JsonApiApiTokenDocument;
+            jsonApiApiTokenInDocument: JsonApiApiTokenInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -15510,7 +17827,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15519,13 +17836,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiAnalyticalDashboardDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiAnalyticalDashboardInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15533,14 +17850,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityAnalyticalDashboards.",
                 );
             }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
+            // verify required parameter 'jsonApiAnalyticalDashboardInDocument' is not null or undefined
             if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
+                jsonApiAnalyticalDashboardInDocument === null ||
+                jsonApiAnalyticalDashboardInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling createEntityAnalyticalDashboards.",
+                    "jsonApiAnalyticalDashboardInDocument",
+                    "Required parameter jsonApiAnalyticalDashboardInDocument was null or undefined when calling createEntityAnalyticalDashboards.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards`.replace(
@@ -15579,15 +17896,15 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
+                typeof jsonApiAnalyticalDashboardInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
+                      jsonApiAnalyticalDashboardInDocument !== undefined
+                          ? jsonApiAnalyticalDashboardInDocument
                           : {},
                   )
-                : jsonApiAnalyticalDashboardDocument || "";
+                : jsonApiAnalyticalDashboardInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15597,89 +17914,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, jsonApiDataDiscriminatorDocument, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling createEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'jsonApiDataDiscriminatorDocument' is not null or undefined
-            if (jsonApiDataDiscriminatorDocument === null || jsonApiDataDiscriminatorDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiDataDiscriminatorDocument",
-                    "Required parameter jsonApiDataDiscriminatorDocument was null or undefined when calling createEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiDataDiscriminatorDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiDataDiscriminatorDocument !== undefined ? jsonApiDataDiscriminatorDocument : {},
-                  )
-                : jsonApiDataDiscriminatorDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15688,13 +17923,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiFilterContextDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiFilterContextInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15702,11 +17937,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityFilterContexts.",
                 );
             }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
+            // verify required parameter 'jsonApiFilterContextInDocument' is not null or undefined
+            if (jsonApiFilterContextInDocument === null || jsonApiFilterContextInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling createEntityFilterContexts.",
+                    "jsonApiFilterContextInDocument",
+                    "Required parameter jsonApiFilterContextInDocument was null or undefined when calling createEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/filterContexts`.replace(
@@ -15745,13 +17980,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
+                typeof jsonApiFilterContextInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
+                      jsonApiFilterContextInDocument !== undefined ? jsonApiFilterContextInDocument : {},
                   )
-                : jsonApiFilterContextDocument || "";
+                : jsonApiFilterContextInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15761,7 +17996,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15770,13 +18005,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiMetricDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiMetricInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15784,11 +18019,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityMetrics.",
                 );
             }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
+            // verify required parameter 'jsonApiMetricInDocument' is not null or undefined
+            if (jsonApiMetricInDocument === null || jsonApiMetricInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling createEntityMetrics.",
+                    "jsonApiMetricInDocument",
+                    "Required parameter jsonApiMetricInDocument was null or undefined when calling createEntityMetrics.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/metrics`.replace(
@@ -15827,11 +18062,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
+                typeof jsonApiMetricInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
+                ? JSON.stringify(jsonApiMetricInDocument !== undefined ? jsonApiMetricInDocument : {})
+                : jsonApiMetricInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15841,7 +18076,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -15850,13 +18085,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, jsonApiVisualizationObjectDocument, variableParam, include } = params;
+            const { workspaceId, jsonApiVisualizationObjectInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -15864,14 +18099,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter workspaceId was null or undefined when calling createEntityVisualizationObjects.",
                 );
             }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
+            // verify required parameter 'jsonApiVisualizationObjectInDocument' is not null or undefined
             if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
+                jsonApiVisualizationObjectInDocument === null ||
+                jsonApiVisualizationObjectInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling createEntityVisualizationObjects.",
+                    "jsonApiVisualizationObjectInDocument",
+                    "Required parameter jsonApiVisualizationObjectInDocument was null or undefined when calling createEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/visualizationObjects`.replace(
@@ -15910,15 +18145,102 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
+                typeof jsonApiVisualizationObjectInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
+                      jsonApiVisualizationObjectInDocument !== undefined
+                          ? jsonApiVisualizationObjectInDocument
                           : {},
                   )
-                : jsonApiVisualizationObjectDocument || "";
+                : jsonApiVisualizationObjectInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, jsonApiWorkspaceDataFilterInDocument, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling createEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceDataFilterInDocument' is not null or undefined
+            if (
+                jsonApiWorkspaceDataFilterInDocument === null ||
+                jsonApiWorkspaceDataFilterInDocument === undefined
+            ) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceDataFilterInDocument",
+                    "Required parameter jsonApiWorkspaceDataFilterInDocument was null or undefined when calling createEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "POST", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceDataFilterInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiWorkspaceDataFilterInDocument !== undefined
+                          ? jsonApiWorkspaceDataFilterInDocument
+                          : {},
+                  )
+                : jsonApiWorkspaceDataFilterInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -15957,67 +18279,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling deleteEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling deleteEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
                 .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
                 .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
@@ -16233,6 +18494,67 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling deleteEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling deleteEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "DELETE", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -16350,95 +18672,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/attributes`.replace(
-                `{${"workspaceId"}}`,
-                encodeURIComponent(String(workspaceId)),
-            );
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            if (page !== undefined) {
-                if (typeof page === "object") {
-                    addFlattenedObjectTo(page, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["page"] = page;
-                }
-            }
-
-            if (size !== undefined) {
-                if (typeof size === "object") {
-                    addFlattenedObjectTo(size, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["size"] = size;
-                }
-            }
-
-            if (sort) {
-                localVarQueryParameter["sort"] = sort;
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, variableParam, include, page, size, sort } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntitiesDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators`.replace(
                 `{${"workspaceId"}}`,
                 encodeURIComponent(String(workspaceId)),
             );
@@ -17212,6 +19445,184 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
         /**
          *
          * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, variableParam, include, page, size, sort } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntitiesWorkspaceDataFilterSettings.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            if (page !== undefined) {
+                if (typeof page === "object") {
+                    addFlattenedObjectTo(page, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["page"] = page;
+                }
+            }
+
+            if (size !== undefined) {
+                if (typeof size === "object") {
+                    addFlattenedObjectTo(size, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["size"] = size;
+                }
+            }
+
+            if (sort) {
+                localVarQueryParameter["sort"] = sort;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, variableParam, include, page, size, sort } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntitiesWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters`.replace(
+                `{${"workspaceId"}}`,
+                encodeURIComponent(String(workspaceId)),
+            );
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            if (page !== undefined) {
+                if (typeof page === "object") {
+                    addFlattenedObjectTo(page, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["page"] = page;
+                }
+            }
+
+            if (size !== undefined) {
+                if (typeof size === "object") {
+                    addFlattenedObjectTo(size, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["size"] = size;
+                }
+            }
+
+            if (sort) {
+                localVarQueryParameter["sort"] = sort;
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {string} objectId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
@@ -17314,77 +19725,6 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/attributes/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const { workspaceId, objectId, variableParam, include } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling getEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling getEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
                 .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
                 .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
             const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
@@ -17994,7 +20334,149 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntityWorkspaceDataFilterSettings.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling getEntityWorkspaceDataFilterSettings.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const { workspaceId, objectId, variableParam, include } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling getEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling getEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "GET", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18004,7 +20486,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
@@ -18013,7 +20495,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             const {
                 workspaceId,
                 objectId,
-                jsonApiAnalyticalDashboardDocument,
+                jsonApiAnalyticalDashboardInDocument,
                 variableParam,
                 include,
             } = params;
@@ -18031,14 +20513,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
-            // verify required parameter 'jsonApiAnalyticalDashboardDocument' is not null or undefined
+            // verify required parameter 'jsonApiAnalyticalDashboardInDocument' is not null or undefined
             if (
-                jsonApiAnalyticalDashboardDocument === null ||
-                jsonApiAnalyticalDashboardDocument === undefined
+                jsonApiAnalyticalDashboardInDocument === null ||
+                jsonApiAnalyticalDashboardInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiAnalyticalDashboardDocument",
-                    "Required parameter jsonApiAnalyticalDashboardDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
+                    "jsonApiAnalyticalDashboardInDocument",
+                    "Required parameter jsonApiAnalyticalDashboardInDocument was null or undefined when calling updateEntityAnalyticalDashboards.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/analyticalDashboards/{objectId}`
@@ -18076,15 +20558,15 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiAnalyticalDashboardDocument !== "string" ||
+                typeof jsonApiAnalyticalDashboardInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiAnalyticalDashboardDocument !== undefined
-                          ? jsonApiAnalyticalDashboardDocument
+                      jsonApiAnalyticalDashboardInDocument !== undefined
+                          ? jsonApiAnalyticalDashboardInDocument
                           : {},
                   )
-                : jsonApiAnalyticalDashboardDocument || "";
+                : jsonApiAnalyticalDashboardInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18095,103 +20577,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): RequestArgs {
-            const {
-                workspaceId,
-                objectId,
-                jsonApiDataDiscriminatorDocument,
-                variableParam,
-                include,
-            } = params;
-            // verify required parameter 'workspaceId' is not null or undefined
-            if (workspaceId === null || workspaceId === undefined) {
-                throw new RequiredError(
-                    "workspaceId",
-                    "Required parameter workspaceId was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'objectId' is not null or undefined
-            if (objectId === null || objectId === undefined) {
-                throw new RequiredError(
-                    "objectId",
-                    "Required parameter objectId was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            // verify required parameter 'jsonApiDataDiscriminatorDocument' is not null or undefined
-            if (jsonApiDataDiscriminatorDocument === null || jsonApiDataDiscriminatorDocument === undefined) {
-                throw new RequiredError(
-                    "jsonApiDataDiscriminatorDocument",
-                    "Required parameter jsonApiDataDiscriminatorDocument was null or undefined when calling updateEntityDataDiscriminators.",
-                );
-            }
-            const localVarPath = `/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}`
-                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
-                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
-            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
-            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
-
-            if (variableParam !== undefined) {
-                if (typeof variableParam === "object") {
-                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["variableParam"] = variableParam;
-                }
-            }
-
-            if (include !== undefined) {
-                if (typeof include === "object") {
-                    addFlattenedObjectTo(include, localVarQueryParameter);
-                } else {
-                    localVarQueryParameter["include"] = include;
-                }
-            }
-
-            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
-
-            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
-            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
-            delete localVarUrlObj.search;
-            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
-            const needsSerialization =
-                typeof jsonApiDataDiscriminatorDocument !== "string" ||
-                localVarRequestOptions.headers["Content-Type"] === "application/json";
-            localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(
-                      jsonApiDataDiscriminatorDocument !== undefined ? jsonApiDataDiscriminatorDocument : {},
-                  )
-                : jsonApiDataDiscriminatorDocument || "";
-
-            return {
-                url: globalImportUrl.format(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18201,13 +20587,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, objectId, jsonApiFilterContextDocument, variableParam, include } = params;
+            const { workspaceId, objectId, jsonApiFilterContextInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -18222,11 +20608,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
-            // verify required parameter 'jsonApiFilterContextDocument' is not null or undefined
-            if (jsonApiFilterContextDocument === null || jsonApiFilterContextDocument === undefined) {
+            // verify required parameter 'jsonApiFilterContextInDocument' is not null or undefined
+            if (jsonApiFilterContextInDocument === null || jsonApiFilterContextInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiFilterContextDocument",
-                    "Required parameter jsonApiFilterContextDocument was null or undefined when calling updateEntityFilterContexts.",
+                    "jsonApiFilterContextInDocument",
+                    "Required parameter jsonApiFilterContextInDocument was null or undefined when calling updateEntityFilterContexts.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/filterContexts/{objectId}`
@@ -18264,13 +20650,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiFilterContextDocument !== "string" ||
+                typeof jsonApiFilterContextInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiFilterContextDocument !== undefined ? jsonApiFilterContextDocument : {},
+                      jsonApiFilterContextInDocument !== undefined ? jsonApiFilterContextInDocument : {},
                   )
-                : jsonApiFilterContextDocument || "";
+                : jsonApiFilterContextInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18281,7 +20667,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18291,13 +20677,13 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
         ): RequestArgs {
-            const { workspaceId, objectId, jsonApiMetricDocument, variableParam, include } = params;
+            const { workspaceId, objectId, jsonApiMetricInDocument, variableParam, include } = params;
             // verify required parameter 'workspaceId' is not null or undefined
             if (workspaceId === null || workspaceId === undefined) {
                 throw new RequiredError(
@@ -18312,11 +20698,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityMetrics.",
                 );
             }
-            // verify required parameter 'jsonApiMetricDocument' is not null or undefined
-            if (jsonApiMetricDocument === null || jsonApiMetricDocument === undefined) {
+            // verify required parameter 'jsonApiMetricInDocument' is not null or undefined
+            if (jsonApiMetricInDocument === null || jsonApiMetricInDocument === undefined) {
                 throw new RequiredError(
-                    "jsonApiMetricDocument",
-                    "Required parameter jsonApiMetricDocument was null or undefined when calling updateEntityMetrics.",
+                    "jsonApiMetricInDocument",
+                    "Required parameter jsonApiMetricInDocument was null or undefined when calling updateEntityMetrics.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/metrics/{objectId}`
@@ -18354,11 +20740,11 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiMetricDocument !== "string" ||
+                typeof jsonApiMetricInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
-                ? JSON.stringify(jsonApiMetricDocument !== undefined ? jsonApiMetricDocument : {})
-                : jsonApiMetricDocument || "";
+                ? JSON.stringify(jsonApiMetricInDocument !== undefined ? jsonApiMetricInDocument : {})
+                : jsonApiMetricInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18369,7 +20755,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18379,7 +20765,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
@@ -18388,7 +20774,7 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             const {
                 workspaceId,
                 objectId,
-                jsonApiVisualizationObjectDocument,
+                jsonApiVisualizationObjectInDocument,
                 variableParam,
                 include,
             } = params;
@@ -18406,14 +20792,14 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
                     "Required parameter objectId was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
-            // verify required parameter 'jsonApiVisualizationObjectDocument' is not null or undefined
+            // verify required parameter 'jsonApiVisualizationObjectInDocument' is not null or undefined
             if (
-                jsonApiVisualizationObjectDocument === null ||
-                jsonApiVisualizationObjectDocument === undefined
+                jsonApiVisualizationObjectInDocument === null ||
+                jsonApiVisualizationObjectInDocument === undefined
             ) {
                 throw new RequiredError(
-                    "jsonApiVisualizationObjectDocument",
-                    "Required parameter jsonApiVisualizationObjectDocument was null or undefined when calling updateEntityVisualizationObjects.",
+                    "jsonApiVisualizationObjectInDocument",
+                    "Required parameter jsonApiVisualizationObjectInDocument was null or undefined when calling updateEntityVisualizationObjects.",
                 );
             }
             const localVarPath = `/api/entities/workspaces/{workspaceId}/visualizationObjects/{objectId}`
@@ -18451,15 +20837,116 @@ export const WorkspaceObjectControllerApiAxiosParamCreator = function (configura
             delete localVarUrlObj.search;
             localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
             const needsSerialization =
-                typeof jsonApiVisualizationObjectDocument !== "string" ||
+                typeof jsonApiVisualizationObjectInDocument !== "string" ||
                 localVarRequestOptions.headers["Content-Type"] === "application/json";
             localVarRequestOptions.data = needsSerialization
                 ? JSON.stringify(
-                      jsonApiVisualizationObjectDocument !== undefined
-                          ? jsonApiVisualizationObjectDocument
+                      jsonApiVisualizationObjectInDocument !== undefined
+                          ? jsonApiVisualizationObjectInDocument
                           : {},
                   )
-                : jsonApiVisualizationObjectDocument || "";
+                : jsonApiVisualizationObjectInDocument || "";
+
+            return {
+                url: globalImportUrl.format(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): RequestArgs {
+            const {
+                workspaceId,
+                objectId,
+                jsonApiWorkspaceDataFilterInDocument,
+                variableParam,
+                include,
+            } = params;
+            // verify required parameter 'workspaceId' is not null or undefined
+            if (workspaceId === null || workspaceId === undefined) {
+                throw new RequiredError(
+                    "workspaceId",
+                    "Required parameter workspaceId was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'objectId' is not null or undefined
+            if (objectId === null || objectId === undefined) {
+                throw new RequiredError(
+                    "objectId",
+                    "Required parameter objectId was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            // verify required parameter 'jsonApiWorkspaceDataFilterInDocument' is not null or undefined
+            if (
+                jsonApiWorkspaceDataFilterInDocument === null ||
+                jsonApiWorkspaceDataFilterInDocument === undefined
+            ) {
+                throw new RequiredError(
+                    "jsonApiWorkspaceDataFilterInDocument",
+                    "Required parameter jsonApiWorkspaceDataFilterInDocument was null or undefined when calling updateEntityWorkspaceDataFilters.",
+                );
+            }
+            const localVarPath = `/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}`
+                .replace(`{${"workspaceId"}}`, encodeURIComponent(String(workspaceId)))
+                .replace(`{${"objectId"}}`, encodeURIComponent(String(objectId)));
+            const localVarUrlObj = globalImportUrl.parse(localVarPath, true);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+            const localVarRequestOptions = { method: "PUT", ...baseOptions, ...options };
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            if (variableParam !== undefined) {
+                if (typeof variableParam === "object") {
+                    addFlattenedObjectTo(variableParam, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["variableParam"] = variableParam;
+                }
+            }
+
+            if (include !== undefined) {
+                if (typeof include === "object") {
+                    addFlattenedObjectTo(include, localVarQueryParameter);
+                } else {
+                    localVarQueryParameter["include"] = include;
+                }
+            }
+
+            localVarHeaderParameter["Content-Type"] = "application/vnd.gooddata.api+json";
+
+            localVarUrlObj.query = { ...localVarUrlObj.query, ...localVarQueryParameter, ...options.query };
+            // @ts-ignore fix override query string Detail: https://stackoverflow.com/a/7517673/1077943
+            delete localVarUrlObj.search;
+            localVarRequestOptions.headers = { ...localVarHeaderParameter, ...options.headers };
+            const needsSerialization =
+                typeof jsonApiWorkspaceDataFilterInDocument !== "string" ||
+                localVarRequestOptions.headers["Content-Type"] === "application/json";
+            localVarRequestOptions.data = needsSerialization
+                ? JSON.stringify(
+                      jsonApiWorkspaceDataFilterInDocument !== undefined
+                          ? jsonApiWorkspaceDataFilterInDocument
+                          : {},
+                  )
+                : jsonApiWorkspaceDataFilterInDocument || "";
 
             return {
                 url: globalImportUrl.format(localVarUrlObj),
@@ -18478,7 +20965,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18487,12 +20974,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityAnalyticalDashboards(params, options);
@@ -18507,36 +20994,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).createEntityDataDiscriminators(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18545,12 +21003,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityFilterContexts(params, options);
@@ -18565,7 +21023,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18574,12 +21032,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityMetrics(params, options);
@@ -18594,7 +21052,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -18603,15 +21061,44 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).createEntityVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).createEntityWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18639,33 +21126,6 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).deleteEntityAnalyticalDashboards(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).deleteEntityDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18758,6 +21218,33 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<void> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).deleteEntityWorkspaceDataFilters(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -18776,7 +21263,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesAnalyticalDashboards(params, options);
@@ -18809,43 +21296,10 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorList> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntitiesDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -18875,7 +21329,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesDatasets(params, options);
@@ -18908,7 +21362,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesFacts(params, options);
@@ -18941,7 +21395,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesFilterContexts(params, options);
@@ -18974,7 +21428,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesLabels(params, options);
@@ -19007,7 +21461,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesMetrics(params, options);
@@ -19040,7 +21494,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesSources(params, options);
@@ -19073,7 +21527,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesTables(params, options);
@@ -19106,10 +21560,79 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 sort?: Array<string>;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectList> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutList> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitiesVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): (
+            axios?: AxiosInstance,
+            basePath?: string,
+        ) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntitiesWorkspaceDataFilterSettings(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutList> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntitiesWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19135,7 +21658,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAnalyticalDashboards(params, options);
@@ -19164,39 +21687,10 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAttributeOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityAttributes(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).getEntityDataDiscriminators(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19222,7 +21716,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDatasetOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityDatasets(params, options);
@@ -19251,7 +21745,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFactOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityFacts(params, options);
@@ -19280,7 +21774,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityFilterContexts(params, options);
@@ -19309,7 +21803,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiLabelOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityLabels(params, options);
@@ -19338,7 +21832,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityMetrics(params, options);
@@ -19367,7 +21861,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTablesOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntitySources(params, options);
@@ -19396,7 +21890,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiSourceTableOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityTables(params, options);
@@ -19425,7 +21919,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).getEntityVisualizationObjects(params, options);
@@ -19441,7 +21935,68 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (
+            axios?: AxiosInstance,
+            basePath?: string,
+        ) => AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntityWorkspaceDataFilterSettings(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).getEntityWorkspaceDataFilters(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19451,12 +22006,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityAnalyticalDashboards(params, options);
@@ -19472,38 +22027,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
-                configuration,
-            ).updateEntityDataDiscriminators(params, options);
-            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
-                const axiosRequestArgs = {
-                    ...localVarAxiosArgs.options,
-                    url: basePath + localVarAxiosArgs.url,
-                };
-                return axios.request(axiosRequestArgs);
-            };
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19513,12 +22037,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiFilterContextOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityFilterContexts(params, options);
@@ -19534,7 +22058,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19544,12 +22068,12 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiMetricOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityMetrics(params, options);
@@ -19565,7 +22089,7 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19575,15 +22099,46 @@ export const WorkspaceObjectControllerApiFp = function (configuration?: Configur
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options: any = {},
-        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
                 configuration,
             ).updateEntityVisualizationObjects(params, options);
+            return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
+                const axiosRequestArgs = {
+                    ...localVarAxiosArgs.options,
+                    url: basePath + localVarAxiosArgs.url,
+                };
+                return axios.request(axiosRequestArgs);
+            };
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options: any = {},
+        ): (axios?: AxiosInstance, basePath?: string) => AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            const localVarAxiosArgs = WorkspaceObjectControllerApiAxiosParamCreator(
+                configuration,
+            ).updateEntityWorkspaceDataFilters(params, options);
             return (axios: AxiosInstance = globalAxios, basePath: string = BASE_PATH) => {
                 const axiosRequestArgs = {
                     ...localVarAxiosArgs.options,
@@ -19608,7 +22163,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19617,12 +22172,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityAnalyticalDashboards(
             params: {
                 workspaceId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityAnalyticalDashboards(
                 params,
                 options,
@@ -19631,30 +22186,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        createEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).createEntityDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19663,12 +22195,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityFilterContexts(
             params: {
                 workspaceId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -19677,7 +22209,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19686,12 +22218,12 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityMetrics(
             params: {
                 workspaceId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -19700,7 +22232,7 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -19709,13 +22241,36 @@ export const WorkspaceObjectControllerApiFactory = function (
         createEntityVisualizationObjects(
             params: {
                 workspaceId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).createEntityVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        createEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).createEntityWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -19737,27 +22292,6 @@ export const WorkspaceObjectControllerApiFactory = function (
             options?: any,
         ): AxiosPromise<void> {
             return WorkspaceObjectControllerApiFp(configuration).deleteEntityAnalyticalDashboards(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        deleteEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-            },
-            options?: any,
-        ): AxiosPromise<void> {
-            return WorkspaceObjectControllerApiFp(configuration).deleteEntityDataDiscriminators(
                 params,
                 options,
             )(axios, basePath);
@@ -19828,6 +22362,27 @@ export const WorkspaceObjectControllerApiFactory = function (
         /**
          *
          * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        deleteEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+            },
+            options?: any,
+        ): AxiosPromise<void> {
+            return WorkspaceObjectControllerApiFp(configuration).deleteEntityWorkspaceDataFilters(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {number} [page] Zero-based page index (0..N)
@@ -19846,7 +22401,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardList> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesAnalyticalDashboards(
                 params,
                 options,
@@ -19873,38 +22428,11 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAttributeList> {
+        ): AxiosPromise<JsonApiAttributeOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesAttributes(params, options)(
                 axios,
                 basePath,
             );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {number} [page] Zero-based page index (0..N)
-         * @param {number} [size] The size of the page to be returned
-         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntitiesDataDiscriminators(
-            params: {
-                workspaceId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-                page?: number;
-                size?: number;
-                sort?: Array<string>;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorList> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntitiesDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
         },
         /**
          *
@@ -19927,7 +22455,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDatasetList> {
+        ): AxiosPromise<JsonApiDatasetOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesDatasets(params, options)(
                 axios,
                 basePath,
@@ -19954,7 +22482,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFactList> {
+        ): AxiosPromise<JsonApiFactOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesFacts(params, options)(
                 axios,
                 basePath,
@@ -19981,7 +22509,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextList> {
+        ): AxiosPromise<JsonApiFilterContextOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20008,7 +22536,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiLabelList> {
+        ): AxiosPromise<JsonApiLabelOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesLabels(params, options)(
                 axios,
                 basePath,
@@ -20035,7 +22563,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricList> {
+        ): AxiosPromise<JsonApiMetricOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesMetrics(params, options)(
                 axios,
                 basePath,
@@ -20062,7 +22590,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTablesList> {
+        ): AxiosPromise<JsonApiSourceTablesOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesSources(params, options)(
                 axios,
                 basePath,
@@ -20089,7 +22617,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTableList> {
+        ): AxiosPromise<JsonApiSourceTableOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesTables(params, options)(
                 axios,
                 basePath,
@@ -20116,8 +22644,62 @@ export const WorkspaceObjectControllerApiFactory = function (
                 sort?: Array<string>;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectList> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutList> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitiesVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesWorkspaceDataFilterSettings(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {number} [page] Zero-based page index (0..N)
+         * @param {number} [size] The size of the page to be returned
+         * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntitiesWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+                page?: number;
+                size?: number;
+                sort?: Array<string>;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutList> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntitiesWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -20139,7 +22721,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityAnalyticalDashboards(
                 params,
                 options,
@@ -20162,31 +22744,8 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAttributeDocument> {
+        ): AxiosPromise<JsonApiAttributeOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityAttributes(params, options)(
-                axios,
-                basePath,
-            );
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        getEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).getEntityDataDiscriminators(params, options)(
                 axios,
                 basePath,
             );
@@ -20208,7 +22767,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiDatasetDocument> {
+        ): AxiosPromise<JsonApiDatasetOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityDatasets(params, options)(
                 axios,
                 basePath,
@@ -20231,7 +22790,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFactDocument> {
+        ): AxiosPromise<JsonApiFactOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityFacts(params, options)(
                 axios,
                 basePath,
@@ -20254,7 +22813,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20277,7 +22836,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiLabelDocument> {
+        ): AxiosPromise<JsonApiLabelOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityLabels(params, options)(
                 axios,
                 basePath,
@@ -20300,7 +22859,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -20323,7 +22882,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTablesDocument> {
+        ): AxiosPromise<JsonApiSourceTablesOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntitySources(params, options)(
                 axios,
                 basePath,
@@ -20346,7 +22905,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiSourceTableDocument> {
+        ): AxiosPromise<JsonApiSourceTableOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityTables(params, options)(
                 axios,
                 basePath,
@@ -20369,7 +22928,7 @@ export const WorkspaceObjectControllerApiFactory = function (
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).getEntityVisualizationObjects(
                 params,
                 options,
@@ -20379,7 +22938,53 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilterSettings(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntityWorkspaceDataFilterSettings(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).getEntityWorkspaceDataFilters(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20389,12 +22994,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+                jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiAnalyticalDashboardDocument> {
+        ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityAnalyticalDashboards(
                 params,
                 options,
@@ -20404,32 +23009,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-         * @param {{ [key: string]: object; }} [variableParam]
-         * @param {object} [include]
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        updateEntityDataDiscriminators(
-            params: {
-                workspaceId: string;
-                objectId: string;
-                jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-                variableParam?: { [key: string]: object };
-                include?: object;
-            },
-            options?: any,
-        ): AxiosPromise<JsonApiDataDiscriminatorDocument> {
-            return WorkspaceObjectControllerApiFp(configuration).updateEntityDataDiscriminators(
-                params,
-                options,
-            )(axios, basePath);
-        },
-        /**
-         *
-         * @param {string} workspaceId
-         * @param {string} objectId
-         * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+         * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20439,12 +23019,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+                jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiFilterContextDocument> {
+        ): AxiosPromise<JsonApiFilterContextOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityFilterContexts(params, options)(
                 axios,
                 basePath,
@@ -20454,7 +23034,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiMetricDocument} jsonApiMetricDocument
+         * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20464,12 +23044,12 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiMetricDocument: JsonApiMetricDocument;
+                jsonApiMetricInDocument: JsonApiMetricInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiMetricDocument> {
+        ): AxiosPromise<JsonApiMetricOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityMetrics(params, options)(
                 axios,
                 basePath,
@@ -20479,7 +23059,7 @@ export const WorkspaceObjectControllerApiFactory = function (
          *
          * @param {string} workspaceId
          * @param {string} objectId
-         * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+         * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
          * @param {{ [key: string]: object; }} [variableParam]
          * @param {object} [include]
          * @param {*} [options] Override http request option.
@@ -20489,13 +23069,38 @@ export const WorkspaceObjectControllerApiFactory = function (
             params: {
                 workspaceId: string;
                 objectId: string;
-                jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+                jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
                 variableParam?: { [key: string]: object };
                 include?: object;
             },
             options?: any,
-        ): AxiosPromise<JsonApiVisualizationObjectDocument> {
+        ): AxiosPromise<JsonApiVisualizationObjectOutDocument> {
             return WorkspaceObjectControllerApiFp(configuration).updateEntityVisualizationObjects(
+                params,
+                options,
+            )(axios, basePath);
+        },
+        /**
+         *
+         * @param {string} workspaceId
+         * @param {string} objectId
+         * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+         * @param {{ [key: string]: object; }} [variableParam]
+         * @param {object} [include]
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        updateEntityWorkspaceDataFilters(
+            params: {
+                workspaceId: string;
+                objectId: string;
+                jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+                variableParam?: { [key: string]: object };
+                include?: object;
+            },
+            options?: any,
+        ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument> {
+            return WorkspaceObjectControllerApiFp(configuration).updateEntityWorkspaceDataFilters(
                 params,
                 options,
             )(axios, basePath);
@@ -20512,7 +23117,7 @@ export interface WorkspaceObjectControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20522,37 +23127,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    createEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20562,17 +23147,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityFilterContexts(
         params: {
             workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20582,17 +23167,17 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityMetrics(
         params: {
             workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -20602,12 +23187,32 @@ export interface WorkspaceObjectControllerApiInterface {
     createEntityVisualizationObjects(
         params: {
             workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    createEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 
     /**
      *
@@ -20619,24 +23224,6 @@ export interface WorkspaceObjectControllerApiInterface {
      * @memberof WorkspaceObjectControllerApiInterface
      */
     deleteEntityAnalyticalDashboards(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ): AxiosPromise<void>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    deleteEntityDataDiscriminators(
         params: {
             workspaceId: string;
             objectId: string;
@@ -20702,6 +23289,24 @@ export interface WorkspaceObjectControllerApiInterface {
     /**
      *
      * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    deleteEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+        },
+        options?: any,
+    ): AxiosPromise<void>;
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {number} [page] Zero-based page index (0..N)
@@ -20721,7 +23326,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardList>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutList>;
 
     /**
      *
@@ -20745,31 +23350,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAttributeList>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    getEntitiesDataDiscriminators(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorList>;
+    ): AxiosPromise<JsonApiAttributeOutList>;
 
     /**
      *
@@ -20793,7 +23374,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDatasetList>;
+    ): AxiosPromise<JsonApiDatasetOutList>;
 
     /**
      *
@@ -20817,7 +23398,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFactList>;
+    ): AxiosPromise<JsonApiFactOutList>;
 
     /**
      *
@@ -20841,7 +23422,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextList>;
+    ): AxiosPromise<JsonApiFilterContextOutList>;
 
     /**
      *
@@ -20865,7 +23446,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiLabelList>;
+    ): AxiosPromise<JsonApiLabelOutList>;
 
     /**
      *
@@ -20889,7 +23470,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricList>;
+    ): AxiosPromise<JsonApiMetricOutList>;
 
     /**
      *
@@ -20913,7 +23494,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTablesList>;
+    ): AxiosPromise<JsonApiSourceTablesOutList>;
 
     /**
      *
@@ -20937,7 +23518,7 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTableList>;
+    ): AxiosPromise<JsonApiSourceTableOutList>;
 
     /**
      *
@@ -20961,7 +23542,55 @@ export interface WorkspaceObjectControllerApiInterface {
             sort?: Array<string>;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectList>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutList>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntitiesWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutList>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntitiesWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutList>;
 
     /**
      *
@@ -20981,7 +23610,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
@@ -21001,27 +23630,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAttributeDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    getEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
+    ): AxiosPromise<JsonApiAttributeOutDocument>;
 
     /**
      *
@@ -21041,7 +23650,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiDatasetDocument>;
+    ): AxiosPromise<JsonApiDatasetOutDocument>;
 
     /**
      *
@@ -21061,7 +23670,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFactDocument>;
+    ): AxiosPromise<JsonApiFactOutDocument>;
 
     /**
      *
@@ -21081,7 +23690,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
@@ -21101,7 +23710,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiLabelDocument>;
+    ): AxiosPromise<JsonApiLabelOutDocument>;
 
     /**
      *
@@ -21121,7 +23730,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
@@ -21141,7 +23750,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTablesDocument>;
+    ): AxiosPromise<JsonApiSourceTablesOutDocument>;
 
     /**
      *
@@ -21161,7 +23770,7 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiSourceTableDocument>;
+    ): AxiosPromise<JsonApiSourceTableOutDocument>;
 
     /**
      *
@@ -21181,13 +23790,53 @@ export interface WorkspaceObjectControllerApiInterface {
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntityWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterSettingOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    getEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21198,40 +23847,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiAnalyticalDashboardDocument>;
+    ): AxiosPromise<JsonApiAnalyticalDashboardOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApiInterface
-     */
-    updateEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ): AxiosPromise<JsonApiDataDiscriminatorDocument>;
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21242,18 +23869,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiFilterContextDocument>;
+    ): AxiosPromise<JsonApiFilterContextOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21264,18 +23891,18 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiMetricDocument>;
+    ): AxiosPromise<JsonApiMetricOutDocument>;
 
     /**
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21286,12 +23913,34 @@ export interface WorkspaceObjectControllerApiInterface {
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
-    ): AxiosPromise<JsonApiVisualizationObjectDocument>;
+    ): AxiosPromise<JsonApiVisualizationObjectOutDocument>;
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApiInterface
+     */
+    updateEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ): AxiosPromise<JsonApiWorkspaceDataFilterOutDocument>;
 }
 
 /**
@@ -21304,7 +23953,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21314,7 +23963,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityAnalyticalDashboards(
         params: {
             workspaceId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21329,32 +23978,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public createEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).createEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21364,7 +23988,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityFilterContexts(
         params: {
             workspaceId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21379,7 +24003,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21389,7 +24013,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityMetrics(
         params: {
             workspaceId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -21404,7 +24028,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -21414,13 +24038,38 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     public createEntityVisualizationObjects(
         params: {
             workspaceId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).createEntityVisualizationObjects(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public createEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).createEntityWorkspaceDataFilters(
             params,
             options,
         )(this.axios, this.basePath);
@@ -21444,29 +24093,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityAnalyticalDashboards(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public deleteEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityDataDiscriminators(
             params,
             options,
         )(this.axios, this.basePath);
@@ -21544,6 +24170,29 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public deleteEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).deleteEntityWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {number} [page] Zero-based page index (0..N)
@@ -21597,35 +24246,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
             this.axios,
             this.basePath,
         );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {number} [page] Zero-based page index (0..N)
-     * @param {number} [size] The size of the page to be returned
-     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public getEntitiesDataDiscriminators(
-        params: {
-            workspaceId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-            page?: number;
-            size?: number;
-            sort?: Array<string>;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
     }
 
     /**
@@ -21863,6 +24483,64 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
     /**
      *
      * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntitiesWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesWorkspaceDataFilterSettings(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {number} [page] Zero-based page index (0..N)
+     * @param {number} [size] The size of the page to be returned
+     * @param {Array<string>} [sort] Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntitiesWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+            page?: number;
+            size?: number;
+            sort?: Array<string>;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntitiesWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
      * @param {string} objectId
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
@@ -21908,31 +24586,6 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
             this.axios,
             this.basePath,
         );
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public getEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).getEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
     }
 
     /**
@@ -22139,7 +24792,57 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiAnalyticalDashboardDocument} jsonApiAnalyticalDashboardDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntityWorkspaceDataFilterSettings(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityWorkspaceDataFilterSettings(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public getEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).getEntityWorkspaceDataFilters(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiAnalyticalDashboardInDocument} jsonApiAnalyticalDashboardInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22150,7 +24853,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiAnalyticalDashboardDocument: JsonApiAnalyticalDashboardDocument;
+            jsonApiAnalyticalDashboardInDocument: JsonApiAnalyticalDashboardInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22166,34 +24869,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiDataDiscriminatorDocument} jsonApiDataDiscriminatorDocument
-     * @param {{ [key: string]: object; }} [variableParam]
-     * @param {object} [include]
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof WorkspaceObjectControllerApi
-     */
-    public updateEntityDataDiscriminators(
-        params: {
-            workspaceId: string;
-            objectId: string;
-            jsonApiDataDiscriminatorDocument: JsonApiDataDiscriminatorDocument;
-            variableParam?: { [key: string]: object };
-            include?: object;
-        },
-        options?: any,
-    ) {
-        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityDataDiscriminators(
-            params,
-            options,
-        )(this.axios, this.basePath);
-    }
-
-    /**
-     *
-     * @param {string} workspaceId
-     * @param {string} objectId
-     * @param {JsonApiFilterContextDocument} jsonApiFilterContextDocument
+     * @param {JsonApiFilterContextInDocument} jsonApiFilterContextInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22204,7 +24880,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiFilterContextDocument: JsonApiFilterContextDocument;
+            jsonApiFilterContextInDocument: JsonApiFilterContextInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22220,7 +24896,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiMetricDocument} jsonApiMetricDocument
+     * @param {JsonApiMetricInDocument} jsonApiMetricInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22231,7 +24907,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiMetricDocument: JsonApiMetricDocument;
+            jsonApiMetricInDocument: JsonApiMetricInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
@@ -22247,7 +24923,7 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
      *
      * @param {string} workspaceId
      * @param {string} objectId
-     * @param {JsonApiVisualizationObjectDocument} jsonApiVisualizationObjectDocument
+     * @param {JsonApiVisualizationObjectInDocument} jsonApiVisualizationObjectInDocument
      * @param {{ [key: string]: object; }} [variableParam]
      * @param {object} [include]
      * @param {*} [options] Override http request option.
@@ -22258,13 +24934,40 @@ export class WorkspaceObjectControllerApi extends BaseAPI implements WorkspaceOb
         params: {
             workspaceId: string;
             objectId: string;
-            jsonApiVisualizationObjectDocument: JsonApiVisualizationObjectDocument;
+            jsonApiVisualizationObjectInDocument: JsonApiVisualizationObjectInDocument;
             variableParam?: { [key: string]: object };
             include?: object;
         },
         options?: any,
     ) {
         return WorkspaceObjectControllerApiFp(this.configuration).updateEntityVisualizationObjects(
+            params,
+            options,
+        )(this.axios, this.basePath);
+    }
+
+    /**
+     *
+     * @param {string} workspaceId
+     * @param {string} objectId
+     * @param {JsonApiWorkspaceDataFilterInDocument} jsonApiWorkspaceDataFilterInDocument
+     * @param {{ [key: string]: object; }} [variableParam]
+     * @param {object} [include]
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof WorkspaceObjectControllerApi
+     */
+    public updateEntityWorkspaceDataFilters(
+        params: {
+            workspaceId: string;
+            objectId: string;
+            jsonApiWorkspaceDataFilterInDocument: JsonApiWorkspaceDataFilterInDocument;
+            variableParam?: { [key: string]: object };
+            include?: object;
+        },
+        options?: any,
+    ) {
+        return WorkspaceObjectControllerApiFp(this.configuration).updateEntityWorkspaceDataFilters(
             params,
             options,
         )(this.axios, this.basePath);

--- a/libs/api-client-tiger/src/generated/metadata-json-api/base.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/base.ts
@@ -18,7 +18,7 @@ import { Configuration } from "./configuration";
 // @ts-ignore
 import globalAxios, { AxiosPromise, AxiosInstance } from "axios";
 
-export const BASE_PATH = "http://localhost".replace(/\/+$/, "");
+export const BASE_PATH = "https://staging.anywhere.gooddata.com".replace(/\/+$/, "");
 
 /**
  *

--- a/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/openapi-spec.json
@@ -6,7 +6,7 @@
     },
     "servers": [
         {
-            "url": "http://localhost:3000",
+            "url": "https://staging.anywhere.gooddata.com",
             "description": "Generated server url"
         },
         {
@@ -18,12 +18,12 @@
         "/api/layout/workspaces": {
             "get": {
                 "tags": ["declarative-layout-controller"],
-                "summary": "Get all workspaces layout",
-                "description": "Retrieve layout of workspaces, including a hierarchy and models.",
+                "summary": "Set all workspaces layout",
+                "description": "Sets complete layout of workspaces, their hierarchy, models.",
                 "operationId": "getWorkspacesLayout",
                 "responses": {
-                    "200": {
-                        "description": "Retrieved all workspaces layout.",
+                    "204": {
+                        "description": "All workspaces layout set.",
                         "content": {
                             "*/*": {
                                 "schema": {
@@ -239,6 +239,47 @@
                 }
             }
         },
+        "/api/layout/workspaceDataFilters": {
+            "get": {
+                "tags": ["declarative-layout-controller"],
+                "summary": "Get workspace data filters for all workspaces",
+                "description": "Retrieve all workspaces and related workspace data filters (and their settings / values).",
+                "operationId": "getWorkspaceDataFiltersLayout",
+                "responses": {
+                    "200": {
+                        "description": "Retrieved all workspace data filters.",
+                        "content": {
+                            "*/*": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilters"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": ["declarative-layout-controller"],
+                "summary": "Set all workspace data filters",
+                "description": "Sets workspace data filters in all workspaces in entire organization.",
+                "operationId": "setWorkspaceDataFiltersLayout",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilters"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "All workspace data filters set."
+                    }
+                }
+            }
+        },
         "/api/layout/organization": {
             "get": {
                 "tags": ["declarative-layout-controller"],
@@ -263,12 +304,38 @@
                 }
             }
         },
-        "/api/dataSources/{dataSourceId}/uploadNotification": {
+        "/api/actions/dataSources/{dataSourceId}/uploadNotification": {
             "post": {
                 "tags": ["notification-controller"],
                 "summary": "Register an upload notification",
                 "description": "Notification sets up all reports to be computed again with new data.",
                 "operationId": "registerUploadNotification",
+                "parameters": [
+                    {
+                        "name": "dataSourceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "An upload notification has been successfully registered."
+                    },
+                    "404": {
+                        "description": "Data source with given name does not exist."
+                    }
+                }
+            }
+        },
+        "/api/dataSources/{dataSourceId}/uploadNotification": {
+            "post": {
+                "tags": ["notification-controller"],
+                "summary": "Register an upload notification",
+                "description": "Notification sets up all reports to be computed again with new data.",
+                "operationId": "registerUploadNotification_1",
                 "parameters": [
                     {
                         "name": "dataSourceId",
@@ -402,7 +469,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLList"
+                                    "$ref": "#/components/schemas/JsonApiACLOutList"
                                 }
                             }
                         }
@@ -434,7 +501,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -446,7 +513,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -491,7 +558,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -532,7 +599,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -544,7 +611,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -617,7 +684,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -658,7 +725,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -670,7 +737,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -715,7 +782,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -756,7 +823,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -768,7 +835,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -813,7 +880,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -854,7 +921,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -866,7 +933,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -911,7 +978,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -952,7 +1019,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -964,7 +1031,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1009,7 +1076,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -1050,7 +1117,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -1062,7 +1129,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -1107,7 +1174,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -1148,7 +1215,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -1160,7 +1227,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -1205,7 +1272,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -1246,7 +1313,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -1258,7 +1325,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -1323,7 +1390,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceList"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutList"
                                 }
                             }
                         }
@@ -1355,7 +1422,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -1367,7 +1434,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1412,7 +1479,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1453,7 +1520,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -1465,7 +1532,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -1558,7 +1625,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleList"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutList"
                                 }
                             }
                         }
@@ -1590,7 +1657,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -1602,7 +1669,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1647,7 +1714,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1688,7 +1755,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -1700,7 +1767,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -1748,25 +1815,25 @@
                                 "schema": {
                                     "oneOf": [
                                         {
-                                            "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                            "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiACLDocument"
+                                            "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                            "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                            "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                            "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiUserDocument"
+                                            "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                         },
                                         {
-                                            "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                            "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                         }
                                     ]
                                 }
@@ -1833,7 +1900,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationList"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutList"
                                 }
                             }
                         }
@@ -1865,7 +1932,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -1877,7 +1944,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1922,7 +1989,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -1963,7 +2030,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -1975,7 +2042,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -2068,7 +2135,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupList"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutList"
                                 }
                             }
                         }
@@ -2100,7 +2167,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -2112,7 +2179,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2157,7 +2224,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2198,7 +2265,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -2210,7 +2277,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -2303,7 +2370,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserList"
+                                    "$ref": "#/components/schemas/JsonApiUserOutList"
                                 }
                             }
                         }
@@ -2335,7 +2402,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -2347,7 +2414,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2392,7 +2459,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2433,7 +2500,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -2445,7 +2512,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -2546,7 +2613,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenList"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutList"
                                 }
                             }
                         }
@@ -2586,7 +2653,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                "$ref": "#/components/schemas/JsonApiApiTokenInDocument"
                             }
                         }
                     },
@@ -2598,7 +2665,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutDocument"
                                 }
                             }
                         }
@@ -2680,7 +2747,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiApiTokenDocument"
+                                    "$ref": "#/components/schemas/JsonApiApiTokenOutDocument"
                                 }
                             }
                         }
@@ -2781,7 +2848,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceList"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutList"
                                 }
                             }
                         }
@@ -2813,7 +2880,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -2825,7 +2892,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -2870,7 +2937,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -2911,7 +2978,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -2923,7 +2990,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -3024,7 +3091,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardList"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutList"
                                 }
                             }
                         }
@@ -3064,7 +3131,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardInDocument"
                             }
                         }
                     },
@@ -3076,7 +3143,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3128,7 +3195,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3176,7 +3243,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                "$ref": "#/components/schemas/JsonApiAnalyticalDashboardInDocument"
                             }
                         }
                     },
@@ -3188,7 +3255,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardDocument"
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutDocument"
                                 }
                             }
                         }
@@ -3296,7 +3363,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeList"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutList"
                                 }
                             }
                         }
@@ -3348,7 +3415,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiAttributeDocument"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutDocument"
                                 }
                             }
                         }
@@ -3374,7 +3441,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiACLDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -3386,7 +3453,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiACLDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -3412,7 +3479,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
@@ -3424,7 +3491,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataSourceDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
@@ -3450,7 +3517,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
                             }
                         }
                     },
@@ -3462,7 +3529,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiModelModuleDocument"
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
                                 }
                             }
                         }
@@ -3488,7 +3555,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
                             }
                         }
                     },
@@ -3500,7 +3567,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiOrganizationDocument"
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
                                 }
                             }
                         }
@@ -3526,7 +3593,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
                             }
                         }
                     },
@@ -3538,7 +3605,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
                                 }
                             }
                         }
@@ -3564,7 +3631,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiUserDocument"
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
                             }
                         }
                     },
@@ -3576,7 +3643,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiUserDocument"
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
                                 }
                             }
                         }
@@ -3602,7 +3669,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
                             }
                         }
                     },
@@ -3614,7 +3681,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceDocument"
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
                                 }
                             }
                         }
@@ -3622,81 +3689,10 @@
                 }
             }
         },
-        "/api/entities/workspaces/{workspaceId}/dataDiscriminators": {
-            "get": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "getEntities@DataDiscriminators",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    },
-                    {
-                        "name": "page",
-                        "in": "query",
-                        "description": "Zero-based page index (0..N)",
-                        "schema": {
-                            "type": "integer",
-                            "default": "0"
-                        }
-                    },
-                    {
-                        "name": "size",
-                        "in": "query",
-                        "description": "The size of the page to be returned",
-                        "schema": {
-                            "type": "integer",
-                            "default": "20"
-                        }
-                    },
-                    {
-                        "name": "sort",
-                        "in": "query",
-                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorList"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/acls": {
             "post": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "createEntity@DataDiscriminators",
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Acls",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3707,19 +3703,11 @@
                         }
                     },
                     {
-                        "name": "variableParam",
-                        "in": "query",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
+                            "type": "string"
                         }
                     }
                 ],
@@ -3727,7 +3715,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                "$ref": "#/components/schemas/JsonApiACLInDocument"
                             }
                         }
                     },
@@ -3739,7 +3727,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                    "$ref": "#/components/schemas/JsonApiACLOutDocument"
                                 }
                             }
                         }
@@ -3747,10 +3735,10 @@
                 }
             }
         },
-        "/api/entities/workspaces/{workspaceId}/dataDiscriminators/{objectId}": {
-            "get": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "getEntity@DataDiscriminators",
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/dataSources": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@DataSources",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3761,77 +3749,11 @@
                         }
                     },
                     {
-                        "name": "objectId",
+                        "name": "childWorkspaceId",
                         "in": "path",
                         "required": true,
                         "schema": {
                             "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Request successfully processed",
-                        "content": {
-                            "application/vnd.gooddata.api+json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "updateEntity@DataDiscriminators",
-                "parameters": [
-                    {
-                        "name": "workspaceId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "objectId",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "variableParam",
-                        "in": "query",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    {
-                        "name": "include",
-                        "in": "query",
-                        "required": false,
-                        "schema": {
-                            "type": "object"
                         }
                     }
                 ],
@@ -3839,28 +3761,30 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                "$ref": "#/components/schemas/JsonApiDataSourceInDocument"
                             }
                         }
                     },
                     "required": true
                 },
                 "responses": {
-                    "200": {
+                    "201": {
                         "description": "Request successfully processed",
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDataDiscriminatorDocument"
+                                    "$ref": "#/components/schemas/JsonApiDataSourceOutDocument"
                                 }
                             }
                         }
                     }
                 }
-            },
-            "delete": {
-                "tags": ["workspace-object-controller"],
-                "operationId": "deleteEntity@DataDiscriminators",
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/modelModules": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@ModelModules",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -3871,7 +3795,45 @@
                         }
                     },
                     {
-                        "name": "objectId",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiModelModuleInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiModelModuleOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/organizations": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Organizations",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
                         "in": "path",
                         "required": true,
                         "schema": {
@@ -3879,17 +3841,172 @@
                         }
                     },
                     {
-                        "name": "variableParam",
-                        "in": "query",
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": true
+                            "type": "string"
                         }
                     }
                 ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiOrganizationInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
                 "responses": {
-                    "204": {
-                        "description": "Successfully deleted"
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiOrganizationOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/userGroups": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@UserGroups",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiUserGroupInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/users": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Users",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiUserInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiUserOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/children/{childWorkspaceId}/workspaces": {
+            "post": {
+                "tags": ["organization-model-controller"],
+                "operationId": "createWorkspaceDataFilterSettingEntity@Workspaces",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "childWorkspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutDocument"
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -3959,7 +4076,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetList"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutList"
                                 }
                             }
                         }
@@ -4011,7 +4128,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiDatasetDocument"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutDocument"
                                 }
                             }
                         }
@@ -4084,7 +4201,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactList"
+                                    "$ref": "#/components/schemas/JsonApiFactOutList"
                                 }
                             }
                         }
@@ -4136,7 +4253,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFactDocument"
+                                    "$ref": "#/components/schemas/JsonApiFactOutDocument"
                                 }
                             }
                         }
@@ -4209,7 +4326,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextList"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutList"
                                 }
                             }
                         }
@@ -4249,7 +4366,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                "$ref": "#/components/schemas/JsonApiFilterContextInDocument"
                             }
                         }
                     },
@@ -4261,7 +4378,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4313,7 +4430,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4361,7 +4478,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                "$ref": "#/components/schemas/JsonApiFilterContextInDocument"
                             }
                         }
                     },
@@ -4373,7 +4490,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextDocument"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutDocument"
                                 }
                             }
                         }
@@ -4481,7 +4598,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelList"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutList"
                                 }
                             }
                         }
@@ -4533,7 +4650,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiLabelDocument"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutDocument"
                                 }
                             }
                         }
@@ -4606,7 +4723,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricList"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutList"
                                 }
                             }
                         }
@@ -4646,7 +4763,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                "$ref": "#/components/schemas/JsonApiMetricInDocument"
                             }
                         }
                     },
@@ -4658,7 +4775,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4710,7 +4827,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4758,7 +4875,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                "$ref": "#/components/schemas/JsonApiMetricInDocument"
                             }
                         }
                     },
@@ -4770,7 +4887,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiMetricDocument"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutDocument"
                                 }
                             }
                         }
@@ -4878,7 +4995,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesList"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutList"
                                 }
                             }
                         }
@@ -4930,7 +5047,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesDocument"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutDocument"
                                 }
                             }
                         }
@@ -5003,7 +5120,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableList"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutList"
                                 }
                             }
                         }
@@ -5055,7 +5172,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableDocument"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutDocument"
                                 }
                             }
                         }
@@ -5128,7 +5245,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectList"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutList"
                                 }
                             }
                         }
@@ -5168,7 +5285,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                "$ref": "#/components/schemas/JsonApiVisualizationObjectInDocument"
                             }
                         }
                     },
@@ -5180,7 +5297,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5232,7 +5349,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5280,7 +5397,7 @@
                     "content": {
                         "application/vnd.gooddata.api+json": {
                             "schema": {
-                                "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                "$ref": "#/components/schemas/JsonApiVisualizationObjectInDocument"
                             }
                         }
                     },
@@ -5292,7 +5409,7 @@
                         "content": {
                             "application/vnd.gooddata.api+json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectDocument"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutDocument"
                                 }
                             }
                         }
@@ -5302,6 +5419,403 @@
             "delete": {
                 "tags": ["workspace-object-controller"],
                 "operationId": "deleteEntity@VisualizationObjects",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Successfully deleted"
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntities@WorkspaceDataFilterSettings",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Zero-based page index (0..N)",
+                        "schema": {
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The size of the page to be returned",
+                        "schema": {
+                            "type": "integer",
+                            "default": "20"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutList"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilterSettings/{objectId}": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntity@WorkspaceDataFilterSettings",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilters": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntities@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "Zero-based page index (0..N)",
+                        "schema": {
+                            "type": "integer",
+                            "default": "0"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The size of the page to be returned",
+                        "schema": {
+                            "type": "integer",
+                            "default": "20"
+                        }
+                    },
+                    {
+                        "name": "sort",
+                        "in": "query",
+                        "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutList"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "createEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/entities/workspaces/{workspaceId}/workspaceDataFilters/{objectId}": {
+            "get": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "getEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "updateEntity@WorkspaceDataFilters",
+                "parameters": [
+                    {
+                        "name": "workspaceId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "objectId",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "variableParam",
+                        "in": "query",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    {
+                        "name": "include",
+                        "in": "query",
+                        "required": false,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/vnd.gooddata.api+json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterInDocument"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "Request successfully processed",
+                        "content": {
+                            "application/vnd.gooddata.api+json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutDocument"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "tags": ["workspace-object-controller"],
+                "operationId": "deleteEntity@WorkspaceDataFilters",
                 "parameters": [
                     {
                         "name": "workspaceId",
@@ -5442,38 +5956,6 @@
                     }
                 },
                 "description": "A table column."
-            },
-            "DeclarativeDataDiscriminator": {
-                "required": ["columnName", "dataSourceName", "id", "title"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "type": "string",
-                        "description": "Data Discriminator ID. This ID is further used to refer to this instance of DD.",
-                        "example": "country_id"
-                    },
-                    "title": {
-                        "type": "string",
-                        "description": "Data Discriminator title.",
-                        "example": "Country ID"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Data Discriminator description.",
-                        "example": "ID of country"
-                    },
-                    "columnName": {
-                        "type": "string",
-                        "description": "Data Discriminator column name. Data are filtered using this physical column.",
-                        "example": "country_id"
-                    },
-                    "dataSourceName": {
-                        "type": "string",
-                        "description": "Data source name (ID). Data Discriminator must always be connected to single data source.",
-                        "example": "sampleDataSource"
-                    }
-                },
-                "description": "Data discriminators serving the discrimination of what data users can see in workspaces."
             },
             "DeclarativeDataSource": {
                 "required": ["name", "tables"],
@@ -5775,9 +6257,10 @@
                     "path": {
                         "type": "array",
                         "description": "Path to table.",
-                        "example": "table_schema.table_name",
+                        "example": ["table_schema", "table_name"],
                         "items": {
-                            "type": "string"
+                            "type": "string",
+                            "example": "table_name"
                         }
                     },
                     "columns": {
@@ -5832,8 +6315,85 @@
                     }
                 }
             },
+            "DeclarativeWorkspaceDataFilter": {
+                "required": ["columnName", "dataSourceName", "id", "title", "workspaceDataFilterSettings"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Workspace Data Filters ID. This ID is further used to refer to this instance.",
+                        "example": "country_id"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Workspace Data Filters title.",
+                        "example": "Country ID"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Workspace Data Filters description.",
+                        "example": "ID of country"
+                    },
+                    "columnName": {
+                        "type": "string",
+                        "description": "Workspace Data Filters column name. Data are filtered using this physical column.",
+                        "example": "country_id"
+                    },
+                    "dataSourceName": {
+                        "type": "string",
+                        "description": "Data source name (ID). Workspace Data Filters must always be connected to single data source.",
+                        "example": "sampleDataSource"
+                    },
+                    "workspaceDataFilterSettings": {
+                        "type": "array",
+                        "description": "Filter settings specifying values of filters valid for the workspace.",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilterSetting"
+                        }
+                    },
+                    "workspace": {
+                        "$ref": "#/components/schemas/WorkspaceIdentifier"
+                    }
+                },
+                "description": "Workspace Data Filters serving the filtering of what data users can see in workspaces."
+            },
+            "DeclarativeWorkspaceDataFilterSetting": {
+                "required": ["filterValues", "id", "title", "workspace"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Workspace Data Filters ID. This ID is further used to refer to this instance.",
+                        "example": "country_id_setting"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Workspace Data Filters setting title.",
+                        "example": "Country ID setting"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Workspace Data Filters setting description.",
+                        "example": "ID of country setting"
+                    },
+                    "filterValues": {
+                        "type": "array",
+                        "description": "Only those rows are returned, where columnName from filter matches those values.",
+                        "example": ["US"],
+                        "items": {
+                            "type": "string",
+                            "description": "Only those rows are returned, where columnName from filter matches those values.",
+                            "example": "[\"US\"]"
+                        }
+                    },
+                    "workspace": {
+                        "$ref": "#/components/schemas/WorkspaceIdentifier"
+                    }
+                },
+                "description": "Workspace Data Filters serving the filtering of what data users can see in workspaces."
+            },
             "DeclarativeWorkspaceModel": {
-                "required": ["analytics", "dataDiscriminators", "ldm", "pdm"],
+                "required": ["analytics", "ldm", "pdm"],
                 "type": "object",
                 "properties": {
                     "ldm": {
@@ -5844,23 +6404,23 @@
                     },
                     "analytics": {
                         "$ref": "#/components/schemas/DeclarativeAnalyticsLayer"
-                    },
-                    "dataDiscriminators": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/DeclarativeDataDiscriminator"
-                        }
                     }
                 }
             },
             "DeclarativeWorkspaces": {
-                "required": ["workspaces"],
+                "required": ["workspaceDataFilters", "workspaces"],
                 "type": "object",
                 "properties": {
                     "workspaces": {
                         "type": "array",
                         "items": {
                             "$ref": "#/components/schemas/DeclarativeWorkspace"
+                        }
+                    },
+                    "workspaceDataFilters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilter"
                         }
                     }
                 }
@@ -5933,7 +6493,9 @@
                         "type": "string",
                         "enum": ["workspace"]
                     }
-                }
+                },
+                "description": "Store filter into this workspace. Empty if it is part of layout of workspaces.",
+                "example": "{ id: demo, type: workspace }"
             },
             "DeclarativeModel": {
                 "required": ["ldm", "pdm"],
@@ -5957,6 +6519,18 @@
                     }
                 },
                 "description": "Entities describing users' view on data."
+            },
+            "DeclarativeWorkspaceDataFilters": {
+                "required": ["workspaceDataFilters"],
+                "type": "object",
+                "properties": {
+                    "workspaceDataFilters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/DeclarativeWorkspaceDataFilter"
+                        }
+                    }
+                }
             },
             "ObjectLinks": {
                 "required": ["self"],
@@ -6022,12 +6596,12 @@
                 },
                 "description": "The \\\"type\\\" and \\\"id\\\" to non-empty members."
             },
-            "JsonApiACLDocument": {
+            "JsonApiACLOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiACL"
+                        "$ref": "#/components/schemas/JsonApiACLOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6039,17 +6613,17 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiACL": {
+            "JsonApiACLOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6105,19 +6679,469 @@
                 },
                 "description": "JSON:API representation of acl entity."
             },
-            "JsonApiDataSourceDocument": {
+            "JsonApiDataSourceOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataSource"
+                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
                     }
                 }
             },
-            "JsonApiDataSource": {
+            "JsonApiDataSourceOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "dataSource"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "POSTGRESQL",
+                                    "REDSHIFT",
+                                    "VERTICA",
+                                    "SNOWFLAKE",
+                                    "ADS",
+                                    "BIGQUERY",
+                                    "MSSQL",
+                                    "PRESTO"
+                                ]
+                            },
+                            "url": {
+                                "type": "string"
+                            },
+                            "schema": {
+                                "type": "string"
+                            },
+                            "username": {
+                                "type": "string"
+                            },
+                            "uploadId": {
+                                "type": "string"
+                            },
+                            "enableCaching": {
+                                "type": "boolean"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of dataSource entity."
+            },
+            "JsonApiModelModuleOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiModelModuleOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiModelModuleOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "modelModule"
+                    },
+                    "attributes": {
+                        "type": "object"
+                    }
+                },
+                "description": "JSON:API representation of modelModule entity."
+            },
+            "JsonApiOrganizationOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiOrganizationOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "organization"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "hostname": {
+                                "type": "string"
+                            },
+                            "oauthIssuerLocation": {
+                                "type": "string"
+                            },
+                            "oauthClientId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            },
+                            "userGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of organization entity."
+            },
+            "JsonApiUserGroupOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiUserGroupOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "userGroup"
+                    },
+                    "attributes": {
+                        "type": "object"
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            },
+                            "acls": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of userGroup entity."
+            },
+            "JsonApiUserOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiUserOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiUserOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "user"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "authenticationId": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "userGroup": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            },
+                            "acls": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of user entity."
+            },
+            "JsonApiWorkspaceOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspaceOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspace"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspace": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspace entity."
+            },
+            "JsonApiACLInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiACLIn"
+                    }
+                }
+            },
+            "JsonApiACLIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "acl"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "access": {
+                                "type": "string",
+                                "enum": ["FULL_ACCESS"]
+                            },
+                            "priority": {
+                                "type": "integer",
+                                "format": "int32"
+                            },
+                            "control": {
+                                "type": "string",
+                                "enum": ["ALLOW", "DENY"]
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "users": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "userGroups": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of acl entity."
+            },
+            "JsonApiDataSourceInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiDataSourceIn"
+                    }
+                }
+            },
+            "JsonApiDataSourceIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6174,19 +7198,16 @@
                 },
                 "description": "JSON:API representation of dataSource entity."
             },
-            "JsonApiModelModuleDocument": {
+            "JsonApiModelModuleInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiModelModule"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/JsonApiModelModuleIn"
                     }
                 }
             },
-            "JsonApiModelModule": {
+            "JsonApiModelModuleIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6207,34 +7228,16 @@
                 },
                 "description": "JSON:API representation of modelModule entity."
             },
-            "JsonApiOrganizationDocument": {
+            "JsonApiOrganizationInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiOrganization"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                }
-                            ]
-                        }
+                        "$ref": "#/components/schemas/JsonApiOrganizationIn"
                     }
                 }
             },
-            "JsonApiOrganization": {
+            "JsonApiOrganizationIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6268,59 +7271,20 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "user": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToOne"
-                                    }
-                                }
-                            },
-                            "userGroup": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToOne"
-                                    }
-                                }
-                            }
-                        }
                     }
                 },
                 "description": "JSON:API representation of organization entity."
             },
-            "JsonApiUserGroupDocument": {
+            "JsonApiUserGroupInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiUserGroup"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
-                                }
-                            ]
-                        }
+                        "$ref": "#/components/schemas/JsonApiUserGroupIn"
                     }
                 }
             },
-            "JsonApiUserGroup": {
+            "JsonApiUserGroupIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6362,34 +7326,16 @@
                 },
                 "description": "JSON:API representation of userGroup entity."
             },
-            "JsonApiUserDocument": {
+            "JsonApiUserInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiUser"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
-                                }
-                            ]
-                        }
+                        "$ref": "#/components/schemas/JsonApiUserIn"
                     }
                 }
             },
-            "JsonApiUser": {
+            "JsonApiUserIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6436,31 +7382,16 @@
                 },
                 "description": "JSON:API representation of user entity."
             },
-            "JsonApiWorkspaceDocument": {
+            "JsonApiWorkspaceInDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiWorkspace"
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
-                                }
-                            ]
-                        }
+                        "$ref": "#/components/schemas/JsonApiWorkspaceIn"
                     }
                 }
             },
-            "JsonApiWorkspace": {
+            "JsonApiWorkspaceIn": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6482,29 +7413,71 @@
                                 "type": "string"
                             }
                         }
+                    }
+                },
+                "description": "JSON:API representation of workspace entity."
+            },
+            "JsonApiAnalyticalDashboardInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardIn"
+                    }
+                }
+            },
+            "JsonApiAnalyticalDashboardIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
                     },
-                    "relationships": {
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "analyticalDashboard"
+                    },
+                    "attributes": {
                         "type": "object",
                         "properties": {
-                            "workspace": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
                                 "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToOne"
-                                    }
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
                                 }
                             }
                         }
                     }
                 },
-                "description": "JSON:API representation of workspace entity."
+                "description": "JSON:API representation of analyticalDashboard entity."
             },
-            "JsonApiAttributeDocument": {
+            "JsonApiAnalyticalDashboardOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiAttribute"
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -6516,17 +7489,907 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiAttribute": {
+            "JsonApiAnalyticalDashboardOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "analyticalDashboard"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "visualizationObjects": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "labels": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "metrics": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "datasets": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "filterContexts": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of analyticalDashboard entity."
+            },
+            "JsonApiFilterContextInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFilterContextIn"
+                    }
+                }
+            },
+            "JsonApiFilterContextIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "filterContext"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of filterContext entity."
+            },
+            "JsonApiFilterContextOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiFilterContextOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiFilterContextOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "filterContext"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "attributes": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "datasets": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "labels": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of filterContext entity."
+            },
+            "JsonApiMetricInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiMetricIn"
+                    }
+                }
+            },
+            "JsonApiMetricIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "metric"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "properties": {
+                                    "format": {
+                                        "type": "string"
+                                    },
+                                    "maql": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of metric entity."
+            },
+            "JsonApiMetricOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiMetricOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiMetricOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "metric"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "properties": {
+                                    "format": {
+                                        "type": "string"
+                                    },
+                                    "maql": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "facts": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "attributes": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "labels": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "metrics": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of metric entity."
+            },
+            "JsonApiVisualizationObjectInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectIn"
+                    }
+                }
+            },
+            "JsonApiVisualizationObjectIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "visualizationObject"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of visualizationObject entity."
+            },
+            "JsonApiVisualizationObjectOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiVisualizationObjectOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "visualizationObject"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "content": {
+                                "type": "object",
+                                "description": "Free-form JSON content.",
+                                "example": {
+                                    "identifier": {
+                                        "id": "label.leaf",
+                                        "type": "label"
+                                    },
+                                    "someBoolProp": false
+                                }
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "facts": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "attributes": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "labels": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "metrics": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "analyticalDashboards": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            },
+                            "datasets": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of visualizationObject entity."
+            },
+            "JsonApiWorkspaceDataFilterInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterIn"
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspaceDataFilter"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "columnName": {
+                                "type": "string"
+                            },
+                            "dataSourceName": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspaceDataFilterSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspaceDataFilter entity."
+            },
+            "JsonApiWorkspaceDataFilterOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "workspaceDataFilter"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "title": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "columnName": {
+                                "type": "string"
+                            },
+                            "dataSourceName": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "relationships": {
+                        "type": "object",
+                        "properties": {
+                            "workspaceDataFilterSettings": {
+                                "type": "object",
+                                "properties": {
+                                    "data": {
+                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of workspaceDataFilter entity."
+            },
+            "JsonApiApiTokenOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    }
+                }
+            },
+            "JsonApiApiTokenOut": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "properties": {
+                            "bearerToken": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
+            },
+            "JsonApiApiTokenInDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiApiTokenIn"
+                    }
+                }
+            },
+            "JsonApiApiTokenIn": {
+                "required": ["id", "type"],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
+                        "type": "string",
+                        "description": "API identifier of an object",
+                        "example": "id1"
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Object type",
+                        "example": "apiToken"
+                    },
+                    "attributes": {
+                        "type": "object"
+                    }
+                },
+                "description": "JSON:API representation of apiToken entity."
+            },
+            "JsonApiApiTokenOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiApiTokenOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiApiTokenOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiApiTokenOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiAttributeOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiAttributeOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiAttributeOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiAttributeOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6602,15 +8465,29 @@
                 },
                 "description": "JSON:API representation of attribute entity."
             },
-            "JsonApiDatasetDocument": {
+            "JsonApiDatasetOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiDatasetOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiDatasetOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataset"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6619,23 +8496,24 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiDataset": {
+            "JsonApiDatasetOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6761,15 +8639,29 @@
                     }
                 }
             },
-            "JsonApiFactDocument": {
+            "JsonApiFactOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiFactOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiFactOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiFact"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6778,14 +8670,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiFact": {
+            "JsonApiFactOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6836,15 +8729,29 @@
                 },
                 "description": "JSON:API representation of fact entity."
             },
-            "JsonApiLabelDocument": {
+            "JsonApiLabelOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiLabelOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiLabelOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiLabel"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6853,14 +8760,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiLabel": {
+            "JsonApiLabelOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6914,15 +8822,29 @@
                 },
                 "description": "JSON:API representation of label entity."
             },
-            "JsonApiSourceTablesDocument": {
+            "JsonApiSourceTablesOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiSourceTablesOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiSourceTablesOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiSourceTables"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6931,14 +8853,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiSourceTables": {
+            "JsonApiSourceTablesOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -6972,15 +8895,29 @@
                 },
                 "description": "A defined data source for analytics data"
             },
-            "JsonApiSourceTableDocument": {
+            "JsonApiSourceTableOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiSourceTableOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiSourceTableOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiSourceTable"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -6989,14 +8926,15 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiSourceTable": {
+            "JsonApiSourceTableOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7016,8 +8954,11 @@
                         "properties": {
                             "path": {
                                 "type": "array",
+                                "description": "Path to table.",
+                                "example": ["table_schema", "table_name"],
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "example": "table_name"
                                 }
                             },
                             "columns": {
@@ -7062,15 +9003,29 @@
                 },
                 "description": "A source table"
             },
-            "JsonApiAnalyticalDashboardDocument": {
+            "JsonApiAnalyticalDashboardOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiAnalyticalDashboardOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboard"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
+                        }
                     },
                     "links": {
-                        "$ref": "#/components/schemas/ObjectLinks"
+                        "$ref": "#/components/schemas/ListLinks"
                     },
                     "included": {
                         "uniqueItems": true,
@@ -7079,26 +9034,213 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
                                 }
                             ]
                         }
                     }
-                }
+                },
+                "description": "A JSON:API document with a list of resources"
             },
-            "JsonApiAnalyticalDashboard": {
+            "JsonApiFilterContextOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiFilterContextOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiFilterContextOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiFilterContextOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiMetricOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiMetricOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiMetricOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiVisualizationObjectOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiVisualizationObjectOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiVisualizationObjectOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiVisualizationObjectOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiMetricOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiWorkspaceDataFilterSettingOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceDataFilterSettingOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiWorkspaceDataFilterSettingOut": {
                 "required": ["id", "type"],
                 "type": "object",
                 "properties": {
@@ -7111,7 +9253,7 @@
                     "type": {
                         "type": "string",
                         "description": "Object type",
-                        "example": "analyticalDashboard"
+                        "example": "workspaceDataFilterSetting"
                     },
                     "attributes": {
                         "type": "object",
@@ -7122,21 +9264,10 @@
                             "description": {
                                 "type": "string"
                             },
-                            "tags": {
+                            "filterValues": {
                                 "type": "array",
                                 "items": {
                                     "type": "string"
-                                }
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
                                 }
                             }
                         }
@@ -7144,57 +9275,64 @@
                     "relationships": {
                         "type": "object",
                         "properties": {
-                            "visualizationObjects": {
+                            "workspaceDataFilter": {
                                 "type": "object",
                                 "properties": {
                                     "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "labels": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "metrics": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "datasets": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "filterContexts": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
+                                        "$ref": "#/components/schemas/JsonApiRelToOne"
                                     }
                                 }
                             }
                         }
                     }
                 },
-                "description": "JSON:API representation of analyticalDashboard entity."
+                "description": "JSON:API representation of workspaceDataFilterSetting entity."
             },
-            "JsonApiFilterContextDocument": {
+            "JsonApiWorkspaceDataFilterOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceDataFilterOutList": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiFilterContext"
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiAttributeOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiAttributeOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -7206,100 +9344,22 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiLabelOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiFilterContext": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "filterContext"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
-                                }
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "attributes": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "datasets": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "labels": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of filterContext entity."
-            },
-            "JsonApiMetricDocument": {
+            "JsonApiDatasetOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiMetric"
+                        "$ref": "#/components/schemas/JsonApiDatasetOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -7311,111 +9371,28 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiFactOutWithLinks"
                                 },
                                 {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiMetric": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "metric"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "content": {
-                                "type": "object",
-                                "properties": {
-                                    "format": {
-                                        "type": "string"
-                                    },
-                                    "maql": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "facts": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "attributes": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "labels": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "metrics": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of metric entity."
-            },
-            "JsonApiVisualizationObjectDocument": {
+            "JsonApiFactOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObject"
+                        "$ref": "#/components/schemas/JsonApiFactOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
@@ -7427,970 +9404,369 @@
                         "items": {
                             "anyOf": [
                                 {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
+                                    "$ref": "#/components/schemas/JsonApiDatasetOutWithLinks"
                                 }
                             ]
                         }
                     }
                 }
             },
-            "JsonApiVisualizationObject": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "visualizationObject"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "tags": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "content": {
-                                "type": "object",
-                                "description": "Free-form JSON content.",
-                                "example": {
-                                    "identifier": {
-                                        "id": "label.leaf",
-                                        "type": "label"
-                                    },
-                                    "someBoolProp": false
-                                }
-                            }
-                        }
-                    },
-                    "relationships": {
-                        "type": "object",
-                        "properties": {
-                            "facts": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "attributes": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "labels": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "metrics": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "analyticalDashboards": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            },
-                            "datasets": {
-                                "type": "object",
-                                "properties": {
-                                    "data": {
-                                        "$ref": "#/components/schemas/JsonApiRelToMany"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of visualizationObject entity."
-            },
-            "JsonApiDataDiscriminatorDocument": {
+            "JsonApiLabelOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/JsonApiDataDiscriminator"
+                        "$ref": "#/components/schemas/JsonApiLabelOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiAttributeOutWithLinks"
+                                }
+                            ]
+                        }
                     }
                 }
             },
-            "JsonApiDataDiscriminator": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "dataDiscriminator"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "title": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "columnName": {
-                                "type": "string"
-                            },
-                            "dataSourceName": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of dataDiscriminator entity."
-            },
-            "JsonApiACLWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiACL"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiACLList": {
+            "JsonApiSourceTablesOutDocument": {
                 "required": ["data"],
                 "type": "object",
                 "properties": {
                     "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiACLWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiDataSourceWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiDataSource"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiDataSourceList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiDataSourceWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiModelModuleWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiModelModule"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiModelModuleList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiModelModuleWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiOrganizationWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiOrganization"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiOrganizationList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiOrganizationWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiUserGroupWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUserGroup"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiUserGroupList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiUserWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiUser"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiUserList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiUserWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiUserGroupWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiACLWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiWorkspaceWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiWorkspace"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiWorkspaceList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiWorkspaceWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiApiTokenWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiApiToken"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiApiTokenList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiApiTokenWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiApiToken": {
-                "required": ["id", "type"],
-                "type": "object",
-                "properties": {
-                    "id": {
-                        "pattern": "^([.A-Za-z0-9_-]{1,255}:)?[.A-Za-z0-9_-]{1,255}$",
-                        "type": "string",
-                        "description": "API identifier of an object",
-                        "example": "id1"
-                    },
-                    "type": {
-                        "type": "string",
-                        "description": "Object type",
-                        "example": "apiToken"
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "properties": {
-                            "bearerToken": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "description": "JSON:API representation of apiToken entity."
-            },
-            "JsonApiAttributeWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiAttribute"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiAttributeList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiDatasetWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiDataset"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiDatasetList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiFactWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiFact"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiFactList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiLabelWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiLabel"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiLabelList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiSourceTablesWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiSourceTables"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiSourceTablesList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiSourceTableWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiSourceTable"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiSourceTableList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiSourceTableWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiSourceTablesWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiAnalyticalDashboardWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiAnalyticalDashboard"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiAnalyticalDashboardList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiFilterContextWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiFilterContext"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiFilterContextList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiFilterContextWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiMetricWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiMetric"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiMetricList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiVisualizationObjectWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiVisualizationObject"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiVisualizationObjectList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiVisualizationObjectWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    },
-                    "included": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "description": "Included resources",
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/JsonApiFactWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAttributeWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiLabelWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiMetricWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiAnalyticalDashboardWithLinks"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/JsonApiDatasetWithLinks"
-                                }
-                            ]
-                        }
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiDataDiscriminatorWithLinks": {
-                "allOf": [
-                    {
-                        "$ref": "#/components/schemas/JsonApiDataDiscriminator"
-                    },
-                    {
-                        "$ref": "#/components/schemas/ObjectLinksContainer"
-                    }
-                ]
-            },
-            "JsonApiDataDiscriminatorList": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "uniqueItems": true,
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/components/schemas/JsonApiDataDiscriminatorWithLinks"
-                        }
-                    },
-                    "links": {
-                        "$ref": "#/components/schemas/ListLinks"
-                    }
-                },
-                "description": "A JSON:API document with a list of resources"
-            },
-            "JsonApiApiTokenDocument": {
-                "required": ["data"],
-                "type": "object",
-                "properties": {
-                    "data": {
-                        "$ref": "#/components/schemas/JsonApiApiToken"
+                        "$ref": "#/components/schemas/JsonApiSourceTablesOut"
                     },
                     "links": {
                         "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiSourceTableOutWithLinks"
+                                }
+                            ]
+                        }
                     }
                 }
+            },
+            "JsonApiSourceTableOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiSourceTableOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiSourceTablesOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiWorkspaceDataFilterSettingOutDocument": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterSettingOut"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ObjectLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceDataFilterOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "JsonApiACLOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiACLOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiACLOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiDataSourceOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiDataSourceOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiDataSourceOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiDataSourceOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiModelModuleOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiModelModuleOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiModelModuleOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiModelModuleOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiOrganizationOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiOrganizationOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiOrganizationOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiOrganizationOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiUserGroupOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserGroupOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiUserGroupOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiUserOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiUserOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiUserOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiUserOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiUserGroupOutWithLinks"
+                                },
+                                {
+                                    "$ref": "#/components/schemas/JsonApiACLOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
+            },
+            "JsonApiWorkspaceOutWithLinks": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JsonApiWorkspaceOut"
+                    },
+                    {
+                        "$ref": "#/components/schemas/ObjectLinksContainer"
+                    }
+                ]
+            },
+            "JsonApiWorkspaceOutList": {
+                "required": ["data"],
+                "type": "object",
+                "properties": {
+                    "data": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
+                        }
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/ListLinks"
+                    },
+                    "included": {
+                        "uniqueItems": true,
+                        "type": "array",
+                        "description": "Included resources",
+                        "items": {
+                            "anyOf": [
+                                {
+                                    "$ref": "#/components/schemas/JsonApiWorkspaceOutWithLinks"
+                                }
+                            ]
+                        }
+                    }
+                },
+                "description": "A JSON:API document with a list of resources"
             }
         }
     }

--- a/libs/api-client-tiger/src/metadataUtilities.ts
+++ b/libs/api-client-tiger/src/metadataUtilities.ts
@@ -7,14 +7,14 @@ import uniqBy from "lodash/uniqBy";
 import { ITigerClient } from "./client";
 import { jsonApiHeaders } from "./constants";
 import {
-    JsonApiAnalyticalDashboardList,
-    JsonApiAttributeList,
-    JsonApiDatasetList,
-    JsonApiFactList,
-    JsonApiFilterContextList,
-    JsonApiLabelList,
-    JsonApiMetricList,
-    JsonApiVisualizationObjectList,
+    JsonApiAnalyticalDashboardOutList,
+    JsonApiAttributeOutList,
+    JsonApiDatasetOutList,
+    JsonApiFactOutList,
+    JsonApiFilterContextOutList,
+    JsonApiLabelOutList,
+    JsonApiMetricOutList,
+    JsonApiVisualizationObjectOutList,
 } from "./generated/metadata-json-api";
 
 const DefaultPageSize = 250;
@@ -63,14 +63,14 @@ export type MetadataGetEntitiesOptions = {
  * @internal
  */
 export type MetadataGetEntitiesResult =
-    | JsonApiVisualizationObjectList
-    | JsonApiAnalyticalDashboardList
-    | JsonApiDatasetList
-    | JsonApiAttributeList
-    | JsonApiLabelList
-    | JsonApiMetricList
-    | JsonApiFactList
-    | JsonApiFilterContextList;
+    | JsonApiVisualizationObjectOutList
+    | JsonApiAnalyticalDashboardOutList
+    | JsonApiDatasetOutList
+    | JsonApiAttributeOutList
+    | JsonApiLabelOutList
+    | JsonApiMetricOutList
+    | JsonApiFactOutList
+    | JsonApiFilterContextOutList;
 
 /**
  * All API client getEntities* functions follow this signature.

--- a/libs/api-client-tiger/src/organizationUtilities.ts
+++ b/libs/api-client-tiger/src/organizationUtilities.ts
@@ -7,11 +7,11 @@ import uniqBy from "lodash/uniqBy";
 import { ITigerClient } from "./client";
 import { jsonApiHeaders } from "./constants";
 import {
-    JsonApiACLList,
-    JsonApiOrganizationList,
-    JsonApiUserList,
-    JsonApiUserGroupList,
-    JsonApiWorkspaceList,
+    JsonApiACLOutList,
+    JsonApiOrganizationOutList,
+    JsonApiUserOutList,
+    JsonApiUserGroupOutList,
+    JsonApiWorkspaceOutList,
 } from "./generated/metadata-json-api";
 
 const DefaultPageSize = 250;
@@ -51,11 +51,11 @@ export type OrganizationGetEntitiesOptions = {
  * @internal
  */
 export type OrganizationGetEntitiesResult =
-    | JsonApiACLList
-    | JsonApiOrganizationList
-    | JsonApiUserList
-    | JsonApiUserGroupList
-    | JsonApiWorkspaceList;
+    | JsonApiACLOutList
+    | JsonApiOrganizationOutList
+    | JsonApiUserOutList
+    | JsonApiUserGroupOutList
+    | JsonApiWorkspaceOutList;
 
 /**
  * All API client getEntities* functions follow this signature.

--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
@@ -72,7 +72,7 @@ class TigerWorkspaceElementsQuery implements IElementsQuery {
         }
 
         const response = await this.authCall((client) => {
-            const elementsRequest: Parameters<typeof client.labelElements.processElementsRequest>[0] = {
+            const elementsRequest: Parameters<typeof client.labelElements.computeLabelElements>[0] = {
                 ...(options?.complement && { complementFilter: options.complement }),
                 ...(options?.filter && { patternFilter: options.filter }),
                 ...(options?.order && { sortOrder: options.order === "asc" ? "ASC" : "DESC" }),
@@ -82,7 +82,7 @@ class TigerWorkspaceElementsQuery implements IElementsQuery {
                 workspaceId: this.workspace,
             };
 
-            return client.labelElements.processElementsRequest(elementsRequest);
+            return client.labelElements.computeLabelElements(elementsRequest);
         });
 
         const { paging, elements } = response.data;

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -153,7 +153,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
         };
 
         const availableItemsResponse = await this.authCall((client) =>
-            client.validObjects.processAfmValidObjectsQuery({
+            client.validObjects.computeValidObjects({
                 workspaceId: this.workspace,
                 afmValidObjectsQuery,
             }),

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -1,13 +1,13 @@
 // (C) 2019-2021 GoodData Corporation
 
 import {
-    JsonApiAttributeList,
-    JsonApiDataset,
+    JsonApiAttributeOutList,
+    JsonApiDatasetOut,
     ITigerClient,
     JsonApiLinkage,
-    JsonApiLabelWithLinks,
-    JsonApiAttributeWithLinks,
-    JsonApiDatasetWithLinks,
+    JsonApiLabelOutWithLinks,
+    JsonApiAttributeOutWithLinks,
+    JsonApiDatasetOutWithLinks,
     MetadataUtilities,
 } from "@gooddata/api-client-tiger";
 import { CatalogItem, ICatalogAttribute, ICatalogDateDataset } from "@gooddata/sdk-backend-spi";
@@ -27,24 +27,24 @@ function lookupRelatedObject(included: JsonApiLinkage[] | undefined, id: string,
 }
 
 function getAttributeLabels(
-    attribute: JsonApiAttributeWithLinks,
+    attribute: JsonApiAttributeOutWithLinks,
     included: JsonApiLinkage[] | undefined,
-): JsonApiLabelWithLinks[] {
+): JsonApiLabelOutWithLinks[] {
     const labelsRefs = attribute.relationships?.labels?.data as JsonApiLinkage[];
-    const allLabels: JsonApiLabelWithLinks[] = labelsRefs
+    const allLabels: JsonApiLabelOutWithLinks[] = labelsRefs
         .map((ref) => {
             const obj = lookupRelatedObject(included, ref.id, ref.type);
             if (!obj) {
                 return;
             }
-            return obj as JsonApiLabelWithLinks;
+            return obj as JsonApiLabelOutWithLinks;
         })
-        .filter((obj): obj is JsonApiLabelWithLinks => obj !== undefined);
+        .filter((obj): obj is JsonApiLabelOutWithLinks => obj !== undefined);
 
     return allLabels;
 }
 
-function isGeoLabel(label: JsonApiLabelWithLinks): boolean {
+function isGeoLabel(label: JsonApiLabelOutWithLinks): boolean {
     /*
      * TODO: this is temporary way to identify labels with geo pushpin; normally this should be done
      *  using some indicator on the metadata object. for sakes of speed & after agreement with tiger team
@@ -53,7 +53,7 @@ function isGeoLabel(label: JsonApiLabelWithLinks): boolean {
     return label.id.search(/^.*\.geo__/) > -1;
 }
 
-function createNonDateAttributes(attributes: JsonApiAttributeList): ICatalogAttribute[] {
+function createNonDateAttributes(attributes: JsonApiAttributeOutList): ICatalogAttribute[] {
     const nonDateAttributes = attributes.data.filter((attr) => attr.attributes?.granularity === undefined);
 
     return nonDateAttributes.map((attribute) => {
@@ -67,12 +67,12 @@ function createNonDateAttributes(attributes: JsonApiAttributeList): ICatalogAttr
 }
 
 type DatasetWithAttributes = {
-    dataset: JsonApiDatasetWithLinks;
-    attributes: JsonApiAttributeWithLinks[];
+    dataset: JsonApiDatasetOutWithLinks;
+    attributes: JsonApiAttributeOutWithLinks[];
 };
 
 function identifyDateDatasets(
-    dateAttributes: JsonApiAttributeWithLinks[],
+    dateAttributes: JsonApiAttributeOutWithLinks[],
     included: JsonApiLinkage[] | undefined,
 ) {
     const datasets: { [id: string]: DatasetWithAttributes } = {};
@@ -82,7 +82,7 @@ function identifyDateDatasets(
         if (!ref) {
             return;
         }
-        const dataset = lookupRelatedObject(included, ref.id, ref.type) as JsonApiDataset;
+        const dataset = lookupRelatedObject(included, ref.id, ref.type) as JsonApiDatasetOut;
         if (!dataset) {
             return;
         }
@@ -100,7 +100,7 @@ function identifyDateDatasets(
     return values(datasets);
 }
 
-function createDateDatasets(attributes: JsonApiAttributeList): ICatalogDateDataset[] {
+function createDateDatasets(attributes: JsonApiAttributeOutList): ICatalogDateDataset[] {
     const dateAttributes = attributes.data.filter((attr) => attr.attributes?.granularity !== undefined);
     const dateDatasets = identifyDateDatasets(dateAttributes, attributes.included);
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/dashboards/index.ts
@@ -128,7 +128,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
             return client.workspaceObjects.createEntityAnalyticalDashboards(
                 {
                     workspaceId: this.workspace,
-                    jsonApiAnalyticalDashboardDocument: {
+                    jsonApiAnalyticalDashboardInDocument: {
                         data: {
                             id: uuidv4(),
                             type: "analyticalDashboard",
@@ -176,7 +176,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
                 {
                     workspaceId: this.workspace,
                     objectId,
-                    jsonApiAnalyticalDashboardDocument: {
+                    jsonApiAnalyticalDashboardInDocument: {
                         data: {
                             id: objectId,
                             type: "analyticalDashboard",
@@ -273,7 +273,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
             return client.workspaceObjects.createEntityFilterContexts(
                 {
                     workspaceId: this.workspace,
-                    jsonApiFilterContextDocument: {
+                    jsonApiFilterContextInDocument: {
                         data: {
                             id: uuidv4(),
                             type: "filterContext",
@@ -324,7 +324,7 @@ export class TigerWorkspaceDashboards implements IWorkspaceDashboardsService {
                 {
                     workspaceId: this.workspace,
                     objectId,
-                    jsonApiFilterContextDocument: {
+                    jsonApiFilterContextInDocument: {
                         data: {
                             id: objectId,
                             type: "filterContext",

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/executionResult.ts
@@ -67,7 +67,12 @@ export class TigerExecutionResult implements IExecutionResult {
 
     public async readAll(): Promise<IDataView> {
         const executionResultPromise = this.authCall((client) =>
-            client.execution.executionResult(this.workspace, this.resultId),
+            client.executionResult
+                .retrieveResult({
+                    workspaceId: this.workspace,
+                    resultId: this.resultId,
+                })
+                .then(({ data }) => data),
         );
 
         return this.asDataView(executionResultPromise);
@@ -78,7 +83,14 @@ export class TigerExecutionResult implements IExecutionResult {
         const saneSize = sanitizeSize(size);
 
         const executionResultPromise = this.authCall((client) =>
-            client.execution.executionResult(this.workspace, this.resultId, saneOffset, saneSize),
+            client.executionResult
+                .retrieveResult({
+                    workspaceId: this.workspace,
+                    resultId: this.resultId,
+                    limit: saneSize,
+                    offset: saneOffset,
+                })
+                .then(({ data }) => data),
         );
 
         return this.asDataView(executionResultPromise);

--- a/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/execution/preparedExecution.ts
@@ -33,13 +33,16 @@ export class TigerPreparedExecution implements IPreparedExecution {
         const afmExecution = toAfmExecution(this.definition);
 
         return this.authCall((client) =>
-            client.execution.executeAfm(this.definition.workspace, afmExecution),
+            client.execution.computeReport({
+                workspaceId: this.definition.workspace,
+                afmExecution,
+            }),
         ).then((response) => {
             return new TigerExecutionResult(
                 this.authCall,
                 this.definition,
                 this.executionFactory,
-                response,
+                response.data,
                 this.dateFormatter,
             );
         });

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -128,7 +128,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
             return client.workspaceObjects.createEntityVisualizationObjects(
                 {
                     workspaceId: this.workspace,
-                    jsonApiVisualizationObjectDocument: {
+                    jsonApiVisualizationObjectInDocument: {
                         data: {
                             id: uuidv4(),
                             type: "visualizationObject",
@@ -155,7 +155,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
                 {
                     objectId: insightId(insight),
                     workspaceId: this.workspace,
-                    jsonApiVisualizationObjectDocument: {
+                    jsonApiVisualizationObjectInDocument: {
                         data: {
                             id: insightId(insight),
                             type: "visualizationObject",

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -1,11 +1,11 @@
 // (C) 2019-2021 GoodData Corporation
 import { IWorkspaceMeasuresService, IMeasureExpressionToken } from "@gooddata/sdk-backend-spi";
 import {
-    JsonApiAttribute,
-    JsonApiFact,
-    JsonApiLabel,
-    JsonApiMetric,
-    JsonApiMetricDocument,
+    JsonApiAttributeOut,
+    JsonApiFactOut,
+    JsonApiLabelOut,
+    JsonApiMetricOut,
+    JsonApiMetricOutDocument,
     jsonApiHeaders,
 } from "@gooddata/api-client-tiger";
 import { ObjRef, idRef, isIdentifierRef } from "@gooddata/sdk-model";
@@ -41,7 +41,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
 
     private resolveToken(
         regexToken: IExpressionToken,
-        metric: JsonApiMetricDocument,
+        metric: JsonApiMetricOutDocument,
     ): IMeasureExpressionToken {
         if (regexToken.type === "text" || regexToken.type === "quoted_text") {
             return { type: "text", value: regexToken.value };
@@ -61,7 +61,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
     ): IMeasureExpressionToken {
         const includedObject = includedObjects.find((includedObject) => {
             return includedObject.id === objectId && includedObject.type === objectType;
-        }) as JsonApiMetric | JsonApiLabel | JsonApiAttribute | JsonApiFact;
+        }) as JsonApiMetricOut | JsonApiLabelOut | JsonApiAttributeOut | JsonApiFactOut;
 
         interface ITypeMapping {
             [tokenObjectType: string]: IMeasureExpressionToken["type"];

--- a/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspaces/index.ts
@@ -5,7 +5,7 @@ import {
     IWorkspacesQueryResult,
     IAnalyticalWorkspace,
 } from "@gooddata/sdk-backend-spi";
-import { JsonApiWorkspaceList, OrganizationUtilities } from "@gooddata/api-client-tiger";
+import { JsonApiWorkspaceOutList, OrganizationUtilities } from "@gooddata/api-client-tiger";
 import { TigerAuthenticatedCallGuard } from "../../types";
 import { DateFormatter } from "../../convertors/fromBackend/dateFormatting/types";
 import { workspaceConverter } from "../../convertors/fromBackend/WorkspaceConverter";
@@ -59,7 +59,7 @@ class TigerWorkspaceQuery implements IWorkspacesQuery {
         return this.queryWorker(this.offset, this.limit, this.search);
     }
 
-    private resultToWorkspaceDescriptors = (result: JsonApiWorkspaceList): IWorkspaceDescriptor[] => {
+    private resultToWorkspaceDescriptors = (result: JsonApiWorkspaceOutList): IWorkspaceDescriptor[] => {
         return result.data.map(workspaceConverter);
     };
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
@@ -2,12 +2,12 @@
 import {
     AnalyticalDashboardObjectModel,
     isFilterContextData,
-    JsonApiAnalyticalDashboardAttributes,
-    JsonApiAnalyticalDashboardDocument,
-    JsonApiAnalyticalDashboardList,
-    JsonApiAnalyticalDashboardWithLinks,
-    JsonApiFilterContextDocument,
-    JsonApiFilterContextWithLinks,
+    JsonApiAnalyticalDashboardInAttributes,
+    JsonApiAnalyticalDashboardOutDocument,
+    JsonApiAnalyticalDashboardOutList,
+    JsonApiAnalyticalDashboardOutWithLinks,
+    JsonApiFilterContextOutDocument,
+    JsonApiFilterContextOutWithLinks,
 } from "@gooddata/api-client-tiger";
 import {
     DashboardWidget,
@@ -25,9 +25,9 @@ import updateWith from "lodash/updateWith";
 import { cloneWithSanitizedIds } from "./IdSanitization";
 
 export const convertAnalyticalDashboard = (
-    analyticalDashboard: JsonApiAnalyticalDashboardWithLinks,
+    analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,
 ): IListedDashboard => {
-    const attributes = analyticalDashboard.attributes as JsonApiAnalyticalDashboardAttributes;
+    const attributes = analyticalDashboard.attributes as JsonApiAnalyticalDashboardInAttributes;
     const { title, description } = attributes;
     return {
         ref: idRef(analyticalDashboard.id, "analyticalDashboard"),
@@ -41,7 +41,7 @@ export const convertAnalyticalDashboard = (
 };
 
 export const convertAnalyticalDashboardToListItems = (
-    analyticalDashboards: JsonApiAnalyticalDashboardList,
+    analyticalDashboards: JsonApiAnalyticalDashboardOutList,
 ): IListedDashboard[] => {
     return analyticalDashboards.data.map(convertAnalyticalDashboard);
 };
@@ -77,7 +77,7 @@ export function convertAnalyticalDashboardContent(
 }
 
 export function convertDashboard(
-    analyticalDashboard: JsonApiAnalyticalDashboardDocument,
+    analyticalDashboard: JsonApiAnalyticalDashboardOutDocument,
     filterContext?: IFilterContext,
 ): IDashboard {
     const { id, attributes = {} } = analyticalDashboard.data;
@@ -100,7 +100,9 @@ export function convertDashboard(
     };
 }
 
-export function convertFilterContextFromBackend(filterContext: JsonApiFilterContextDocument): IFilterContext {
+export function convertFilterContextFromBackend(
+    filterContext: JsonApiFilterContextOutDocument,
+): IFilterContext {
     const { id, type, attributes } = filterContext.data;
     const { title = "", description = "", content } = attributes!;
 
@@ -117,7 +119,7 @@ export function convertFilterContextFromBackend(filterContext: JsonApiFilterCont
 }
 
 export function getFilterContextFromIncluded(included: any[]): IFilterContext | undefined {
-    const filterContext = included.find(isFilterContextData) as JsonApiFilterContextWithLinks;
+    const filterContext = included.find(isFilterContextData) as JsonApiFilterContextOutWithLinks;
     if (!filterContext) {
         return;
     }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
@@ -1,11 +1,11 @@
 // (C) 2019-2021 GoodData Corporation
 import { idRef } from "@gooddata/sdk-model";
 import {
-    JsonApiAttributeWithLinks,
-    JsonApiDatasetWithLinks,
-    JsonApiFactWithLinks,
-    JsonApiLabelWithLinks,
-    JsonApiMetricWithLinks,
+    JsonApiAttributeOutWithLinks,
+    JsonApiDatasetOutWithLinks,
+    JsonApiFactOutWithLinks,
+    JsonApiLabelOutWithLinks,
+    JsonApiMetricOutWithLinks,
 } from "@gooddata/api-client-tiger";
 import { toSdkGranularity } from "./dateGranularityConversions";
 import {
@@ -38,10 +38,10 @@ const commonGroupableCatalogItemModifications = <
 };
 
 export const convertAttribute = (
-    attribute: JsonApiAttributeWithLinks,
-    defaultLabel: JsonApiLabelWithLinks,
-    geoLabels: JsonApiLabelWithLinks[],
-    allLabels: JsonApiLabelWithLinks[],
+    attribute: JsonApiAttributeOutWithLinks,
+    defaultLabel: JsonApiLabelOutWithLinks,
+    geoLabels: JsonApiLabelOutWithLinks[],
+    allLabels: JsonApiLabelOutWithLinks[],
 ): ICatalogAttribute => {
     const geoPinDisplayForms = geoLabels.map((label) => {
         return newAttributeDisplayFormMetadataObject(
@@ -70,7 +70,7 @@ export const convertAttribute = (
     );
 };
 
-export const convertMeasure = (measure: JsonApiMetricWithLinks): ICatalogMeasure => {
+export const convertMeasure = (measure: JsonApiMetricOutWithLinks): ICatalogMeasure => {
     const maql = measure.attributes?.content?.maql;
 
     return newCatalogMeasure((catalogM) =>
@@ -82,7 +82,7 @@ export const convertMeasure = (measure: JsonApiMetricWithLinks): ICatalogMeasure
     );
 };
 
-export const convertFact = (fact: JsonApiFactWithLinks): ICatalogFact => {
+export const convertFact = (fact: JsonApiFactOutWithLinks): ICatalogFact => {
     return newCatalogFact((catalogF) =>
         catalogF
             .fact(idRef(fact.id, "fact"), (f) => f.modify(commonMetadataObjectModifications(fact)))
@@ -91,8 +91,8 @@ export const convertFact = (fact: JsonApiFactWithLinks): ICatalogFact => {
 };
 
 export const convertDateAttribute = (
-    attribute: JsonApiAttributeWithLinks,
-    label: JsonApiLabelWithLinks,
+    attribute: JsonApiAttributeOutWithLinks,
+    label: JsonApiLabelOutWithLinks,
 ): ICatalogDateAttribute => {
     return newCatalogDateAttribute((dateAttribute) => {
         return dateAttribute
@@ -107,7 +107,7 @@ export const convertDateAttribute = (
 };
 
 export const convertDateDataset = (
-    dataset: JsonApiDatasetWithLinks,
+    dataset: JsonApiDatasetOutWithLinks,
     attributes: ICatalogDateAttribute[],
 ): ICatalogDateDataset => {
     return newCatalogDateDataset((dateDataset) => {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
@@ -1,5 +1,5 @@
 // (C) 2020-2021 GoodData Corporation
-import { VisualizationObjectModel, JsonApiVisualizationObjectWithLinks } from "@gooddata/api-client-tiger";
+import { VisualizationObjectModel, JsonApiVisualizationObjectOutWithLinks } from "@gooddata/api-client-tiger";
 import { idRef, IInsight, IInsightDefinition } from "@gooddata/sdk-model";
 import { convertVisualizationObject } from "./VisualizationObjectConverter";
 
@@ -19,8 +19,8 @@ export const insightFromInsightDefinition = (
 };
 
 export const visualizationObjectsItemToInsight = (
-    visualizationObject: JsonApiVisualizationObjectWithLinks,
-) => {
+    visualizationObject: JsonApiVisualizationObjectOutWithLinks,
+): IInsight => {
     return insightFromInsightDefinition(
         convertVisualizationObject(
             visualizationObject!.attributes!.content! as VisualizationObjectModel.IVisualizationObject,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
@@ -1,16 +1,16 @@
 // (C) 2019-2021 GoodData Corporation
 import {
-    JsonApiAttribute,
-    JsonApiAttributeDocument,
-    JsonApiAttributeList,
-    JsonApiAttributeWithLinks,
-    JsonApiDatasetWithLinks,
-    JsonApiFactWithLinks,
-    JsonApiLabel,
-    JsonApiLabelDocument,
-    JsonApiLabelWithLinks,
+    JsonApiAttributeOut,
+    JsonApiAttributeOutDocument,
+    JsonApiAttributeOutList,
+    JsonApiAttributeOutWithLinks,
+    JsonApiDatasetOutWithLinks,
+    JsonApiFactOutWithLinks,
+    JsonApiLabelOut,
+    JsonApiLabelOutDocument,
+    JsonApiLabelOutWithLinks,
     JsonApiLinkage,
-    JsonApiMetricWithLinks,
+    JsonApiMetricOutWithLinks,
 } from "@gooddata/api-client-tiger";
 import keyBy from "lodash/keyBy";
 import {
@@ -28,11 +28,11 @@ import { idRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 
 export type MetadataObjectFromApi =
-    | JsonApiAttributeWithLinks
-    | JsonApiFactWithLinks
-    | JsonApiMetricWithLinks
-    | JsonApiLabelWithLinks
-    | JsonApiDatasetWithLinks;
+    | JsonApiAttributeOutWithLinks
+    | JsonApiFactOutWithLinks
+    | JsonApiMetricOutWithLinks
+    | JsonApiLabelOutWithLinks
+    | JsonApiDatasetOutWithLinks;
 
 export const commonMetadataObjectModifications = <
     TItem extends MetadataObjectFromApi,
@@ -46,20 +46,20 @@ export const commonMetadataObjectModifications = <
         .title(item.attributes?.title || "")
         .description(item.attributes?.description || "");
 
-function createLabelMap(included: any[] | undefined): Record<string, JsonApiLabelWithLinks> {
+function createLabelMap(included: any[] | undefined): Record<string, JsonApiLabelOutWithLinks> {
     if (!included) {
         return {};
     }
 
-    const labels: JsonApiLabel[] = included
+    const labels: JsonApiLabelOut[] = included
         .map((include) => {
             if ((include as JsonApiLinkage).type !== "label") {
                 return null;
             }
 
-            return include as JsonApiLabelWithLinks;
+            return include as JsonApiLabelOutWithLinks;
         })
-        .filter((include): include is JsonApiLabelWithLinks => include !== null);
+        .filter((include): include is JsonApiLabelOutWithLinks => include !== null);
 
     return keyBy(labels, (t) => t.id);
 }
@@ -68,8 +68,8 @@ function createLabelMap(included: any[] | undefined): Record<string, JsonApiLabe
  * Converts all labels of this attribute. The map contains sideloaded label information
  */
 function convertAttributeLabels(
-    attribute: JsonApiAttribute,
-    labelsMap: Record<string, JsonApiLabelWithLinks>,
+    attribute: JsonApiAttributeOut,
+    labelsMap: Record<string, JsonApiLabelOutWithLinks>,
 ): IAttributeDisplayFormMetadataObject[] {
     const labelsRefs = attribute.relationships?.labels?.data as JsonApiLinkage[];
 
@@ -90,8 +90,8 @@ function convertAttributeLabels(
  * Converts attribute when its sideloaded
  */
 function convertAttributeWithLinks(
-    attribute: JsonApiAttributeWithLinks,
-    labels: Record<string, JsonApiLabel>,
+    attribute: JsonApiAttributeOutWithLinks,
+    labels: Record<string, JsonApiLabelOut>,
 ): IAttributeMetadataObject {
     return newAttributeMetadataObject(idRef(attribute.id, "attribute"), (m) =>
         m
@@ -104,8 +104,8 @@ function convertAttributeWithLinks(
  * Converts attribute when its top-level
  */
 function convertAttributeDocument(
-    attributeDoc: JsonApiAttributeDocument,
-    labels: Record<string, JsonApiLabel>,
+    attributeDoc: JsonApiAttributeOutDocument,
+    labels: Record<string, JsonApiLabelOut>,
 ): IAttributeMetadataObject {
     const attribute = attributeDoc.data;
 
@@ -124,7 +124,7 @@ function convertAttributeDocument(
  * contain relationships
  */
 function convertLabelWithLinks(
-    label: JsonApiLabelWithLinks,
+    label: JsonApiLabelOutWithLinks,
     attributeId: string,
 ): IAttributeDisplayFormMetadataObject {
     return newAttributeDisplayFormMetadataObject(idRef(label.id, "displayForm"), (m) =>
@@ -141,7 +141,7 @@ function convertLabelWithLinks(
 /**
  * Converts label when its top-level
  */
-function convertLabelDocument(labelDoc: JsonApiLabelDocument): IAttributeDisplayFormMetadataObject {
+function convertLabelDocument(labelDoc: JsonApiLabelOutDocument): IAttributeDisplayFormMetadataObject {
     const label = labelDoc.data;
     const attributes = label.attributes;
 
@@ -171,7 +171,7 @@ function convertLabelDocument(labelDoc: JsonApiLabelDocument): IAttributeDisplay
  * @param labelDoc - response from backend
  */
 export function convertLabelWithSideloadedAttribute(
-    labelDoc: JsonApiLabelDocument,
+    labelDoc: JsonApiLabelOutDocument,
 ): IAttributeDisplayFormMetadataObject {
     return convertLabelDocument(labelDoc);
 }
@@ -182,7 +182,7 @@ export function convertLabelWithSideloadedAttribute(
  * @param attribute - response from backend
  */
 export function convertAttributeWithSideloadedLabels(
-    attribute: JsonApiAttributeDocument,
+    attribute: JsonApiAttributeOutDocument,
 ): IAttributeMetadataObject {
     const labels = createLabelMap(attribute.included);
 
@@ -195,7 +195,7 @@ export function convertAttributeWithSideloadedLabels(
  * @param attributes - response from backend
  */
 export function convertAttributesWithSideloadedLabels(
-    attributes: JsonApiAttributeList,
+    attributes: JsonApiAttributeOutList,
 ): IAttributeMetadataObject[] {
     const labels = createLabelMap(attributes.included);
 
@@ -213,7 +213,7 @@ export function convertAttributesWithSideloadedLabels(
  *
  * @param dataset - sideloaded dataset
  */
-export function convertDatasetWithLinks(dataset: JsonApiDatasetWithLinks): IDataSetMetadataObject {
+export function convertDatasetWithLinks(dataset: JsonApiDatasetOutWithLinks): IDataSetMetadataObject {
     return newDataSetMetadataObject(idRef(dataset.id, "dataSet"), (m) =>
         m.modify(commonMetadataObjectModifications(dataset)),
     );

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/WorkspaceConverter.ts
@@ -1,8 +1,11 @@
 // (C) 2019-2021 GoodData Corporation
-import { JsonApiWorkspaceWithLinks } from "@gooddata/api-client-tiger";
+import { JsonApiWorkspaceOutWithLinks } from "@gooddata/api-client-tiger";
 import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
 
-export const workspaceConverter = ({ attributes, id }: JsonApiWorkspaceWithLinks): IWorkspaceDescriptor => {
+export const workspaceConverter = ({
+    attributes,
+    id,
+}: JsonApiWorkspaceOutWithLinks): IWorkspaceDescriptor => {
     const workspace: IWorkspaceDescriptor = {
         description: attributes?.name || id,
         title: attributes?.name || id,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
@@ -82,7 +82,7 @@ function transformDimension(
                             const newItem: IMeasureDescriptor = {
                                 measureHeaderItem: {
                                     localIdentifier: m.measureHeaderItem.localIdentifier,
-                                    name: m.measureHeaderItem.localIdentifier,
+                                    name: m.measureHeaderItem.name ?? m.measureHeaderItem.localIdentifier,
                                     format: m.measureHeaderItem.format ?? DEFAULT_FORMAT,
                                     identifier,
                                     ref,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/result.ts
@@ -4,7 +4,7 @@ import {
     ExecutionResult,
     ExecutionResultGrandTotal,
     isResultAttributeHeader,
-    JsonApiAttributeAttributesGranularityEnum,
+    JsonApiAttributeOutAttributesGranularityEnum,
 } from "@gooddata/api-client-tiger";
 import {
     DataValue,
@@ -33,12 +33,12 @@ export type TransformerResult = {
 };
 
 // gets all the enum values
-const supportedSuffixes: string[] = Object.keys(JsonApiAttributeAttributesGranularityEnum)
+const supportedSuffixes: string[] = Object.keys(JsonApiAttributeOutAttributesGranularityEnum)
     .filter((item) => isNaN(Number(item)))
     .map(
         (key) =>
-            JsonApiAttributeAttributesGranularityEnum[
-                key as keyof typeof JsonApiAttributeAttributesGranularityEnum
+            JsonApiAttributeOutAttributesGranularityEnum[
+                key as keyof typeof JsonApiAttributeOutAttributesGranularityEnum
             ],
     );
 
@@ -51,7 +51,7 @@ function getGranularity(header: IDimensionItemDescriptor): DateAttributeGranular
     const suffix = identifier.substr(identifier.lastIndexOf(".") + 1);
 
     return supportedSuffixes.includes(suffix)
-        ? toSdkGranularity(suffix as JsonApiAttributeAttributesGranularityEnum)
+        ? toSdkGranularity(suffix as JsonApiAttributeOutAttributesGranularityEnum)
         : undefined; // not a date attribute
 }
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/dateGranularityConversions.ts
@@ -1,13 +1,13 @@
 // (C) 2019-2021 GoodData Corporation
 import {
-    JsonApiAttributeAttributesGranularityEnum,
+    JsonApiAttributeOutAttributesGranularityEnum,
     RelativeDateFilterBodyGranularityEnum,
 } from "@gooddata/api-client-tiger";
 import { DateAttributeGranularity } from "@gooddata/sdk-model";
 import { NotSupported } from "@gooddata/sdk-backend-spi";
 
 type TigerToSdk = {
-    [key in JsonApiAttributeAttributesGranularityEnum]: DateAttributeGranularity;
+    [key in JsonApiAttributeOutAttributesGranularityEnum]: DateAttributeGranularity;
 };
 
 type SdkToTiger = {
@@ -34,22 +34,22 @@ type SdkToTiger = {
  */
 
 const TigerToSdkGranularityMap: TigerToSdk = {
-    [JsonApiAttributeAttributesGranularityEnum.YEAR]: "GDC.time.year",
-    [JsonApiAttributeAttributesGranularityEnum.QUARTER]: "GDC.time.quarter",
-    [JsonApiAttributeAttributesGranularityEnum.MONTH]: "GDC.time.month",
-    [JsonApiAttributeAttributesGranularityEnum.WEEK]: "GDC.time.week_us",
-    [JsonApiAttributeAttributesGranularityEnum.DAY]: "GDC.time.date",
-    [JsonApiAttributeAttributesGranularityEnum.HOUR]: "GDC.time.hour",
-    [JsonApiAttributeAttributesGranularityEnum.MINUTE]: "GDC.time.minute",
+    [JsonApiAttributeOutAttributesGranularityEnum.YEAR]: "GDC.time.year",
+    [JsonApiAttributeOutAttributesGranularityEnum.QUARTER]: "GDC.time.quarter",
+    [JsonApiAttributeOutAttributesGranularityEnum.MONTH]: "GDC.time.month",
+    [JsonApiAttributeOutAttributesGranularityEnum.WEEK]: "GDC.time.week_us",
+    [JsonApiAttributeOutAttributesGranularityEnum.DAY]: "GDC.time.date",
+    [JsonApiAttributeOutAttributesGranularityEnum.HOUR]: "GDC.time.hour",
+    [JsonApiAttributeOutAttributesGranularityEnum.MINUTE]: "GDC.time.minute",
 
-    [JsonApiAttributeAttributesGranularityEnum.QUARTEROFYEAR]: "GDC.time.quarter_in_year",
-    [JsonApiAttributeAttributesGranularityEnum.MONTHOFYEAR]: "GDC.time.month_in_year",
-    [JsonApiAttributeAttributesGranularityEnum.WEEKOFYEAR]: "GDC.time.week_in_year",
-    [JsonApiAttributeAttributesGranularityEnum.DAYOFYEAR]: "GDC.time.day_in_year",
-    [JsonApiAttributeAttributesGranularityEnum.DAYOFMONTH]: "GDC.time.day_in_month",
-    [JsonApiAttributeAttributesGranularityEnum.DAYOFWEEK]: "GDC.time.day_in_week",
-    [JsonApiAttributeAttributesGranularityEnum.HOUROFDAY]: "GDC.time.hour_in_day",
-    [JsonApiAttributeAttributesGranularityEnum.MINUTEOFHOUR]: "GDC.time.minute_in_hour",
+    [JsonApiAttributeOutAttributesGranularityEnum.QUARTEROFYEAR]: "GDC.time.quarter_in_year",
+    [JsonApiAttributeOutAttributesGranularityEnum.MONTHOFYEAR]: "GDC.time.month_in_year",
+    [JsonApiAttributeOutAttributesGranularityEnum.WEEKOFYEAR]: "GDC.time.week_in_year",
+    [JsonApiAttributeOutAttributesGranularityEnum.DAYOFYEAR]: "GDC.time.day_in_year",
+    [JsonApiAttributeOutAttributesGranularityEnum.DAYOFMONTH]: "GDC.time.day_in_month",
+    [JsonApiAttributeOutAttributesGranularityEnum.DAYOFWEEK]: "GDC.time.day_in_week",
+    [JsonApiAttributeOutAttributesGranularityEnum.HOUROFDAY]: "GDC.time.hour_in_day",
+    [JsonApiAttributeOutAttributesGranularityEnum.MINUTEOFHOUR]: "GDC.time.minute_in_hour",
 };
 
 /**
@@ -58,7 +58,7 @@ const TigerToSdkGranularityMap: TigerToSdk = {
  * @param granularity - tiger granularity
  */
 export function toSdkGranularity(
-    granularity: JsonApiAttributeAttributesGranularityEnum,
+    granularity: JsonApiAttributeOutAttributesGranularityEnum,
 ): DateAttributeGranularity {
     return TigerToSdkGranularityMap[granularity];
 }

--- a/tools/catalog-export/src/loaders/tiger/index.ts
+++ b/tools/catalog-export/src/loaders/tiger/index.ts
@@ -14,7 +14,7 @@ import { ITigerClient, jsonApiHeaders } from "@gooddata/api-client-tiger";
 import { tigerLoad } from "./tigerLoad";
 import { createTigerClient } from "./tigerClient";
 import open from "open";
-import { JsonApiWorkspaceList } from "@gooddata/api-client-tiger";
+import { JsonApiWorkspaceOutList } from "@gooddata/api-client-tiger";
 
 /**
  * Tests if the provided tiger client can access the backend.
@@ -114,7 +114,7 @@ async function getTigerClient(hostname: string, usernameFromConfig: string | nul
     }
 }
 
-async function loadWorkspaces(client: ITigerClient): Promise<JsonApiWorkspaceList> {
+async function loadWorkspaces(client: ITigerClient): Promise<JsonApiWorkspaceOutList> {
     const response = await client.organizationObjects.getAllEntitiesWorkspaces(
         {
             page: 0,

--- a/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
@@ -1,15 +1,15 @@
 // (C) 2007-2021 GoodData Corporation
 import { Attribute, Catalog, Fact, Metric } from "../../base/types";
 import {
-    JsonApiAttributeList,
-    JsonApiFactList,
-    JsonApiMetricList,
+    JsonApiAttributeOutList,
+    JsonApiFactOutList,
+    JsonApiMetricOutList,
     ITigerClient,
     MetadataUtilities,
 } from "@gooddata/api-client-tiger";
 import { convertAttribute, createLabelMap } from "./tigerCommon";
 
-function convertMetrics(metrics: JsonApiMetricList): Metric[] {
+function convertMetrics(metrics: JsonApiMetricOutList): Metric[] {
     return metrics.data.map((metric) => {
         return {
             metric: {
@@ -23,7 +23,7 @@ function convertMetrics(metrics: JsonApiMetricList): Metric[] {
     });
 }
 
-function convertFacts(facts: JsonApiFactList): Fact[] {
+function convertFacts(facts: JsonApiFactOutList): Fact[] {
     return facts.data.map((fact) => {
         return {
             fact: {
@@ -37,7 +37,7 @@ function convertFacts(facts: JsonApiFactList): Fact[] {
     });
 }
 
-function convertAttributes(attributes: JsonApiAttributeList): Attribute[] {
+function convertAttributes(attributes: JsonApiAttributeOutList): Attribute[] {
     const labels = createLabelMap(attributes.included);
 
     /*

--- a/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
@@ -1,31 +1,31 @@
 // (C) 2007-2021 GoodData Corporation
 import {
-    JsonApiAttribute,
-    JsonApiDataset,
-    JsonApiLabel,
-    JsonApiAttributeRelationships,
+    JsonApiAttributeOut,
+    JsonApiDatasetOut,
+    JsonApiLabelOut,
+    JsonApiAttributeOutRelationships,
     JsonApiLinkage,
 } from "@gooddata/api-client-tiger";
 import keyBy from "lodash/keyBy";
 import { Attribute, DisplayForm } from "../../base/types";
 
-export type LabelMap = { [id: string]: JsonApiLabel };
-export type DatasetMap = { [id: string]: JsonApiDataset };
+export type LabelMap = { [id: string]: JsonApiLabelOut };
+export type DatasetMap = { [id: string]: JsonApiDatasetOut };
 
 export function createLabelMap(included: any[] | undefined): LabelMap {
     if (!included) {
         return {};
     }
 
-    const labels: JsonApiLabel[] = included
+    const labels: JsonApiLabelOut[] = included
         .map((include) => {
             if ((include as JsonApiLinkage).type !== "label") {
                 return null;
             }
 
-            return include as JsonApiLabel;
+            return include as JsonApiLabelOut;
         })
-        .filter((include): include is JsonApiLabel => include !== null);
+        .filter((include): include is JsonApiLabelOut => include !== null);
 
     return keyBy(labels, (t) => t.id);
 }
@@ -35,15 +35,15 @@ export function createDatasetMap(included: any[] | undefined): DatasetMap {
         return {};
     }
 
-    const datasets: JsonApiDataset[] = included
+    const datasets: JsonApiDatasetOut[] = included
         .map((include) => {
             if ((include as JsonApiLinkage).type !== "dataset") {
                 return null;
             }
 
-            return include as JsonApiDataset;
+            return include as JsonApiDatasetOut;
         })
-        .filter((include): include is JsonApiDataset => include !== null);
+        .filter((include): include is JsonApiDatasetOut => include !== null);
 
     return keyBy(datasets, (t) => t.id);
 }
@@ -51,12 +51,12 @@ export function createDatasetMap(included: any[] | undefined): DatasetMap {
 export function getReferencedDataset(
     relationships: object | undefined,
     datasetsMap: DatasetMap,
-): JsonApiDataset | undefined {
+): JsonApiDatasetOut | undefined {
     if (!relationships) {
         return;
     }
 
-    const datasetsRef: JsonApiLinkage = (relationships as JsonApiAttributeRelationships)?.dataset
+    const datasetsRef: JsonApiLinkage = (relationships as JsonApiAttributeOutRelationships)?.dataset
         ?.data as JsonApiLinkage;
 
     if (!datasetsRef) {
@@ -66,7 +66,7 @@ export function getReferencedDataset(
     return datasetsMap[datasetsRef.id];
 }
 
-export function convertLabels(attribute: JsonApiAttribute, labelsMap: LabelMap): DisplayForm[] {
+export function convertLabels(attribute: JsonApiAttributeOut, labelsMap: LabelMap): DisplayForm[] {
     const labelsRefs = attribute.relationships?.labels?.data as JsonApiLinkage[];
     return labelsRefs
         .map((ref) => {
@@ -87,7 +87,7 @@ export function convertLabels(attribute: JsonApiAttribute, labelsMap: LabelMap):
         .filter((df): df is DisplayForm => df !== undefined);
 }
 
-export function convertAttribute(attribute: JsonApiAttribute, labels: LabelMap): Attribute | undefined {
+export function convertAttribute(attribute: JsonApiAttributeOut, labels: LabelMap): Attribute | undefined {
     return {
         attribute: {
             content: {

--- a/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
@@ -2,9 +2,9 @@
 
 import { Attribute, DateDataSet } from "../../base/types";
 import {
-    JsonApiAttributeList,
-    JsonApiAttribute,
-    JsonApiDataset,
+    JsonApiAttributeOutList,
+    JsonApiAttributeOut,
+    JsonApiDatasetOut,
     ITigerClient,
     MetadataUtilities,
 } from "@gooddata/api-client-tiger";
@@ -19,12 +19,12 @@ import {
 import values from "lodash/values";
 
 type DatasetWithAttributes = {
-    dataset: JsonApiDataset;
-    attributes: JsonApiAttribute[];
+    dataset: JsonApiDatasetOut;
+    attributes: JsonApiAttributeOut[];
 };
 
 function findDateDatasetsWithAttributes(
-    attributes: JsonApiAttributeList,
+    attributes: JsonApiAttributeOutList,
     datasetsMap: DatasetMap,
 ): DatasetWithAttributes[] {
     const res: { [id: string]: DatasetWithAttributes } = {};


### PR DESCRIPTION
As part of this additional sanity in the tiger client was done:

* the tiger client was re-generated -> this made some type changes that I adapted to in the rest of the codebase
* new endpoints from the `/api/actions` were used instead of the old equivalents
* the execution part of api-client-tiger now uses the generated controllers (as do the other endpoints) - this needed a break of the API - it now returns `AxiosPromise` like the rest of the endpoints

Since the api-client-tiger is broken as is, I think this breaking change is ok now.

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
