### PR TITLE
RELATED: RAIL-3091 - Flag more stuff with TIGER-HACK, remove one hack

### DIFF
--- a/libs/sdk-backend-tiger/src/auth.ts
+++ b/libs/sdk-backend-tiger/src/auth.ts
@@ -63,11 +63,6 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
         const client = context.client as ITigerClient;
 
         try {
-            // TODO: this is here because /api/profile is now weird and returns some dummy HTML page
-            //  for everyone - it's not really an authenticated resource. until the profile is
-            //  fixed the code tries to access user's org which is properly protected by auth.
-            await client.axios.get<TigerUserProfile>("/api/entities/organization");
-
             return (await client.axios.get<TigerUserProfile>("/api/profile")).data;
         } catch (err) {
             throw convertApiError(err);

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -46,7 +46,7 @@ function getAttributeLabels(
 
 function isGeoLabel(label: JsonApiLabelOutWithLinks): boolean {
     /*
-     * TODO: this is temporary way to identify labels with geo pushpin; normally this should be done
+     * TODO: TIGER-HACK this is temporary way to identify labels with geo pushpin; normally this should be done
      *  using some indicator on the metadata object. for sakes of speed & after agreement with tiger team
      *  falling back to use of id convention.
      */

--- a/libs/sdk-backend-tiger/src/utils/errorHandling.ts
+++ b/libs/sdk-backend-tiger/src/utils/errorHandling.ts
@@ -30,7 +30,7 @@ export function createNotAuthenticatedError(error: Error): NotAuthenticated | un
 
     const exc = new NotAuthenticated("No session or session expired", error);
 
-    // TODO: both of these params need to come from the backend.
+    // TODO: TIGER-HACK both of these params need to come from the backend.
     //  current problems:
     //  - some resources do not send login URL (empty 401), some do
     //  - no resources send returnRedirectParam


### PR DESCRIPTION
-  The extra call to get organization is no longer needed. Verified that /api/profile now correctly returns 401 

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
