### PR TITLE
RELATED: RAIL-3079, RAIL-3054 Implement getInsightReferencingObjects on tiger, disable goechart on tiger

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -27,6 +27,7 @@ import { ICatalogFact } from '@gooddata/sdk-backend-spi';
 import { ICatalogGroup } from '@gooddata/sdk-backend-spi';
 import { ICatalogMeasure } from '@gooddata/sdk-backend-spi';
 import { IDashboardFilterReference } from '@gooddata/sdk-backend-spi';
+import { IDashboardMetadataObject } from '@gooddata/sdk-backend-spi';
 import { IDataSetMetadataObject } from '@gooddata/sdk-backend-spi';
 import { IDataView } from '@gooddata/sdk-backend-spi';
 import { IDimension } from '@gooddata/sdk-model';
@@ -280,6 +281,10 @@ export type CustomCallContext = {
     state: CustomBackendState;
     client: any;
 };
+
+// @beta
+export class DashboardMetadataObjectBuilder<T extends IDashboardMetadataObject = IDashboardMetadataObject> extends MetadataObjectBuilder<T> {
+}
 
 // @beta (undocumented)
 export type DataProvider = (context: DataProviderContext) => Promise<IDataView>;
@@ -671,6 +676,9 @@ export const newCatalogGroup: (modifications?: BuilderModifications<CatalogGroup
 
 // @beta
 export const newCatalogMeasure: (modifications?: BuilderModifications<CatalogMeasureBuilder>) => ICatalogMeasure;
+
+// @beta
+export const newDashboardMetadataObject: (ref: ObjRef, modifications?: BuilderModifications<DashboardMetadataObjectBuilder>) => IDashboardMetadataObject;
 
 // @beta
 export const newDataSetMetadataObject: (ref: ObjRef, modifications?: BuilderModifications<DataSetMetadataObjectBuilder>) => IDataSetMetadataObject;

--- a/libs/sdk-backend-base/src/index.ts
+++ b/libs/sdk-backend-base/src/index.ts
@@ -124,5 +124,9 @@ export {
     newVariableMetadataObject,
     VariableMetadataObjectBuilder,
 } from "./ldmFactories/metadata/variableFactory";
+export {
+    newDashboardMetadataObject,
+    DashboardMetadataObjectBuilder,
+} from "./ldmFactories/metadata/dashboardFactory";
 
 export { ResultHeaderTransformer, transformResultHeaders } from "./convertors/fromBackend/afm/result";

--- a/libs/sdk-backend-base/src/ldmFactories/metadata/dashboardFactory.ts
+++ b/libs/sdk-backend-base/src/ldmFactories/metadata/dashboardFactory.ts
@@ -1,0 +1,30 @@
+// (C) 2019-2021 GoodData Corporation
+import identity from "lodash/identity";
+import { ObjRef } from "@gooddata/sdk-model";
+import { MetadataObjectBuilder } from "./factory";
+import { IDashboardMetadataObject } from "@gooddata/sdk-backend-spi";
+import { builderFactory, BuilderModifications } from "../builder";
+
+/**
+ * Dashboard metadata object builder
+ * See {@link Builder}
+ *
+ * @beta
+ */
+export class DashboardMetadataObjectBuilder<
+    T extends IDashboardMetadataObject = IDashboardMetadataObject
+> extends MetadataObjectBuilder<T> {}
+
+/**
+ * Dashboard metadata object factory
+ *
+ * @param ref - dashboard reference
+ * @param modifications - dashboard builder modifications to perform
+ * @returns created dashboard metadata object
+ * @beta
+ */
+export const newDashboardMetadataObject = (
+    ref: ObjRef,
+    modifications: BuilderModifications<DashboardMetadataObjectBuilder> = identity,
+): IDashboardMetadataObject =>
+    builderFactory(DashboardMetadataObjectBuilder, { type: "analyticalDashboard", ref }, modifications);

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -476,6 +476,12 @@ export interface IDashboardLayoutSizeByScreenSize {
     xs?: IDashboardLayoutSize;
 }
 
+// @public
+export interface IDashboardMetadataObject extends IMetadataObject {
+    // (undocumented)
+    type: "analyticalDashboard";
+}
+
 // @alpha
 export interface IDashboardObjectIdentity {
     readonly identifier: string;
@@ -1133,6 +1139,9 @@ export function isDashboardLayoutItem<TWidget>(obj: unknown): obj is IDashboardL
 
 // @alpha
 export function isDashboardLayoutSection<TWidget>(obj: unknown): obj is IDashboardLayoutSection<TWidget>;
+
+// @public
+export function isDashboardMetadataObject(obj: unknown): obj is IDashboardMetadataObject;
 
 // @alpha
 export const isDashboardWidget: (obj: unknown) => obj is DashboardWidget;
@@ -1804,7 +1813,7 @@ export function layoutWidgets<TWidget extends DashboardWidget>(layout: IDashboar
 export function layoutWidgetsWithPaths<TWidget extends DashboardWidget>(layout: IDashboardLayout<TWidget>): IWidgetWithLayoutPath<TWidget>[];
 
 // @public
-export type MetadataObject = IAttributeMetadataObject | IAttributeDisplayFormMetadataObject | IFactMetadataObject | IMeasureMetadataObject | IDataSetMetadataObject | IVariableMetadataObject;
+export type MetadataObject = IAttributeMetadataObject | IAttributeDisplayFormMetadataObject | IFactMetadataObject | IMeasureMetadataObject | IDataSetMetadataObject | IVariableMetadataObject | IDashboardMetadataObject;
 
 // @public
 export const metadataObjectId: (metadataObject: MetadataObject) => string;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -347,6 +347,8 @@ export {
     isMetadataObject,
     MetadataObject,
     metadataObjectId,
+    IDashboardMetadataObject,
+    isDashboardMetadataObject,
 } from "./workspace/fromModel/ldm/metadata";
 
 export {

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/dashboard/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/dashboard/index.ts
@@ -1,0 +1,21 @@
+// (C) 2019-2021 GoodData Corporation
+import { IMetadataObject, isMetadataObject } from "../types";
+
+/**
+ * Dashboard metadata object
+ *
+ * @public
+ */
+export interface IDashboardMetadataObject extends IMetadataObject {
+    type: "analyticalDashboard";
+}
+
+/**
+ * Tests whether the provided object is of type {@link IDashboardMetadataObject}.
+ *
+ * @param obj - object to test
+ * @public
+ */
+export function isDashboardMetadataObject(obj: unknown): obj is IDashboardMetadataObject {
+    return isMetadataObject(obj) && obj.type === "analyticalDashboard";
+}

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IMetadataObject, isMetadataObject } from "./types";
 
 import { IAttributeMetadataObject, isAttributeMetadataObject } from "./attribute";
@@ -10,6 +10,7 @@ import { IFactMetadataObject, isFactMetadataObject } from "./fact";
 import { IMeasureMetadataObject, isMeasureMetadataObject } from "./measure";
 import { IDataSetMetadataObject, isDataSetMetadataObject } from "./dataSet";
 import { IVariableMetadataObject, isVariableMetadataObject } from "./variable";
+import { IDashboardMetadataObject, isDashboardMetadataObject } from "./dashboard";
 
 export {
     IMetadataObject,
@@ -26,6 +27,8 @@ export {
     isDataSetMetadataObject,
     IVariableMetadataObject,
     isVariableMetadataObject,
+    IDashboardMetadataObject,
+    isDashboardMetadataObject,
 };
 
 /**
@@ -39,7 +42,8 @@ export type MetadataObject =
     | IFactMetadataObject
     | IMeasureMetadataObject
     | IDataSetMetadataObject
-    | IVariableMetadataObject;
+    | IVariableMetadataObject
+    | IDashboardMetadataObject;
 
 /**
  * Get metadata object identifier

--- a/libs/sdk-backend-tiger/src/backend/user/settings.ts
+++ b/libs/sdk-backend-tiger/src/backend/user/settings.ts
@@ -24,7 +24,8 @@ export class TigerUserSettingsService implements IUserSettingsService {
                 enableComboChart: true,
                 enableNewADFilterBar: true,
                 enableMeasureValueFilters: true,
-                enablePushpinGeoChart: true,
+                // geochart must be disabled for now on tiger backend due to missing mapbox token infrastructure there (RAIL-3058)
+                enablePushpinGeoChart: false,
                 hidePixelPerfectExperience: true,
                 enableBulletChart: true,
                 enableCsvUploader: true,

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -37,8 +37,8 @@ import {
 import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToUri, objRefToIdentifier } from "../../../utils/api";
 import { convertVisualizationObject } from "../../../convertors/fromBackend/VisualizationObjectConverter";
+import { convertAnalyticalDashboardWithLinks } from "../../../convertors/fromBackend/MetadataConverter";
 import { convertInsight } from "../../../convertors/toBackend/InsightConverter";
-import { convertAnalyticalDashboardToMetadataObject } from "../../../convertors/fromBackend/AnalyticalDashboardConverter";
 
 import { visualizationClasses as visualizationClassesMocks } from "./mocks/visualizationClasses";
 import { InMemoryPaging } from "@gooddata/sdk-backend-base";
@@ -216,7 +216,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
         const dashboards = (apiResult.data.included ?? []) as JsonApiAnalyticalDashboardOutWithLinks[];
 
         return Promise.resolve({
-            analyticalDashboards: dashboards.map(convertAnalyticalDashboardToMetadataObject),
+            analyticalDashboards: dashboards.map(convertAnalyticalDashboardWithLinks),
         });
     };
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -27,6 +27,7 @@ import {
     jsonApiHeaders,
     MetadataUtilities,
     MetadataGetEntitiesOptions,
+    JsonApiAnalyticalDashboardOutWithLinks,
 } from "@gooddata/api-client-tiger";
 import {
     insightFromInsightDefinition,
@@ -37,6 +38,7 @@ import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToUri, objRefToIdentifier } from "../../../utils/api";
 import { convertVisualizationObject } from "../../../convertors/fromBackend/VisualizationObjectConverter";
 import { convertInsight } from "../../../convertors/toBackend/InsightConverter";
+import { convertAnalyticalDashboardToMetadataObject } from "../../../convertors/fromBackend/AnalyticalDashboardConverter";
 
 import { visualizationClasses as visualizationClassesMocks } from "./mocks/visualizationClasses";
 import { InMemoryPaging } from "@gooddata/sdk-backend-base";
@@ -193,8 +195,29 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
         return Promise.resolve({});
     };
 
-    public getInsightReferencingObjects = async (_ref: ObjRef): Promise<IInsightReferencing> => {
-        return Promise.resolve({});
+    public getInsightReferencingObjects = async (ref: ObjRef): Promise<IInsightReferencing> => {
+        const id = await objRefToIdentifier(ref, this.authCall);
+
+        const apiResult = await this.authCall((client) =>
+            client.workspaceObjects.getEntityVisualizationObjects(
+                {
+                    objectId: id,
+                    workspaceId: this.workspace,
+                },
+                {
+                    headers: jsonApiHeaders,
+                    params: {
+                        include: "analyticalDashboards",
+                    },
+                },
+            ),
+        );
+
+        const dashboards = (apiResult.data.included ?? []) as JsonApiAnalyticalDashboardOutWithLinks[];
+
+        return Promise.resolve({
+            analyticalDashboards: dashboards.map(convertAnalyticalDashboardToMetadataObject),
+        });
     };
 
     public getInsightWithAddedFilters = async <T extends IInsightDefinition>(

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/mocks/visualizationClasses.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/mocks/visualizationClasses.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IVisualizationClass } from "@gooddata/sdk-model";
 import sortBy from "lodash/sortBy";
 
@@ -172,18 +172,19 @@ export const visualizationClasses: IVisualizationClass[] = sortBy(
                 uri: "/gdc/md/gtl83h4doozbp26q0kf5qg8uiyu4glyn/obj/1000",
             },
         },
-        {
-            visualizationClass: {
-                checksum: "local",
-                icon: "local:pushpin",
-                orderIndex: 20,
-                iconSelected: "local:pushpin.selected",
-                url: "local:pushpin",
-                title: "Geo Pushpin",
-                identifier: "gdc.visualization.pushpin",
-                uri: "/gdc/md/gtl83h4doozbp26q0kf5qg8uiyu4glyn/obj/1001",
-            },
-        },
+        // geochart must be disabled for now on tiger backend due to missing mapbox token infrastructure there (RAIL-3058)
+        // {
+        //     visualizationClass: {
+        //         checksum: "local",
+        //         icon: "local:pushpin",
+        //         orderIndex: 20,
+        //         iconSelected: "local:pushpin.selected",
+        //         url: "local:pushpin",
+        //         title: "Geo Pushpin",
+        //         identifier: "gdc.visualization.pushpin",
+        //         uri: "/gdc/md/gtl83h4doozbp26q0kf5qg8uiyu4glyn/obj/1001",
+        //     },
+        // },
     ],
     (cls) => cls.visualizationClass.orderIndex,
 );

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -14,7 +14,8 @@ const HardcodedSettings = {
 
     // AD specific
     analyticalDesigner: true,
-    enablePushpinGeoChart: true,
+    // geochart must be disabled for now on tiger backend due to missing mapbox token infrastructure there (RAIL-3058)
+    enablePushpinGeoChart: false,
     enableBulletChart: true,
     enableComboChart: true,
     enableNewADFilterBar: true,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
@@ -15,6 +15,7 @@ import {
     IDashboardLayout,
     IFilterContext,
     IListedDashboard,
+    IMetadataObject,
     LayoutPath,
     walkLayout,
 } from "@gooddata/sdk-backend-spi";
@@ -23,6 +24,24 @@ import { IdentifierRef, idRef, ObjectType } from "@gooddata/sdk-model";
 import omit from "lodash/omit";
 import updateWith from "lodash/updateWith";
 import { cloneWithSanitizedIds } from "./IdSanitization";
+
+export const convertAnalyticalDashboardToMetadataObject = (
+    analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,
+): IMetadataObject => {
+    const attributes = analyticalDashboard.attributes as JsonApiAnalyticalDashboardInAttributes;
+    const { title, description } = attributes;
+    return {
+        ref: idRef(analyticalDashboard.id, "analyticalDashboard"),
+        uri: analyticalDashboard.links!.self,
+        id: analyticalDashboard.id,
+        deprecated: false,
+        production: true,
+        type: "analyticalDashboard",
+        unlisted: false,
+        title: title ?? "",
+        description: description ?? "",
+    };
+};
 
 export const convertAnalyticalDashboard = (
     analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
@@ -15,7 +15,6 @@ import {
     IDashboardLayout,
     IFilterContext,
     IListedDashboard,
-    IMetadataObject,
     LayoutPath,
     walkLayout,
 } from "@gooddata/sdk-backend-spi";
@@ -24,24 +23,6 @@ import { IdentifierRef, idRef, ObjectType } from "@gooddata/sdk-model";
 import omit from "lodash/omit";
 import updateWith from "lodash/updateWith";
 import { cloneWithSanitizedIds } from "./IdSanitization";
-
-export const convertAnalyticalDashboardToMetadataObject = (
-    analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,
-): IMetadataObject => {
-    const attributes = analyticalDashboard.attributes as JsonApiAnalyticalDashboardInAttributes;
-    const { title, description } = attributes;
-    return {
-        ref: idRef(analyticalDashboard.id, "analyticalDashboard"),
-        uri: analyticalDashboard.links!.self,
-        id: analyticalDashboard.id,
-        deprecated: false,
-        production: true,
-        type: "analyticalDashboard",
-        unlisted: false,
-        title: title ?? "",
-        description: description ?? "",
-    };
-};
 
 export const convertAnalyticalDashboard = (
     analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/MetadataConverter.ts
@@ -1,5 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import {
+    JsonApiAnalyticalDashboardOutWithLinks,
     JsonApiAttributeOut,
     JsonApiAttributeOutDocument,
     JsonApiAttributeOutList,
@@ -16,12 +17,14 @@ import keyBy from "lodash/keyBy";
 import {
     IAttributeDisplayFormMetadataObject,
     IAttributeMetadataObject,
+    IDashboardMetadataObject,
     IDataSetMetadataObject,
 } from "@gooddata/sdk-backend-spi";
 import {
     IMetadataObjectBuilder,
     newAttributeDisplayFormMetadataObject,
     newAttributeMetadataObject,
+    newDashboardMetadataObject,
     newDataSetMetadataObject,
 } from "@gooddata/sdk-backend-base";
 import { idRef } from "@gooddata/sdk-model";
@@ -32,7 +35,8 @@ export type MetadataObjectFromApi =
     | JsonApiFactOutWithLinks
     | JsonApiMetricOutWithLinks
     | JsonApiLabelOutWithLinks
-    | JsonApiDatasetOutWithLinks;
+    | JsonApiDatasetOutWithLinks
+    | JsonApiAnalyticalDashboardOutWithLinks;
 
 export const commonMetadataObjectModifications = <
     TItem extends MetadataObjectFromApi,
@@ -216,5 +220,18 @@ export function convertAttributesWithSideloadedLabels(
 export function convertDatasetWithLinks(dataset: JsonApiDatasetOutWithLinks): IDataSetMetadataObject {
     return newDataSetMetadataObject(idRef(dataset.id, "dataSet"), (m) =>
         m.modify(commonMetadataObjectModifications(dataset)),
+    );
+}
+
+/**
+ * Converts sideloaded dashboard into {@link IDashboardMetadataObject}
+ *
+ * @param dashboard - sideloaded dashboard
+ */
+export function convertAnalyticalDashboardWithLinks(
+    dashboard: JsonApiAnalyticalDashboardOutWithLinks,
+): IDashboardMetadataObject {
+    return newDashboardMetadataObject(idRef(dashboard.id, "analyticalDashboard"), (m) =>
+        m.modify(commonMetadataObjectModifications(dashboard)),
     );
 }

--- a/libs/sdk-ui-geo/styles/scss/tooltip.scss
+++ b/libs/sdk-ui-geo/styles/scss/tooltip.scss
@@ -126,7 +126,7 @@
         max-height: 2.6em;
 
         &.clamp-two-line {
-            display: box;
+            display: flex;
 
             /*! autoprefixer: ignore next */
             -webkit-box-orient: vertical;


### PR DESCRIPTION
* RAIL-3079 - This is needed to display dashboards using a given insight.
* RAIL-3054 - Tiger backend is not ready to handle mapbox tokens yet

Also one small tweak of scss was done to avoid warnings.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
