### PR TITLE
RELATED: RAIL-3132 Fix MAQL parser in tiger

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -21,6 +21,19 @@ describe("tokenizeExpression", () => {
             { type: "text", value: ") and " },
             { type: "identifier", value: "snapshot.year" },
             { type: "text", value: " > 2011" },
+        ]);
+    });
+
+    it("parses MAQL without whitespace around operators (RAIL-3132)", () => {
+        const tokens = tokenizeExpression(
+            "SELECT SUM({fact.opportunitysnapshot.amount}*{fact.opportunitysnapshot.amount2})",
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM(" },
+            { type: "identifier", value: "fact.opportunitysnapshot.amount" },
+            { type: "text", value: "*" },
+            { type: "identifier", value: "fact.opportunitysnapshot.amount2" },
+            { type: "text", value: ")" },
         ]);
     });
 });

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 export type ExpressionTokenType = "text" | "quoted_text" | "fact" | "metric" | "attribute" | "label";
 
 export interface IExpressionToken {
@@ -10,10 +10,10 @@ const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
     ["text", /^[^{}[\]"]+/],
     ["quoted_text", /^"(?:[^"\\]|\\\\.)*"/],
-    ["fact", /^\{fact\/\S*\}/],
-    ["metric", /^\{metric\/\S*\}/],
-    ["label", /^\{label\/\S*\}/],
-    ["attribute", /^\{attribute\/\S*\}/],
+    ["fact", /^\{fact\/[^}]*\}/],
+    ["metric", /^\{metric\/[^}]*\}/],
+    ["label", /^\{label\/[^}]*\}/],
+    ["attribute", /^\{attribute\/[^}]*\}/],
 ];
 
 export const tokenizeExpression = (expression: string): IExpressionToken[] => {

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -19,6 +19,17 @@ describe("tokenizeExpression", () => {
             { type: "quoted_text", value: '"Canceled"' },
             { type: "text", value: ")) by all except " },
             { type: "attribute", value: "attribute/attr.customer.c_custkey" },
+        ]);
+    });
+
+    it("parses MAQL without whitespace around operators (RAIL-3132)", () => {
+        const tokens = tokenizeExpression("SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity})");
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM(" },
+            { type: "fact", value: "fact/order_lines.price" },
+            { type: "text", value: "*" },
+            { type: "fact", value: "fact/order_lines.quantity" },
+            { type: "text", value: ")" },
         ]);
     });
 });


### PR DESCRIPTION
Now it can parse MAQL without whitespaces around operators.
This is done by replacing the "\S" (non-whitespace)
by "[^}]" (non-closing-bracket) which is more precise.

Checked also the bear version with a similar test, it was already correct, however.

JIRA: RAIL-3132

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
