### PR TITLE
RELATED: RAIL-3304 Fix global readme and the examples readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can also view our [live examples](https://gdui-examples.herokuapp.com/login)
     cd gooddata-ui-sdk
     nvm install
     nvm use
-    npm i -g @microsoft/rush pnpm
+    npm i -g @microsoft/rush
     rush install
     ```
 

--- a/examples/sdk-examples/README.md
+++ b/examples/sdk-examples/README.md
@@ -5,8 +5,7 @@
 You can start the live examples locally in development mode using the `npm run examples` or `yarn examples` commands. This
 will start the Webpack dev server.
 
-The application in dev mode still works on top of a live project in GoodData platform - you will need to
-log in using your credentials for the official [live examples](https://gooddata-examples.herokuapp.com/registration).
+The application in dev mode works on top of a live project in GoodData platform running in a way that does not require authentication - no registration needed.
 
 ## Adding new examples
 


### PR DESCRIPTION
* remove mention of registration for live examples
* remove necessity to install `pnpm` globally,
  the official rush docs do not mention it anymore

  JIRA: RAIL-3304

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
