### PR TITLE
RELATED: RAIL-3062 Fix getBrokenAlertFiltersBasicInfo 

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/brokenFilterUtils.ts
@@ -52,13 +52,6 @@ export function isBrokenAlertAttributeFilterInfo(
     return isDashboardAttributeFilter(item.alertFilter);
 }
 
-function isFilterNoop(filter: IDashboardAttributeFilter): boolean {
-    return (
-        filter.attributeFilter.negativeSelection &&
-        attributeElementsIsEmpty(filter.attributeFilter.attributeElements)
-    );
-}
-
 /**
  * Gets the information about the so called broken alert filters. These are filters that are set up on the alert,
  * but the currently applied filters either do not contain them, or the KPI has started ignoring them
@@ -100,15 +93,13 @@ export function getBrokenAlertFiltersBasicInfo(
             return;
         }
 
-        // deleted attribute filters are broken only if they are not noop
+        // deleted attribute filters are broken even if they are noop
         const isInAppliedFilters = appliedAttributeFilters.some((f) =>
             areObjRefsEqual(filterObjRef(f), alertFilter.attributeFilter.displayForm),
         );
 
         const isDeleted = !isInAppliedFilters;
-        const isNoop = isFilterNoop(alertFilter);
-
-        if (isDeleted && !isNoop) {
+        if (isDeleted) {
             result.push({
                 alertFilter,
                 brokenType: "deleted",

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/brokenFilterUtils.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/utils/test/brokenFilterUtils.test.ts
@@ -204,6 +204,21 @@ describe("getBrokenAlertFiltersBasicInfo", () => {
             expect(actual).toEqual(expected);
         });
 
+        it("should detect deleted attribute filter even if it is noop", () => {
+            const alert = getAlertWithFilters([noopAttributeFilter]);
+            const kpi = kpiBase;
+
+            const expected: IBrokenAlertFilterBasicInfo[] = [
+                {
+                    alertFilter: noopAttributeFilter,
+                    brokenType: "deleted",
+                },
+            ];
+
+            const actual = getBrokenAlertFiltersBasicInfo(alert, kpi, []);
+            expect(actual).toEqual(expected);
+        });
+
         it("should NOT detect attribute filter if it is applied", () => {
             const alert = getAlertWithFilters([attributeFilter]);
             const kpi = kpiBase;
@@ -211,14 +226,6 @@ describe("getBrokenAlertFiltersBasicInfo", () => {
             const actual = getBrokenAlertFiltersBasicInfo(alert, kpi, [
                 newPositiveAttributeFilter(displayForm, { uris: ["/gdc/md/foo?id=1"] }),
             ]);
-            expect(actual).toEqual([]);
-        });
-
-        it("should NOT detect deleted attribute filter if it is noop", () => {
-            const alert = getAlertWithFilters([noopAttributeFilter]);
-            const kpi = kpiBase;
-
-            const actual = getBrokenAlertFiltersBasicInfo(alert, kpi, []);
             expect(actual).toEqual([]);
         });
     });


### PR DESCRIPTION
Turns out noop deleted filters are also considered broken.
The code was migrated wrongly from KD originally.

JIRA: RAIL-3062

Port of #1130 to master

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
