### PR TITLE
RELATED: RAIL-3158 Fix bear visualization object converter

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/ObjRefConverter.ts
@@ -1,0 +1,35 @@
+// (C) 2007-2021 GoodData Corporation
+
+import { isLocalIdRef, isUriRef, ObjectType, ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
+
+/**
+ * Converts reference into a format acceptable by the SPI. URI references are left as-is, while
+ * the identifier references have the object type added.
+ *
+ * @param ref - reference
+ * @param defaultType - type to use it the ref has none specified
+ * @internal
+ */
+export function fromBearRef(ref: ObjRef, defaultType?: ObjectType): ObjRef {
+    if (isUriRef(ref)) {
+        return ref;
+    }
+
+    return { identifier: ref.identifier, type: ref.type ?? defaultType };
+}
+
+/**
+ * Converts scoped reference into a format acceptable by the bear SPI. URI references are left as-is, scoped
+ * references are left as is, while the identifier references have the object type added.
+ *
+ * @param ref - reference
+ * @param defaultType - type to use it the ref has none specified
+ * @internal
+ */
+export function fromScopedBearRef(ref: ObjRefInScope, defaultType?: ObjectType): ObjRefInScope {
+    if (isLocalIdRef(ref)) {
+        return ref;
+    }
+
+    return fromBearRef(ref, defaultType);
+}


### PR DESCRIPTION
Makes sure type is added to id refs since we know the type when converting.
This makes the covertor more usable in certain contexts.

JIRA: RAIL-3158

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
