### PR TITLE
Update PivotTable drill example so it's able to handle null references

### DIFF
--- a/examples/sdk-examples/src/examples/pivotTable/PivotTableDrillExample.tsx
+++ b/examples/sdk-examples/src/examples/pivotTable/PivotTableDrillExample.tsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { PivotTable } from "@gooddata/sdk-ui-pivot";
 import { HeaderPredicates, IDrillEvent } from "@gooddata/sdk-ui";
 import { attributeIdentifier, measureIdentifier, ITotal } from "@gooddata/sdk-model";
+import isNil from "lodash/isNil";
 
 import { LdmExt, Ldm } from "../../ldm";
 
@@ -84,7 +85,7 @@ export class PivotTableDrillExample extends Component<unknown, IPivotTableDrillE
                 ? drillEvent.drillContext.row[drillEvent.drillContext.columnIndex]
                 : undefined;
 
-        const drillValue = typeof drillColumn === "object" ? drillColumn.name : drillColumn;
+        const drillValue = !isNil(drillColumn) ? drillColumn.name : drillColumn;
 
         return (
             <h3>


### PR DESCRIPTION
- change assertion from `typeof drillColumn === 'object'` to `!isNil(drillColumn)` (because `typeof null === 'object'`)

JIRA: RAIL-3239

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
