### PR TITLE
RELATED: RAIL-3163 - Fix error logging interceptor

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -328,12 +328,17 @@ function createAxios(
 function interceptBackendErrorsToConsole(client: AxiosInstance): AxiosInstance {
     client.interceptors.response.use(identity, (error) => {
         const response: AxiosResponse = error.response;
-        if (inRange(response.status, 400, 600)) {
+
+        // If the response is an object (JSON parsed by axios) and there is a problem, then log error
+        // into console for easier diagnostics.
+        if (inRange(response.status, 400, 600) && typeof response.data === "object") {
             // Title is redundant (Bad Request)
             const details = omit(response.data, ["title"]);
             // eslint-disable-next-line no-console
             console.error("Tiger backend threw an error:", details);
         }
+
+        return Promise.reject(error);
     });
 
     return client;


### PR DESCRIPTION
-  Was doing log & sink - thus breaking a lot of stuff bound to exception handling such as login
-  In some (weird) cases, Tiger response may not be JSON object but text/html returned by axios as a string
-  DO not do anything with those

JIRA: RAIL-3163

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
