### PR TITLE
Add useBackendStrict / useWorkspaceStrict hooks

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/RAIL-3307_2021-04-23-09-21.json
+++ b/common/changes/@gooddata/sdk-ui-all/RAIL-3307_2021-04-23-09-21.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Add useBackendStrict / useWorkspaceStrict hooks for better developer experience.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "matyas.kandl@gooddata.com"
+}

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -1276,6 +1276,9 @@ export function uriMatch(uri: string): IHeaderPredicate;
 // @public
 export const useBackend: (backend?: IAnalyticalBackend | undefined) => IAnalyticalBackend | undefined;
 
+// @public
+export const useBackendStrict: (backend?: IAnalyticalBackend | undefined) => IAnalyticalBackend;
+
 // @beta
 export function useCancelablePromise<TResult, TError = any>({ promise, onLoading, onPending, onCancel, onSuccess, onError, }: {
     promise: (() => Promise<TResult>) | undefined | null;
@@ -1356,6 +1359,9 @@ export function usePagedResource<TParams, TItem>(resourceFactory: (params: TPara
 
 // @public
 export const useWorkspace: (workspace?: string | undefined) => string | undefined;
+
+// @public
+export const useWorkspaceStrict: (workspace?: string | undefined) => string;
 
 // @public (undocumented)
 export type ValueFormatter = (value: DataValue, format: string) => string;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -53,10 +53,17 @@ export {
  */
 export { LoadingComponent, ILoadingProps } from "./react/LoadingComponent";
 export { ErrorComponent, IErrorProps } from "./react/ErrorComponent";
-export { BackendProvider, useBackend, withBackend, IBackendProviderProps } from "./react/BackendContext";
+export {
+    BackendProvider,
+    useBackend,
+    useBackendStrict,
+    withBackend,
+    IBackendProviderProps,
+} from "./react/BackendContext";
 export {
     WorkspaceProvider,
     useWorkspace,
+    useWorkspaceStrict,
     withWorkspace,
     IWorkspaceProviderProps,
 } from "./react/WorkspaceContext";

--- a/libs/sdk-ui/src/base/react/BackendContext.tsx
+++ b/libs/sdk-ui/src/base/react/BackendContext.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { wrapDisplayName } from "./wrapDisplayName";
+import invariant from "ts-invariant";
 
 const BackendContext = React.createContext<IAnalyticalBackend | undefined>(undefined);
 BackendContext.displayName = "BackendContext";
@@ -30,6 +31,8 @@ export const BackendProvider: React.FC<IBackendProviderProps> = ({ children, bac
  * You can optionally set a backend override that will be returned if defined.
  * This makes the usage more ergonomic (see the following example).
  *
+ * Note: For a better TypeScript experience without the hassle of undefined values, you can use the useBackendStrict hook.
+ *
  * @example
  * // instead of
  * const fromContext = useBackend();
@@ -43,6 +46,35 @@ export const BackendProvider: React.FC<IBackendProviderProps> = ({ children, bac
 export const useBackend = (backend?: IAnalyticalBackend): IAnalyticalBackend | undefined => {
     const backendFromContext = React.useContext(BackendContext);
     return backend ?? backendFromContext;
+};
+
+/**
+ * Hook to get analytical backend instance provided to BackendProvider.
+ * You can optionally set a backend override that will be returned if defined.
+ * This makes the usage more ergonomic (see the following example).
+ *
+ * Note: If you do not provide an IAnalyticalBackend instance to BackendProvider or as a parameter for this hook,
+ * an invariant error is raised.
+ *
+ * @example
+ * // instead of
+ * const fromContext = useBackendStrict();
+ * const effectiveBackend = fromArguments ?? fromContext.
+ * // you can write
+ * const backend = useBackendStrict(fromArguments);
+ *
+ *
+ * @param backend - backend to use instead of context value. If undefined, the context value is used.
+ * @public
+ */
+export const useBackendStrict = (backend?: IAnalyticalBackend): IAnalyticalBackend => {
+    const backendFromContext = React.useContext(BackendContext);
+    const effectiveBackend = backend ?? backendFromContext;
+    invariant(
+        effectiveBackend,
+        "useBackendStrict: IAnalyticalBackend must be defined. Either pass it as a parameter or make sure there is a BackendProvider up the component tree.",
+    );
+    return effectiveBackend;
 };
 
 /**

--- a/libs/sdk-ui/src/base/react/WorkspaceContext.tsx
+++ b/libs/sdk-ui/src/base/react/WorkspaceContext.tsx
@@ -1,6 +1,7 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { wrapDisplayName } from "./wrapDisplayName";
+import invariant from "ts-invariant";
 
 const WorkspaceContext = React.createContext<string | undefined>(undefined);
 WorkspaceContext.displayName = "WorkspaceContext";
@@ -25,9 +26,11 @@ export const WorkspaceProvider: React.FC<IWorkspaceProviderProps> = ({ children,
 };
 
 /**
- * Hook to get workspace instance provided to BackendProvider.
+ * Hook to get workspace instance provided to WorkspaceProvider.
  * You can optionally set a workspace override that will be returned if defined.
  * This makes the usage more ergonomic (see the following example).
+ *
+ * Note: For a better TypeScript experience without the hassle of undefined values, you can use the useWorkspaceStrict hook.
  *
  * @example
  * // instead of
@@ -42,6 +45,34 @@ export const WorkspaceProvider: React.FC<IWorkspaceProviderProps> = ({ children,
 export const useWorkspace = (workspace?: string): string | undefined => {
     const workspaceFromContext = React.useContext(WorkspaceContext);
     return workspace ?? workspaceFromContext;
+};
+
+/**
+ * Hook to get workspace instance provided to WorkspaceProvider.
+ * You can optionally set a workspace override that will be returned if defined.
+ * This makes the usage more ergonomic (see the following example).
+ *
+ * Note: Note: If you do not provide a workspace identifier to WorkspaceProvider or as a parameter for this hook,
+ * an invariant error is raised.
+ *
+ * @example
+ * // instead of
+ * const fromContext = useWorkspaceStrict();
+ * const effectiveWorkspace = fromArguments ?? fromContext.
+ * // you can write
+ * const workspace = useWorkspaceStrict(fromArguments);
+ *
+ * @param workspace - workspace to use instead of context value. If undefined, the context value is used.
+ * @public
+ */
+export const useWorkspaceStrict = (workspace?: string): string => {
+    const workspaceFromContext = React.useContext(WorkspaceContext);
+    const effectiveWorkspace = workspace ?? workspaceFromContext;
+    invariant(
+        effectiveWorkspace,
+        "useWorkspaceStrict: workspace must be defined. Either pass it as a parameter or make sure there is a WorkspaceProvider up the component tree.",
+    );
+    return effectiveWorkspace;
 };
 
 /**


### PR DESCRIPTION
Add stricter variant of useBackend/useWorkspace hooks for more convenient developer experience,
so it's not necessary to check for undefined values every time.

JIRA: RAIL-3307

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
