### PR TITLE
RELATED: RAIL-3161 Fix InsightView error handling

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -17,6 +17,7 @@ import {
     isGoodDataSdkError,
     UnexpectedSdkError,
     OnLoadingChanged,
+    OnError,
 } from "@gooddata/sdk-ui";
 import { IInsightViewProps } from "./types";
 import { InsightRenderer } from "./InsightRenderer";
@@ -210,6 +211,11 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         this.props.onLoadingChanged?.({ isLoading });
     };
 
+    private handleError: OnError = (error): void => {
+        this.setError(error);
+        this.props.onError?.(error);
+    };
+
     public render(): React.ReactNode {
         const { LoadingComponent } = this.props;
         const { error, isDataLoading, isVisualizationLoading } = this.state;
@@ -227,6 +233,7 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
                     locale={this.props.locale || (this.state.settings?.locale as ILocale) || DefaultLocale}
                     settings={this.state.settings}
                     onLoadingChanged={this.handleLoadingChanged}
+                    onError={this.handleError}
                 />
             </>
         );


### PR DESCRIPTION
We must intercept the errors coming from the InsightRenderer
so that we can display the appropriate error component (e.g. No data).

JIRA: RAIL-3161

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
