### PR TITLE
Extension of execution components and hooks

### DIFF
--- a/examples/sdk-examples/src/examples/execution/UseDataViewAttributeValuesExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewAttributeValuesExample.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
-import { LoadingComponent, ErrorComponent, useDataView } from "@gooddata/sdk-ui";
+import { LoadingComponent, ErrorComponent, useExecutionDataView } from "@gooddata/sdk-ui";
 import toPairs from "lodash/toPairs";
 import groupBy from "lodash/groupBy";
 
@@ -20,7 +20,7 @@ export const UseDataViewAttributeValuesExample: React.FC = () => {
         .workspace(workspace)
         .execution()
         .forItems([Ldm.LocationState, Ldm.LocationName.Default]);
-    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+    const { result, error, status } = useExecutionDataView({ execution });
 
     let renderAttributeValues: React.ReactNode = null;
     if (result) {

--- a/examples/sdk-examples/src/examples/execution/UseDataViewExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewExample.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import React, { useState } from "react";
-import { LoadingComponent, ErrorComponent, useDataView, useExecution } from "@gooddata/sdk-ui";
+import { LoadingComponent, ErrorComponent, useExecutionDataView } from "@gooddata/sdk-ui";
 import { newMeasure } from "@gooddata/sdk-model";
 import { LdmExt } from "../../ldm";
 
@@ -27,10 +27,7 @@ export const UseDataViewExample: React.FC = () => {
 
     const measure = newMeasure(willFail ? "thisDoesNotExits" : LdmExt.totalSalesIdentifier);
     const seriesBy = [measure];
-    const execution = useExecution({
-        seriesBy,
-    });
-    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+    const { result, error, status } = useExecutionDataView({ execution: { seriesBy } });
 
     const measureSeries = result?.data().series().firstForMeasure(measure);
 

--- a/examples/sdk-examples/src/examples/execution/UseDataViewWithCustomVisualizationExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewWithCustomVisualizationExample.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
-import { LoadingComponent, ErrorComponent, useExecution, useDataView } from "@gooddata/sdk-ui";
+import { LoadingComponent, ErrorComponent, useExecutionDataView } from "@gooddata/sdk-ui";
 import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Legend, Bar } from "recharts";
 
 import * as LdmExt from "../../ldm/ext";
@@ -16,11 +16,7 @@ const slicesBy = [LdmExt.monthDate];
 const colors = ["rgb(20,178,226)", "rgb(0,193,141)", "rgb(229,77,66)"];
 
 export const UseDataViewWithCustomVisualizationExample: React.FC = () => {
-    const execution = useExecution({
-        seriesBy,
-        slicesBy,
-    });
-    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
+    const { result, error, status } = useExecutionDataView({ execution: { seriesBy, slicesBy } });
     const series = result?.data().series().toArray();
     const slices = result?.data().slices().toArray();
 

--- a/examples/sdk-examples/src/examples/execution/UseDataViewWithSlicesExample.tsx
+++ b/examples/sdk-examples/src/examples/execution/UseDataViewWithSlicesExample.tsx
@@ -1,6 +1,6 @@
 // (C) 2007-2019 GoodData Corporation
 import React from "react";
-import { ErrorComponent, LoadingComponent, useDataView, useExecution } from "@gooddata/sdk-ui";
+import { ErrorComponent, LoadingComponent, useExecutionDataView } from "@gooddata/sdk-ui";
 import { Ldm } from "../../ldm";
 import { newAttributeSort, newPositiveAttributeFilter } from "@gooddata/sdk-model";
 const style = { border: "1px black solid" };
@@ -11,13 +11,9 @@ const sortBy = [newAttributeSort(Ldm.LocationState, "asc")];
 const filters = [newPositiveAttributeFilter(Ldm.LocationState, ["Florida", "Texas"])];
 
 export const UseDataViewWithSlicesExample: React.FC = () => {
-    const execution = useExecution({
-        seriesBy,
-        slicesBy,
-        sortBy,
-        filters,
+    const { result, error, status } = useExecutionDataView({
+        execution: { seriesBy, slicesBy, sortBy, filters },
     });
-    const { result, error, status } = useDataView({ execution }, [execution?.fingerprint()]);
     const slices = result?.data().slices().toArray();
 
     return (

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -16,6 +16,7 @@ import { IBucket } from '@gooddata/sdk-model';
 import { IColor } from '@gooddata/sdk-model';
 import { IColorPalette } from '@gooddata/sdk-model';
 import { IDataView } from '@gooddata/sdk-backend-spi';
+import { IDimension } from '@gooddata/sdk-model';
 import { IDimensionDescriptor } from '@gooddata/sdk-backend-spi';
 import { IDimensionItemDescriptor } from '@gooddata/sdk-backend-spi';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
@@ -40,6 +41,7 @@ import { ISeparators as ISeparators_2 } from '@gooddata/numberjs';
 import { ISortItem } from '@gooddata/sdk-model';
 import { ITotal } from '@gooddata/sdk-model';
 import { ITotalDescriptor } from '@gooddata/sdk-backend-spi';
+import { ObjRef } from '@gooddata/sdk-model';
 import { default as React_2 } from 'react';
 import { WrappedComponentProps } from 'react-intl';
 
@@ -323,6 +325,9 @@ export class ErrorComponent extends React_2.Component<IErrorProps> {
 
 // @public
 export const Execute: React_2.ComponentType<IExecuteProps>;
+
+// @beta
+export const ExecuteInsight: React_2.ComponentType<IExecuteInsightProps>;
 
 // @internal
 export function fillMissingTitles<T extends IInsightDefinition>(insight: T, locale: ILocale, maxArithmeticMeasureTitleLength?: number): T;
@@ -761,6 +766,24 @@ export interface IExecuteErrorComponentProps {
     error: GoodDataSdkError;
 }
 
+// @beta (undocumented)
+export interface IExecuteInsightProps extends IWithLoadingEvents<IExecuteInsightProps> {
+    backend?: IAnalyticalBackend;
+    children: (executionResult: WithLoadingResult) => React_2.ReactElement | null;
+    componentName?: string;
+    dateFormat?: string | ((def: IExecutionDefinition, props: IExecuteInsightProps) => string);
+    dimensions?: IDimension[] | ((def: IExecutionDefinition, props: IExecuteInsightProps) => IDimension[]);
+    ErrorComponent?: IExecuteErrorComponent;
+    exportTitle?: string;
+    filters?: INullableFilter[];
+    insight: ObjRef;
+    LoadingComponent?: IExecuteLoadingComponent;
+    loadOnMount?: boolean;
+    sorts?: ISortItem[] | ((def: IExecutionDefinition, props: IExecuteInsightProps) => ISortItem[]);
+    window?: DataViewWindow;
+    workspace?: string;
+}
+
 // @public
 export type IExecuteLoadingComponent = ComponentType;
 
@@ -780,6 +803,16 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
     totals?: ITotal[];
     window?: DataViewWindow;
     workspace?: string;
+}
+
+// @beta (undocumented)
+export interface IExecutionConfiguration {
+    componentName?: string;
+    filters?: INullableFilter[];
+    seriesBy: IAttributeOrMeasure[];
+    slicesBy?: IAttribute[];
+    sortBy?: ISortItem[];
+    totals?: ITotal[];
 }
 
 // @alpha
@@ -1101,6 +1134,26 @@ export interface IUseExecutionConfig {
     workspace?: string;
 }
 
+// @beta (undocumented)
+export interface IUseExecutionDataViewConfig {
+    backend?: IAnalyticalBackend;
+    execution?: IPreparedExecution | IExecutionConfiguration;
+    window?: DataViewWindow;
+    workspace?: string;
+}
+
+// @beta (undocumented)
+export interface IUseInsightDataViewConfig {
+    backend?: IAnalyticalBackend;
+    dateFormat?: string | ((def: IExecutionDefinition) => string);
+    dimensions?: IDimension[] | ((def: IExecutionDefinition) => IDimension[]);
+    filters?: INullableFilter[];
+    insight?: ObjRef;
+    sorts?: ISortItem[] | ((def: IExecutionDefinition) => ISortItem[]);
+    window?: DataViewWindow;
+    workspace?: string;
+}
+
 // @public (undocumented)
 export interface IUsePagedResourceResult<TItem> extends IUsePagedResourceState<TItem> {
     // (undocumented)
@@ -1139,7 +1192,7 @@ export interface IVisualizationProps {
 // @internal
 export interface IWithExecution<T> {
     events?: IWithLoadingEvents<T> | ((props: T) => IWithLoadingEvents<T>);
-    execution: IPreparedExecution | ((props: T) => IPreparedExecution);
+    execution: IPreparedExecution | ((props: T) => IPreparedExecution) | ((props: T) => Promise<IPreparedExecution>);
     exportTitle: string | ((props: T) => string);
     loadOnMount?: boolean | ((props: T) => boolean);
     shouldRefetch?: (prevProps: T, nextProps: T) => boolean;
@@ -1240,6 +1293,14 @@ export class ProtectedReportSdkError extends GoodDataSdkError {
 // @public
 export const RawExecute: React_2.ComponentClass<IRawExecuteProps, any>;
 
+// @beta
+export function resolveUseCancelablePromisesError<TError>(states: UseCancelablePromiseState<unknown, TError>[]): TError | undefined;
+
+// @beta
+export function resolveUseCancelablePromisesStatus(cancelablePromisesStates: UseCancelablePromiseState<unknown, unknown>[], options?: {
+    strategy?: "serial" | "parallel";
+}): UseCancelablePromiseStatus;
+
 // @public (undocumented)
 export type SdkErrorType = keyof typeof ErrorCodes;
 
@@ -1277,7 +1338,7 @@ export function uriMatch(uri: string): IHeaderPredicate;
 export const useBackend: (backend?: IAnalyticalBackend | undefined) => IAnalyticalBackend | undefined;
 
 // @public
-export const useBackendStrict: (backend?: IAnalyticalBackend | undefined) => IAnalyticalBackend;
+export const useBackendStrict: (backend?: IAnalyticalBackend | undefined, context?: string) => IAnalyticalBackend;
 
 // @beta
 export function useCancelablePromise<TResult, TError = any>({ promise, onLoading, onPending, onCancel, onSuccess, onError, }: {
@@ -1354,6 +1415,12 @@ export type UseDataViewState = UseCancelablePromiseState<DataViewFacade, GoodDat
 // @beta
 export function useExecution(config: IUseExecutionConfig): IPreparedExecution;
 
+// @beta
+export function useExecutionDataView(config: IUseExecutionDataViewConfig, deps?: React.DependencyList): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+
+// @beta
+export function useInsightDataView(config: IUseInsightDataViewConfig, deps?: React.DependencyList): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+
 // @public
 export function usePagedResource<TParams, TItem>(resourceFactory: (params: TParams) => Promise<IPagedResource<TItem>>, fetchParams: TParams[], fetchDeps: React.DependencyList, resetDeps: React.DependencyList, getCacheKey?: (params: TParams) => string, initialState?: IUsePagedResourceState<TItem>): IUsePagedResourceResult<TItem>;
 
@@ -1361,7 +1428,7 @@ export function usePagedResource<TParams, TItem>(resourceFactory: (params: TPara
 export const useWorkspace: (workspace?: string | undefined) => string | undefined;
 
 // @public
-export const useWorkspaceStrict: (workspace?: string | undefined) => string;
+export const useWorkspaceStrict: (workspace?: string | undefined, context?: string) => string;
 
 // @public (undocumented)
 export type ValueFormatter = (value: DataValue, format: string) => string;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -82,6 +82,10 @@ export { withContexts } from "./react/withContexts";
 export { wrapDisplayName } from "./react/wrapDisplayName";
 export { CancelError, ICancelablePromise, makeCancelable, isCancelError } from "./react/CancelablePromise";
 export { withEntireDataView, ILoadingInjectedProps } from "./react/legacy/withEntireDataView";
+export {
+    resolveUseCancelablePromisesError,
+    resolveUseCancelablePromisesStatus,
+} from "./react/useCancelablePromiseUtils";
 
 /*
  * Localization exports

--- a/libs/sdk-ui/src/base/react/BackendContext.tsx
+++ b/libs/sdk-ui/src/base/react/BackendContext.tsx
@@ -65,14 +65,18 @@ export const useBackend = (backend?: IAnalyticalBackend): IAnalyticalBackend | u
  *
  *
  * @param backend - backend to use instead of context value. If undefined, the context value is used.
+ * @param context - optionally provide context to improve error message in raised invariant (e.g. parent hook name).
  * @public
  */
-export const useBackendStrict = (backend?: IAnalyticalBackend): IAnalyticalBackend => {
+export const useBackendStrict = (
+    backend?: IAnalyticalBackend,
+    context = "useBackendStrict",
+): IAnalyticalBackend => {
     const backendFromContext = React.useContext(BackendContext);
     const effectiveBackend = backend ?? backendFromContext;
     invariant(
         effectiveBackend,
-        "useBackendStrict: IAnalyticalBackend must be defined. Either pass it as a parameter or make sure there is a BackendProvider up the component tree.",
+        `${context}: IAnalyticalBackend must be defined. Either pass it as a parameter or make sure there is a BackendProvider up the component tree.`,
     );
     return effectiveBackend;
 };

--- a/libs/sdk-ui/src/base/react/WorkspaceContext.tsx
+++ b/libs/sdk-ui/src/base/react/WorkspaceContext.tsx
@@ -63,14 +63,15 @@ export const useWorkspace = (workspace?: string): string | undefined => {
  * const workspace = useWorkspaceStrict(fromArguments);
  *
  * @param workspace - workspace to use instead of context value. If undefined, the context value is used.
+ * @param context - optionally provide context to improve error message in raised invariant (e.g. parent hook name).
  * @public
  */
-export const useWorkspaceStrict = (workspace?: string): string => {
+export const useWorkspaceStrict = (workspace?: string, context = "useWorkspaceStrict"): string => {
     const workspaceFromContext = React.useContext(WorkspaceContext);
     const effectiveWorkspace = workspace ?? workspaceFromContext;
     invariant(
         effectiveWorkspace,
-        "useWorkspaceStrict: workspace must be defined. Either pass it as a parameter or make sure there is a WorkspaceProvider up the component tree.",
+        `${context}: workspace must be defined. Either pass it as a parameter or make sure there is a WorkspaceProvider up the component tree.`,
     );
     return effectiveWorkspace;
 };

--- a/libs/sdk-ui/src/base/react/tests/useCancelablePromiseUtils.test.ts
+++ b/libs/sdk-ui/src/base/react/tests/useCancelablePromiseUtils.test.ts
@@ -1,0 +1,112 @@
+// (C) 2019-2021 GoodData Corporation
+
+import {
+    resolveUseCancelablePromisesStatus,
+    resolveUseCancelablePromisesError,
+} from "../useCancelablePromiseUtils";
+import { UseCancelablePromiseState, UseCancelablePromiseStatus } from "../useCancelablePromise";
+import { GoodDataSdkError, UnexpectedSdkError } from "../../errors/GoodDataSdkError";
+
+const pendingState: UseCancelablePromiseState<unknown, GoodDataSdkError> = {
+    status: "pending",
+    result: undefined,
+    error: undefined,
+};
+
+const loadingState: UseCancelablePromiseState<unknown, GoodDataSdkError> = {
+    status: "loading",
+    result: undefined,
+    error: undefined,
+};
+
+const errorState: UseCancelablePromiseState<unknown, GoodDataSdkError> = {
+    status: "error",
+    result: undefined,
+    error: new UnexpectedSdkError(),
+};
+
+const successState: UseCancelablePromiseState<unknown, GoodDataSdkError> = {
+    status: "success",
+    result: true,
+    error: undefined,
+};
+
+describe("useCancelablePromiseUtils", () => {
+    describe("resolveUseCancelablePromisesStatus - serial", () => {
+        type Scenario = [
+            scenarioName: string,
+            expectedResult: UseCancelablePromiseStatus,
+            statuses: UseCancelablePromiseState<unknown, unknown>[],
+        ];
+
+        const scenarios: Scenario[] = [
+            ["short-cirtcuit to the first state, when it's pending", "pending", [pendingState, successState]],
+            ["short-cirtcuit to the first state, when it's loading", "loading", [loadingState, successState]],
+            ["short-cirtcuit to the first state, when it's error", "error", [errorState, successState]],
+            [
+                "continue to the second state, when first state is success",
+                "pending",
+                [successState, pendingState],
+            ],
+            [
+                "continue to the second state, when first state is success",
+                "loading",
+                [successState, loadingState],
+            ],
+            [
+                "continue to the second state, when first state is success",
+                "error",
+                [successState, errorState],
+            ],
+            ["return success, when all states are success", "success", [successState, successState]],
+            ["handle also single state", "success", [successState]],
+        ];
+
+        it.each(scenarios)("should %s", (_, expectedResult, statuses) => {
+            expect(resolveUseCancelablePromisesStatus(statuses)).toBe(expectedResult);
+        });
+    });
+
+    describe("resolveUseCancelablePromisesStatus - parallel", () => {
+        type Scenario = [
+            scenarioName: string,
+            expectedResult: UseCancelablePromiseStatus,
+            statuses: UseCancelablePromiseState<unknown, unknown>[],
+        ];
+
+        const scenarios: Scenario[] = [
+            ["when any state is pending", "pending", [successState, pendingState]],
+            ["when any state is loading", "loading", [successState, loadingState]],
+            ["when any state is error", "error", [successState, errorState]],
+            ["when all states are success", "success", [successState, successState]],
+            ["for single state success", "success", [successState]],
+        ];
+
+        it.each(scenarios)("%s should return status: %s", (_, expectedResult, statuses) => {
+            expect(resolveUseCancelablePromisesStatus(statuses, { strategy: "parallel" })).toBe(
+                expectedResult,
+            );
+        });
+    });
+
+    describe("resolveUseCancelablePromisesError", () => {
+        type Scenario = [
+            scenarioName: string,
+            expectedResult: GoodDataSdkError | undefined,
+            statuses: UseCancelablePromiseState<unknown, unknown>[],
+        ];
+
+        const scenarios: Scenario[] = [
+            ["should return first error", errorState.error, [successState, errorState]],
+            [
+                "should return undefined when error state is not present",
+                undefined,
+                [successState, pendingState, loadingState],
+            ],
+        ];
+
+        it.each(scenarios)("%s", (_, expectedResult, errors) => {
+            expect(resolveUseCancelablePromisesError(errors)).toBe(expectedResult);
+        });
+    });
+});

--- a/libs/sdk-ui/src/base/react/useCancelablePromiseUtils.ts
+++ b/libs/sdk-ui/src/base/react/useCancelablePromiseUtils.ts
@@ -1,0 +1,122 @@
+// (C) 2019-2021 GoodData Corporation
+import identity from "lodash/identity";
+import { UseCancelablePromiseState, UseCancelablePromiseStatus } from "./useCancelablePromise";
+import { UnexpectedSdkError } from "../errors/GoodDataSdkError";
+
+/**
+ * Resolve status of multiple useCancelablePromise hooks.
+ *
+ * This is useful for useCancelablePromise composition - when you want to wrap multiple useCancelablePromise hooks in another hook,
+ * and keep the return value shape of the hook same as for useCancelablePromise.
+ *
+ * You can choose between 2 strategies to resolve the status (default strategy is "serial"):
+ * - serial: Short-circuits to the first pending/loading/error status, and returns the last status
+ *   only when all previous statuses are "success".
+ * - parallel: Is resolved to the status which has the highest priority.
+ *   Priority of the statuses has the following order (from highest to lowest): pending, loading, error, success.
+ *   Examples:
+ *     - ["pending", "loading"] will be resolved to "pending"
+ *     - ["loading", "error"] will be resolved to "loading"
+ *     - ["error", "success"] will be resolved to "error"
+ *     - ["success", "success"] will be resolved to "success"
+ *
+ * @param states - cancelable promise states (useCancelablePromise return values)
+ * @param options - optionally specify options for resolving the status
+ * @returns resolved status
+ * @beta
+ */
+export function resolveUseCancelablePromisesStatus(
+    cancelablePromisesStates: UseCancelablePromiseState<unknown, unknown>[],
+    options: {
+        strategy?: "serial" | "parallel";
+    } = {},
+): UseCancelablePromiseStatus {
+    const statuses = collectUseCancelablePromiseStatuses(cancelablePromisesStates);
+    const strategy = options.strategy ?? "serial";
+
+    return strategy === "parallel"
+        ? resolveUseCancelablePromisesStatusParallel(statuses)
+        : resolveUseCancelablePromisesStatusSerial(statuses);
+}
+
+/**
+ * Resolve error of multiple useCancelablePromise hooks - gets first error in the sequence of cancelable promise states.
+ *
+ * This is useful for useCancelablePromise composition - when you want to wrap multiple useCancelablePromise hooks in another hook,
+ * and keep the return value shape of the hook same as for useCancelablePromise.
+ *
+ * @param states - cancelable promise states (useCancelablePromise return values)
+ * @returns first error
+ * @beta
+ */
+export function resolveUseCancelablePromisesError<TError>(
+    states: UseCancelablePromiseState<unknown, TError>[],
+): TError | undefined {
+    const errors = collectUseCancelablePromiseErrors(states);
+    return errors.find(identity);
+}
+
+/**
+ * @internal
+ */
+export function resolveUseCancelablePromisesStatusSerial(
+    statuses: UseCancelablePromiseStatus[],
+): UseCancelablePromiseStatus {
+    return statuses.reduce((prevStatus, nextStatus) => {
+        switch (prevStatus) {
+            case "pending":
+            case "loading":
+            case "error":
+                return prevStatus;
+            case "success":
+                return nextStatus;
+            default: {
+                const a: never = prevStatus;
+                throw new UnexpectedSdkError(`Unknown useCancelablePromise status: ${a}`);
+            }
+        }
+    });
+}
+
+const priorityByStatus: { [status in UseCancelablePromiseStatus]: number } = {
+    pending: 0,
+    loading: 1,
+    error: 2,
+    success: 3,
+};
+
+function compareStatus(a: UseCancelablePromiseStatus, b: UseCancelablePromiseStatus): number {
+    const aPriority = priorityByStatus[a];
+    const bPriority = priorityByStatus[b];
+
+    if (aPriority < bPriority) {
+        return -1;
+    }
+    if (aPriority > bPriority) {
+        return 1;
+    }
+
+    return 0;
+}
+
+/**
+ * @internal
+ */
+export function resolveUseCancelablePromisesStatusParallel(
+    statuses: UseCancelablePromiseStatus[],
+): UseCancelablePromiseStatus {
+    const [finalStatus] = [...statuses].sort(compareStatus);
+    return finalStatus;
+}
+
+function collectUseCancelablePromiseStatuses(
+    results: UseCancelablePromiseState<unknown, unknown>[],
+): UseCancelablePromiseStatus[] {
+    return results.map((r) => r.status);
+}
+
+function collectUseCancelablePromiseErrors<TError>(
+    results: UseCancelablePromiseState<unknown, TError>[],
+): Array<TError | undefined> {
+    return results.map((r) => r.error);
+}

--- a/libs/sdk-ui/src/execution/ExecuteInsight.tsx
+++ b/libs/sdk-ui/src/execution/ExecuteInsight.tsx
@@ -1,0 +1,232 @@
+// (C) 2019 GoodData Corporation
+import React from "react";
+import { withExecution } from "./withExecution";
+import { DataViewWindow, IWithLoadingEvents, WithLoadingResult } from "./withExecutionLoading";
+import { IDimension, IExecutionDefinition, INullableFilter, ISortItem, ObjRef } from "@gooddata/sdk-model";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import isEqual from "lodash/isEqual";
+import { withContexts } from "../base";
+import { IExecuteErrorComponent, IExecuteLoadingComponent } from "./interfaces";
+import invariant from "ts-invariant";
+
+/**
+ * @beta
+ */
+export interface IExecuteInsightProps extends IWithLoadingEvents<IExecuteInsightProps> {
+    /**
+     * Backend to execute against.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace in whose context to perform the execution.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+
+    /**
+     * Reference to the insight for which you want to get the data view.
+     */
+    insight: ObjRef;
+
+    /**
+     * Optionally modify sorts on prepared insight execution, before it's executed.
+     */
+    sorts?: ISortItem[] | ((def: IExecutionDefinition, props: IExecuteInsightProps) => ISortItem[]);
+
+    /**
+     * Optionally modify dimensions on prepared insight execution, before it's executed.
+     */
+    dimensions?: IDimension[] | ((def: IExecutionDefinition, props: IExecuteInsightProps) => IDimension[]);
+
+    /**
+     * Optionally modify date formatting on prepared insight execution, before it's executed.
+     */
+    dateFormat?: string | ((def: IExecutionDefinition, props: IExecuteInsightProps) => string);
+
+    /**
+     * Optional filters to apply on server side.
+     */
+    filters?: INullableFilter[];
+
+    /**
+     * Optional name to use for files exported from this component. If you do not specify this, then
+     * the componentName will be used instead.
+     *
+     * Note: it is also possible to pass custom name to the export function that will be sent via the
+     * onExportReady callback. That approach is preferred if you need to assign the names in an ad-hoc
+     * fashion.
+     */
+    exportTitle?: string;
+
+    /**
+     * Optional informative name of the component. This value is sent as telemetry information together
+     * with the actual execution request. We recommend to set this because it can be useful for diagnostic
+     * purposes.
+     *
+     * Defaults 'Execute'.
+     */
+    componentName?: string;
+
+    /**
+     * Specifies whether `Execute` should trigger execution and loading right after it is
+     * mounted. If not specified defaults to `true`.
+     *
+     * If set to `false`, then the {@link WithLoadingResult#reload} function needs to be called
+     * to trigger the execution and loading.
+     */
+    loadOnMount?: boolean;
+
+    /**
+     * Specifies whether `Execute` should load all data from backend or just a particular window - specified by
+     * offset and size of the window.
+     *
+     * If not specified, all data will be loaded.
+     */
+    window?: DataViewWindow;
+
+    /**
+     * Child component to which rendering is delegated. This is a function that will be called
+     * every time state of execution and data loading changes.
+     *
+     * @param executionResult - execution result, indicating state and/or results
+     */
+    children: (executionResult: WithLoadingResult) => React.ReactElement | null;
+
+    /**
+     * Optionally provide component for rendering of the loading state.
+     *
+     * Note: When you provide both LoadingComponent and ErrorComponent, the children function with the execution result
+     * will be called only with a successful result.
+     */
+    LoadingComponent?: IExecuteLoadingComponent;
+
+    /**
+     * Optionally provide component for rendering of the error state.
+     *
+     * Note: When you provide both LoadingComponent and ErrorComponent, the children function with the execution result
+     * will be called only with a successful result.
+     */
+    ErrorComponent?: IExecuteErrorComponent;
+}
+
+type Props = IExecuteInsightProps & WithLoadingResult;
+
+const CoreExecute: React.FC<Props> = (props: Props) => {
+    const { children, error, isLoading, reload, result, LoadingComponent, ErrorComponent } = props;
+
+    if (ErrorComponent && error) {
+        return <ErrorComponent error={error} />;
+    }
+
+    if (LoadingComponent && isLoading) {
+        return <LoadingComponent />;
+    }
+
+    if (LoadingComponent && ErrorComponent && !result) {
+        return null;
+    }
+
+    return children({
+        error,
+        isLoading,
+        reload,
+        result,
+    });
+};
+
+function componentName(props: IExecuteInsightProps): string {
+    return props.componentName || "ExecuteInsight";
+}
+
+function exportTitle(props: IExecuteInsightProps): string {
+    return props.exportTitle || componentName(props);
+}
+
+/**
+ * Gets data for a specific stored insight.
+ *
+ * @beta
+ */
+export const ExecuteInsight = withContexts(
+    withExecution<IExecuteInsightProps>({
+        exportTitle,
+        execution: async (props) => {
+            const { insight: insightRef, filters, sorts, dimensions, dateFormat, backend, workspace } = props;
+            invariant(
+                backend,
+                "The backend in ExecuteInsight must be defined. Either pass it as a prop or make sure there is a BackendProvider up the component tree.",
+            );
+            invariant(
+                workspace,
+                "The workspace in ExecuteInsight must be defined. Either pass it as a prop or make sure there is a WorkspaceProvider up the component tree.",
+            );
+
+            const insight = await backend.workspace(workspace).insights().getInsight(insightRef);
+            let insightExecution = backend.workspace(workspace).execution().forInsightByRef(insight, filters);
+
+            if (sorts) {
+                const resolvedSorts =
+                    typeof sorts === "function" ? sorts(insightExecution.definition, props) : sorts;
+                insightExecution = insightExecution.withSorting(...resolvedSorts);
+            }
+            if (dimensions) {
+                const resolvedDimensions =
+                    typeof dimensions === "function"
+                        ? dimensions(insightExecution.definition, props)
+                        : dimensions;
+                insightExecution = insightExecution.withDimensions(...resolvedDimensions);
+            }
+            if (dateFormat) {
+                const resolvedDateFormat =
+                    typeof dateFormat === "function"
+                        ? dateFormat(insightExecution.definition, props)
+                        : dateFormat;
+                insightExecution = insightExecution.withDateFormat(resolvedDateFormat);
+            }
+
+            return insightExecution;
+        },
+        events: (props: IExecuteInsightProps) => {
+            const { onError, onLoadingChanged, onLoadingFinish, onLoadingStart, onExportReady } = props;
+
+            return {
+                onError,
+                onLoadingChanged,
+                onLoadingFinish,
+                onLoadingStart,
+                onExportReady,
+            };
+        },
+        shouldRefetch: (prevProps: IExecuteInsightProps, nextProps: IExecuteInsightProps) => {
+            const relevantProps: Array<keyof IExecuteInsightProps> = [
+                "onError",
+                "onLoadingChanged",
+                "onLoadingFinish",
+                "onLoadingStart",
+            ];
+
+            const relevantPropsDeepEqual: Array<keyof IExecuteInsightProps> = [
+                "insight",
+                "filters",
+                "window",
+            ];
+
+            return (
+                relevantProps.some((propName) => prevProps[propName] !== nextProps[propName]) ||
+                relevantPropsDeepEqual.some((propName) => !isEqual(prevProps[propName], nextProps[propName]))
+            );
+        },
+        loadOnMount: (props?: IExecuteInsightProps) => {
+            const { loadOnMount = true } = props ?? {};
+
+            return loadOnMount;
+        },
+        window: (props: IExecuteInsightProps) => props.window,
+    })(CoreExecute),
+);

--- a/libs/sdk-ui/src/execution/index.ts
+++ b/libs/sdk-ui/src/execution/index.ts
@@ -13,4 +13,11 @@ export { Execute, IExecuteProps } from "./Execute";
 export { useDataExport, UseDataExportCallbacks, UseDataExportState } from "./useDataExport";
 export { useDataView, UseDataViewCallbacks, UseDataViewState } from "./useDataView";
 export { useExecution, IUseExecutionConfig } from "./useExecution";
+export {
+    IExecutionConfiguration,
+    IUseExecutionDataViewConfig,
+    useExecutionDataView,
+} from "./useExecutionDataView";
+export { IUseInsightDataViewConfig, useInsightDataView } from "./useInsightDataView";
+export { ExecuteInsight, IExecuteInsightProps } from "./ExecuteInsight";
 export { IExecuteErrorComponent, IExecuteErrorComponentProps, IExecuteLoadingComponent } from "./interfaces";

--- a/libs/sdk-ui/src/execution/useExecutionDataView.ts
+++ b/libs/sdk-ui/src/execution/useExecutionDataView.ts
@@ -1,0 +1,119 @@
+// (C) 2019-2021 GoodData Corporation
+import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
+import { IAttribute, IAttributeOrMeasure, INullableFilter, ISortItem, ITotal } from "@gooddata/sdk-model";
+import { DataViewWindow } from "./withExecutionLoading";
+import {
+    DataViewFacade,
+    GoodDataSdkError,
+    useBackendStrict,
+    useWorkspaceStrict,
+    UseCancelablePromiseState,
+} from "../base";
+import { useDataView } from "./useDataView";
+import isEmpty from "lodash/isEmpty";
+import { createExecution } from "./createExecution";
+
+/**
+ * @beta
+ */
+export interface IExecutionConfiguration {
+    /**
+     * Data series will be built using the provided measures that are optionally further scoped for
+     * elements of the specified attributes.
+     */
+    seriesBy: IAttributeOrMeasure[];
+
+    /**
+     * Optionally slice all data series by elements of these attributes.
+     */
+    slicesBy?: IAttribute[];
+
+    /**
+     * Optionally include these totals among the data slices.
+     */
+    totals?: ITotal[];
+
+    /**
+     * Optional filters to apply on server side.
+     */
+    filters?: INullableFilter[];
+
+    /**
+     * Optional sorting to apply on server side.
+     */
+    sortBy?: ISortItem[];
+
+    /**
+     * Optional informative name of the component. This value is sent as telemetry information together
+     * with the actual execution request. We recommend to set this because it can be useful for diagnostic
+     * purposes.
+     *
+     * Defaults 'Execute'.
+     */
+    componentName?: string;
+}
+
+/**
+ * @internal
+ */
+function isExecutionConfiguration(obj: unknown): obj is IExecutionConfiguration {
+    return !isEmpty(obj) && !!(obj as IExecutionConfiguration)?.seriesBy;
+}
+
+/**
+ * @beta
+ */
+export interface IUseExecutionDataViewConfig {
+    /**
+     * Prepared execution, or execution configuration for which you want to get the data view.
+     */
+    execution?: IPreparedExecution | IExecutionConfiguration;
+
+    /**
+     * Optionally, you can define only a specific "window" of data to load.
+     * This is useful if you want to page data.
+     */
+    window?: DataViewWindow;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where execution should be executed.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * React hook to get data for a specific execution.
+ *
+ * @beta
+ */
+export function useExecutionDataView(
+    config: IUseExecutionDataViewConfig,
+    deps?: React.DependencyList,
+): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
+    const { execution, window } = config;
+    const backend = useBackendStrict(config.backend, "useExecutionDataView");
+    const workspace = useWorkspaceStrict(config.workspace, "useExecutionDataView");
+    const effectiveDeps = deps ?? [];
+
+    const preparedExecution = isExecutionConfiguration(execution)
+        ? createExecution({ ...execution, backend, workspace })
+        : execution;
+
+    return useDataView({ execution: preparedExecution, window }, [
+        backend,
+        workspace,
+        preparedExecution?.fingerprint() ?? "__executionFingerprint__",
+        ...effectiveDeps,
+    ]);
+}

--- a/libs/sdk-ui/src/execution/useInsight.ts
+++ b/libs/sdk-ui/src/execution/useInsight.ts
@@ -1,0 +1,56 @@
+// (C) 2019-2021 GoodData Corporation
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IInsight, ObjRef, objRefToString } from "@gooddata/sdk-model";
+import {
+    useBackendStrict,
+    useWorkspaceStrict,
+    useCancelablePromise,
+    UseCancelablePromiseState,
+    GoodDataSdkError,
+} from "../base";
+
+/**
+ * @internal
+ */
+export interface IUseInsightConfig {
+    /**
+     * Insight reference - when the reference is not provided, hook is locked in a "pending" state.
+     */
+    insight?: ObjRef;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where execution should be executed.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * @internal
+ */
+export function useInsight(
+    config: IUseInsightConfig,
+    deps?: React.DependencyList,
+): UseCancelablePromiseState<IInsight, GoodDataSdkError> {
+    const { insight } = config;
+    const backend = useBackendStrict(config.backend, "useInsight");
+    const workspace = useWorkspaceStrict(config.workspace, "useInsight");
+    const promise = insight ? () => backend.workspace(workspace).insights().getInsight(insight) : null;
+
+    return useCancelablePromise({ promise }, [
+        backend,
+        workspace,
+        insight ? objRefToString(insight) : "__insightRef__",
+        ...(deps ?? []),
+    ]);
+}

--- a/libs/sdk-ui/src/execution/useInsightDataView.ts
+++ b/libs/sdk-ui/src/execution/useInsightDataView.ts
@@ -1,0 +1,125 @@
+// (C) 2019-2021 GoodData Corporation
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IDimension, IExecutionDefinition, INullableFilter, ISortItem, ObjRef } from "@gooddata/sdk-model";
+import {
+    useBackendStrict,
+    useWorkspaceStrict,
+    resolveUseCancelablePromisesStatus,
+    resolveUseCancelablePromisesError,
+    UseCancelablePromiseState,
+    DataViewFacade,
+    GoodDataSdkError,
+} from "../base";
+import { useExecutionDataView } from "./useExecutionDataView";
+import { DataViewWindow } from "./withExecutionLoading";
+import { useInsight } from "./useInsight";
+
+/**
+ * @beta
+ */
+export interface IUseInsightDataViewConfig {
+    /**
+     * Reference to the insight for which you want to get the data view.
+     *
+     * Note: When the reference or identifier is not provided, hook is locked in a "pending" state.
+     */
+    insight?: ObjRef;
+
+    /**
+     * Optionally modify sorts on prepared insight execution, before it's executed.
+     */
+    sorts?: ISortItem[] | ((def: IExecutionDefinition) => ISortItem[]);
+
+    /**
+     * Optionally modify dimensions on prepared insight execution, before it's executed.
+     */
+    dimensions?: IDimension[] | ((def: IExecutionDefinition) => IDimension[]);
+
+    /**
+     * Optionally modify date formatting on prepared insight execution, before it's executed.
+     */
+    dateFormat?: string | ((def: IExecutionDefinition) => string);
+
+    /**
+     * Optionally specify filters to merge with filters already defined in the insight.
+     */
+    filters?: INullableFilter[];
+
+    /**
+     * Optionally, you can define only a specific "window" of data to load.
+     * This is useful if you want to page data.
+     */
+    window?: DataViewWindow;
+
+    /**
+     * Backend to work with.
+     *
+     * Note: the backend must come either from this property or from BackendContext. If you do not specify
+     * backend here, then the executor MUST be rendered within an existing BackendContext.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Workspace where execution should be executed.
+     *
+     * Note: the workspace must come either from this property or from WorkspaceContext. If you do not specify
+     * workspace here, then the executor MUST be rendered within an existing WorkspaceContext.
+     */
+    workspace?: string;
+}
+
+/**
+ * React hook to get data for a specific insight.
+ *
+ * @beta
+ */
+export function useInsightDataView(
+    config: IUseInsightDataViewConfig,
+    deps?: React.DependencyList,
+): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
+    const { insight: insightRef, sorts, dateFormat, dimensions, filters, window } = config;
+    const backend = useBackendStrict(config.backend, "useInsightDataView");
+    const workspace = useWorkspaceStrict(config.workspace, "useInsightDataView");
+    const effectiveDeps = deps ?? [];
+
+    const insightPromise = useInsight({ insight: insightRef, backend, workspace }, effectiveDeps);
+
+    let insightExecution =
+        insightPromise.result &&
+        backend.workspace(workspace).execution().forInsightByRef(insightPromise.result, filters);
+
+    if (insightExecution) {
+        if (sorts) {
+            const resolvedSorts = typeof sorts === "function" ? sorts(insightExecution.definition) : sorts;
+            insightExecution = insightExecution.withSorting(...resolvedSorts);
+        }
+        if (dimensions) {
+            const resolvedDimensions =
+                typeof dimensions === "function" ? dimensions(insightExecution.definition) : dimensions;
+            insightExecution = insightExecution.withDimensions(...resolvedDimensions);
+        }
+        if (dateFormat) {
+            const resolvedDateFormat =
+                typeof dateFormat === "function" ? dateFormat(insightExecution.definition) : dateFormat;
+            insightExecution = insightExecution.withDateFormat(resolvedDateFormat);
+        }
+    }
+
+    const executionDataViewPromise = useExecutionDataView(
+        {
+            execution: insightExecution,
+            window,
+            backend,
+            workspace,
+        },
+        deps,
+    );
+
+    const cancelablePromises = [insightPromise, executionDataViewPromise];
+
+    return {
+        result: executionDataViewPromise.result,
+        error: resolveUseCancelablePromisesError(cancelablePromises),
+        status: resolveUseCancelablePromisesStatus(cancelablePromises),
+    } as UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+}

--- a/libs/sdk-ui/src/execution/withExecution.ts
+++ b/libs/sdk-ui/src/execution/withExecution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IPreparedExecution, isNoDataError } from "@gooddata/sdk-backend-spi";
 import {
     withExecutionLoading,
@@ -21,7 +21,10 @@ export interface IWithExecution<T> {
     /**
      * Specify execution that the HOC will drive.
      */
-    execution: IPreparedExecution | ((props: T) => IPreparedExecution);
+    execution:
+        | IPreparedExecution
+        | ((props: T) => IPreparedExecution)
+        | ((props: T) => Promise<IPreparedExecution>);
 
     /**
      * Specify export title that will be used unless the export function caller sends their own custom title.
@@ -75,7 +78,7 @@ export function withExecution<T>(
     return (WrappedComponent: React.ComponentType<T & WithLoadingResult>) => {
         const withLoadingParams = {
             promiseFactory: async (props: T, window?: DataViewWindow) => {
-                const _execution = typeof execution === "function" ? execution(props) : execution;
+                const _execution = typeof execution === "function" ? await execution(props) : execution;
                 const executionResult = await _execution.execute();
                 try {
                     const dataView = !window


### PR DESCRIPTION
- Add ExecuteInsight component, which makes it easier to get data for a specific insight
- Add useInsightDataView hook as an alternative to ExecuteInsight component
- Add useExecutionDataView hook, which makes it easier to get data for a specific execution (combines useExecution & useDataView hooks and also supports an interface for execution similar to the Execution component)
- Add few utility functions for easier useCancelablePromise composition

JIRA: RAIL-2739

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
