### PR TITLE
RELATED: RAIL-3220 Fix tiger getInsightReferencingObjects

### DIFF
--- a/libs/api-client-tiger/openapi-generator/api.mustache
+++ b/libs/api-client-tiger/openapi-generator/api.mustache
@@ -22,20 +22,22 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
         }
     }
     to roughly
-    { "filter[title][like]": "foo" }
+    { "filter.title.like": "foo" }
     and assigns it to a given target object.
     So given the example object and localVarQueryParameter as target, it is equivalent to doing
 
-    localVarQueryParameter["filter[title][like]"] = "foo";
+    localVarQueryParameter["filter.title.like"] = "foo";
 
     This is needed because the url parser does not support nested objects.
 }}
 const addFlattenedObjectTo = (object: any, target: any): void => {
-    const flattened = globalImportQs.parse(globalImportQs.stringify(object), { depth: 0 });
+    const flattened = globalImportQs.parse(globalImportQs.stringify(object, { allowDots: true }), {
+        depth: 0,
+    });
     Object.keys(flattened).forEach((key) => {
         target[key] = (flattened as any)[key];
     });
-}
+};
 
 {{#models}}
 {{#model}}{{#isEnum}}{{>modelEnum}}{{/isEnum}}{{#oneOf}}{{#-first}}{{>modelOneOf}}{{/-first}}{{/oneOf}}{{^isEnum}}{{^oneOf}}{{>modelGeneric}}{{/oneOf}}{{/isEnum}}{{/model}}

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -24,7 +24,9 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
 
 // utility function that adds support for nested objects in query
 const addFlattenedObjectTo = (object: any, target: any): void => {
-    const flattened = globalImportQs.parse(globalImportQs.stringify(object), { depth: 0 });
+    const flattened = globalImportQs.parse(globalImportQs.stringify(object, { allowDots: true }), {
+        depth: 0,
+    });
     Object.keys(flattened).forEach((key) => {
         target[key] = (flattened as any)[key];
     });

--- a/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
+++ b/libs/api-client-tiger/src/generated/metadata-json-api/api.ts
@@ -24,7 +24,9 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
 
 // utility function that adds support for nested objects in query
 const addFlattenedObjectTo = (object: any, target: any): void => {
-    const flattened = globalImportQs.parse(globalImportQs.stringify(object), { depth: 0 });
+    const flattened = globalImportQs.parse(globalImportQs.stringify(object, { allowDots: true }), {
+        depth: 0,
+    });
     Object.keys(flattened).forEach((key) => {
         target[key] = (flattened as any)[key];
     });

--- a/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
+++ b/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
@@ -10,6 +10,8 @@ import { IAnalyticalBackendConfig } from '@gooddata/sdk-backend-spi';
 import { IAuthenticatedPrincipal } from '@gooddata/sdk-backend-spi';
 import { IAuthenticationContext } from '@gooddata/sdk-backend-spi';
 import { IAuthenticationProvider } from '@gooddata/sdk-backend-spi';
+import { NotAuthenticated } from '@gooddata/sdk-backend-spi';
+import { NotAuthenticatedHandler } from '@gooddata/sdk-backend-spi';
 
 export { AnonymousAuthProvider }
 
@@ -70,8 +72,11 @@ export const BearToBackendConvertors: {
 
 // @public
 export class ContextDeferredAuthProvider extends BearAuthProviderBase implements IAuthenticationProvider {
+    constructor(notAuthenticatedHandler?: NotAuthenticatedHandler | undefined);
     // (undocumented)
     authenticate(context: IAuthenticationContext): Promise<IAuthenticatedPrincipal>;
+    // (undocumented)
+    onNotAuthenticated: (context: IAuthenticationContext, error: NotAuthenticated) => void;
 }
 
 // @public

--- a/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/insights/index.ts
@@ -28,7 +28,6 @@ import {
     jsonApiHeaders,
     MetadataUtilities,
     MetadataGetEntitiesOptions,
-    JsonApiAnalyticalDashboardOutWithLinks,
     VisualizationObjectModelV1,
     VisualizationObjectModelV2,
     JsonApiVisualizationObjectInTypeEnum,
@@ -220,22 +219,23 @@ export class TigerWorkspaceInsights implements IWorkspaceInsightsService {
     public getInsightReferencingObjects = async (ref: ObjRef): Promise<IInsightReferencing> => {
         const id = await objRefToIdentifier(ref, this.authCall);
 
-        const apiResult = await this.authCall((client) =>
-            client.workspaceObjects.getEntityVisualizationObjects(
+        const dashboards = await this.authCall((client) =>
+            MetadataUtilities.getAllPagesOf(
+                client,
+                client.workspaceObjects.getAllEntitiesAnalyticalDashboards,
                 {
-                    objectId: id,
                     workspaceId: this.workspace,
-                },
-                {
-                    headers: jsonApiHeaders,
-                    params: {
-                        include: "analyticalDashboards",
+                    include: ["visualizationObjects"], // we must include the visualizationObjects so that we can do predicates on them
+                    predicate: {
+                        visualizationObjects: {
+                            id, // return only dashboards that have a link to the given id in their visualizationObjects
+                        },
                     },
                 },
-            ),
+            )
+                .then(MetadataUtilities.mergeEntitiesResults)
+                .then((result) => result.data ?? []),
         );
-
-        const dashboards = (apiResult.data.included ?? []) as JsonApiAnalyticalDashboardOutWithLinks[];
 
         return Promise.resolve({
             analyticalDashboards: dashboards.map(convertAnalyticalDashboardWithLinks),


### PR DESCRIPTION
Tiger no longer supports links insight -> dashboard,
so we need to go the other way around.

Also the query handling was improved so that objects use dot notation
as the backend cannot handle the [] notation apparently.

JIRA: RAIL-3220

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
