### PR TITLE
RELATED: RAIL-3142 Add missing localization strings for KPI alert dialog

### DIFF
--- a/libs/sdk-ui/src/base/localization/bundles/de-DE.json
+++ b/libs/sdk-ui/src/base/localization/bundles/de-DE.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "Die Geo-Diagramm-Konfiguration benötigt einen gültigen API-Zugriffstoken.",
     "visualization.tooltip.resetZoom": "Vergrößern zurücksetzen",
     "visualization.tooltip.interaction": "Klicken Sie das Diagramm um zu drillen",
+    "gs.filterLabel.all": "Alle ",
+    "gs.filterLabel.none": "Keine",
     "gs.filter.loading": "Filter wird geladen…",
     "gs.filter.error": "Fehler beim Laden des Filters",
     "gs.list.loading": "Liste wird geladen…",

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -214,6 +214,16 @@
         "comment": "",
         "limit": 0
     },
+    "gs.filterLabel.all": {
+        "value": "All",
+        "comment": "",
+        "limit": 0
+    },
+    "gs.filterLabel.none": {
+        "value": "None",
+        "comment": "",
+        "limit": 0
+    },
     "gs.filter.loading": {
         "value": "Loading filter…",
         "comment": "Use '…' as one character, not 3 dots ('...').",

--- a/libs/sdk-ui/src/base/localization/bundles/es-ES.json
+++ b/libs/sdk-ui/src/base/localization/bundles/es-ES.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "La configuración del gráfico geográfico requiere un token de acceso a la API válido.",
     "visualization.tooltip.resetZoom": "Restablecer acercar/alejar",
     "visualization.tooltip.interaction": "Haga clic en el gráfico para explorar",
+    "gs.filterLabel.all": "Todo",
+    "gs.filterLabel.none": "Ninguno",
     "gs.filter.loading": "Cargando filtro…",
     "gs.filter.error": "Error al cargar filtro",
     "gs.list.loading": "Cargando lista…",

--- a/libs/sdk-ui/src/base/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui/src/base/localization/bundles/fr-FR.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "La configuration de graphique géographique nécessite un jeton d'accès à l'API valide.",
     "visualization.tooltip.resetZoom": "Réinitialiser le zoom",
     "visualization.tooltip.interaction": "Cliquez sur le graphique pour l'explorer",
+    "gs.filterLabel.all": "Tout",
+    "gs.filterLabel.none": "Aucun(e)",
     "gs.filter.loading": "Chargement du filtre en cours …",
     "gs.filter.error": "Erreur lors du chargement du filtre",
     "gs.list.loading": "Chargement de la liste en cours…",

--- a/libs/sdk-ui/src/base/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui/src/base/localization/bundles/ja-JP.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "Geochart 設定には有効な API アクセストークンが必要です。",
     "visualization.tooltip.resetZoom": "ズームをリセット",
     "visualization.tooltip.interaction": "チャートをクリックしてドリル",
+    "gs.filterLabel.all": "すべて",
+    "gs.filterLabel.none": "なし",
     "gs.filter.loading": "フィルターを読み込み中…",
     "gs.filter.error": "フィルターの読み込みエラー",
     "gs.list.loading": "リストを読み込み中…",

--- a/libs/sdk-ui/src/base/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui/src/base/localization/bundles/nl-NL.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "U hebt een API-toegangstoken nodig voor de configuratie met de geografische kaart.",
     "visualization.tooltip.resetZoom": "Zoomen resetten",
     "visualization.tooltip.interaction": "Klik op grafiek om in te zoomen",
+    "gs.filterLabel.all": "Alles",
+    "gs.filterLabel.none": "Geen",
     "gs.filter.loading": "Filter wordt ingelezen…",
     "gs.filter.error": "Fout bij inlezen filter",
     "gs.list.loading": "Lijst wordt ingelezen…",

--- a/libs/sdk-ui/src/base/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui/src/base/localization/bundles/pt-BR.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "A configuração de Geochart requer um token de acesso válido à API.",
     "visualization.tooltip.resetZoom": "Redefinir zoom",
     "visualization.tooltip.interaction": "Clique no gráfico para detalhar",
+    "gs.filterLabel.all": "Todos",
+    "gs.filterLabel.none": "Nenhum",
     "gs.filter.loading": "Carregando filtro…",
     "gs.filter.error": "Erro ao carregar filtro",
     "gs.list.loading": "Carregando lista…",

--- a/libs/sdk-ui/src/base/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui/src/base/localization/bundles/pt-PT.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "A configuração do gráfico geográfico exige um token de acesso à API válido.",
     "visualization.tooltip.resetZoom": "Repor zoom",
     "visualization.tooltip.interaction": "Clique no gráfico para explorar",
+    "gs.filterLabel.all": "Todos",
+    "gs.filterLabel.none": "Nenhum",
     "gs.filter.loading": "A carregar filtro…",
     "gs.filter.error": "Erro ao carregar filtro",
     "gs.list.loading": "A carregar lista…",

--- a/libs/sdk-ui/src/base/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui/src/base/localization/bundles/zh-Hans.json
@@ -42,6 +42,8 @@
     "visualization.ErrorDescriptionMissingMapboxToken": "Geochart 配置需要有效的 API 访问令牌。",
     "visualization.tooltip.resetZoom": "重置缩放",
     "visualization.tooltip.interaction": "点击图表以深入查看",
+    "gs.filterLabel.all": "全部",
+    "gs.filterLabel.none": "无",
     "gs.filter.loading": "正在加载筛选器...",
     "gs.filter.error": "加载筛选器时出错",
     "gs.list.loading": "正在加载列表...",


### PR DESCRIPTION
The values were sourced from AD where these were already defined.

JIRA: RAIL-3142

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
