### PR TITLE
Extend Live Examples by complementary palette

### DIFF
--- a/examples/sdk-examples/src/components/ExampleWithSource.tsx
+++ b/examples/sdk-examples/src/components/ExampleWithSource.tsx
@@ -28,9 +28,30 @@ const SourceSection: React.FC<ISourceSectionProps> = ({ source, sourceJS }) => {
                 :global(pre) {
                     overflow: auto;
                 }
+
+                .gd-source-button {
+                    font-family: Avenir, "Helvetica Neue", arial, sans-serif;
+                    text-transform: none;
+                }
+
+                .gd-source-button:focus {
+                    border-color: rgba(20, 178, 226, 0.75);
+                }
+
+                --gd-shadow-color: initial;
+                --gd-palette-complementary-0: initial;
+                --gd-palette-complementary-1: initial;
+                --gd-palette-complementary-2: initial;
+                --gd-palette-complementary-3: initial;
+                --gd-palette-complementary-4: initial;
+                --gd-palette-complementary-5: initial;
+                --gd-palette-complementary-6: initial;
+                --gd-palette-complementary-7: initial;
+                --gd-palette-complementary-8: initial;
+                --gd-palette-complementary-9: initial;
             `}</style>
             <button
-                className={`gd-button gd-button-secondary button-dropdown icon-right ${iconClassName}`}
+                className={`gd-button gd-button-secondary button-dropdown icon-right gd-source-button ${iconClassName}`}
                 onClick={() => setState(!hidden)}
             >
                 source code
@@ -64,7 +85,7 @@ export const ExampleWithSource: React.FC<IExampleWithSourceProps> = ({
                 .example {
                     padding: 20px;
                     box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
-                    background-color: white;
+                    background-color: var(--gd-palette-complementary-0, #fff);
                 }
             `}</style>
             <div className="example">

--- a/examples/sdk-examples/src/components/SourceContainer.tsx
+++ b/examples/sdk-examples/src/components/SourceContainer.tsx
@@ -39,10 +39,12 @@ export const SourceContainer: React.FC<ISourceContainerProps> = ({ isJS, toggleI
                     .gd-tab,
                     .gd-tab:hover {
                         color: #94a1ad;
+                        font-family: Avenir, "Helvetica Neue", arial, sans-serif;
                     }
 
                     .gd-tab.is-active {
                         color: #ffffff;
+                        border-color: #14b2e2;
                     }
                 `}
             </style>

--- a/examples/sdk-examples/src/constants/customTheme.ts
+++ b/examples/sdk-examples/src/constants/customTheme.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import { ITheme } from "@gooddata/sdk-backend-spi";
 
 export const customTheme: ITheme = {
@@ -31,10 +31,26 @@ export const customTheme: ITheme = {
         warning: {
             base: "#ddff19",
         },
+        complementary: {
+            c0: "#303030",
+            c9: "#ffffff",
+        },
     },
     tooltip: {
         backgroundColor: "#101050",
         color: "#fff",
+    },
+    chart: {
+        backgroundColor: "#303030",
+        gridColor: "#999",
+        axisColor: "#eaeaea",
+        axisLabelColor: "#eaeaea",
+        axisValueColor: "#eaeaea",
+        legendValueColor: "#eaeaea",
+        tooltipBackgroundColor: "#333",
+        tooltipBorderColor: "#555",
+        tooltipLabelColor: "#eaeaea",
+        tooltipValueColor: "#fff",
     },
     typography: {
         font: "url(https://cdn.jsdelivr.net/npm/roboto-font@0.1.0/fonts/Roboto/roboto-regular-webfont.ttf)",

--- a/examples/sdk-examples/src/examples/theming/ThemedComponentsExample.tsx
+++ b/examples/sdk-examples/src/examples/theming/ThemedComponentsExample.tsx
@@ -3,17 +3,22 @@
 import React, { useState } from "react";
 import { Button, ExportDialog } from "@gooddata/sdk-ui-kit";
 import { ThemeProvider, useTheme, useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
-import { newPositiveAttributeFilter, newRankingFilter } from "@gooddata/sdk-model";
-import { AttributeFilter, RankingFilter } from "@gooddata/sdk-ui-filters";
+import { newPositiveAttributeFilter } from "@gooddata/sdk-model";
+import { AttributeFilter } from "@gooddata/sdk-ui-filters";
+import { BarChart } from "@gooddata/sdk-ui-charts";
 
-import { attributeDropdownItems, measureDropdownItems } from "../rankingFilter/RankingFilterExample";
 import { DateFilterComponentExample } from "../dateFilter/DateFilterComponentExample";
 import { Ldm, LdmExt } from "../../ldm";
 import { customTheme } from "../../constants/customTheme";
 
+const style = {
+    color: "var(--gd-palette-complementary-8, #464e56)",
+    backgroundColor: "var(--gd-palette-complementary-0, #fff)",
+};
+
 export const ThemeProviderExample: React.FC = () => {
     return (
-        <div className="s-theme-provider">
+        <div className="s-theme-provider" style={style}>
             <ThemeProvider theme={customTheme}>
                 <ThemedComponentsExample />
             </ThemeProvider>
@@ -43,17 +48,6 @@ const ThemedComponentsExample: React.FC = () => {
                     <AttributeFilter
                         filter={newPositiveAttributeFilter(Ldm.EmployeeName.Default, ["Abbie Adams"])}
                         onApply={() => {}}
-                    />
-                    <br />
-                    <br />
-                    RankingFilter
-                    <br />
-                    <RankingFilter
-                        measureItems={measureDropdownItems}
-                        attributeItems={attributeDropdownItems}
-                        filter={newRankingFilter(LdmExt.franchiseSalesLocalId, "TOP", 3)}
-                        onApply={() => {}}
-                        buttonTitle={"Ranking filter configuration"}
                     />
                     <br />
                     <br />
@@ -90,6 +84,13 @@ const ThemedComponentsExample: React.FC = () => {
                             }}
                         />
                     )}
+                    <br />
+                    <br />
+                    Bar chart
+                    <br />
+                    <div style={{ height: 300 }}>
+                        <BarChart measures={[LdmExt.TotalSales1]} viewBy={Ldm.LocationResort} />
+                    </div>
                 </div>
             )}
         </div>


### PR DESCRIPTION
- add complementary palette to customTheme used by themed examples
- overwrite several css variables inside ExampleWithSource in order to avoid theming in source part
- remove themed RankingFilter example as it is not fully supported by complementary palette yet
- add themed BarChart example

![Screenshot 2021-04-01 at 5 15 54 PM](https://user-images.githubusercontent.com/64783306/113315822-fa696080-930d-11eb-8cd1-0c871a2d1a3b.png)

JIRA: BB-2888

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
