### PR TITLE
Fix Highcharts and PivotTable sizing

### DIFF
--- a/examples/sdk-examples/src/App.tsx
+++ b/examples/sdk-examples/src/App.tsx
@@ -107,7 +107,7 @@ export const App: React.FC = () => {
                                 flex-direction: column;
                                 justify-content: flex-start;
                                 align-items: stretch;
-                                width: 100%;
+                                overflow: hidden;
                                 padding: 20px 40px;
                             }
                         `}</style>

--- a/libs/sdk-ui-charts/styles/scss/charts.scss
+++ b/libs/sdk-ui-charts/styles/scss/charts.scss
@@ -30,6 +30,9 @@
 }
 
 .highcharts-container {
+    // Without position: static, there is a sizing issue in Safari (in DashboardView)
+    // stylelint-disable-next-line declaration-no-important
+    position: static !important;
     // If the outer container have scroll bar, the chart can be showed by scrolling.
     // stylelint-disable-next-line declaration-no-important
     overflow: visible !important;

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -42,8 +42,11 @@ export interface IInsightRendererProps extends Omit<IInsightViewProps, "insight"
 
 const getElementId = () => `gd-vis-${uuidv4()}`;
 
-const visualizationUriRootStyle = {
+const visualizationUriRootStyle: React.CSSProperties = {
     height: "100%",
+    display: "flex",
+    flex: "1 1 auto",
+    flexDirection: "column",
 };
 
 // this needs to be a pure component as it can happen that this might be rendered multiple times

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -350,6 +350,9 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
                         const pivotWrapperStyle: React.CSSProperties = {
                             height: isNil(height) ? "100%" : 328,
                             textAlign: "left",
+                            display: "flex",
+                            flex: "1 1 auto",
+                            flexDirection: "column",
                         };
 
                         const configWithMaxHeight: IPivotTableConfig = {


### PR DESCRIPTION
- To fix sizing/overflowing issues in Safari
- Also fix examples in Safari (so they do not overflow out of the screen)

JIRA: RAIL-3214

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
