### PR TITLE
RELATED: RAIL-3087 Fix tiger insights sorting

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -106,7 +106,7 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
             }
             // tiger still does not support the "updated" property -> sort by title
             else {
-                sanitizedOrder = sortBy(allInsights, (insight) => insightTitle(insight));
+                sanitizedOrder = sortBy(allInsights, (insight) => insightTitle(insight).toUpperCase());
             }
         }
 


### PR DESCRIPTION
We need to use toUpperCase, otherwise "new insight" would be after "ZZZ"

JIRA: RAIL-3087

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
