### PR TITLE
Make sure the CommunityDialog links are underlined

### DIFF
--- a/libs/sdk-ui-kit/styles/scss/dialog.scss
+++ b/libs/sdk-ui-kit/styles/scss/dialog.scss
@@ -220,6 +220,7 @@
 
         a {
             color: $default-gd-color-link;
+            text-decoration: underline;
         }
     }
 }


### PR DESCRIPTION
In some apps the links ended up being not underlined so we force it to be sure.

JIRA: RAIL-3093

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
