### PR TITLE
Pivot table reacts to change of the height

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -294,6 +294,13 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
             if (!isEqual(prevColumnWidths, columnWidths)) {
                 this.internal.table?.applyColumnSizes(this.getResizingConfig());
             }
+
+            if (
+                this.props.config?.maxHeight &&
+                !isEqual(this.props.config?.maxHeight, prevProps.config?.maxHeight)
+            ) {
+                this.updateDesiredHeight();
+            }
         }
     }
 

--- a/libs/sdk-ui-tests/stories/end-to-end/pivotTable/PivotTableHeight.tsx
+++ b/libs/sdk-ui-tests/stories/end-to-end/pivotTable/PivotTableHeight.tsx
@@ -1,0 +1,66 @@
+// (C) 2021 GoodData Corporation
+import { ReferenceLdm } from "@gooddata/reference-workspace";
+import { PivotTable } from "@gooddata/sdk-ui-pivot";
+import { storiesOf } from "@storybook/react";
+import React, { Component, Fragment } from "react";
+import { ReferenceWorkspaceId, StorybookBackend } from "../../_infra/backend";
+import { StoriesForEndToEndTests } from "../../_infra/storyGroups";
+import { withMultipleScreenshots } from "../../_infra/backstopWrapper";
+
+const backend = StorybookBackend();
+const measures = [ReferenceLdm.Amount, ReferenceLdm.Won];
+const attributes = [ReferenceLdm.Product.Name, ReferenceLdm.Department];
+const columns = [ReferenceLdm.ForecastCategory, ReferenceLdm.Region];
+
+class PivotTableHeight extends Component {
+    state = {
+        height: 200,
+    };
+    public render() {
+        return (
+            <Fragment>
+                <div>
+                    <button onClick={() => this.setState({ height: 200 })}>Change height to 200</button>
+                    <button id="s-height-change" onClick={() => this.setState({ height: 400 })}>
+                        Change height to 400
+                    </button>
+                </div>
+                <div
+                    style={{
+                        width: 1000,
+                        height: this.state.height,
+                        marginTop: 20,
+                        resize: "both",
+                        overflow: "auto",
+                    }}
+                    className="s-pivot-table-height"
+                >
+                    <PivotTable
+                        backend={backend}
+                        workspace={ReferenceWorkspaceId}
+                        measures={measures}
+                        rows={attributes}
+                        columns={columns}
+                        config={{
+                            maxHeight: this.state.height,
+                        }}
+                    />
+                </div>
+            </Fragment>
+        );
+    }
+}
+
+const screenshotProps = {
+    pivotTableHeight: {
+        clickSelector: "#s-height-change",
+        postInteractionWait: 200,
+    },
+};
+
+storiesOf(
+    `${StoriesForEndToEndTests}/Pivot Table`,
+    module,
+).add("complex table with multiple columns and with height change", () =>
+    withMultipleScreenshots(<PivotTableHeight />, screenshotProps),
+);

--- a/tools/reference-workspace/src/recordings/dataSample.ts
+++ b/tools/reference-workspace/src/recordings/dataSample.ts
@@ -1,6 +1,8 @@
+// (C) 2021 GoodData Corporation
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable header/header */
-/* THIS FILE WAS AUTO-GENERATED USING MOCK HANDLING TOOL; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-03-08T14:57:46.404Z; */
+/* THIS FILE WAS AUTO-GENERATED USING MOCK HANDLING TOOL; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-03-19T16:19:51.618Z; */
 
 const df_label_product_id_name = require("./metadata/displayForms/label.product.id.name/elements.json");
 const df_label_owner_department = require("./metadata/displayForms/label.owner.department/elements.json");

