### PR TITLE
RELATED: RAIL-3317 Pin mapbox-gl to ^1.13.1

### DIFF
--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -66,7 +66,7 @@
         "classnames": "^2.3.1",
         "custom-event": "^1.0.1",
         "lodash": "^4.17.19",
-        "mapbox-gl": "^1.9.1",
+        "mapbox-gl": "^1.13.1",
         "react-intl": "^3.6.0",
         "react-measure": "^2.3.0",
         "ts-invariant": "^0.7.3",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -134,7 +134,7 @@
         "eslint-plugin-react-hooks": "^4.0.8",
         "eslint-plugin-react": "^7.20.5",
         "eslint": "^7.5.0",
-        "mapbox-gl": "^1.9.1",
+        "mapbox-gl": "^1.13.1",
         "prettier": "~2.2.1",
         "react-dom": "^16.10.0",
         "react": "^16.10.0",


### PR DESCRIPTION
This version fixes an issue with attribution icon missing in 1.12.0.
The 1.13.1 was already used by the SDK (so no changes to the lockfile).

We pin mapbox-gl to newer version so that our users are not affected
by the bug as well.

JIRA: RAIL-3317

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
