### PR TITLE
RELATED: RAIL-3133 - Fix logout error handling

### DIFF
--- a/libs/sdk-backend-tiger/src/auth.ts
+++ b/libs/sdk-backend-tiger/src/auth.ts
@@ -33,7 +33,10 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
         try {
             await client.axios.post("/logout");
         } catch (error) {
-            convertApiError(error);
+            // eslint-disable-next-line no-console
+            console.debug("Error during logout", error);
+
+            throw convertApiError(error);
         }
     }
 


### PR DESCRIPTION
-  Error handling was noop
-  Now is debug log and throw

NOTE: this does not fix the issue itself. it's just something i discovered while digging in the code. The root cause of the problem is likely in other systems.

JIRA: RAIL-3133

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
