### PR TITLE
RAIL-1842 DateFilter Mark available granularities as deprecated

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/map-rail-1842-deprecate-available-granularities_2021-04-15-13-15.json
+++ b/common/changes/@gooddata/sdk-ui-all/map-rail-1842-deprecate-available-granularities_2021-04-15-13-15.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "RelativeDateFilterForm availableGranularities deprecated, use availableGranularities in DateFilter instead. ",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "martin.plavek@gooddata.com"
+}

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -40,6 +40,8 @@ export const AttributeFilter: React_2.ComponentType<IAttributeFilterProps>;
 export class DateFilter extends React_2.PureComponent<IDateFilterProps, IDateFilterState> {
     constructor(props: IDateFilterProps);
     // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
     static defaultProps: Partial<IDateFilterProps>;
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDateFilterProps, prevState: IDateFilterState): IDateFilterState;

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -11,7 +11,12 @@ import { canExcludeCurrentPeriod } from "./utils/PeriodExlusion";
 
 import { DateFilterCore } from "./DateFilterCore";
 import { validateFilterOption } from "./validation/OptionValidation";
-import { DateFilterOption, IDateFilterOptionsByType } from "./interfaces";
+import {
+    DateFilterOption,
+    IDateFilterOptionsByType,
+    IUiAbsoluteDateFilterForm,
+    IUiRelativeDateFilterForm
+} from "./interfaces";
 import { DEFAULT_DATE_FORMAT } from "./constants/Platform";
 
 const normalizeSelectedFilterOption = (selectedFilterOption: DateFilterOption): DateFilterOption => {
@@ -123,9 +128,27 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
         };
     };
 
