### PR TITLE
When FF `enableCustomHeight` is true, XL Geochart should not increase its height automatically…

### DIFF
--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/legacy.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/legacy.ts
@@ -40,8 +40,9 @@ export function getGeoPushpinWidgetStyle(
     visualizationItemWidth: number,
     currentColumnWidth: number,
     windowHeight: number,
+    enableCustomHeight: boolean,
 ): React.CSSProperties {
-    if (isFullWidthGeoPushpin(currentColumnWidth, visType)) {
+    if (isFullWidthGeoPushpin(currentColumnWidth, visType) && !enableCustomHeight) {
         const { height, maxHeight } = calculateGeoPushpinWidgetHeight(windowHeight, visualizationItemWidth);
         return {
             height,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/legacy.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/legacy.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 import {
     calculateGeoPushpinWidgetHeight,
@@ -51,15 +51,22 @@ describe("legacy", () => {
         };
 
         it.each([
-            ["return height and maxHeight", 12, expectedGeoPushpinFullWidthStyle],
-            ["doesn't return height and maxHeight", 8, null],
-        ])("should getStyle %s", (_text, currentColumnWidth, expected) => {
+            ["return height and maxHeight", 12, expectedGeoPushpinFullWidthStyle, false],
+            ["doesn't return height and maxHeight", 8, null, false],
+            ["doesn't return height and maxHeight when enableCustomHeight FF is set to true", 12, null, true],
+        ])("should getStyle %s", (_text, currentColumnWidth, expected, enableCustomHeight) => {
             const visType = "pushpin";
             const visWidth = 1000;
             const windowHeight = 768;
-            expect(getGeoPushpinWidgetStyle(visType, visWidth, currentColumnWidth, windowHeight)).toEqual(
-                expected,
-            );
+            expect(
+                getGeoPushpinWidgetStyle(
+                    visType,
+                    visWidth,
+                    currentColumnWidth,
+                    windowHeight,
+                    enableCustomHeight,
+                ),
+            ).toEqual(expected);
         });
     });
 });


### PR DESCRIPTION
…, but should reflect its set height

JIRA: ONE-4914

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
