### PR TITLE
Kpis with or without PoP take correct custom gridHeight over default …

### DIFF
--- a/libs/sdk-ui-ext/styles/internal/scss/layout.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/layout.scss
@@ -52,7 +52,7 @@ $gd-dashboards-section-description-color: var(
 }
 
 .gd-fluidlayout-column-container.custom-height {
-    .kpi-with-pop {
+    .kpi {
         min-height: 100%;
     }
 


### PR DESCRIPTION
…height.

JIRA: ONE-4934

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
