### PR TITLE
UI Kit: Render insight update time in local time

### DIFF
--- a/libs/sdk-ui-kit/src/List/InsightListItemDate.tsx
+++ b/libs/sdk-ui-kit/src/List/InsightListItemDate.tsx
@@ -1,8 +1,7 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
-import utcToZonedTime from "date-fns-tz/utcToZonedTime";
+import toDate from "date-fns-tz/toDate";
 import subDays from "date-fns/subDays";
-import parseISO from "date-fns/parseISO";
 import isSameDay from "date-fns/isSameDay";
 import isSameYear from "date-fns/isSameYear";
 import { FormattedMessage, FormattedTime, FormattedDate } from "react-intl";
@@ -47,7 +46,7 @@ export const InsightListItemDate: React.FC<IInsightListItemDateProps> = ({ confi
     return <FormattedDate value={config.date} format="shortWithYear" />;
 };
 
-const META_TIMEZONE = "Europe/Prague";
+export const META_DATA_TIMEZONE = "Europe/Prague";
 
 /**
  * @internal
@@ -70,19 +69,17 @@ export function getDateTimeConfig(
     date: string,
     options: IDateTimeConfigOptions = {},
 ): IInsightListItemDateConfig {
-    const { dateTimezone = META_TIMEZONE, now = new Date() } = options;
+    const { dateTimezone = META_DATA_TIMEZONE, now = new Date() } = options;
 
-    const dateWithTimezoneInLocal = parseISO(date);
-    const dateWithTimezone = utcToZonedTime(dateWithTimezoneInLocal, dateTimezone);
-
+    const dateInLocalTimezone = toDate(date, { timeZone: dateTimezone });
     const yesterday = subDays(now, 1);
 
-    const isToday = isSameDay(dateWithTimezoneInLocal, now);
-    const isYesterday = isSameDay(dateWithTimezoneInLocal, yesterday);
-    const isCurrentYear = isSameYear(dateWithTimezoneInLocal, now);
+    const isToday = isSameDay(dateInLocalTimezone, now);
+    const isYesterday = isSameDay(dateInLocalTimezone, yesterday);
+    const isCurrentYear = isSameYear(dateInLocalTimezone, now);
 
     return {
-        date: dateWithTimezone,
+        date: dateInLocalTimezone,
         isToday,
         isYesterday,
         isCurrentYear,

--- a/libs/sdk-ui-kit/src/List/tests/InsightListItemDate.test.ts
+++ b/libs/sdk-ui-kit/src/List/tests/InsightListItemDate.test.ts
@@ -1,7 +1,7 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import toDate from "date-fns-tz/toDate";
 
-import { getDateTimeConfig } from "../InsightListItemDate";
+import { getDateTimeConfig, META_DATA_TIMEZONE } from "../InsightListItemDate";
 
 interface ITestOptions {
     now: Date;
@@ -9,32 +9,44 @@ interface ITestOptions {
     updatedYesterday: string;
     updatedThisYear: string;
     updatedLastYear: string;
+    timeZone: string;
 }
+
+const toZonedDate = (date: string, timeZone: string) => {
+    const metaDataDate = toDate(date, { timeZone: META_DATA_TIMEZONE });
+    return toDate(metaDataDate, { timeZone });
+};
 
 describe("InsightListItemDate", () => {
     describe("getDateTimeConfig today/yesterday/current year", () => {
         const shouldBehaveCorrectlyForDate = (options: ITestOptions) => {
-            const { now, updatedToday, updatedYesterday, updatedThisYear, updatedLastYear } = options;
+            const { now, timeZone } = options;
 
             it("should correctly format today's date", () => {
+                const { updatedToday } = options;
                 const config = getDateTimeConfig(updatedToday, { now });
                 expect(config).toMatchObject({
+                    date: toZonedDate(updatedToday, timeZone),
                     isToday: true,
                     isYesterday: false,
                 });
             });
 
             it("should correctly format yesterdays date", () => {
+                const { updatedYesterday } = options;
                 const config = getDateTimeConfig(updatedYesterday, { now });
                 expect(config).toMatchObject({
+                    date: toZonedDate(updatedYesterday, timeZone),
                     isToday: false,
                     isYesterday: true,
                 });
             });
 
             it("should correctly format date in this year", () => {
+                const { updatedThisYear } = options;
                 const config = getDateTimeConfig(updatedThisYear, { now });
                 expect(config).toMatchObject({
+                    date: toZonedDate(updatedThisYear, timeZone),
                     isToday: false,
                     isYesterday: false,
                     isCurrentYear: true,
@@ -42,8 +54,10 @@ describe("InsightListItemDate", () => {
             });
 
             it("should correctly format date in last year", () => {
+                const { updatedLastYear } = options;
                 const config = getDateTimeConfig(updatedLastYear, { now });
                 expect(config).toMatchObject({
+                    date: toZonedDate(updatedLastYear, timeZone),
                     isToday: false,
                     isYesterday: false,
                     isCurrentYear: false,
@@ -59,18 +73,21 @@ describe("InsightListItemDate", () => {
         };
 
         describe("Europe/Prague default timezone", () => {
-            const now = toDate("2016-03-20 15:00", { timeZone: "Europe/Prague" });
-            shouldBehaveCorrectlyForDate({ now, ...options });
+            const timeZone = "Europe/Prague";
+            const now = toDate("2016-03-20 15:00", { timeZone });
+            shouldBehaveCorrectlyForDate({ now, timeZone, ...options });
         });
 
         describe("America/Los_Angeles default timezone", () => {
-            const now = toDate("2016-03-20 07:00", { timeZone: "America/Los_Angeles" });
-            shouldBehaveCorrectlyForDate({ now, ...options });
+            const timeZone = "America/Los_Angeles";
+            const now = toDate("2016-03-20 07:00", { timeZone });
+            shouldBehaveCorrectlyForDate({ now, timeZone, ...options });
         });
 
         describe("Asia/Bangkok default timezone", () => {
-            const now = toDate("2016-03-20 20:00", { timeZone: "Asia/Bangkok" });
-            shouldBehaveCorrectlyForDate({ now, ...options });
+            const timeZone = "Asia/Bangkok";
+            const now = toDate("2016-03-20 20:00", { timeZone });
+            shouldBehaveCorrectlyForDate({ now, timeZone, ...options });
         });
     });
 });


### PR DESCRIPTION
The date of insight update was not rendered in local time if AD/KD saved insight list is opened in a different time zone than the one metadata are saved in, i.e., in different one than Europe/Prague.

JIRA: FET-713

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
