### PR TITLE
RELATED: RAIL-3128 - Fix analytical dashboard isLocked & tags behavior

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -171,8 +171,6 @@ export namespace AnalyticalDashboardObjectModel {
     export interface IAnalyticalDashboard {
         // (undocumented)
         analyticalDashboard: {
-            isLocked?: boolean;
-            tags?: string[];
             layout?: IDashboardLayout;
             filterContextRef?: ObjRef;
             dateFilterConfig?: IDashboardDateFilterConfig;

--- a/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardObjectModel.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardObjectModel.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import {
     IDashboardDateFilterConfig,
     IDashboardLayout,
@@ -9,8 +9,6 @@ import { ObjRef } from "@gooddata/sdk-model";
 export namespace AnalyticalDashboardObjectModel {
     export interface IAnalyticalDashboard {
         analyticalDashboard: {
-            isLocked?: boolean;
-            tags?: string[];
             layout?: IDashboardLayout;
             filterContextRef?: ObjRef;
             dateFilterConfig?: IDashboardDateFilterConfig;

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/AnalyticalDashboardConverter.ts
@@ -23,6 +23,7 @@ import { IdentifierRef, idRef, ObjectType } from "@gooddata/sdk-model";
 import omit from "lodash/omit";
 import updateWith from "lodash/updateWith";
 import { cloneWithSanitizedIds } from "./IdSanitization";
+import { isInheritedObject } from "./utils";
 
 export const convertAnalyticalDashboard = (
     analyticalDashboard: JsonApiAnalyticalDashboardOutWithLinks,
@@ -68,8 +69,6 @@ export function convertAnalyticalDashboardContent(
     analyticalDashboard: AnalyticalDashboardObjectModel.IAnalyticalDashboard["analyticalDashboard"],
 ): AnalyticalDashboardObjectModel.IAnalyticalDashboard["analyticalDashboard"] {
     return {
-        isLocked: analyticalDashboard.isLocked,
-        tags: analyticalDashboard.tags,
         dateFilterConfig: cloneWithSanitizedIds(analyticalDashboard.dateFilterConfig),
         filterContextRef: cloneWithSanitizedIds(analyticalDashboard.filterContextRef),
         layout: setWidgetRefsInLayout(cloneWithSanitizedIds(analyticalDashboard.layout)),
@@ -95,6 +94,9 @@ export function convertDashboard(
         description,
         created: "",
         updated: "",
+        // TODO: TIGER-HACK: inherited objects must be locked; they are read-only for all
+        isLocked: isInheritedObject(id),
+        tags: attributes.tags,
         filterContext,
         ...omit(dashboardData, ["filterContextRef"]),
     };

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
@@ -1,6 +1,7 @@
 // (C) 2020-2021 GoodData Corporation
 import { VisualizationObjectModel, JsonApiVisualizationObjectOutWithLinks } from "@gooddata/api-client-tiger";
 import { idRef, IInsight, IInsightDefinition } from "@gooddata/sdk-model";
+import { isInheritedObject } from "./utils";
 import { convertVisualizationObject } from "./VisualizationObjectConverter";
 
 export const insightFromInsightDefinition = (
@@ -14,11 +15,8 @@ export const insightFromInsightDefinition = (
             identifier: id,
             uri,
             ref: idRef(id, "visualizationObject"),
-            // TODO: TIGER-HACK: vis objects inherited from parent must be read-only. However there is no
-            //  first-class way to discover this at the moment through the API. This hack relies on Tiger behavior
-            //  where objects inherited from parent workspace have their id's in format `some_workspace_id:object_id`.
-            //  Nothing else to do but to check for the colon. Luckily, the colon character cannot be used by clients.
-            isLocked: id.indexOf(":") > -1,
+            // TODO: TIGER-HACK: inherited objects must be locked; they are read-only for all
+            isLocked: isInheritedObject(id),
         },
     };
 };

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/utils.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/utils.ts
@@ -1,0 +1,11 @@
+// (C) 2020-2021 GoodData Corporation
+
+/**
+ * TODO: TIGER-HACK: a nasty way to identify that an object is inherited from some parent workspace. This is
+ *  determined by checking for colon character in the object identifier.
+ *
+ * @param id - object identifier
+ */
+export function isInheritedObject(id: string): boolean {
+    return id.indexOf(":") > -1;
+}

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
@@ -40,8 +40,6 @@ export function convertAnalyticalDashboard(
 
     return {
         analyticalDashboard: {
-            isLocked: dashboard.isLocked,
-            tags: dashboard.tags,
             dateFilterConfig: cloneWithSanitizedIds(dashboard.dateFilterConfig),
             filterContextRef: cloneWithSanitizedIds(filterContextRef),
             layout: cloneWithSanitizedIds(layout),


### PR DESCRIPTION
-  Tags need to come from MD object attributes.tags; they are not part of the
   dashboard content that is controlled by SDK
-  The isLocked indicator is the same. It comes from the backend.. now through
   the nasty tiger-hack where inherited objects in child workspace are locked and
   this is determined by presence of colon char in the identifier.

JIRA: RAIL-3127

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