+    private static checkInitialFilterOption = (filterOption: DateFilterOption) => {
+        const {
+            type
+        } = filterOption;
+
+        if (type === "absoluteForm" && !((filterOption as IUiAbsoluteDateFilterForm).from && (filterOption as IUiAbsoluteDateFilterForm).to)) {
+            // eslint-disable-next-line no-console
+            console.warn("The default filter option is not valid. Values 'from' and 'to' from absoluteForm filter option must be specified.");
+        }
+
+        if (type === "relativeForm" && !((filterOption as IUiRelativeDateFilterForm).from && (filterOption as IUiRelativeDateFilterForm).to)) {
+            // eslint-disable-next-line no-console
+            console.warn("The default filter option is not valid. Values 'from' and 'to' from relativeForm filter option must be specified.");
+        }
+    }
+
     constructor(props: IDateFilterProps) {
         super(props);
         this.state = DateFilter.getStateFromProps(props);
+
+        DateFilter.checkInitialFilterOption(props.selectedFilterOption);
 
         // eslint-disable-next-line no-console
         console.warn(

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -1,6 +1,7 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
 import isEqual from "lodash/isEqual";
+import isNil from "lodash/isNil";
 import noop from "lodash/noop";
 import {
     isRelativeDateFilterForm,
@@ -125,14 +126,14 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
     };
 
     private static checkInitialFilterOption = (filterOption: DateFilterOption) => {
-        if (isAbsoluteDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
+        if (isAbsoluteDateFilterForm(filterOption) && (isNil(filterOption.from) || isNil(filterOption.to))) {
             // eslint-disable-next-line no-console
             console.warn(
                 "The default filter option is not valid. Values 'from' and 'to' from absoluteForm filter option must be specified.",
             );
         }
 
-        if (isRelativeDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
+        if (isRelativeDateFilterForm(filterOption) && (isNil(filterOption.from) || isNil(filterOption.to))) {
             // eslint-disable-next-line no-console
             console.warn(
                 "The default filter option is not valid. Values 'from' and 'to' from relativeForm filter option must be specified.",
@@ -144,12 +145,14 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
         super(props);
         this.state = DateFilter.getStateFromProps(props);
 
-        DateFilter.checkInitialFilterOption(props.selectedFilterOption);
-
         // eslint-disable-next-line no-console
         console.warn(
             "DateFilter component is still in beta. Component and its API may change in the future.",
         );
+    }
+
+    componentDidMount() {
+        DateFilter.checkInitialFilterOption(this.props.selectedFilterOption);
     }
 
     public render(): React.ReactNode {

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -5,7 +5,7 @@ import noop from "lodash/noop";
 import {
     isRelativeDateFilterForm,
     DateFilterGranularity,
-    DashboardDateFilterConfigMode,
+    DashboardDateFilterConfigMode, isAbsoluteDateFilterForm,
 } from "@gooddata/sdk-backend-spi";
 import { canExcludeCurrentPeriod } from "./utils/PeriodExlusion";
 
@@ -14,8 +14,6 @@ import { validateFilterOption } from "./validation/OptionValidation";
 import {
     DateFilterOption,
     IDateFilterOptionsByType,
-    IUiAbsoluteDateFilterForm,
-    IUiRelativeDateFilterForm
 } from "./interfaces";
 import { DEFAULT_DATE_FORMAT } from "./constants/Platform";
 
@@ -129,16 +127,12 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
     };
 
     private static checkInitialFilterOption = (filterOption: DateFilterOption) => {
-        const {
-            type
-        } = filterOption;
-
-        if (type === "absoluteForm" && !((filterOption as IUiAbsoluteDateFilterForm).from && (filterOption as IUiAbsoluteDateFilterForm).to)) {
+        if (isAbsoluteDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
             // eslint-disable-next-line no-console
             console.warn("The default filter option is not valid. Values 'from' and 'to' from absoluteForm filter option must be specified.");
         }
 
-        if (type === "relativeForm" && !((filterOption as IUiRelativeDateFilterForm).from && (filterOption as IUiRelativeDateFilterForm).to)) {
+        if (isRelativeDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
             // eslint-disable-next-line no-console
             console.warn("The default filter option is not valid. Values 'from' and 'to' from relativeForm filter option must be specified.");
         }

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -5,16 +5,14 @@ import noop from "lodash/noop";
 import {
     isRelativeDateFilterForm,
     DateFilterGranularity,
-    DashboardDateFilterConfigMode, isAbsoluteDateFilterForm,
+    DashboardDateFilterConfigMode,
+    isAbsoluteDateFilterForm,
 } from "@gooddata/sdk-backend-spi";
 import { canExcludeCurrentPeriod } from "./utils/PeriodExlusion";
 
 import { DateFilterCore } from "./DateFilterCore";
 import { validateFilterOption } from "./validation/OptionValidation";
-import {
-    DateFilterOption,
-    IDateFilterOptionsByType,
-} from "./interfaces";
+import { DateFilterOption, IDateFilterOptionsByType } from "./interfaces";
 import { DEFAULT_DATE_FORMAT } from "./constants/Platform";
 
 const normalizeSelectedFilterOption = (selectedFilterOption: DateFilterOption): DateFilterOption => {
@@ -129,14 +127,18 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
     private static checkInitialFilterOption = (filterOption: DateFilterOption) => {
         if (isAbsoluteDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
             // eslint-disable-next-line no-console
-            console.warn("The default filter option is not valid. Values 'from' and 'to' from absoluteForm filter option must be specified.");
+            console.warn(
+                "The default filter option is not valid. Values 'from' and 'to' from absoluteForm filter option must be specified.",
+            );
         }
 
         if (isRelativeDateFilterForm(filterOption) && !(filterOption.from && filterOption.to)) {
             // eslint-disable-next-line no-console
-            console.warn("The default filter option is not valid. Values 'from' and 'to' from relativeForm filter option must be specified.");
+            console.warn(
+                "The default filter option is not valid. Values 'from' and 'to' from relativeForm filter option must be specified.",
+            );
         }
-    }
+    };
 
     constructor(props: IDateFilterProps) {
         super(props);

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
@@ -335,6 +335,7 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
             selectedFilterOption,
             onSelectedFilterOptionChange,
             isMobile,
+            availableGranularities,
         } = this.props;
         return filterOptions.relativePreset ? (
             <RelativePresetFilterItems
@@ -343,6 +344,7 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
                 selectedFilterOption={selectedFilterOption}
                 onSelectedFilterOptionChange={onSelectedFilterOptionChange}
                 className={isMobile && ITEM_CLASS_MOBILE}
+                availableGranularities={availableGranularities}
             />
         ) : null;
     };
@@ -377,7 +379,7 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
             );
         }
         if (route === "relativeForm") {
-            return (
+            return isEmpty(this.props.availableGranularities) ? null : (
                 <>
                     <DateFilterHeader changeRoute={this.changeRoute}>
                         <FormattedMessage id="filters.floatingRange" />
@@ -394,7 +396,7 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
             <>
                 {this.renderAllTime()}
                 {this.renderAbsoluteForm()}
-                {this.renderRelativeForm()}
+                {!isEmpty(this.props.availableGranularities) && this.renderRelativeForm()}
                 {this.renderAbsolutePreset()}
                 {this.renderRelativePreset()}
             </>

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/RelativePresetFilterItems.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/RelativePresetFilterItems.tsx
@@ -23,11 +23,24 @@ export const RelativePresetFilterItems: React.FC<{
     selectedFilterOption: DateFilterOption;
     className?: string;
     onSelectedFilterOptionChange: (option: DateFilterOption) => void;
-}> = ({ dateFormat, filterOption, selectedFilterOption, onSelectedFilterOptionChange, className }) => {
+    availableGranularities: DateFilterGranularity[];
+}> = ({
+    dateFormat,
+    filterOption,
+    selectedFilterOption,
+    onSelectedFilterOptionChange,
+    className,
+    availableGranularities,
+}) => {
     const relativePresets = granularityOrder
-        .filter((granularity) =>
-            Boolean(filterOption && filterOption[granularity] && filterOption[granularity].length > 0),
-        )
+        .filter((granularity) => {
+            return Boolean(
+                filterOption &&
+                    filterOption[granularity] &&
+                    filterOption[granularity].length > 0 &&
+                    availableGranularities.indexOf(granularity) > -1,
+            );
+        })
         .map((granularity) => ({
             granularity,
             items: filterOption[granularity] as IRelativeDateFilterPreset[],

--- a/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
@@ -85,6 +85,12 @@ export class DynamicSelect extends React.Component<IDynamicSelectProps, IDynamic
         }
     };
 
+    public blur = (): void => {
+        if (this.inputRef.current) {
+            this.inputRef.current.blur();
+        }
+    };
+
     public onInputValueChanged = (inputValue: string): void => {
         if (inputValue !== this.state.inputValue) {
             this.setState({ inputValue });

--- a/libs/sdk-ui-filters/src/DateFilter/RelativeDateFilterForm/RelativeDateFilterForm.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/RelativeDateFilterForm/RelativeDateFilterForm.tsx
@@ -6,6 +6,9 @@ import { RelativeRangePicker } from "../RelativeRangePicker/RelativeRangePicker"
 import { DateFilterGranularity } from "@gooddata/sdk-backend-spi";
 
 export interface IRelativeDateFilterFormProps {
+    /**
+     * @deprecated use availableGranularities in {@link IDateFilterOwnProps} instead
+     */
     availableGranularities: DateFilterGranularity[];
     selectedFilterOption: IUiRelativeDateFilterForm;
     onSelectedFilterOptionChange: (dateFilterOption: DateFilterOption) => void;

--- a/libs/sdk-ui-filters/src/DateFilter/RelativeRangePicker/RelativeRangePicker.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/RelativeRangePicker/RelativeRangePicker.tsx
@@ -66,8 +66,12 @@ class RelativeRangePickerComponent extends React.Component<
         );
     }
 
+    private isTouchDevice = (): boolean | number => {
+        return "ontouchstart" in window || navigator.msMaxTouchPoints;
+    };
+
     private focusToField = (): void => {
-        const isTouchDevice = "ontouchstart" in window || navigator.msMaxTouchPoints;
+        const isTouchDevice = this.isTouchDevice();
         if (this.toFieldRef.current) {
             /**
              * Prevents hover style from persisting after switching to another field on
@@ -81,6 +85,17 @@ class RelativeRangePickerComponent extends React.Component<
         }
     };
 
+    private blurToField = (): void => {
+        const isTouchDevice = this.isTouchDevice();
+        if (this.toFieldRef.current) {
+            isTouchDevice
+                ? setTimeout(() => {
+                      this.toFieldRef.current.blur();
+                  }, 0)
+                : this.toFieldRef.current.blur();
+        }
+    };
+
     private handleFromChange = (from: number | undefined): void => {
         this.props.onSelectedFilterOptionChange({ ...this.props.selectedFilterOption, from });
         if (from !== undefined) {
@@ -90,6 +105,7 @@ class RelativeRangePickerComponent extends React.Component<
 
     private handleToChange = (to: number | undefined): void => {
         this.props.onSelectedFilterOptionChange({ ...this.props.selectedFilterOption, to });
+        this.blurToField();
     };
 }
 


### PR DESCRIPTION
Description of changes.

- RAIL-1842 availableGranularities in DateFilter marked as deprecated
- RAIL-1603 issue with reopening 'to' field after choosing its value in relativeFilterForm
- RAIL-1624 consider available granularities in relativeFilterForm and presets
- RAIL-1872 console warning about incorrect DateFilter setup 

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
