### PR TITLE
RELATED: RAIL-3138 Add supportsRankingFilterWithMeasureValueFilter capability

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -57,6 +57,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsCsvUploader: true,
     supportsLegacyReports: true,
     supportsRankingFilter: true,
+    supportsRankingFilterWithMeasureValueFilter: true,
     supportsElementsQueryParentFiltering: true,
     supportsKpiWidget: true,
 };

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -289,6 +289,7 @@ export interface IBackendCapabilities {
     supportsKpiWidget?: boolean;
     supportsObjectUris?: boolean;
     supportsRankingFilter?: boolean;
+    supportsRankingFilterWithMeasureValueFilter?: boolean;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -78,6 +78,11 @@ export interface IBackendCapabilities {
     supportsRankingFilter?: boolean;
 
     /**
+     * Indicates whether backend supports ranking filters in combination with measure value filters (in the same execution).
+     */
+    supportsRankingFilterWithMeasureValueFilter?: boolean;
+
+    /**
      * Indicates whether backend supports element query parent filtering.
      */
     supportsElementsQueryParentFiltering?: boolean;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -52,6 +52,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsObjectUris: false,
     supportsCsvUploader: false,
     supportsRankingFilter: true,
+    supportsRankingFilterWithMeasureValueFilter: false,
     supportsElementsQueryParentFiltering: false,
     supportsKpiWidget: false,
 };


### PR DESCRIPTION
Tiger does not support measure value filters with ranking filters at the same time,
it only supports one or the other.

JIRA: RAIL-3138

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
