### PR TITLE
RELATED: RAIL-3188 Handle NAuth errors in tiger isAuthenticated

### DIFF
--- a/libs/sdk-backend-spi/src/backend/index.ts
+++ b/libs/sdk-backend-spi/src/backend/index.ts
@@ -177,7 +177,7 @@ export interface IAuthenticationProvider {
     initializeClient?(client: any): void;
 
     /**
-     * Optionally specify function to call when the Analytical Backend runs into NotAuthenticated error.
+     * Optionally specify function to call when the Analytical Backend raises a NotAuthenticated error.
      *
      * @param context - context in which the authentication is done
      * @param error - an instance of NotAuthenticated error

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -203,7 +203,7 @@ export class TigerBackend implements IAnalyticalBackend {
                     resolve(res);
                 })
                 .catch((err) => {
-                    if (isNotAuthenticatedResponse(err)) {
+                    if (isNotAuthenticatedResponse(err) || isNotAuthenticated(err)) {
                         resolve(null);
                     }
 


### PR DESCRIPTION
Previously only 401 responses were handled there, but we need
to also handle NAuth errors, for example "Session expired" errors.

Also, make onNotAuthenticated contract more precise.

JIRA: RAIL-3188

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
