### PR TITLE
RELATED: RAIL-3302, RAIL-3308 small InsightView fixes

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -82,6 +82,11 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
             return;
         }
 
+        // if there is no insight, bail early
+        if (!this.props.insight) {
+            return;
+        }
+
         const { config = {} } = this.props;
         const { responsiveUiDateFormat } = this.props.settings ?? {};
 
@@ -111,6 +116,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
     };
 
     private setupVisualization = async () => {
+        // if there is no insight, bail early
         if (!this.props.insight) {
             return;
         }

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -218,14 +218,16 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         this.props.onError?.(error);
     };
 
-    private resolveInsightTitle = (insight: IInsight): string | undefined => {
+    private resolveInsightTitle = (insight: IInsight | undefined): string | undefined => {
         switch (typeof this.props.showTitle) {
             case "string":
-                return this.props.showTitle ? this.props.showTitle : undefined;
+                return this.props.showTitle;
             case "boolean":
-                return this.props.showTitle && insight ? insightTitle(insight) : undefined;
+                return !this.state.isDataLoading && this.props.showTitle && insight
+                    ? insightTitle(insight)
+                    : undefined;
             case "function":
-                return this.props.showTitle(insight);
+                return !this.state.isDataLoading && insight && this.props.showTitle(insight);
             default:
                 return undefined;
         }
@@ -235,11 +237,11 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         const { LoadingComponent, TitleComponent } = this.props;
         const { error, isDataLoading, isVisualizationLoading } = this.state;
 
+        const resolvedTitle = this.resolveInsightTitle(this.state.insight);
+
         return (
             <div className="insight-view-container">
-                {!isDataLoading && this.state.insight && (
-                    <TitleComponent title={this.resolveInsightTitle(this.state.insight)} />
-                )}
+                {resolvedTitle && <TitleComponent title={resolvedTitle} />}
                 {(isDataLoading || isVisualizationLoading) && (
                     <div className="insight-view-loader">
                         <LoadingComponent />

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -191,6 +191,13 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
 
         const needsNewColorPalette = this.props.workspace !== prevProps.workspace;
 
+        if (this.props.workspace !== prevProps.workspace) {
+            // if workspace changed, clear the insight as it is definitely wrong
+            // this prevents wrong renders with mismatching insight and workspace
+            // (as workspace changes immediately, but insight change is async)
+            this.setState({ insight: undefined });
+        }
+
         if (needsNewSetup || needsNewColorPalette) {
             this.startDataLoading();
             await Promise.all(


### PR DESCRIPTION
* RAIL-3302 - prevent inconsistent state in certain LCM scenarios
* RAIL-3308 - improve UX of insight title when provided as a constant

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
