### PR TITLE
RELATED: RAIL-3189 Clean up tiger free-form types

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -5601,46 +5601,8 @@ export namespace VisualizationObjectModelV1 {
 
 // @public (undocumented)
 export namespace VisualizationObjectModelV2 {
-    export interface IAttribute {
-        // (undocumented)
-        alias?: string;
-        // (undocumented)
-        label: ObjectIdentifier;
-        // (undocumented)
-        localIdentifier: Identifier;
-    }
-    // (undocumented)
-    export type Identifier = string;
-    export interface IDimension {
-        // (undocumented)
-        itemIdentifiers: Identifier[];
-        // (undocumented)
-        localIdentifier: string;
-        // (undocumented)
-        sorting?: SortKey[];
-        // (undocumented)
-        totals?: ITotalItem[];
-    }
-    export interface IMeasure {
-        // (undocumented)
-        alias?: string;
-        // (undocumented)
-        definition: MeasureDefinition;
-        // (undocumented)
-        format?: string;
-        // (undocumented)
-        localIdentifier: Identifier;
-    }
     // (undocumented)
     export function isVisualizationObject(visualizationObject: unknown): visualizationObject is IVisualizationObject;
-    export interface ITotalItem {
-        // (undocumented)
-        attributeIdentifier: LocalIdentifier;
-        // (undocumented)
-        measureIdentifier: LocalIdentifier;
-        // (undocumented)
-        type: TotalType;
-    }
     export interface IVisualizationObject {
         // (undocumented)
         buckets: IBucket[];
@@ -5655,11 +5617,6 @@ export namespace VisualizationObjectModelV2 {
         // (undocumented)
         visualizationUrl: string;
     }
-    // (undocumented)
-    export type SortKey = SortKeyAttribute | SortKeyValue;
-    // (undocumented)
-    export type TotalType = "sum" | "avg" | "max" | "min" | "nat" | "med";
-    {};
 }
 
 // @public

--- a/libs/api-client-tiger/src/gd-tiger-model/VisualizationObjectModelV1.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/VisualizationObjectModelV1.ts
@@ -29,7 +29,7 @@ export namespace VisualizationObjectModelV1 {
     /**
      * Attribute format used in executions
      *
-     * @deprecated use {@link VisualizationObjectModelV2.IAttribute} instead
+     * @deprecated use {@link AttributeItem} instead
      */
     export interface IAttribute {
         localIdentifier: Identifier;
@@ -40,7 +40,7 @@ export namespace VisualizationObjectModelV1 {
     /**
      * Measure format used in executions
      *
-     * @deprecated use {@link VisualizationObjectModelV2.IMeasure} instead
+     * @deprecated use {@link MeasureItem} instead
      */
     export interface IMeasure {
         localIdentifier: Identifier;
@@ -52,7 +52,7 @@ export namespace VisualizationObjectModelV1 {
     /**
      * Dimension format used in executions
      *
-     * @deprecated use {@link VisualizationObjectModelV2.IDimension} instead
+     * @deprecated use {@link Dimension} instead
      */
     export interface IDimension {
         localIdentifier: string;
@@ -64,7 +64,7 @@ export namespace VisualizationObjectModelV1 {
     /**
      * Total format used in executions
      *
-     * @deprecated use {@link VisualizationObjectModelV2.ITotalItem} instead
+     * @deprecated use {@link GrandTotal} instead
      */
     export interface ITotalItem {
         measureIdentifier: LocalIdentifier;

--- a/libs/api-client-tiger/src/gd-tiger-model/VisualizationObjectModelV2.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/VisualizationObjectModelV2.ts
@@ -1,13 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { IBucket, IFilter, ISortItem, VisualizationProperties } from "@gooddata/sdk-model";
-import {
-    LocalIdentifier,
-    MeasureDefinition,
-    ObjectIdentifier,
-    SortKeyAttribute,
-    SortKeyValue,
-} from "../generated/afm-rest-api";
 
 export namespace VisualizationObjectModelV2 {
     /**
@@ -21,50 +14,6 @@ export namespace VisualizationObjectModelV2 {
         sorts: ISortItem[];
         properties: VisualizationProperties;
     }
-
-    /**
-     * Attribute format used in executions
-     */
-    export interface IAttribute {
-        localIdentifier: Identifier;
-        label: ObjectIdentifier;
-        alias?: string;
-    }
-
-    /**
-     * Measure format used in executions
-     */
-    export interface IMeasure {
-        localIdentifier: Identifier;
-        definition: MeasureDefinition;
-        alias?: string;
-        format?: string;
-    }
-
-    /**
-     * Dimension format used in executions
-     */
-    export interface IDimension {
-        localIdentifier: string;
-        itemIdentifiers: Identifier[];
-        sorting?: SortKey[];
-        totals?: ITotalItem[];
-    }
-
-    /**
-     * Total format used in executions
-     */
-    export interface ITotalItem {
-        measureIdentifier: LocalIdentifier;
-        type: TotalType;
-        attributeIdentifier: LocalIdentifier;
-    }
-
-    type SortKey = SortKeyAttribute | SortKeyValue;
-
-    type TotalType = "sum" | "avg" | "max" | "min" | "nat" | "med";
-
-    type Identifier = string;
 
     export function isVisualizationObject(
         visualizationObject: unknown,

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -21,7 +21,7 @@ import {
     insightFilters,
     areObjRefsEqual,
 } from "@gooddata/sdk-model";
-import { AfmValidObjectsQueryTypesEnum } from "@gooddata/api-client-tiger";
+import { AfmValidObjectsQuery, AfmValidObjectsQueryTypesEnum } from "@gooddata/api-client-tiger";
 import intersectionWith from "lodash/intersectionWith";
 import uniq from "lodash/uniq";
 
@@ -142,7 +142,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
 
         const { filters: afmFilters, auxMeasures } = convertAfmFilters(attributes, measures, filters);
 
-        const afmValidObjectsQuery = {
+        const afmValidObjectsQuery: AfmValidObjectsQuery = {
             types: relevantRestrictingTypes.map(mapToTigerType),
             afm: {
                 attributes: attributes.map(convertAttribute),

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AttributeConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AttributeConverter.ts
@@ -1,11 +1,11 @@
 // (C) 2020-2021 GoodData Corporation
 
 import { IAttribute } from "@gooddata/sdk-model";
-import { VisualizationObjectModelV2 } from "@gooddata/api-client-tiger";
+import { AttributeItem } from "@gooddata/api-client-tiger";
 
 import { toLabelQualifier } from "../ObjRefConverter";
 
-export function convertAttribute(attribute: IAttribute, idx: number): VisualizationObjectModelV2.IAttribute {
+export function convertAttribute(attribute: IAttribute, idx: number): AttributeItem {
     const alias = attribute.attribute.alias;
     const aliasProp = alias ? { alias } : {};
     const labelRef = attribute.attribute.displayForm;

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
@@ -4,7 +4,6 @@ import {
     SortDirection as TigerSortDirection,
     SortKeyAttribute,
     SortKeyValue,
-    VisualizationObjectModelV2,
 } from "@gooddata/api-client-tiger";
 import {
     IExecutionDefinition,
@@ -19,10 +18,7 @@ import isEmpty from "lodash/isEmpty";
 
 type SortKey = SortKeyAttribute | SortKeyValue;
 
-function merge(
-    dims: VisualizationObjectModelV2.IDimension[],
-    sorting: SortKey[][],
-): VisualizationObjectModelV2.IDimension[] {
+function merge(dims: Dimension[], sorting: SortKey[][]): Dimension[] {
     return dims.map((dim, idx) => {
         if (!isEmpty(sorting[idx])) {
             return {
@@ -102,10 +98,7 @@ function convertMeasureLocators(locators: ILocatorItem[]): { [key: string]: stri
  * @param dims - dimensions to add sorting to
  * @param sorts - sort items defined by SDK user
  */
-function dimensionsWithSorts(
-    dims: VisualizationObjectModelV2.IDimension[],
-    sorts: ISortItem[],
-): VisualizationObjectModelV2.IDimension[] {
+function dimensionsWithSorts(dims: Dimension[], sorts: ISortItem[]): Dimension[] {
     if (isEmpty(sorts)) {
         return dims;
     }
@@ -161,7 +154,7 @@ function dimensionsWithSorts(
                 value: {
                     direction: convertSortDirection(sortItem.measureSortItem.direction),
                     dataColumnLocators: {
-                        [measureDim.localIdentifier]: convertMeasureLocators(
+                        [measureDim.localIdentifier!]: convertMeasureLocators(
                             sortItem.measureSortItem.locators,
                         ),
                     },
@@ -182,7 +175,7 @@ function dimensionsWithSorts(
  * @param def
  */
 export function convertDimensions(def: IExecutionDefinition): Dimension[] {
-    const dimensionsWithoutSorts: VisualizationObjectModelV2.IDimension[] = def.dimensions.map((dim, idx) => {
+    const dimensionsWithoutSorts: Dimension[] = def.dimensions.map((dim, idx) => {
         return {
             localIdentifier: `dim_${idx}`, // FIXME synchronize with convertTotals
             itemIdentifiers: dim.itemIdentifiers,

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
@@ -4,11 +4,11 @@ import {
     ArithmeticMeasureDefinitionArithmeticMeasureOperatorEnum,
     FilterDefinitionForSimpleMeasure,
     MeasureDefinition,
+    MeasureItem,
     PopDatasetMeasureDefinition,
     PopDateMeasureDefinition,
     SimpleMeasureDefinition,
     SimpleMeasureDefinitionMeasureAggregationEnum,
-    VisualizationObjectModelV2,
 } from "@gooddata/api-client-tiger";
 import {
     ArithmeticMeasureOperator,
@@ -35,7 +35,7 @@ import {
 } from "../ObjRefConverter";
 import { convertFilter } from "./FilterConverter";
 
-export function convertMeasure(measure: IMeasure): VisualizationObjectModelV2.IMeasure {
+export function convertMeasure(measure: IMeasure): MeasureItem {
     const {
         measure: { definition },
     } = measure;

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/TotalsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/TotalsConverter.ts
@@ -67,7 +67,7 @@ export function withTotals<T>(
     });
 }
 
-export function totalLocalIdentifier(type: TotalType, dimIdx: number) {
+export function totalLocalIdentifier(type: TotalType, dimIdx: number): string {
     return `total_${dimIdx}_${type}`;
 }
 


### PR DESCRIPTION
Remove useless types for executions, we should use the types from open API.

JIRA: RAIL-3189

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
