### PR TITLE
RELATED: RAIL-3277 Make tiger error interceptor more robust

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -329,9 +329,14 @@ function interceptBackendErrorsToConsole(client: AxiosInstance): AxiosInstance {
     client.interceptors.response.use(identity, (error) => {
         const response: AxiosResponse = error.response;
 
-        // If the response is an object (JSON parsed by axios) and there is a problem, then log error
+        // If there is no response object (for example for blocked requests), print the whole error.
+        if (!response) {
+            // eslint-disable-next-line no-console
+            console.error("Tiger backend threw an error:", error);
+        }
+        // Else if the response is an object (JSON parsed by axios) and there is a problem, then log error
         // into console for easier diagnostics.
-        if (inRange(response.status, 400, 600) && typeof response.data === "object") {
+        else if (inRange(response.status, 400, 600) && typeof response.data === "object") {
             // Title is redundant (Bad Request)
             const details = omit(response.data, ["title"]);
             // eslint-disable-next-line no-console


### PR DESCRIPTION
In case a request is blocked by client, we would not see the error
as in that case, the response is undefined.

JIRA: RAIL-3277

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
