### PR TITLE
RELATED: RAIL-2781 Print out workspace id in catalog-export

### DIFF
--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -85,7 +85,9 @@ async function run() {
         }
 
         logSuccess("All data have been successfully exported");
-        logBox(chalk`The result is located at {bold ${filePath}}`);
+        logBox(
+            chalk`The result generated from workspace with id {bold ${projectMetadata.workspaceId}} is located at {bold ${filePath}}`,
+        );
 
         process.exit(0);
     } catch (err) {


### PR DESCRIPTION
This is to make getting the workspace id easier for the user.

Relevant PR in create-gooddata-react-app: https://github.com/gooddata/gooddata-create-gooddata-react-app/pull/96

JIRA: RAIL-2781

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
