### PR TITLE
RELATED: RAIL-3241 Fix normalizingBackend for NoDataErrors

### DIFF
--- a/libs/sdk-backend-base/api/sdk-backend-base.api.md
+++ b/libs/sdk-backend-base/api/sdk-backend-base.api.md
@@ -443,7 +443,7 @@ export function dummyBackend(config?: DummyBackendConfig): IAnalyticalBackend;
 
 // @internal (undocumented)
 export type DummyBackendConfig = IAnalyticalBackendConfig & {
-    raiseNoDataExceptions: boolean;
+    raiseNoDataExceptions: false | "without-data-view" | "with-data-view";
 };
 
 // @internal

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -62,8 +62,11 @@ export type DummyBackendConfig = IAnalyticalBackendConfig & {
      * the returned data view.
      *
      * Throwing NoDataError is closer to how normal backends behave.
+     *
+     * If set to "without-data-view", it will throw NoDataErrors without a DataView.
+     * If set to "with-data-view", it will throw NoDataErrors with a DataView.
      */
-    raiseNoDataExceptions: boolean;
+    raiseNoDataExceptions: false | "without-data-view" | "with-data-view";
 };
 
 /**
@@ -71,7 +74,7 @@ export type DummyBackendConfig = IAnalyticalBackendConfig & {
  */
 export const defaultDummyBackendConfig: DummyBackendConfig = {
     hostname: "test",
-    raiseNoDataExceptions: true,
+    raiseNoDataExceptions: "without-data-view",
 };
 
 /**
@@ -267,14 +270,28 @@ function dummyExecutionResult(
         dimensions: [],
         readAll(): Promise<IDataView> {
             if (config.raiseNoDataExceptions) {
-                return Promise.reject(new NoDataError("Empty data view from dummy backend"));
+                return Promise.reject(
+                    new NoDataError(
+                        "Empty data view from dummy backend",
+                        config.raiseNoDataExceptions === "with-data-view"
+                            ? dummyDataView(definition, result, config)
+                            : undefined,
+                    ),
+                );
             }
 
             return Promise.resolve(dummyDataView(definition, result, config));
         },
         readWindow(_1: number[], _2: number[]): Promise<IDataView> {
             if (config.raiseNoDataExceptions) {
-                return Promise.reject(new NoDataError("Empty data view from dummy backend"));
+                return Promise.reject(
+                    new NoDataError(
+                        "Empty data view from dummy backend",
+                        config.raiseNoDataExceptions === "with-data-view"
+                            ? dummyDataView(definition, result, config)
+                            : undefined,
+                    ),
+                );
             }
 
             return Promise.resolve(dummyDataView(definition, result, config));

--- a/libs/sdk-backend-base/src/normalizingBackend/tests/withNormalization.test.ts
+++ b/libs/sdk-backend-base/src/normalizingBackend/tests/withNormalization.test.ts
@@ -1,22 +1,25 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 
 import { withNormalization } from "../index";
-import { dummyBackendEmptyData } from "../../dummyBackend";
+import { dummyBackend, dummyBackendEmptyData } from "../../dummyBackend";
 import { ReferenceLdm, ReferenceLdmExt } from "@gooddata/reference-workspace";
+import { NoDataError } from "@gooddata/sdk-backend-spi";
 
 describe("withNormalization", () => {
+    const measures = [
+        ReferenceLdm.Won,
+        ReferenceLdm.Amount,
+        ReferenceLdmExt.WonPopClosedYear,
+        ReferenceLdmExt.WonPreviousPeriod,
+        ReferenceLdmExt.AmountWithRatio,
+        ReferenceLdmExt.MaxAmount,
+        ReferenceLdmExt.CalculatedLost,
+    ];
+
+    const attributes = [ReferenceLdm.Region, ReferenceLdm.Product.Name];
+
     it("should keep transparency of exec definition", async () => {
         const backend = withNormalization(dummyBackendEmptyData());
-        const measures = [
-            ReferenceLdm.Won,
-            ReferenceLdm.Amount,
-            ReferenceLdmExt.WonPopClosedYear,
-            ReferenceLdmExt.WonPreviousPeriod,
-            ReferenceLdmExt.AmountWithRatio,
-            ReferenceLdmExt.MaxAmount,
-            ReferenceLdmExt.CalculatedLost,
-        ];
-        const attributes = [ReferenceLdm.Region, ReferenceLdm.Product.Name];
 
         const result = await backend
             .workspace("testWorkspace")
@@ -26,5 +29,28 @@ describe("withNormalization", () => {
 
         expect(result.definition.attributes).toEqual(attributes);
         expect(result.definition.measures).toEqual(measures);
+    });
+
+    it("should keep transparency of exec definition in case of no data error (RAIL-3232)", async () => {
+        const backend = withNormalization(
+            dummyBackend({
+                // make sure the dataView is passed to the NoDataError
+                raiseNoDataExceptions: "with-data-view",
+            }),
+        );
+
+        const result = await backend
+            .workspace("testWorkspace")
+            .execution()
+            .forItems([...attributes, ...measures])
+            .execute();
+
+        try {
+            await result.readAll();
+        } catch (err) {
+            const typedError = err as NoDataError;
+            expect(typedError.dataView?.definition.attributes).toEqual(attributes);
+            expect(typedError.dataView?.definition.measures).toEqual(measures);
+        }
     });
 });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -46,7 +46,7 @@ describe("PluggableColumnBarCharts", () => {
         return new PluggableColumnChart(props);
     }
 
-    const executionFactory = dummyBackend({ hostname: "test", raiseNoDataExceptions: true })
+    const executionFactory = dummyBackend({ hostname: "test", raiseNoDataExceptions: "without-data-view" })
         .workspace("PROJECTID")
         .execution();
 

--- a/libs/sdk-ui-tests/tests/_infra/backendWithCapturing.ts
+++ b/libs/sdk-ui-tests/tests/_infra/backendWithCapturing.ts
@@ -45,25 +45,28 @@ export function backendWithCapturing(
         dataRequestResolver = resolve;
     });
 
-    let backend = withEventing(dummyBackend({ hostname: "test", raiseNoDataExceptions: true }), {
-        beforeExecute: (def) => {
-            interactions.triggeredExecution = def;
-        },
-        failedResultReadAll: (_) => {
-            interactions.dataViewRequests.allData = true;
+    let backend = withEventing(
+        dummyBackend({ hostname: "test", raiseNoDataExceptions: "without-data-view" }),
+        {
+            beforeExecute: (def) => {
+                interactions.triggeredExecution = def;
+            },
+            failedResultReadAll: (_) => {
+                interactions.dataViewRequests.allData = true;
 
-            dataRequestResolver(interactions);
-        },
-        failedResultReadWindow: (offset: number[], size: number[]) => {
-            if (!interactions.dataViewRequests.windows) {
-                interactions.dataViewRequests.windows = [];
-            }
+                dataRequestResolver(interactions);
+            },
+            failedResultReadWindow: (offset: number[], size: number[]) => {
+                if (!interactions.dataViewRequests.windows) {
+                    interactions.dataViewRequests.windows = [];
+                }
 
-            interactions.dataViewRequests.windows.push({ offset, size });
+                interactions.dataViewRequests.windows.push({ offset, size });
 
-            dataRequestResolver(interactions);
+                dataRequestResolver(interactions);
+            },
         },
-    });
+    );
 
     if (normalize) {
         backend = withNormalization(backend, {

--- a/libs/sdk-ui/src/execution/tests/Execute.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/Execute.test.tsx
@@ -113,7 +113,7 @@ describe("Execute", () => {
         expect(onLoadingFinish).toBeCalledTimes(1);
     });
 
-    it("should invoke onError when execution fails", async () => {
+    it("should invoke onError when execution fails with a NoDataError without a DataView", async () => {
         const child = makeChild();
         const onLoadingStart = jest.fn();
         const onLoadingChanged = jest.fn();
@@ -128,7 +128,7 @@ describe("Execute", () => {
                 onLoadingFinish,
                 onLoadingStart,
             },
-            dummyBackend(),
+            dummyBackend({ raiseNoDataExceptions: "without-data-view" }),
         );
 
         await createDummyPromise({ delay: 100 });
@@ -136,7 +136,33 @@ describe("Execute", () => {
         expect(onError).toBeCalledTimes(1);
         expect(onLoadingStart).toBeCalledTimes(1);
         expect(onLoadingChanged).toBeCalledTimes(2);
-        expect(onLoadingFinish).toBeCalledTimes(0);
+        expect(onLoadingFinish).not.toBeCalled();
+    });
+
+    it("should NOT invoke onError when execution fails with a NoDataError with a DataView", async () => {
+        const child = makeChild();
+        const onLoadingStart = jest.fn();
+        const onLoadingChanged = jest.fn();
+        const onLoadingFinish = jest.fn();
+        const onError = jest.fn();
+
+        renderDummyExecutor(
+            child,
+            {
+                onError,
+                onLoadingChanged,
+                onLoadingFinish,
+                onLoadingStart,
+            },
+            dummyBackend({ raiseNoDataExceptions: "with-data-view" }),
+        );
+
+        await createDummyPromise({ delay: 100 });
+
+        expect(onError).not.toBeCalled();
+        expect(onLoadingStart).toBeCalledTimes(1);
+        expect(onLoadingChanged).toBeCalledTimes(2);
+        expect(onLoadingFinish).toBeCalledTimes(1);
     });
 });
 

--- a/libs/sdk-ui/src/execution/tests/RawExecute.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/RawExecute.test.tsx
@@ -110,7 +110,7 @@ describe("RawExecute", () => {
         expect(onLoadingFinish).toBeCalledTimes(1);
     });
 
-    it("should invoke onError when execution fails", async () => {
+    it("should invoke onError when execution fails with a NoDataError without a DataView", async () => {
         const child = makeChild();
         const onLoadingStart = jest.fn();
         const onLoadingChanged = jest.fn();
@@ -125,7 +125,7 @@ describe("RawExecute", () => {
                 onLoadingFinish,
                 onLoadingStart,
             },
-            dummyBackend(),
+            dummyBackend({ raiseNoDataExceptions: "without-data-view" }),
         );
 
         await createDummyPromise({ delay: 100 });
@@ -133,6 +133,32 @@ describe("RawExecute", () => {
         expect(onError).toBeCalledTimes(1);
         expect(onLoadingStart).toBeCalledTimes(1);
         expect(onLoadingChanged).toBeCalledTimes(2);
-        expect(onLoadingFinish).toBeCalledTimes(0);
+        expect(onLoadingFinish).not.toBeCalled();
+    });
+
+    it("should NOT invoke onError when execution fails with a NoDataError with a DataView", async () => {
+        const child = makeChild();
+        const onLoadingStart = jest.fn();
+        const onLoadingChanged = jest.fn();
+        const onLoadingFinish = jest.fn();
+        const onError = jest.fn();
+
+        renderDummyExecutor(
+            child,
+            {
+                onError,
+                onLoadingChanged,
+                onLoadingFinish,
+                onLoadingStart,
+            },
+            dummyBackend({ raiseNoDataExceptions: "with-data-view" }),
+        );
+
+        await createDummyPromise({ delay: 100 });
+
+        expect(onError).not.toBeCalled();
+        expect(onLoadingStart).toBeCalledTimes(1);
+        expect(onLoadingChanged).toBeCalledTimes(2);
+        expect(onLoadingFinish).toBeCalledTimes(1);
     });
 });

--- a/libs/sdk-ui/src/execution/tests/withExecutionLoading.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/withExecutionLoading.test.tsx
@@ -102,24 +102,38 @@ describe("withExecution", () => {
         expect(onLoadingFinish).toBeCalledTimes(1);
     });
 
-    it("should invoke onError", async () => {
+    it("should invoke onError for NoDataErrors without a DataView", async () => {
         const onError = jest.fn();
 
-        /*
-         * this test uses dummy backend in the default config which raises NO_DATA errors.
-         */
         renderEnhancedComponent(
             {
                 events: {
                     onError,
                 },
             },
-            dummyBackend(),
+            dummyBackend({ raiseNoDataExceptions: "without-data-view" }),
         );
 
         await createDummyPromise({ delay: 150 });
 
         expect(onError).toBeCalledTimes(1);
+    });
+
+    it("should NOT invoke onError for NoDataErrors with a DataView", async () => {
+        const onError = jest.fn();
+
+        renderEnhancedComponent(
+            {
+                events: {
+                    onError,
+                },
+            },
+            dummyBackend({ raiseNoDataExceptions: "with-data-view" }),
+        );
+
+        await createDummyPromise({ delay: 150 });
+
+        expect(onError).not.toBeCalled();
     });
 
     it("should do readAll when no window specified", async () => {


### PR DESCRIPTION
Make sure the dataViews passed in the NoDataErrors are denormalized
to ensure that only denormalized data views come from the executions

To test this, dummyBackend had to be extended to allow different
NoDataErrors to be thrown (with or without dataViews).
Using this, some tests were extended to cover both cases.

JIRA: RAIL-3241

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
