### PR TITLE
RELATED: RAIL-3260 - Filter invalid measures from catalog

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/factory.ts
@@ -18,7 +18,7 @@ import { loadAttributesAndDateDatasets } from "./datasetLoader";
 import flatten from "lodash/flatten";
 import flatMap from "lodash/flatMap";
 import uniqBy from "lodash/uniqBy";
-import { MetadataUtilities } from "@gooddata/api-client-tiger";
+import { MetadataUtilities, ValidateRelationsHeader } from "@gooddata/api-client-tiger";
 import invariant from "ts-invariant";
 
 export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
@@ -117,8 +117,10 @@ export class TigerWorkspaceCatalogFactory implements IWorkspaceCatalogFactory {
                 {
                     workspaceId: this.workspace,
                 },
-                { query: { tags: tags.join(",") } },
-            ).then(MetadataUtilities.mergeEntitiesResults);
+                { query: { tags: tags.join(",") }, headers: ValidateRelationsHeader },
+            )
+                .then(MetadataUtilities.mergeEntitiesResults)
+                .then(MetadataUtilities.filterValidEntities);
         });
 
         return measures.data.map(convertMeasure);


### PR DESCRIPTION
-  Measures may reference non-existent LDM objects
-  We forgot to filter these out the last time when updating insight/dashboard/catalog-export services

JIRA: RAIL-3260

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
