### PR TITLE
RELATED: RAIL-3246 Fix tiger totals conversion

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/dimensions.ts
@@ -21,6 +21,7 @@ import {
 import keyBy from "lodash/keyBy";
 import mapValues from "lodash/mapValues";
 import groupBy from "lodash/groupBy";
+import uniqBy from "lodash/uniqBy";
 
 const DEFAULT_FORMAT = "#,#.##";
 
@@ -108,7 +109,7 @@ function getAttrTotals(def: IExecutionDefinition): AttrTotals {
     const attrTotals: AttrTotals[] = def.dimensions.map((dim) => {
         const totalsByAttrId = groupBy(dim.totals ?? [], (total) => total.attributeIdentifier);
         return mapValues(totalsByAttrId, (totals) =>
-            totals.map((total) => ({ totalHeaderItem: { name: total.type } })),
+            uniqBy(totals, (total) => total.type).map((total) => ({ totalHeaderItem: { name: total.type } })),
         );
     });
     return Object.assign({}, ...attrTotals);

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/dimensions.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/__snapshots__/dimensions.test.ts.snap
@@ -117,6 +117,123 @@ Array [
 ]
 `;
 
+exports[`transformResultDimensions should fill in totals with multiple totals of the same type on one attribute (RAIL-3246) 1`] = `
+Array [
+  Object {
+    "headers": Array [
+      Object {
+        "attributeHeader": Object {
+          "formOf": Object {
+            "identifier": "event_date.quarter",
+            "name": "event_date - Quarter/Year",
+            "ref": Object {
+              "identifier": "event_date.quarter",
+              "type": "attribute",
+            },
+            "uri": "/obj/0",
+          },
+          "identifier": "event_date.quarter.label",
+          "localIdentifier": "localAttr1",
+          "name": "event_date - Quarter/Year",
+          "ref": Object {
+            "identifier": "event_date.quarter.label",
+            "type": "displayForm",
+          },
+          "totalItems": Array [
+            Object {
+              "totalHeaderItem": Object {
+                "name": "sum",
+              },
+            },
+          ],
+          "uri": "/obj/0",
+        },
+      },
+      Object {
+        "attributeHeader": Object {
+          "formOf": Object {
+            "identifier": "event_date.quarter",
+            "name": "event_date - Quarter/Year",
+            "ref": Object {
+              "identifier": "event_date.quarter",
+              "type": "attribute",
+            },
+            "uri": "/obj/1",
+          },
+          "identifier": "event_date.quarter.label",
+          "localIdentifier": "localAttr2",
+          "name": "event_date - Quarter/Year",
+          "ref": Object {
+            "identifier": "event_date.quarter.label",
+            "type": "displayForm",
+          },
+          "totalItems": Array [
+            Object {
+              "totalHeaderItem": Object {
+                "name": "sum",
+              },
+            },
+          ],
+          "uri": "/obj/1",
+        },
+      },
+    ],
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "measureGroupHeader": Object {
+          "items": Array [
+            Object {
+              "measureHeaderItem": Object {
+                "format": "#,##0.00",
+                "identifier": undefined,
+                "localIdentifier": "measureLocalId",
+                "name": "measureLocalId",
+                "ref": undefined,
+                "uri": undefined,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+  Object {
+    "headers": Array [
+      Object {
+        "attributeHeader": Object {
+          "formOf": Object {
+            "identifier": "event_date.quarter",
+            "name": "event_date - Quarter/Year",
+            "ref": Object {
+              "identifier": "event_date.quarter",
+              "type": "attribute",
+            },
+            "uri": "/obj/0",
+          },
+          "identifier": "event_date.quarter.label",
+          "localIdentifier": "localAttr3",
+          "name": "event_date - Quarter/Year",
+          "ref": Object {
+            "identifier": "event_date.quarter.label",
+            "type": "displayForm",
+          },
+          "totalItems": Array [
+            Object {
+              "totalHeaderItem": Object {
+                "name": "max",
+              },
+            },
+          ],
+          "uri": "/obj/0",
+        },
+      },
+    ],
+  },
+]
+`;
+
 exports[`transformResultDimensions should fill in uris and refs for attribute descriptors 1`] = `
 Array [
   Object {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/dimensions.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/tests/dimensions.test.ts
@@ -32,13 +32,26 @@ describe("transformResultDimensions", () => {
     const Total1 = newTotal("sum", "measureLocalId", "localAttr1");
     const Subtotal1 = newTotal("sum", "measureLocalId", "localAttr2");
     const Total2 = newTotal("max", "measureLocalId", "localAttr3");
-    const TotalDef = defWithDimensions(
-        emptyDef("test"),
-        newDimension(["localAttr1", "localAttr2"], [Total1, Subtotal1]),
-        newDimension([MeasureGroupIdentifier]),
-        newDimension(["localAttr3"], [Total2]),
-    );
+
     it("should fill in totals", () => {
+        const TotalDef = defWithDimensions(
+            emptyDef("test"),
+            newDimension(["localAttr1", "localAttr2"], [Total1, Subtotal1]),
+            newDimension([MeasureGroupIdentifier]),
+            newDimension(["localAttr3"], [Total2]),
+        );
+        expect(transformResultDimensions(mockMultipleDimensions, TotalDef)).toMatchSnapshot();
+    });
+
+    it("should fill in totals with multiple totals of the same type on one attribute (RAIL-3246)", () => {
+        // same attribute and type as Total2, different measure
+        const Total3 = newTotal("max", "measureLocalId2", "localAttr3");
+        const TotalDef = defWithDimensions(
+            emptyDef("test"),
+            newDimension(["localAttr1", "localAttr2"], [Total1, Subtotal1]),
+            newDimension([MeasureGroupIdentifier]),
+            newDimension(["localAttr3"], [Total2, Total3]),
+        );
         expect(transformResultDimensions(mockMultipleDimensions, TotalDef)).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
Make sure the totals added to the descriptor are unique.

It can happen that there is more than one total of the same type
for a given attribute, but the server will only return data for
the given total type once and there were mismatches in collection
lengths: for example two rows of totals for three total descriptors
(two of which are the same) which broke the components down the road.
So we make sure to only send unique types forward to avoid this mismatch
(effectively mimicking the backend which seems to be de-duplicating
the totals too).

JIRA: RAIL-3246

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