--- a/tools/reference-workspace/src/recordings/index.ts
+++ b/tools/reference-workspace/src/recordings/index.ts
@@ -1,6 +1,8 @@
+// (C) 2021 GoodData Corporation
+
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable header/header */
-/* THIS FILE WAS AUTO-GENERATED USING MOCK HANDLING TOOL; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-03-08T14:57:46.404Z; */
+/* THIS FILE WAS AUTO-GENERATED USING MOCK HANDLING TOOL; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-03-19T16:19:51.618Z; */
 
 const fp_00ab8c432637030b305313405b3f4efc = {
     definition: require("./uiTestScenarios/executions/00ab8c432637030b305313405b3f4efc/definition.json"),
@@ -83,6 +85,12 @@ const fp_17662e51ac28bd3756cd43f58679fd89 = {
     dataView_o0_0s100_1000: require("./uiTestScenarios/executions/17662e51ac28bd3756cd43f58679fd89/dataView_o0_0s100_1000.json"),
     dataView_o0_0s22_1000: require("./uiTestScenarios/executions/17662e51ac28bd3756cd43f58679fd89/dataView_o0_0s22_1000.json"),
     scenarios: require("./uiTestScenarios/executions/17662e51ac28bd3756cd43f58679fd89/scenarios.json"),
+};
+const fp_1773f94f158f36a01aabd607341c5fab = {
+    definition: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/definition.json"),
+    executionResult: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/executionResult.json"),
+    dataView_all: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/dataView_all.json"),
+    scenarios: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/scenarios.json"),
 };
 const fp_179f06a3a73ef41de634960f77cded42 = {
     definition: require("./uiTestScenarios/executions/179f06a3a73ef41de634960f77cded42/definition.json"),
@@ -778,12 +786,6 @@ const fp_ff74085f6f31c71f4797251924d3205d = {
     dataView_o0_0s100_1000: require("./uiTestScenarios/executions/ff74085f6f31c71f4797251924d3205d/dataView_o0_0s100_1000.json"),
     dataView_o0_0s22_1000: require("./uiTestScenarios/executions/ff74085f6f31c71f4797251924d3205d/dataView_o0_0s22_1000.json"),
 };
-const fp_1773f94f158f36a01aabd607341c5fab = {
-    definition: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/definition.json"),
-    executionResult: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/executionResult.json"),
-    dataView_all: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/dataView_all.json"),
-    scenarios: require("./uiTestScenarios/executions/1773f94f158f36a01aabd607341c5fab/scenarios.json"),
-};
 export const Scenarios = {
     ComboChart: {
         MultipleMeasuresAndNoViewBy: { scenarioIndex: 0, execution: fp_00ab8c432637030b305313405b3f4efc },
@@ -947,6 +949,7 @@ export const Scenarios = {
     },
     ColumnChart: {
         TwoMeasuresWithTwoViewBy: { scenarioIndex: 1, execution: fp_036a8d52f628b2c9847579f40be9afed },
+        DenseChartWithTwoViewBy: { scenarioIndex: 0, execution: fp_1773f94f158f36a01aabd607341c5fab },
         TwoMeasuresWithViewBySortedByMeasure: {
             scenarioIndex: 2,
             execution: fp_2176513b2ab7574386aeb644eaaa1bc6,
@@ -974,7 +977,6 @@ export const Scenarios = {
             scenarioIndex: 3,
             execution: fp_e1030dca208f6b7b3ac060bfdb341df6,
         },
-        DenseChartWithTwoViewBy: { scenarioIndex: 0, execution: fp_1773f94f158f36a01aabd607341c5fab },
     },
     LineChart: {
         SingleMeasureWithTrendByAndSegmentBy: {
@@ -2998,6 +3000,7 @@ export const Recordings = {
         fp_1494c32c1045f1684b4c59654c46f671,
         fp_15dd8db0e7c949c054ed836c4865a465,
         fp_17662e51ac28bd3756cd43f58679fd89,
+        fp_1773f94f158f36a01aabd607341c5fab,
         fp_179f06a3a73ef41de634960f77cded42,
         fp_17bdc7cd45b303fc54f97cde57ba1816,
         fp_1d7bbf8347dc010b86bf16a1916decb6,
@@ -3114,7 +3117,6 @@ export const Recordings = {
         fp_fd4473fef32dc8b57cdba96564af53e1,
         fp_fde7a6a9ba205f28ce4a5391836f1153,
         fp_ff74085f6f31c71f4797251924d3205d,
-        fp_1773f94f158f36a01aabd607341c5fab,
     },
     metadata: {
         catalog,


### PR DESCRIPTION
JIRA: ONE-4935

As we implemented a manual change of widget height, we noticed that Pivot Table does not react to the heigh change. Therefore we have to add logic that will cause a change of pivot table height.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
