### PR TITLE
RELATED: RAIL-3093 Fix AppHeader in case there are no badges

### DIFF
--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -318,7 +318,7 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
     };
 
     private renderVerticalMenu = () => {
-        const { badges = [] } = this.props;
+        const { badges } = this.props;
 
         const menuItemsGroups = !this.state.isHelpMenuOpen
             ? this.addHelpItemGroup(this.props.menuItemsGroups)
@@ -370,7 +370,7 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
     };
 
     private renderStandardNav = () => {
-        const { badges = [] } = this.props;
+        const { badges } = this.props;
 
         return (
             <div className="gd-header-stretch gd-header-menu-wrapper">


### PR DESCRIPTION
Removes accidental blank space caused by useless defaulting of prop.

JIRA: RAIL-3093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
