### PR TITLE
RELATED: RAIL-3092 Add widgetRef to IDashboardDrillEvent

### DIFF
--- a/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
+++ b/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
@@ -99,8 +99,8 @@ export const defaultDashboardThemeModifier: (theme: ITheme) => ITheme;
 
 // @beta
 export interface IDashboardDrillEvent extends IDrillEvent {
-    // (undocumented)
     drillDefinitions?: Array<DrillDefinition | IDrillDownDefinition>;
+    widgetRef?: ObjRef;
 }
 
 // @beta

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
@@ -41,7 +41,7 @@ import {
     useDashboardViewConfig,
     useUserWorkspaceSettings,
 } from "../../contexts";
-import { OnFiredDashboardViewDrillEvent } from "../../types";
+import { OnFiredDashboardViewDrillEvent, IDashboardDrillEvent } from "../../types";
 
 const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative" };
 
@@ -167,9 +167,14 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
     }, [implicitDrillDefinitions]);
 
     const handleDrill = useCallback((event: IDrillEvent) => {
+        const enrichedEvent: IDashboardDrillEvent = {
+            ...event,
+            widgetRef: insightWidget.ref,
+        };
+
         // if there are drillable items, we do not want to return any drillDefinitions as the implicit drills are not even used
         if (drillableItems) {
-            return onDrill(event);
+            return onDrill(enrichedEvent);
         }
 
         const facade = DataViewFacade.for(event.dataView);
@@ -183,7 +188,7 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
         });
 
         return onDrill({
-            ...event,
+            ...enrichedEvent,
             drillDefinitions: matchingImplicitDrillDefinitions.map((info) => info.drillDefinition),
         });
     }, []);

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiExecutor.tsx
@@ -162,6 +162,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                 dataView: result.dataView,
                 drillContext,
                 drillDefinitions,
+                widgetRef: kpiWidget.ref,
             });
         },
         [onDrill, result],

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/types.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/types.ts
@@ -52,12 +52,19 @@ export function isDrillDownDefinition(obj: unknown): obj is IDrillDownDefinition
 }
 
 /**
- * A {@link @gooddata/sdk-ui#IDrillEvent} with added field that contains info about all the drilling interactions set in KPI dashboards
- * that are relevant to the given drill event (including drill downs).
+ * A {@link @gooddata/sdk-ui#IDrillEvent} with added information about the drill event specific to the DashboardView context.
  * @beta
  */
 export interface IDashboardDrillEvent extends IDrillEvent {
+    /**
+     * All the drilling interactions set in KPI dashboards that are relevant to the given drill event (including drill downs).
+     */
     drillDefinitions?: Array<DrillDefinition | IDrillDownDefinition>;
+
+    /**
+     * Reference to the widget that triggered the drill event.
+     */
+    widgetRef?: ObjRef;
 }
 
 /**


### PR DESCRIPTION
This allows the users to identify the widget that triggered the drillEvent.

JIRA: RAIL-3092

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
