### PR TITLE
RELATED: RAIL-3131 - Support ranking filters that reference attributes by localId

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -140,7 +140,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
         const measures = relevantItems.filter(isMeasure);
         const filters = relevantItems.filter(isFilter);
 
-        const { filters: afmFilters, auxMeasures } = convertAfmFilters(measures, filters);
+        const { filters: afmFilters, auxMeasures } = convertAfmFilters(attributes, measures, filters);
 
         const afmValidObjectsQuery = {
             types: relevantRestrictingTypes.map(mapToTigerType),

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
@@ -2,6 +2,9 @@
 import { LocalIdentifier, ObjectIdentifier } from "@gooddata/api-client-tiger";
 import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
 import {
+    attributeDisplayFormRef,
+    attributesFind,
+    IAttribute,
     isIdentifierRef,
     isLocalIdRef,
     isObjRef,
@@ -9,6 +12,7 @@ import {
     ObjRef,
     ObjRefInScope,
 } from "@gooddata/sdk-model";
+import { invariant } from "ts-invariant";
 import { TigerAfmType, TigerObjectType } from "../../types";
 import {
     isTigerCompatibleType,
@@ -102,12 +106,19 @@ export function toMeasureValueFilterMeasureQualifier(ref: ObjRefInScope): LocalI
 /**
  * @internal
  */
-export function toRankingFilterDimensionalityIdentifier(ref: ObjRefInScope): ObjectIdentifier {
+export function toRankingFilterDimensionalityIdentifier(
+    ref: ObjRefInScope,
+    afmAttributes: IAttribute[],
+): ObjectIdentifier {
     if (isObjRef(ref)) {
         return toObjQualifier(ref);
     } else {
-        throw new NotSupported(
-            "Tiger backend only allows specifying ranking attributes by object identifiers",
-        );
+        invariant(afmAttributes.length > 0);
+
+        const attribute = attributesFind(afmAttributes, ref.localIdentifier);
+
+        invariant(attribute);
+
+        return toObjQualifier(attributeDisplayFormRef(attribute));
     }
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AfmFiltersConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AfmFiltersConverter.ts
@@ -1,6 +1,7 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { FilterDefinition, MeasureItem } from "@gooddata/api-client-tiger";
 import {
+    IAttribute,
     Identifier,
     IFilter,
     IMeasure,
@@ -70,6 +71,7 @@ function determineComputeRatioMeasureNumerators(
  * being generated (intended to be used by the callers in crafting the final backend AFM).
  */
 export function convertAfmFilters(
+    afmAttributes: IAttribute[],
     afmMeasures: IMeasure[],
     afmFilters: IFilter[],
 ): { filters: FilterDefinition[]; auxMeasures: MeasureItem[] } {
@@ -99,7 +101,7 @@ export function convertAfmFilters(
         }
     });
     return {
-        filters: compact(transformedFilters.map(convertFilter)),
+        filters: compact(transformedFilters.map((filter) => convertFilter(filter, afmAttributes))),
         auxMeasures: Array.from(computeRatioMeasureNumerators.values()).map(convertMeasure),
     };
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/FilterConverter.ts
@@ -15,6 +15,7 @@ import {
 import {
     filterIsEmpty,
     IAbsoluteDateFilter,
+    IAttribute,
     IAttributeElements,
     IAttributeFilter,
     IFilter,
@@ -214,10 +215,18 @@ function convertMeasureValueFilter(
     return null;
 }
 
-function convertRankingFilter(filter: IRankingFilter, applyOnResultProp: ApplyOnResultProp): RankingFilter {
+function convertRankingFilter(
+    filter: IRankingFilter,
+    applyOnResultProp: ApplyOnResultProp,
+    afmAttributes: IAttribute[],
+): RankingFilter {
     const { measure, attributes, operator, value } = filter.rankingFilter;
     const dimensionalityProp = attributes
-        ? { dimensionality: attributes.map(toRankingFilterDimensionalityIdentifier) }
+        ? {
+              dimensionality: attributes.map((attr) =>
+                  toRankingFilterDimensionalityIdentifier(attr, afmAttributes),
+              ),
+          }
         : {};
     return {
         rankingFilter: {
@@ -230,7 +239,10 @@ function convertRankingFilter(filter: IRankingFilter, applyOnResultProp: ApplyOn
     };
 }
 
-export function convertFilter(filter0: IFilter | IFilterWithApplyOnResult): FilterDefinition | null {
+export function convertFilter(
+    filter0: IFilter | IFilterWithApplyOnResult,
+    afmAttributes: IAttribute[] = [],
+): FilterDefinition | null {
     const [filter, applyOnResult] = isFilter(filter0)
         ? [filter0, undefined]
         : [filter0.filter, filter0.applyOnResult];
@@ -244,7 +256,7 @@ export function convertFilter(filter0: IFilter | IFilterWithApplyOnResult): Filt
     } else if (isMeasureValueFilter(filter)) {
         return convertMeasureValueFilter(filter, applyOnResultProp);
     } else if (isRankingFilter(filter)) {
-        return convertRankingFilter(filter, applyOnResultProp);
+        return convertRankingFilter(filter, applyOnResultProp, afmAttributes);
     } else {
         // eslint-disable-next-line no-console
         console.warn("Tiger does not support this filter. The filter will be ignored");

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import {
     ArithmeticMeasureDefinition,
     ArithmeticMeasureDefinitionArithmeticMeasureOperatorEnum,
@@ -102,7 +102,9 @@ function convertSimpleMeasureDefinition(definition: IMeasureDefinition): SimpleM
     const { measureDefinition } = definition;
 
     const filters: FilterDefinitionForSimpleMeasure[] = measureDefinition.filters
-        ? (compact(measureDefinition.filters.map(convertFilter)) as FilterDefinitionForSimpleMeasure[]) // measureDefinition.filters is IMeasureFilter, it contains only date and attribute filter, equally result contains this subset, it corresponds to type FilterDefinitionForSimpleMeasure
+        ? (compact(
+              measureDefinition.filters.map((filter) => convertFilter(filter)),
+          ) as FilterDefinitionForSimpleMeasure[]) // measureDefinition.filters is IMeasureFilter, it contains only date and attribute filter, equally result contains this subset, it corresponds to type FilterDefinitionForSimpleMeasure
         : [];
     const filtersProp = filters.length ? { filters } : {};
 

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AfmFilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AfmFilterConverter.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import {
     newMeasureValueFilter,
     newRankingFilter,
@@ -15,7 +15,7 @@ describe("convertAfmFilters", () => {
 
     it("should transform measure based filter of ratio measure", () => {
         const ratioFilter = newMeasureValueFilter("ratio", "GREATER_THAN", 128);
-        expect(convertAfmFilters(afmMeasures, [ratioFilter])).toMatchSnapshot();
+        expect(convertAfmFilters([], afmMeasures, [ratioFilter])).toMatchSnapshot();
     });
 
     it("should not transform measure based filter of non-ratio measure", () => {
@@ -25,11 +25,11 @@ describe("convertAfmFilters", () => {
             "TOP",
             3,
         );
-        expect(convertAfmFilters(afmMeasures, [nonRatioFilter])).toMatchSnapshot();
+        expect(convertAfmFilters([], afmMeasures, [nonRatioFilter])).toMatchSnapshot();
     });
 
     it("should keep non-measure based filter", () => {
         const positiveAttributeFilter = newPositiveAttributeFilter(ReferenceLdm.Product.Name, ["value"]);
-        expect(convertAfmFilters(afmMeasures, [positiveAttributeFilter])).toMatchSnapshot();
+        expect(convertAfmFilters([], afmMeasures, [positiveAttributeFilter])).toMatchSnapshot();
     });
 });

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
@@ -14,6 +14,7 @@ import {
     uriRef,
 } from "@gooddata/sdk-model";
 import { ReferenceLdm } from "@gooddata/reference-workspace";
+import { InvariantError } from "ts-invariant";
 
 describe("tiger filter converter from model to AFM", () => {
     describe("convert measure value filter", () => {
@@ -156,6 +157,24 @@ describe("tiger filter converter from model to AFM", () => {
 
             expect(convertFilter(emptyPositiveFilter)).toBeNull();
             expect(convertFilter(emptyNegativeFilter)).toBeNull();
+        });
+
+        it("should convert ranking filter when localIds used for attributes", () => {
+            const rankingFilter = newRankingFilter(ReferenceLdm.Won, [ReferenceLdm.IsActive], "TOP", 3);
+
+            expect(convertFilter(rankingFilter, [ReferenceLdm.IsActive])).toMatchSnapshot();
+        });
+
+        it("should throw error when converting ranking filter with localIds used for attributes and no attribute list", () => {
+            const rankingFilter = newRankingFilter(ReferenceLdm.Won, [ReferenceLdm.IsActive], "TOP", 3);
+
+            expect(() => convertFilter(rankingFilter)).toThrow(InvariantError);
+        });
+
+        it("should throw error when converting ranking filter with localIds used for attributes and no matching attribute provided", () => {
+            const rankingFilter = newRankingFilter(ReferenceLdm.Won, [ReferenceLdm.IsActive], "TOP", 3);
+
+            expect(() => convertFilter(rankingFilter, [ReferenceLdm.Product.Name])).toThrow(InvariantError);
         });
     });
 });

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -19,6 +19,28 @@ exports[`tiger filter converter from model to AFM convert absolute date filter s
 
 exports[`tiger filter converter from model to AFM convert absolute date filter should convert absolute date filter without 'to' attribute 1`] = `null`;
 
+exports[`tiger filter converter from model to AFM convert filter should convert ranking filter when localIds used for attributes 1`] = `
+Object {
+  "rankingFilter": Object {
+    "dimensionality": Array [
+      Object {
+        "identifier": Object {
+          "id": "label.stage.isactive",
+          "type": "label",
+        },
+      },
+    ],
+    "measures": Array [
+      Object {
+        "localIdentifier": "m_acugFHNJgsBy",
+      },
+    ],
+    "operator": "TOP",
+    "value": 3,
+  },
+}
+`;
+
 exports[`tiger filter converter from model to AFM convert filter should return absolute date filter 1`] = `
 Object {
   "absoluteDateFilter": Object {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
@@ -14,7 +14,7 @@ function convertAFM(def: IExecutionDefinition): AFM {
     const measures: MeasureItem[] = def.measures.map(convertMeasure);
     const measuresProp = { measures };
 
-    const { filters, auxMeasures } = convertAfmFilters(def.measures, def.filters || []);
+    const { filters, auxMeasures } = convertAfmFilters(def.attributes, def.measures, def.filters || []);
     const filtersProp = { filters };
     const auxMeasuresProp = { auxMeasures };
 


### PR DESCRIPTION
-  This is not supported by tiger backend
-  Modified convertor code to tunnel attributes into the filter convertor
   so that ranking filter convertor can do lookup

JIRA: RAIL-3131

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
