### PR TITLE
RELATED: RAIL-3191 fix catalog-export on tiger

### DIFF
--- a/tools/catalog-export/src/loaders/bear/bearLoad.ts
+++ b/tools/catalog-export/src/loaders/bear/bearLoad.ts
@@ -41,6 +41,14 @@ export async function bearLoad(workspaceId: string): Promise<WorkspaceMetadata> 
         };
     } catch (err) {
         spinner.fail();
+        if (err?.response?.status === 404) {
+            // handle known error more gracefully to avoid general-type error messages
+            logError(
+                `Workspace with id '${workspaceId}' was not found. Please make sure you are passing a correct value to the 'workspace-id' argument.`,
+            );
+            process.exit(1);
+        }
+
         const more = err.response ? err.response.url : "";
         logError(`Exception: ${err.message} ${more}\n${err.stack}`);
 

--- a/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
@@ -24,7 +24,7 @@ export async function tigerLoad(client: ITigerClient, workspaceId: string): Prom
         const insights = await loadInsights(client, workspaceId);
         spinner.succeed("Insights loaded");
 
-        spinner.start("Loading analytical dashboards");
+        spinner.start("Loading analytical dashboards…");
         const analyticalDashboards = await loadAnalyticalDashboards(client, workspaceId);
         spinner.succeed("Analytical dashboards loaded");
 
@@ -37,6 +37,14 @@ export async function tigerLoad(client: ITigerClient, workspaceId: string): Prom
         };
     } catch (err) {
         spinner.fail();
+        if (err?.response?.status === 404) {
+            // handle known error more gracefully to avoid general-type error messages
+            logError(
+                `Workspace with id '${workspaceId}' was not found. Please make sure you are passing a correct value to the 'workspace-id' argument.`,
+            );
+            process.exit(1);
+        }
+
         const more = err.response ? err.response.url : "";
         logError(`Exception: ${err.message} ${more}\n${err.stack}`);
 

--- a/tools/catalog-export/src/transform/toTypescript.ts
+++ b/tools/catalog-export/src/transform/toTypescript.ts
@@ -160,6 +160,8 @@ function generateSdkModelImports(): OptionalKind<ImportDeclarationStructure> {
     return {
         moduleSpecifier: "@gooddata/sdk-model",
         namedImports: ["newAttribute", "newMeasure", "IAttribute", "IMeasure", "IMeasureDefinition", "idRef"],
+        leadingTrivia:
+            "// @ts-ignore ignore unused imports here if they happen (e.g. when there is no measure in the workspace)",
     };
 }
 


### PR DESCRIPTION
* prevent TypeScript errors in generated files in case there are no measures in the workspace for instance
* update the guide shown when the TIGER_API_TOKEN is not set - we always need to guide the user to create a new token as retrieving the value of existing token in impossible
* handle invalid values of workspace-id more gracefully (on both tiger and bear)

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
