### PR TITLE
RELATED: RAIL-3091 - Set insight as locked if it comes from parent workspace

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
@@ -14,6 +14,11 @@ export const insightFromInsightDefinition = (
             identifier: id,
             uri,
             ref: idRef(id, "visualizationObject"),
+            // TODO: TIGER-HACK: vis objects inherited from parent must be read-only. However there is no
+            //  first-class way to discover this at the moment through the API. This hack relies on Tiger behavior
+            //  where objects inherited from parent workspace have their id's in format `some_workspace_id:object_id`.
+            //  Nothing else to do but to check for the colon. Luckily, the colon character cannot be used by clients.
+            isLocked: id.indexOf(":") > -1,
         },
     };
 };


### PR DESCRIPTION
-  A hacky way to do this atm because there is no official way to do this

JIRA: RAIL-3091

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
