### PR TITLE
RELATED: FET-723 avoid lodash/get in the rest of the packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,11 @@ module.exports = {
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
         "import/order": "off",
+        "no-restricted-imports": [
+            "error",
+            {
+                paths: [{ name: "lodash/get", message: "Please use the ?. and ?? operators instead." }],
+            },
+        ],
     },
 };

--- a/common/config/dep-cruiser/default.config.js
+++ b/common/config/dep-cruiser/default.config.js
@@ -169,15 +169,7 @@ const DefaultRules = [
         from: {},
         to: { path: "lodash/lodash.js", dependencyTypes: ["npm"] },
     },
-    {
-        name: "not-to-lodash-get",
-        comment:
-            "This module depends on the lodash/get function. Please use the ?. and ?? operators instead." +
-            "This helps with keeping the type information sane and makes refactors easier (less magic strings)",
-        severity: "error",
-        from: {},
-        to: { path: "lodash/get.js", dependencyTypes: ["npm"] },
-    },
+    noLodashGet(),
     {
         name: "not-to-whole-date-fns",
         comment:
@@ -345,10 +337,30 @@ function moduleWithDependencies(module, dir, deps) {
     };
 }
 
+/**
+ * Creates dep cruiser rule which will ensure that code in particular package will not import lodash/get.
+ * Optionally, you can specify exceptions where the lodash/get will be allowed (if there is no workaround there).
+ * @param {RegExp|String|RegExp[]|String[]} exceptions exceptions where importing the lodash/get will be allowed
+ * @returns
+ */
+function noLodashGet(exceptions) {
+    const from = exceptions ? { pathNot: exceptions } : {};
+    return {
+        name: "not-to-lodash-get",
+        comment:
+            "This module depends on the lodash/get function. Please use the ?. and ?? operators instead." +
+            "This helps with keeping the type information sane and makes refactors easier (less magic strings)",
+        severity: "error",
+        from,
+        to: { path: "lodash/get.js", dependencyTypes: ["npm"] },
+    };
+}
+
 module.exports = {
     DefaultRules,
     DefaultOptions,
     DefaultSdkRules,
     isolatedSubmodule,
     moduleWithDependencies,
+    noLodashGet,
 };

--- a/libs/api-client-bear/.dependency-cruiser.js
+++ b/libs/api-client-bear/.dependency-cruiser.js
@@ -1,11 +1,7 @@
 const depCruiser = require("../../common/config/dep-cruiser/default.config");
 
 options = {
-    forbidden: [
-        // api-client-bear relies on string based paths quite heavily, refactoring is not feasible now
-        ...depCruiser.DefaultRules.filter((rule) => rule.name !== "not-to-lodash-get"),
-        ...depCruiser.DefaultSdkRules,
-    ],
+    forbidden: [...depCruiser.DefaultRules, ...depCruiser.DefaultSdkRules],
     options: depCruiser.DefaultOptions,
 };
 

--- a/libs/api-client-bear/src/catalogue.ts
+++ b/libs/api-client-bear/src/catalogue.ts
@@ -1,5 +1,4 @@
 // (C) 2007-2021 GoodData Corporation
-import get from "lodash/get";
 import find from "lodash/find";
 import omit from "lodash/omit";
 import omitBy from "lodash/omitBy";
@@ -41,20 +40,20 @@ const LOAD_DATE_DATASET_DEFAULTS = {
  * </ul>
  * @returns {Object} "requiredDataSets" object hash.
  */
-const getRequiredDataSets = (options: any) => {
-    if (get(options, "returnAllRelatedDateDataSets")) {
+const getRequiredDataSets = (options: GdcCatalog.ILoadDateDataSetsParams = {}) => {
+    if (options.returnAllRelatedDateDataSets) {
         return {};
     }
 
-    if (get(options, "returnAllDateDataSets")) {
+    if (options.returnAllDateDataSets) {
         return { requiredDataSets: { type: "ALL" } };
     }
 
-    if (get(options, "dataSetIdentifier")) {
+    if (options.dataSetIdentifier) {
         return {
             requiredDataSets: {
                 type: "CUSTOM",
-                customIdentifiers: [get(options, "dataSetIdentifier")],
+                customIdentifiers: [options.dataSetIdentifier],
             },
         };
     }
@@ -77,7 +76,7 @@ const buildItemDescriptionObjects = ({ columns, definitions }: IColumnsAndDefini
             definitions,
             ({ metricDefinition }) => metricDefinition.identifier === column,
         );
-        const maql = get(definition, "metricDefinition.expression");
+        const maql = definition?.metricDefinition?.expression;
         if (maql) {
             return { expression: maql };
         }
@@ -198,7 +197,7 @@ export class CatalogueModule {
     }
 
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    public loadItems(projectId: string, options = {}) {
+    public loadItems(projectId: string, options: any = {}) {
         const request = omit(
             {
                 ...REQUEST_DEFAULTS,
@@ -208,9 +207,9 @@ export class CatalogueModule {
             ["dataSetIdentifier", "returnAllDateDataSets", "attributesMap"],
         );
 
-        const mdObj = get(cloneDeep(options), "bucketItems");
-        const attributesMap = get(options, "attributesMap");
-        const hasBuckets = get(mdObj, "buckets") !== undefined;
+        const mdObj = cloneDeep(options)?.bucketItems;
+        const attributesMap = options?.attributesMap;
+        const hasBuckets = mdObj?.buckets !== undefined;
         if (hasBuckets) {
             return this.loadItemDescriptions(projectId, mdObj, attributesMap).then((bucketItems: any) =>
                 this.loadCatalog(projectId, { ...request, bucketItems }),
@@ -229,7 +228,7 @@ export class CatalogueModule {
     }> {
         const mdObj = cloneDeep(options).bucketItems;
         const bucketItems = mdObj
-            ? await this.loadItemDescriptions(projectId, mdObj, get(options, "attributesMap")!)
+            ? await this.loadItemDescriptions(projectId, mdObj, options.attributesMap!)
             : undefined;
 
         const omittedOptions = [

--- a/libs/api-client-bear/src/config.ts
+++ b/libs/api-client-bear/src/config.ts
@@ -1,6 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
 import set from "lodash/set";
-import get from "lodash/get";
 
 /**
  * Config module holds SDK configuration variables
@@ -54,6 +53,7 @@ export interface IOriginPackage {
 export interface IConfigStorage {
     domain?: string;
     originPackage?: IOriginPackage;
+    xhrSettings?: { headers?: Record<string, string> };
 }
 
 /**
@@ -122,7 +122,7 @@ export class ConfigModule {
         set(this.configStorage, ["xhrSettings", "headers", key], value);
     }
 
-    public getRequestHeader(key: string): string {
-        return get(this.configStorage, ["xhrSettings", "headers", key]);
+    public getRequestHeader(key: string): string | undefined {
+        return this.configStorage?.xhrSettings?.headers?.[key];
     }
 }

--- a/libs/api-client-bear/src/execution/execute-afm.ts
+++ b/libs/api-client-bear/src/execution/execute-afm.ts
@@ -2,7 +2,6 @@
 import invariant from "ts-invariant";
 import qs from "qs";
 import range from "lodash/range";
-import get from "lodash/get";
 import { GdcExecution, GdcExecuteAFM } from "@gooddata/api-model-bear";
 
 import { XhrModule, ApiResponseError } from "../xhr";
@@ -57,7 +56,7 @@ export class ExecuteAfmModule {
         projectId: string,
         execution: GdcExecuteAFM.IExecution,
     ): Promise<GdcExecution.IExecutionResponses> {
-        validateNumOfDimensions(get(execution, "execution.resultSpec.dimensions").length);
+        validateNumOfDimensions(execution.execution.resultSpec?.dimensions?.length ?? 0);
         return this.getExecutionResponse(projectId, execution).then(
             (executionResponse: GdcExecution.IExecutionResponse) => {
                 return this.getExecutionResult(executionResponse.links.executionResult)
@@ -85,7 +84,7 @@ export class ExecuteAfmModule {
         projectId: string,
         execution: GdcExecuteAFM.IExecution,
     ): Promise<GdcExecution.IExecutionResponse> {
-        validateNumOfDimensions(get(execution, "execution.resultSpec.dimensions").length);
+        validateNumOfDimensions(execution.execution.resultSpec?.dimensions?.length ?? 0);
         return this.xhr
             .post(`/gdc/app/projects/${projectId}/executeAfm`, { body: convertExecutionToJson(execution) })
             .then((apiResponse) => apiResponse.getData())
@@ -399,12 +398,12 @@ export function mergePage(
 
     // update page count
     if (paging.offset.length === 1) {
-        result.paging.count = [get(result, "headerItems[0][0]", []).length];
+        result.paging.count = [result?.headerItems?.[0]?.[0]?.length ?? 0];
     }
     if (paging.offset.length === 2) {
         result.paging.count = [
-            get(result, "headerItems[0][0]", []).length,
-            get(result, "headerItems[1][0]", []).length,
+            result?.headerItems?.[0]?.[0]?.length ?? 0,
+            result?.headerItems?.[1]?.[0]?.length ?? 0,
         ];
     }
 

--- a/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
+++ b/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
@@ -1,7 +1,6 @@
 // (C) 2007-2020 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
-import get from "lodash/get";
 import range from "lodash/range";
 import cloneDeep from "lodash/cloneDeep";
 
@@ -30,7 +29,7 @@ function missingMetricDefinition(
     metricDefinition: IMetricDefinition,
     closestMetricDefinition: IMetricDefinition,
 ) {
-    const title = get(metricDefinition, "title");
+    const title = metricDefinition.title;
 
     fail(
         `Metric definition (${title}) was not found:
@@ -51,7 +50,7 @@ function getClosestMatch(candidates: any[], getDistance: (candidate: any) => num
 
     const closestMatch = first(sortBy(table, (row) => row.distance));
 
-    return get(closestMatch, "candidate");
+    return closestMatch?.candidate;
 }
 
 function getClosestColumn(column: string, candidates: any[]) {
@@ -70,7 +69,7 @@ function getClosestMetricDefinition(definition: IMetricDefinition, candidates: I
 }
 
 function expectColumns(expected: string[], reportDefinition: IReportDefinition) {
-    const actualColumns = get(reportDefinition, "columns");
+    const actualColumns = reportDefinition.columns;
 
     expected.forEach((expectedColumn: any) => {
         if (!includes(actualColumns, expectedColumn)) {
@@ -82,10 +81,9 @@ function expectColumns(expected: string[], reportDefinition: IReportDefinition) 
 }
 
 function expectMetricDefinition(expected: IMetricDefinition, reportDefinition: IReportDefinition) {
-    const actualMetricDefinitions: IMetricDefinition[] = get(
-        reportDefinition,
-        "definitions",
-    ).map((definition: any) => get(definition, "metricDefinition"));
+    const actualMetricDefinitions: IMetricDefinition[] = reportDefinition.definitions.map(
+        (definition) => definition.metricDefinition as any,
+    );
 
     const defFound = find(actualMetricDefinitions, expected);
 
@@ -367,7 +365,10 @@ describe("execution", () => {
                         )
                         .then(() => {
                             const request = fetchMock.lastCall(matcher)[1] as RequestInit;
-                            expect(get(request.headers, "X-GDC-REQUEST", "")).toEqual("foo");
+                            expect(
+                                // type cast to narrow the type down to the one we know is used in this context
+                                (request.headers as Record<string, string>)?.["X-GDC-REQUEST"] ?? "",
+                            ).toEqual("foo");
                         });
                 });
             });

--- a/libs/api-client-bear/src/metadata.ts
+++ b/libs/api-client-bear/src/metadata.ts
@@ -1,6 +1,5 @@
 // (C) 2007-2021 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
-import get from "lodash/get";
 import chunk from "lodash/chunk";
 import flatten from "lodash/flatten";
 import pick from "lodash/pick";
@@ -11,7 +10,7 @@ import {
     GdcMetadataObject,
     GdcProjectDashboard,
 } from "@gooddata/api-model-bear";
-import { getIn, handlePolling, queryString } from "./util";
+import { getQueryEntries, handlePolling, queryString } from "./util";
 import { ApiResponse, ApiResponseError, XhrModule } from "./xhr";
 import {
     IGetObjectsByQueryOptions,
@@ -35,7 +34,7 @@ export class MetadataModule {
     constructor(private xhr: XhrModule) {}
 
     /**
-     * Get default display form value of provided atrribute element uri
+     * Get default display form value of provided attribute element uri
      * @param attributeElementUri string
      */
     public async getAttributeElementDefaultDisplayFormValue(
@@ -139,7 +138,7 @@ export class MetadataModule {
                     return r.getData();
                 })
                 .then((result: any) =>
-                    get(result, ["objects", "items"]).map((item: any) => {
+                    result.objects.items.map((item: any) => {
                         if (item.visualizationObject) {
                             return {
                                 visualizationObject: item.visualizationObject,
@@ -388,7 +387,7 @@ export class MetadataModule {
             .then((apiResponse: ApiResponse) =>
                 apiResponse.response.ok ? apiResponse.getData() : apiResponse.response,
             )
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**
@@ -404,7 +403,7 @@ export class MetadataModule {
             .then((apiResponse: ApiResponse) =>
                 apiResponse.response.ok ? apiResponse.getData() : apiResponse.response,
             )
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**
@@ -421,7 +420,7 @@ export class MetadataModule {
             .then((apiResponse: ApiResponse) =>
                 apiResponse.response.ok ? apiResponse.getData() : apiResponse.response,
             )
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**
@@ -441,7 +440,7 @@ export class MetadataModule {
             return this.xhr
                 .get(`/gdc/md/${pId}/query/folders${typeURL}`)
                 .then((r) => r.getData())
-                .then(getIn("query.entries"));
+                .then(getQueryEntries);
         };
 
         switch (type) {
@@ -474,7 +473,7 @@ export class MetadataModule {
             .then((apiResponse: ApiResponse) =>
                 apiResponse.response.ok ? apiResponse.getData() : apiResponse.response,
             )
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**
@@ -490,7 +489,7 @@ export class MetadataModule {
             .then((apiResponse: ApiResponse) =>
                 apiResponse.response.ok ? apiResponse.getData() : apiResponse.response,
             )
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**
@@ -883,7 +882,7 @@ export class MetadataModule {
                     ],
                 },
             })
-            .then((r: ApiResponse) => (r.response.ok ? get(r.getData(), "elementLabelUri") : r.response));
+            .then((r: ApiResponse) => (r.response.ok ? r.getData()?.elementLabelUri : r.response));
     }
 
     /**

--- a/libs/api-client-bear/src/project.ts
+++ b/libs/api-client-bear/src/project.ts
@@ -1,5 +1,5 @@
 // (C) 2007-2020 GoodData Corporation
-import { getIn, handlePolling, getAllPagesByOffsetLimit, parseSettingItemValue } from "./util";
+import { getQueryEntries, handlePolling, getAllPagesByOffsetLimit, parseSettingItemValue } from "./util";
 import { ITimezone, IColor, IColorPalette, IFeatureFlags } from "./interfaces";
 import { IStyleSettingsResponse, IFeatureFlagsResponse } from "./apiResponsesInterfaces";
 import { XhrModule, ApiResponse, ApiError } from "./xhr";
@@ -135,7 +135,7 @@ export class ProjectModule {
         return this.xhr
             .get(`/gdc/md/${projectId}/query/datasets`)
             .then((r) => r.getData())
-            .then(getIn("query.entries"));
+            .then(getQueryEntries);
     }
 
     /**

--- a/libs/api-client-bear/src/tests/catalogue.fixtures.ts
+++ b/libs/api-client-bear/src/tests/catalogue.fixtures.ts
@@ -97,7 +97,7 @@ export const requestForMeasureTypeFactWithFilter = {
     },
 };
 
-const attributesMapForMeasureWithFilterAndCategory = {
+const attributesMapForMeasureWithFilterAndCategory: Record<string, any> = {
     "/gdc/md/FoodMartDemo/obj/124": {
         attribute: {
             content: {},
@@ -354,7 +354,7 @@ export const requestForMeasureWithNotInFilterAndCategoryShowInPercent = {
     },
 };
 
-const attributesMapForMeasureWithShowInPercent = {
+const attributesMapForMeasureWithShowInPercent: Record<string, any> = {
     "/gdc/md/FoodMartDemo/obj/124": {
         attribute: {
             content: {},

--- a/libs/api-client-bear/src/tests/catalogue.test.ts
+++ b/libs/api-client-bear/src/tests/catalogue.test.ts
@@ -2,7 +2,6 @@
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 
-import get from "lodash/get";
 import cloneDeep from "lodash/cloneDeep";
 import * as fixtures from "./catalogue.fixtures";
 import { CatalogueModule } from "../catalogue";
@@ -61,12 +60,11 @@ describe("Catalogue", () => {
                 .then(() => {
                     expect(getRequestBody()).toEqual(fixtures.requestForMeasureWithFilterAndCategory);
 
-                    const attributeDF = get(
-                        options,
-                        "bucketItems.buckets.1.items.0.visualizationAttribute.displayForm.uri",
-                    );
-                    expect(get(getRequestBody(), "catalogRequest.bucketItems.0")).toBe(
-                        get(options, ["attributesMap", attributeDF, "attribute", "meta", "uri"]),
+                    const attributeDF = (options.bucketItems.buckets[1].items[0] as any)
+                        .visualizationAttribute.displayForm.uri;
+
+                    expect(getRequestBody().catalogRequest.bucketItems[0]).toBe(
+                        options.attributesMap[attributeDF]!.attribute.meta.uri,
                     );
                 });
         });
@@ -89,12 +87,11 @@ describe("Catalogue", () => {
                 .then(() => {
                     expect(getRequestBody()).toEqual(fixtures.requestForMeasureWithShowInPercent);
 
-                    const attributeDF = get(
-                        options,
-                        "bucketItems.buckets.1.items.0.visualizationAttribute.displayForm.uri",
-                    );
-                    expect(get(getRequestBody(), "catalogRequest.bucketItems[0]")).toBe(
-                        get(options, ["attributesMap", attributeDF, "attribute", "meta", "uri"]),
+                    const attributeDF = (options.bucketItems.buckets[1].items[0] as any)
+                        .visualizationAttribute.displayForm.uri;
+
+                    expect(getRequestBody().catalogRequest.bucketItems[0]).toBe(
+                        options.attributesMap[attributeDF]!.attribute.meta.uri,
                     );
                 });
         });

--- a/libs/api-client-bear/src/tests/util.test.ts
+++ b/libs/api-client-bear/src/tests/util.test.ts
@@ -2,30 +2,11 @@
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { mockPollingRequestWithStatus } from "./utils/polling";
-import { getIn, handleHeadPolling, IPollingOptions, queryString, parseSettingItemValue } from "../util";
+import { handleHeadPolling, IPollingOptions, queryString, parseSettingItemValue } from "../util";
 import { ApiResponse, XhrModule } from "../xhr";
 import { GdcExport } from "@gooddata/api-model-bear";
 
 describe("util", () => {
-    const testObj = {
-        a: 1,
-        b: { c: { d: 2 } },
-    };
-
-    describe("getIn", () => {
-        it("should return partially applied get", () => {
-            expect(getIn("b.c.d")(testObj)).toBe(2);
-        });
-
-        it("should work as resolve function of promise", () => {
-            return Promise.resolve(testObj)
-                .then(getIn("b.c"))
-                .then((result) => {
-                    expect(result).toEqual({ d: 2 });
-                });
-        });
-    });
-
     describe("queryString", () => {
         it("should handle undefined", () => {
             expect(queryString(undefined)).toBe("");

--- a/libs/api-client-bear/src/util.ts
+++ b/libs/api-client-bear/src/util.ts
@@ -1,5 +1,4 @@
 // (C) 2007-2020 GoodData Corporation
-import get from "lodash/get";
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
 import isObject from "lodash/isObject";
@@ -29,15 +28,10 @@ export const omitEmpty = omitBy((val) => {
  *
  */
 
-/**
- * Create getter function for accessing nested objects
- *
- * @param {String} path Target path to nested object
- * @method getIn
- * @private
- */
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const getIn = (path: string) => (object: any) => get(object, path);
+export const getQueryEntries = (obj: any): any => {
+    return obj?.query?.entries;
+};
 
 export interface IPollingOptions {
     attempts?: number;
@@ -174,11 +168,11 @@ export function getAllPagesByOffsetLimit(
     return new Promise((resolve: any, reject: any) => {
         xhr.get(`${uri}?offset=${offset}&limit=${PAGE_LIMIT}`)
             .then((r: any) => r.getData())
-            .then((dataObjects: any[]) => {
-                const projects = get(dataObjects, itemKey);
+            .then((dataObjects: any) => {
+                const projects = dataObjects?.[itemKey];
                 const data = pagesData.concat(projects.items);
 
-                const totalCount = get(projects, "paging.totalCount", 0);
+                const totalCount = projects?.paging?.totalCount ?? 0;
                 const nextPage = offset + PAGE_LIMIT;
                 if (nextPage > totalCount) {
                     resolve(data);

--- a/libs/sdk-ui-ext/.dependency-cruiser.js
+++ b/libs/sdk-ui-ext/.dependency-cruiser.js
@@ -7,8 +7,6 @@ const options = {
         depCruiser.noLodashGet([
             // used for the supported properties, part of the PlugVis API
             "src/internal/utils/propertiesHelper.ts",
-            // TODO remove this once the suspicious code in the file is resolved
-            "src/internal/utils/bucketHelper.ts",
         ]),
 
         ...depCruiser.DefaultSdkRules,

--- a/libs/sdk-ui-ext/.dependency-cruiser.js
+++ b/libs/sdk-ui-ext/.dependency-cruiser.js
@@ -2,8 +2,15 @@ const depCruiser = require("../../common/config/dep-cruiser/default.config");
 
 const options = {
     forbidden: [
-        // sdk-ui-ext relies on string based paths heavily, refactoring is not feasible now (especially because of supportedProperties spec)
         ...depCruiser.DefaultRules.filter((rule) => rule.name !== "not-to-lodash-get"),
+        // replace the default noLodashGet with our custom rule with some minimal exceptions
+        depCruiser.noLodashGet([
+            // used for the supported properties, part of the PlugVis API
+            "src/internal/utils/propertiesHelper.ts",
+            // TODO remove this once the suspicious code in the file is resolved
+            "src/internal/utils/bucketHelper.ts",
+        ]),
+
         ...depCruiser.DefaultSdkRules,
         depCruiser.isolatedSubmodule("internal", "src/internal"),
         depCruiser.moduleWithDependencies("insightView", "src/insightView", [

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/ConfigSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/ConfigSection.tsx
@@ -4,7 +4,6 @@ import { injectIntl, WrappedComponentProps } from "react-intl";
 import cx from "classnames";
 import cloneDeep from "lodash/cloneDeep";
 import noop from "lodash/noop";
-import get from "lodash/get";
 import set from "lodash/set";
 
 import DisabledBubbleMessage from "../DisabledBubbleMessage";
@@ -51,7 +50,7 @@ export class ConfigSection extends React.Component<IConfigSectionProps, IConfigS
         this.toggleCollapsed = this.toggleCollapsed.bind(this);
         this.toggleValue = this.toggleValue.bind(this);
 
-        const collapsed = get(props, `propertiesMeta.${this.props.id}.collapsed`, true);
+        const collapsed = props.propertiesMeta?.[props.id]?.collapsed ?? true;
 
         this.state = {
             collapsed,
@@ -59,7 +58,8 @@ export class ConfigSection extends React.Component<IConfigSectionProps, IConfigS
     }
 
     public UNSAFE_componentWillReceiveProps(nextProps: IConfigSectionOwnProps & WrappedComponentProps): void {
-        const collapsed = get(nextProps, `propertiesMeta.${this.props.id}.collapsed`, true);
+        // TODO: should the indexer be "nextProps.id"? Leaving as-is for now to be safe.
+        const collapsed = nextProps.propertiesMeta?.[this.props.id]?.collapsed ?? true;
         this.setState({ collapsed });
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/DataLabelsControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/DataLabelsControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import get from "lodash/get";
 import DropdownControl from "./DropdownControl";
 
 import { dataLabelsDropdownItems } from "../../constants/dropdowns";
@@ -23,7 +22,7 @@ class DataLabelsControl extends React.Component<IDataLabelsControlProps & Wrappe
     };
     public render() {
         const { pushData, properties, intl, isDisabled, showDisabledMessage, defaultValue } = this.props;
-        const dataLabels = get(properties, "controls.dataLabels.visible", defaultValue);
+        const dataLabels = properties?.controls?.dataLabels?.visible ?? defaultValue;
 
         return (
             <div className="s-data-labels-config">

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/DataPointsControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/DataPointsControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import get from "lodash/get";
 import DropdownControl from "./DropdownControl";
 
 import { dataPointsDropdownLabels } from "../../constants/dropdowns";
@@ -23,7 +22,7 @@ class DataPointsControl extends React.Component<IDataPointsControlProps & Wrappe
     };
     public render() {
         const { pushData, properties, intl, isDisabled, showDisabledMessage, defaultValue } = this.props;
-        const dataPoints = get(properties, "controls.dataPoints.visible", defaultValue);
+        const dataPoints = properties?.controls?.dataPoints?.visible ?? defaultValue;
 
         return (
             <div className="s-data-points-config">

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/MinMaxControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/MinMaxControl.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
-import get from "lodash/get";
 
 import { WrappedComponentProps, injectIntl } from "react-intl";
 
@@ -30,7 +29,7 @@ class MinMaxControl extends React.Component<
     IMinMaxControlState
 > {
     public static getDerivedStateFromProps(props: IMinMaxControlProps & WrappedComponentProps) {
-        if (get(props, ["propertiesMeta", "undoApplied"], false)) {
+        if (props.propertiesMeta?.undoApplied) {
             return defaultMinMaxControlState;
         }
 
@@ -48,9 +47,11 @@ class MinMaxControl extends React.Component<
 
     private renderMinMaxSection() {
         const { properties, basePath, isDisabled } = this.props;
-        const axisScaleMin = get(this.props, `properties.controls.${basePath}.min`, "");
-        const axisScaleMax = get(this.props, `properties.controls.${basePath}.max`, "");
-        const axisVisible = get(this.props, `properties.controls.${basePath}.visible`, true);
+
+        const basePathPropertiesControls = properties?.controls?.[basePath];
+        const axisScaleMin = basePathPropertiesControls?.min ?? "";
+        const axisScaleMax = basePathPropertiesControls?.max ?? "";
+        const axisVisible = basePathPropertiesControls?.visible ?? true;
 
         return (
             <ConfigSubsection title="properties.axis.scale">
@@ -61,9 +62,7 @@ class MinMaxControl extends React.Component<
                     type="number"
                     hasWarning={this.minScaleHasWarning()}
                     value={
-                        this.minScaleHasIncorrectValue()
-                            ? get(this.state, "minScale.incorrectValue")
-                            : axisScaleMin
+                        this.minScaleHasIncorrectValue() ? this.state.minScale?.incorrectValue : axisScaleMin
                     }
                     disabled={isDisabled || !axisVisible}
                     properties={properties}
@@ -78,9 +77,7 @@ class MinMaxControl extends React.Component<
                     type="number"
                     hasWarning={this.maxScaleHasWarning()}
                     value={
-                        this.maxScaleHasIncorrectValue()
-                            ? get(this.state, "maxScale.incorrectValue")
-                            : axisScaleMax
+                        this.maxScaleHasIncorrectValue() ? this.state.maxScale?.incorrectValue : axisScaleMax
                     }
                     disabled={isDisabled || !axisVisible}
                     properties={properties}
@@ -112,23 +109,23 @@ class MinMaxControl extends React.Component<
     };
 
     private minScaleHasIncorrectValue() {
-        return get(this.state, "minScale.incorrectValue", "") !== "";
+        return (this.state.minScale?.incorrectValue ?? "") !== "";
     }
 
     private maxScaleHasIncorrectValue() {
-        return get(this.state, "maxScale.incorrectValue", "") !== "";
+        return (this.state.maxScale?.incorrectValue ?? "") !== "";
     }
 
     private minScaleHasWarning() {
-        return get(this.state, "minScale.hasWarning", false);
+        return this.state.minScale?.hasWarning ?? false;
     }
 
     private maxScaleHasWarning() {
-        return get(this.state, "maxScale.hasWarning", false);
+        return this.state.maxScale?.hasWarning ?? false;
     }
 
     private renderMinErrorMessage() {
-        const minScaleWarningMessage = get(this.state, "minScale.warningMessage", "");
+        const minScaleWarningMessage = this.state.minScale?.warningMessage ?? "";
         if (!this.minScaleHasWarning() || minScaleWarningMessage === "") {
             return false;
         }
@@ -141,7 +138,7 @@ class MinMaxControl extends React.Component<
     }
 
     private renderMaxErrorMessage() {
-        const maxScaleWarningMessage = get(this.state, "maxScale.warningMessage", "");
+        const maxScaleWarningMessage = this.state.maxScale?.warningMessage ?? "";
         if (!this.maxScaleHasWarning() || maxScaleWarningMessage === "") {
             return false;
         }

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/PushpinSizeControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/PushpinSizeControl.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 
-import get from "lodash/get";
 import { IVisualizationProperties } from "../../interfaces/Visualization";
 import ConfigSubsection from "./ConfigSubsection";
 import DropdownControl from "./DropdownControl";
@@ -16,7 +15,7 @@ export interface IPushpinSizeControl {
 }
 
 function getPushpinProperty(props: IPushpinSizeControl & WrappedComponentProps) {
-    const { minSize = "default", maxSize = "default" } = get(props, "properties.controls.points", {});
+    const { minSize = "default", maxSize = "default" } = props.properties?.controls?.points ?? {};
     return {
         minSize,
         maxSize,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/PushpinViewportControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/PushpinViewportControl.tsx
@@ -1,6 +1,5 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
-import get from "lodash/get";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 
 import DropdownControl from "./DropdownControl";
@@ -16,7 +15,7 @@ export interface IPushpinViewportControl {
 }
 
 function getPushpinProperty(props: IPushpinViewportControl & WrappedComponentProps): IGeoConfigViewport {
-    return get(props, "properties.controls.viewport", { area: "auto" });
+    return props.properties?.controls?.viewport ?? { area: "auto" };
 }
 
 function PushpinViewportControl(props: IPushpinViewportControl & WrappedComponentProps): React.ReactElement {

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import get from "lodash/get";
 
 import DropdownControl from "../DropdownControl";
 import { getTranslatedDropdownItems } from "../../../utils/translations";
@@ -37,13 +36,11 @@ class LabelRotationControl extends React.PureComponent<ILabelRotationControl & W
     }
 
     private getControlProperties(): IVisualizationProperties {
-        const axisVisible = get(this.props, `properties.controls.${this.props.axis}.visible`, true);
-        const axisLabelsEnabled = get(
-            this.props,
-            `properties.controls.${this.props.axis}.labelsEnabled`,
-            true,
-        );
-        const axisRotation = get(this.props, `properties.controls.${this.props.axis}.rotation`, "auto");
+        const axisProperties = this.props.properties?.controls?.[this.props.axis];
+
+        const axisVisible = axisProperties?.visible ?? true;
+        const axisLabelsEnabled = axisProperties?.labelsEnabled ?? true;
+        const axisRotation = axisProperties?.rotation ?? "auto";
 
         return {
             axisVisible,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelSubsection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelSubsection.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import ConfigSubsection from "../../configurationControls/ConfigSubsection";
-import get from "lodash/get";
 import { AxisType } from "../../../interfaces/AxisType";
 import LabelRotationControl from "./LabelRotationControl";
 import { IVisualizationProperties } from "../../../interfaces/Visualization";
@@ -42,12 +41,11 @@ class LabelSubsection extends React.PureComponent<ILabelSubsection & WrappedComp
     }
 
     private getControlProperties(): IVisualizationProperties {
-        const axisVisible = get(this.props, `properties.controls.${this.props.axis}.visible`, true);
-        const axisLabelsEnabled = get(
-            this.props,
-            `properties.controls.${this.props.axis}.labelsEnabled`,
-            true,
-        );
+        const axisProperties = this.props.properties?.controls?.[this.props.axis];
+
+        const axisVisible = axisProperties?.visible ?? true;
+        const axisLabelsEnabled = axisProperties?.labelsEnabled ?? true;
+
         return {
             axisVisible,
             axisLabelsEnabled,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NamePositionControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NamePositionControl.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
-import get from "lodash/get";
 
 import DropdownControl from "../DropdownControl";
 import { getTranslatedDropdownItems } from "../../../utils/translations";
@@ -39,12 +38,11 @@ class NamePositionControl extends React.PureComponent<IConfigItemSubsection & Wr
     }
 
     private getControlProperties(): IVisualizationProperties {
-        const { axis } = this.props;
-        const controlsAxis = get(this.props, `properties.controls.${axis}`, {});
+        const axisProperties = this.props.properties?.controls?.[this.props.axis];
 
-        const axisVisible = get(controlsAxis, "visible", true);
-        const axisNameVisible = get(controlsAxis, "name.visible", true);
-        const namePosition = get(controlsAxis, "name.position", "auto");
+        const axisVisible = axisProperties?.visible ?? true;
+        const axisNameVisible = axisProperties?.name?.visible ?? true;
+        const namePosition = axisProperties?.name?.position ?? "auto";
 
         return {
             axisVisible,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NameSubsection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NameSubsection.tsx
@@ -1,5 +1,4 @@
 // (C) 2019 GoodData Corporation
-import get from "lodash/get";
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import ConfigSubsection from "../../configurationControls/ConfigSubsection";
@@ -35,13 +34,10 @@ class NameSubsection extends React.PureComponent<IConfigItemSubsection & Wrapped
     }
 
     private getControlProperties(): IVisualizationProperties {
-        const controlsAxis: IVisualizationProperties = get(
-            this.props,
-            `properties.controls.${this.props.axis}`,
-            {},
-        );
-        const axisVisible: boolean = get(controlsAxis, "visible", true);
-        const axisNameVisible: boolean = get(controlsAxis, "name.visible", true);
+        const axisProperties = this.props.properties?.controls?.[this.props.axis];
+
+        const axisVisible = axisProperties?.visible ?? true;
+        const axisNameVisible = axisProperties?.name?.visible ?? true;
 
         return {
             axisVisible,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/ColorsSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/ColorsSection.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import set from "lodash/set";
-import get from "lodash/get";
 import cloneDeep from "lodash/cloneDeep";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IColor } from "@gooddata/sdk-model";
@@ -108,7 +107,7 @@ class ColorsSection extends React.Component<IColorsSectionProps & WrappedCompone
 
     private isDefaultColorMapping() {
         const { properties } = this.props;
-        const colorMapping = get(properties, "controls.colorMapping", []);
+        const colorMapping = properties?.controls?.colorMapping ?? [];
         return !colorMapping || colorMapping.length === 0;
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendSection.tsx
@@ -3,7 +3,6 @@ import React from "react";
 import ConfigSection from "../ConfigSection";
 import LegendPositionControl from "./LegendPositionControl";
 import { IVisualizationProperties } from "../../../interfaces/Visualization";
-import get from "lodash/get";
 
 export interface ILegendSection {
     controlsDisabled: boolean;
@@ -16,9 +15,9 @@ class LegendSection extends React.PureComponent<ILegendSection> {
     public render(): React.ReactNode {
         const { controlsDisabled, properties, pushData } = this.props;
 
-        const legendEnabled = get(this.props, "properties.controls.legend.enabled", true);
-        const legendPosition = get(this.props, "properties.controls.legend.position", "auto");
-        const legendToggleDisabledByVisualization = !get(this.props, "propertiesMeta.legend_enabled", true);
+        const legendEnabled = this.props.properties?.controls?.legend?.enabled ?? true;
+        const legendPosition = this.props.properties?.controls?.legend?.position ?? "auto";
+        const legendToggleDisabledByVisualization = !(this.props.propertiesMeta?.legend_enabled ?? true);
 
         const toggleDisabled = controlsDisabled || legendToggleDisabledByVisualization;
         const legendPositionControlDisabled = !legendEnabled || toggleDisabled;

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import get from "lodash/get";
 import includes from "lodash/includes";
 import { BucketNames } from "@gooddata/sdk-ui";
 import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
@@ -84,15 +83,15 @@ export default class BaseChartConfigurationPanel extends ConfigurationPanelConte
 
     protected getControlProperties(): { gridEnabled: boolean; axes: IAxisProperties[] } {
         const props = this.props;
-        const gridEnabled = get(props, "properties.controls.grid.enabled", true);
+        const gridEnabled = props.properties?.controls?.grid?.enabled ?? true;
         const axisType = includes(DUAL_AXES_SUPPORTED_CHARTS, props.type)
-            ? get(props, "axis") || AXIS.PRIMARY
+            ? props.axis ?? AXIS.PRIMARY
             : AXIS.PRIMARY;
         const configurations = this.getAxesConfiguration(axisType);
         const axes: IAxisProperties[] = configurations.map((axis: any) => {
             return {
                 ...axis,
-                visible: get(props, `properties.controls.${axis.name}.visible`, true),
+                visible: props.properties?.controls?.[axis.name]?.visible ?? true,
             };
         });
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/GeoPushpinConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/GeoPushpinConfigurationPanel.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
-import get from "lodash/get";
 import { bucketIsEmpty, IInsightDefinition, insightBucket, insightHasMeasures } from "@gooddata/sdk-model";
 import { BucketNames } from "@gooddata/sdk-ui";
 import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
@@ -24,9 +23,7 @@ import ColorsSection from "../configurationControls/colors/ColorsSection";
 
 export default class GeoPushpinConfigurationPanel extends ConfigurationPanelContent {
     protected getControlProperties(): { groupNearbyPoints: boolean } {
-        const { props } = this;
-        const groupNearbyPoints = get(props, "properties.controls.points.groupNearbyPoints", true);
-
+        const groupNearbyPoints = this.props.properties?.controls?.points?.groupNearbyPoints ?? true;
         return {
             groupNearbyPoints,
         };

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/HeatMapConfigurationPanel.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
-import get from "lodash/get";
 import cx from "classnames";
 import NameSubsection from "../configurationControls/axis/NameSubsection";
 
@@ -128,8 +127,9 @@ export default class HeatMapConfigurationPanel extends ConfigurationPanelContent
     }
 
     private getControlProperties() {
-        const xAxisVisible = get(this.props, "properties.controls.xaxis.visible", true);
-        const yAxisVisible = get(this.props, "properties.controls.yaxis.visible", true);
+        const propertiesControls = this.props.properties?.controls;
+        const xAxisVisible = propertiesControls?.xaxis?.visible ?? true;
+        const yAxisVisible = propertiesControls?.yaxis?.visible ?? true;
         return {
             xAxisVisible,
             yAxisVisible,

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/ScatterPlotConfigurationPanel.tsx
@@ -18,7 +18,6 @@ import {
     SHOW_DELAY_DEFAULT,
 } from "../../constants/bubble";
 import { insightHasAttributes } from "@gooddata/sdk-model";
-import get from "lodash/get";
 import NameSubsection from "../configurationControls/axis/NameSubsection";
 import { countItemsOnAxes } from "../pluggableVisualizations/baseChart/insightIntrospection";
 
@@ -169,10 +168,11 @@ export default class ScatterPlotConfigurationPanel extends ConfigurationPanelCon
     }
 
     private getControlProperties() {
-        const xAxisVisible = get(this.props, "properties.controls.xaxis.visible", true);
-        const yAxisVisible = get(this.props, "properties.controls.yaxis.visible", true);
+        const propertiesControls = this.props.properties?.controls;
 
-        const gridEnabled = get(this.props, "properties.controls.grid.enabled", true);
+        const xAxisVisible = propertiesControls?.xaxis?.visible ?? true;
+        const yAxisVisible = propertiesControls?.yaxis?.visible ?? true;
+        const gridEnabled = propertiesControls?.grid?.enabled ?? true;
 
         return {
             xAxisVisible,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
@@ -1,5 +1,4 @@
 // (C) 2019 GoodData Corporation
-import get from "lodash/get";
 import set from "lodash/set";
 import {
     bucketIsEmpty,
@@ -18,10 +17,9 @@ import {
 } from "@gooddata/sdk-ui";
 import { AXIS } from "../../constants/axis";
 import { BUCKETS } from "../../constants/bucket";
-import { MAX_CATEGORIES_COUNT, MAX_STACKS_COUNT, UICONFIG, UICONFIG_AXIS } from "../../constants/uiConfig";
+import { MAX_CATEGORIES_COUNT, MAX_STACKS_COUNT } from "../../constants/uiConfig";
 import { drillDownFromAttributeLocalId } from "../../utils/ImplicitDrillDownHelper";
 import {
-    IBucketOfFun,
     IDrillDownContext,
     IExtendedReferencePoint,
     IImplicitDrillDown,
@@ -64,7 +62,7 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
         return super.getExtendedReferencePoint(referencePoint).then((ext: IExtendedReferencePoint) => {
             let newExt = setSecondaryMeasures(ext, this.secondaryAxis);
 
-            this.axis = get(newExt, UICONFIG_AXIS, AXIS.PRIMARY);
+            this.axis = newExt?.uiConfig?.axis ?? AXIS.PRIMARY;
 
             // filter out unnecessary stacking props for some specific cases such as one measure or empty stackBy
             this.supportedPropertiesList = removeImmutableOptionalStackingProperties(
@@ -115,15 +113,12 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
     }
 
     protected configureBuckets(extendedReferencePoint: IExtendedReferencePoint): void {
-        const buckets: IBucketOfFun[] = get(extendedReferencePoint, BUCKETS, []);
+        const buckets = extendedReferencePoint?.buckets ?? [];
         const measures = getFilteredMeasuresForStackedCharts(buckets);
         const dateItems = getDateItems(buckets);
         const mainDateItem = getMainDateItem(dateItems);
-        const categoriesCount: number = get(
-            extendedReferencePoint,
-            [UICONFIG, BUCKETS, BucketNames.VIEW, "itemsLimit"],
-            MAX_CATEGORIES_COUNT,
-        );
+        const categoriesCount =
+            extendedReferencePoint.uiConfig?.buckets?.[BucketNames.VIEW]?.itemsLimit ?? MAX_CATEGORIES_COUNT;
         const allAttributesWithoutStacks = getAllCategoriesAttributeItems(buckets);
         const allAttributesWithoutStacksWithDatesHandled = removeDivergentDateItems(
             allAttributesWithoutStacks,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -48,7 +48,6 @@ import LineChartBasedConfigurationPanel from "../../configurationPanels/LineChar
 
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import {
     addIntersectionFiltersToInsight,
@@ -204,7 +203,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
     }
 
     private getBucketItems(referencePoint: IReferencePoint) {
-        const buckets = get(referencePoint, BUCKETS, []);
+        const buckets = referencePoint?.buckets ?? [];
         const measures = getFilteredMeasuresForStackedCharts(buckets);
         const dateItems = getDateItems(buckets);
         const mainDateItem = getMainDateItem(dateItems);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/PluggableBarChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/PluggableBarChart.test.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import { OverTimeComparisonTypes } from "@gooddata/sdk-ui";
 import { PluggableBarChart } from "../PluggableBarChart";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
@@ -121,8 +120,8 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_xaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_xaxis.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toBeUndefined();
             expect(axis).toBeUndefined();
         });
@@ -134,8 +133,8 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.multipleMetricsAndCategoriesReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_xaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_xaxis.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toEqual(["m3", "m4"]);
             expect(axis).toEqual(AXIS.DUAL);
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -24,7 +24,7 @@ import { render } from "react-dom";
 import { BUCKETS } from "../../../constants/bucket";
 import { DASHBOARDS_ENVIRONMENT } from "../../../constants/properties";
 import { BASE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
-import { DEFAULT_BASE_CHART_UICONFIG, MAX_CATEGORIES_COUNT, UICONFIG } from "../../../constants/uiConfig";
+import { DEFAULT_BASE_CHART_UICONFIG, MAX_CATEGORIES_COUNT } from "../../../constants/uiConfig";
 import { AxisType } from "../../../interfaces/AxisType";
 import { IColorConfiguration } from "../../../interfaces/Colors";
 import {
@@ -75,7 +75,6 @@ import { isOpenAsReportSupportedByVisualization } from "../../../utils/visualiza
 import BaseChartConfigurationPanel from "../../configurationPanels/BaseChartConfigurationPanel";
 import { AbstractPluggableVisualization } from "../AbstractPluggableVisualization";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import isEmpty from "lodash/isEmpty";
 import set from "lodash/set";
 import tail from "lodash/tail";
@@ -162,12 +161,10 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 
     protected configureBuckets(extendedReferencePoint: IExtendedReferencePoint): void {
-        const buckets: IBucketOfFun[] = get(extendedReferencePoint, BUCKETS, []);
-        const categoriesCount: number = get(
-            extendedReferencePoint,
-            [UICONFIG, BUCKETS, BucketNames.VIEW, "itemsLimit"],
-            MAX_CATEGORIES_COUNT,
-        );
+        const buckets = extendedReferencePoint?.buckets ?? [];
+        const categoriesCount =
+            extendedReferencePoint?.uiConfig?.buckets?.[BucketNames.VIEW]?.itemsLimit ?? MAX_CATEGORIES_COUNT;
+
         set(extendedReferencePoint, BUCKETS, [
             {
                 localIdentifier: BucketNames.MEASURES,
@@ -359,7 +356,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         supportedControls: IVisualizationProperties,
     ): IChartConfig {
         const { config = {}, customVisualizationConfig = {} } = options;
-        const colorMapping: IColorMappingItem[] = get(supportedControls, "colorMapping");
+        const colorMapping: IColorMappingItem[] = supportedControls?.colorMapping;
 
         const validColorMapping =
             colorMapping &&
@@ -393,7 +390,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 
     private getSupportedControls(insight: IInsightDefinition, options: IVisProps) {
-        let supportedControls = cloneDeep(get(this.visualizationProperties, "controls", {}));
+        let supportedControls = cloneDeep(this.visualizationProperties?.controls ?? {});
         const defaultControls = getSupportedPropertiesControls(
             this.defaultControlsProperties,
             this.supportedPropertiesList,
@@ -433,7 +430,7 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         insight: IInsightDefinition,
         options: IVisProps,
     ) {
-        const legendPosition = get(controlProperties, "legend.position", "auto");
+        const legendPosition = controlProperties?.legend?.position ?? "auto";
 
         if (this.environment === DASHBOARDS_ENVIRONMENT) {
             const width = options.dimensions?.width;
@@ -460,8 +457,8 @@ function canSortStackTotalValue(
     insight: IInsightDefinition,
     supportedControls: IVisualizationProperties,
 ): boolean {
-    const stackMeasures = get(supportedControls, "stackMeasures", false);
-    const secondaryAxis: IAxisConfig = get(supportedControls, "secondary_yaxis", { measures: [] });
+    const stackMeasures = supportedControls?.stackMeasures ?? false;
+    const secondaryAxis: IAxisConfig = supportedControls?.secondary_yaxis ?? { measures: [] };
     const allMeasuresOnSingleAxis = areAllMeasuresOnSingleAxis(insight, secondaryAxis);
 
     return stackMeasures && allMeasuresOnSingleAxis;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/insightIntrospection.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/insightIntrospection.ts
@@ -3,7 +3,6 @@ import { bucketItems, IInsightDefinition, insightBucket } from "@gooddata/sdk-mo
 import { BucketNames } from "@gooddata/sdk-ui";
 import { isBarChart, isScatterPlot, isBubbleChart, isBulletChart } from "@gooddata/sdk-ui-charts";
 import { IVisualizationProperties } from "../../../interfaces/Visualization";
-import get from "lodash/get";
 
 export function countBucketItems(
     insight: IInsightDefinition,
@@ -47,8 +46,8 @@ export function countItemsOnAxes(
     const totalMeasureItemCount = measureItemCount + secondaryMeasureItemCount;
 
     const secondaryMeasureCountInConfig = (isBarFamilyChartType
-        ? get(controls, "secondary_xaxis.measures", [])
-        : get(controls, "secondary_yaxis.measures", [])
+        ? controls?.secondary_xaxis?.measures ?? []
+        : controls?.secondary_yaxis?.measures ?? []
     ).length;
 
     if (isBarFamilyChartType) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/PluggableBubbleChart.tsx
@@ -10,7 +10,7 @@ import { configureOverTimeComparison, configurePercent } from "../../../utils/bu
 
 import {
     getAllAttributeItems,
-    getMeasures,
+    getAllMeasures,
     getPreferredBucketItems,
     limitNumberOfMeasuresInBuckets,
     removeAllArithmeticMeasuresFromDerived,
@@ -59,7 +59,7 @@ export class PluggableBubbleChart extends PluggableBaseChart {
             [BucketNames.TERTIARY_MEASURES],
             [METRIC],
         );
-        const allMeasures = getMeasures(buckets);
+        const allMeasures = getAllMeasures(buckets);
 
         // skip first to reserve first items to be picked later
         const secondaryAndTertiaryItems = [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import { PluggableColumnChart } from "../PluggableColumnChart";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
 import { AXIS } from "../../../../constants/axis";
@@ -109,8 +108,8 @@ describe("PluggableColumnChart", () => {
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_yaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_yaxis.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toBeUndefined();
             expect(axis).toBeUndefined();
         });
@@ -122,8 +121,8 @@ describe("PluggableColumnChart", () => {
                 referencePointMocks.multipleMetricsAndCategoriesReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_yaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_yaxis?.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toEqual(["m3", "m4"]);
             expect(axis).toEqual(AXIS.DUAL);
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
@@ -29,7 +29,6 @@ import { setComboChartUiConfigDeprecated } from "../../../utils/uiConfigHelpers/
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import without from "lodash/without";
 
@@ -49,7 +48,7 @@ export class PluggableComboChartDeprecated extends PluggableBaseChart {
             uiConfig: cloneDeep(COMBO_CHART_UICONFIG_DEPRECATED),
         };
 
-        const buckets = get(clonedReferencePoint, BUCKETS, []);
+        const buckets = clonedReferencePoint?.buckets ?? [];
 
         const attributes = getAllAttributeItemsWithPreference(buckets, [
             BucketNames.TREND,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
@@ -1,9 +1,7 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
-import { PROPERTY_CONTROLS } from "../../../../constants/properties";
 import { PluggableComboChart } from "../PluggableComboChart";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
 import {
@@ -13,7 +11,7 @@ import {
     IUiConfig,
 } from "../../../../interfaces/Visualization";
 import { AXIS } from "../../../../constants/axis";
-import { UICONFIG_AXIS, COMBO_CHART_UICONFIG } from "../../../../constants/uiConfig";
+import { COMBO_CHART_UICONFIG } from "../../../../constants/uiConfig";
 import { COMBO_CHART_SUPPORTED_PROPERTIES } from "../../../../constants/supportedProperties";
 import { VisualizationTypes, OverTimeComparisonTypes } from "@gooddata/sdk-ui";
 import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
@@ -205,7 +203,7 @@ describe("PluggableComboChart", () => {
             async (_desc: string, refPoint: IReferencePoint, expectedMeasures: string[]) => {
                 const chart = createComponent(defaultProps);
                 const extendedReferencePoint = await chart.getExtendedReferencePoint(refPoint);
-                const measures = get(extendedReferencePoint, "properties.controls.secondary_yaxis.measures");
+                const measures = extendedReferencePoint?.properties?.controls?.secondary_yaxis?.measures;
 
                 expect(measures).toEqual(expectedMeasures);
             },
@@ -225,10 +223,13 @@ describe("PluggableComboChart", () => {
                 const chart = createComponent(mockProps);
 
                 const ext = await chart.getExtendedReferencePoint(refPoint);
-                const axisType = get(ext, UICONFIG_AXIS, AXIS.PRIMARY);
+                const axisType = ext?.uiConfig?.axis ?? AXIS.PRIMARY;
 
                 expect(axisType).toEqual(axis);
-                expect(get(chart, "supportedPropertiesList")).toEqual(COMBO_CHART_SUPPORTED_PROPERTIES[axis]);
+                // TODO avoid testing protected property
+                expect((chart as any).supportedPropertiesList).toEqual(
+                    COMBO_CHART_SUPPORTED_PROPERTIES[axis],
+                );
             },
         );
     });
@@ -348,7 +349,7 @@ describe("PluggableComboChart", () => {
 
                 return Promise.all(refPoints).then((extRefPoints: IExtendedReferencePoint[]) => {
                     for (const extRefPoint of extRefPoints) {
-                        const axisType = get(extRefPoint, UICONFIG_AXIS, AXIS.PRIMARY);
+                        const axisType = extRefPoint?.uiConfig?.axis ?? AXIS.PRIMARY;
                         expect(axisType).toEqual(axis);
                         expect(comboChart.getSupportedPropertiesList()).toEqual(
                             COMBO_CHART_SUPPORTED_PROPERTIES[axis],
@@ -475,7 +476,7 @@ describe("PluggableComboChart", () => {
         it("should return default chart type", async () => {
             const refPointMock = referencePointMocks.multipleMetricBucketsAndCategoryReferencePoint;
             const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
-            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+            const controls = extRefPoint?.properties?.controls ?? {};
 
             expect(controls.primaryChartType).toBe("column");
             expect(controls.secondaryChartType).toBe("line");
@@ -503,7 +504,7 @@ describe("PluggableComboChart", () => {
                 },
             );
             const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
-            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+            const controls = extRefPoint?.properties?.controls ?? {};
 
             expect(controls.primaryChartType).toBe("line");
             expect(controls.secondaryChartType).toBe("column");
@@ -523,7 +524,7 @@ describe("PluggableComboChart", () => {
                 },
             );
             const extRefPoint: IExtendedReferencePoint = await getExtendedReferencePoint(refPointMock);
-            const controls = get(extRefPoint, PROPERTY_CONTROLS, {});
+            const controls = extRefPoint?.properties?.controls ?? {};
 
             expect(controls.primaryChartType).toBe("line");
             expect(controls.secondaryChartType).toBe("area");

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -19,7 +19,7 @@ import {
     getAttributeItemsWithoutStacks,
     getItemsCount,
     getItemsFromBuckets,
-    getMeasures,
+    getAllMeasures,
     getPreferredBucketItems,
     isDateBucketItem,
     limitNumberOfMeasuresInBuckets,
@@ -110,7 +110,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
             newExtendedReferencePoint.buckets,
             NUMBER_MEASURES_IN_BUCKETS_LIMIT,
         );
-        const allMeasures: IBucketItem[] = getMeasures(buckets);
+        const allMeasures: IBucketItem[] = getAllMeasures(buckets);
         const primaryMeasures: IBucketItem[] = getPreferredBucketItems(
             buckets,
             [BucketNames.MEASURES, BucketNames.SIZE],

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -52,7 +52,6 @@ import {
 } from "@gooddata/sdk-model";
 import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
 import { CoreGeoChart, getGeoChartDimensions, IGeoConfig } from "@gooddata/sdk-ui-geo";
-import get from "lodash/get";
 import set from "lodash/set";
 import isEmpty from "lodash/isEmpty";
 import includes from "lodash/includes";
@@ -374,7 +373,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
     }
 
     private updateSupportedProperties(referencePoint: IExtendedReferencePoint): IExtendedReferencePoint {
-        const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
+        const buckets = referencePoint?.buckets ?? [];
         const locationItem = this.getLocationItems(buckets)[0];
         if (!locationItem) {
             return referencePoint;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import { PluggableHeatmap } from "../PluggableHeatmap";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
 import * as uiConfigMocks from "../../../../tests/mocks/uiConfigMocks";
@@ -137,9 +136,9 @@ describe("PluggableHeatmap", () => {
             ],
         };
 
-        const extendedReferencePoint = heatmap.getExtendedReferencePoint(referencePoint);
+        const extendedReferencePoint = await heatmap.getExtendedReferencePoint(referencePoint);
 
-        expect(get(extendedReferencePoint, "buckets.0.items.0.0.showInPercent")).toBeFalsy();
+        expect(extendedReferencePoint.buckets?.[0]?.items?.[0]?.[0]?.showInPercent).toBeFalsy();
     });
 
     describe("Arithmetic measures", () => {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -6,7 +6,7 @@ import { AXIS, AXIS_NAME } from "../../../constants/axis";
 
 import { BUCKETS } from "../../../constants/bucket";
 import { LINE_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
-import { DEFAULT_LINE_UICONFIG, UICONFIG_AXIS } from "../../../constants/uiConfig";
+import { DEFAULT_LINE_UICONFIG } from "../../../constants/uiConfig";
 import {
     IBucketItem,
     IDrillDownContext,
@@ -38,7 +38,6 @@ import { setLineChartUiConfig } from "../../../utils/uiConfigHelpers/lineChartUi
 import LineChartBasedConfigurationPanel from "../../configurationPanels/LineChartBasedConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import { IInsight, IInsightDefinition } from "@gooddata/sdk-model";
 import {
@@ -69,7 +68,7 @@ export class PluggableLineChart extends PluggableBaseChart {
             uiConfig: cloneDeep(DEFAULT_LINE_UICONFIG),
         };
 
-        const buckets = get(clonedReferencePoint, BUCKETS, []);
+        const buckets = clonedReferencePoint?.buckets ?? [];
         const measures = getMeasureItems(buckets);
         const masterMeasures = filterOutDerivedMeasures(measures);
         let attributes: IBucketItem[] = [];
@@ -95,7 +94,7 @@ export class PluggableLineChart extends PluggableBaseChart {
             if (
                 masterMeasures.length <= 1 &&
                 allAttributes.length > 1 &&
-                !isDateBucketItem(get(allAttributes, "1"))
+                !isDateBucketItem(allAttributes?.[1])
             ) {
                 stacks = allAttributes.slice(1, 2);
             }
@@ -120,7 +119,7 @@ export class PluggableLineChart extends PluggableBaseChart {
 
         newReferencePoint = setSecondaryMeasures(newReferencePoint, AXIS_NAME.SECONDARY_Y);
 
-        this.axis = get(newReferencePoint, UICONFIG_AXIS, AXIS.PRIMARY);
+        this.axis = newReferencePoint?.uiConfig?.axis ?? AXIS.PRIMARY;
         this.supportedPropertiesList = this.getSupportedPropertiesList();
 
         newReferencePoint = setLineChartUiConfig(newReferencePoint, this.intl, this.type);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import { IBucketOfFun, IFilters } from "../../../../interfaces/Visualization";
 import { PluggableLineChart } from "../PluggableLineChart";
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
@@ -481,8 +480,8 @@ describe("PluggableLineChart", () => {
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_yaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_yaxis.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toBeUndefined();
             expect(axis).toBeUndefined();
         });
@@ -494,8 +493,8 @@ describe("PluggableLineChart", () => {
                 referencePointMocks.multipleMetricsAndCategoriesReferencePoint,
             );
 
-            const measures = get(extendedReferencePoint, "properties.controls.secondary_yaxis.measures");
-            const axis = get(extendedReferencePoint, "uiConfig.axis");
+            const measures = extendedReferencePoint?.properties?.controls?.secondary_yaxis.measures;
+            const axis = extendedReferencePoint?.uiConfig?.axis;
             expect(measures).toEqual(["m3", "m4"]);
             expect(axis).toEqual(AXIS.DUAL);
         });
@@ -510,21 +509,26 @@ describe("PluggableLineChart", () => {
             await chart.getExtendedReferencePoint(
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
                 LINE_CHART_SUPPORTED_PROPERTIES[AXIS.PRIMARY],
             );
 
             await chart.getExtendedReferencePoint(
                 referencePointMocks.measuresOnSecondaryAxisAndAttributeReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
                 LINE_CHART_SUPPORTED_PROPERTIES[AXIS.SECONDARY],
             );
 
             await chart.getExtendedReferencePoint(
                 referencePointMocks.multipleMetricsAndCategoriesReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(LINE_CHART_SUPPORTED_PROPERTIES[AXIS.DUAL]);
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
+                LINE_CHART_SUPPORTED_PROPERTIES[AXIS.DUAL],
+            );
         });
     });
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -38,7 +38,6 @@ import { setPieChartUiConfig } from "../../../utils/uiConfigHelpers/pieChartUiCo
 import PieChartConfigurationPanel from "../../configurationPanels/PieChartConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import { IInsightDefinition } from "@gooddata/sdk-model";
 
@@ -60,7 +59,7 @@ export class PluggablePieChart extends PluggableBaseChart {
         newReferencePoint = removeAllArithmeticMeasuresFromDerived(newReferencePoint);
         newReferencePoint = removeAllDerivedMeasures(newReferencePoint);
 
-        const buckets = get(clonedReferencePoint, BUCKETS, []);
+        const buckets = clonedReferencePoint?.buckets ?? [];
         const attributes = getAttributeItems(buckets);
 
         if (attributes.length) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -7,7 +7,6 @@ import {
 } from "../drillDownUtil";
 import cloneDeep from "lodash/cloneDeep";
 import flatMap from "lodash/flatMap";
-import get from "lodash/get";
 import isNil from "lodash/isNil";
 import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
@@ -178,11 +177,8 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
             },
         ]);
 
-        const originalSortItems: ISortItem[] = get(newReferencePoint.properties, "sortItems", []);
-        const originalColumnWidths: ColumnWidthItem[] = get(
-            newReferencePoint.properties,
-            "controls.columnWidths",
-        );
+        const originalSortItems: ISortItem[] = newReferencePoint.properties?.sortItems ?? [];
+        const originalColumnWidths: ColumnWidthItem[] = newReferencePoint.properties?.controls?.columnWidths;
 
         const columnWidths = adaptReferencePointWidthItemsToPivotTable(
             originalColumnWidths,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -1,6 +1,5 @@
 // (C) 2019 GoodData Corporation
 import noop from "lodash/noop";
-import get from "lodash/get";
 import cloneDeep from "lodash/cloneDeep";
 import * as referencePointMocks from "../../../tests/mocks/referencePointMocks";
 import { IBucketOfFun, IFilters, IVisProps, IVisConstruct } from "../../../interfaces/Visualization";
@@ -233,7 +232,8 @@ describe("PluggableColumnBarCharts", () => {
             await chart.getExtendedReferencePoint(
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
                 COLUMN_CHART_SUPPORTED_PROPERTIES[AXIS.PRIMARY].filter(
                     (props: string) => props !== OPTIONAL_STACKING_PROPERTIES[0],
                 ),
@@ -242,14 +242,16 @@ describe("PluggableColumnBarCharts", () => {
             await chart.getExtendedReferencePoint(
                 referencePointMocks.measuresOnSecondaryAxisAndAttributeReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
                 COLUMN_CHART_SUPPORTED_PROPERTIES[AXIS.SECONDARY],
             );
 
             await chart.getExtendedReferencePoint(
                 referencePointMocks.multipleMetricsAndCategoriesReferencePoint,
             );
-            expect(get(chart, "supportedPropertiesList")).toEqual(
+            // TODO avoid testing protected property
+            expect((chart as any).supportedPropertiesList).toEqual(
                 COLUMN_CHART_SUPPORTED_PROPERTIES[AXIS.DUAL],
             );
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -1,7 +1,6 @@
 // (C) 2019 GoodData Corporation
 import React from "react";
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import isEmpty from "lodash/isEmpty";
 import set from "lodash/set";
 import tail from "lodash/tail";
@@ -66,7 +65,7 @@ export class PluggableTreemap extends PluggableBaseChart {
         newReferencePoint = removeAllArithmeticMeasuresFromDerived(newReferencePoint);
         newReferencePoint = removeAllDerivedMeasures(newReferencePoint);
 
-        const buckets = get(clonedReferencePoint, BUCKETS, []);
+        const buckets = clonedReferencePoint?.buckets ?? [];
 
         let measures = getMeasureItems(buckets);
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/xirrBucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/xirrBucketHelper.ts
@@ -5,7 +5,7 @@ import {
     getDateItems,
     findBucket,
     limitNumberOfMeasuresInBuckets,
-    getMeasures,
+    getAllMeasures,
 } from "../../../utils/bucketHelper";
 
 export const getXirrBuckets = ({ buckets }: Readonly<IReferencePoint>): IBucketOfFun[] => {
@@ -14,7 +14,7 @@ export const getXirrBuckets = ({ buckets }: Readonly<IReferencePoint>): IBucketO
     const currentMeasureBucket = findBucket(limitedMeasureBuckets, BucketNames.MEASURES);
     const currentAttributeBucket = findBucket(buckets, BucketNames.ATTRIBUTE);
 
-    const measureItem = getMeasures(limitedMeasureBuckets)[0];
+    const measureItem = getAllMeasures(limitedMeasureBuckets)[0];
     const dateAttributeItem = getDateItems(buckets)[0];
 
     return [

--- a/libs/sdk-ui-ext/src/internal/utils/colors.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/colors.ts
@@ -1,5 +1,4 @@
 // (C) 2019-2020 GoodData Corporation
-import get from "lodash/get";
 import set from "lodash/set";
 import isEqual from "lodash/isEqual";
 import uniqBy from "lodash/uniqBy";
@@ -69,7 +68,7 @@ function mergeColorMappingToProperties(properties: IVisualizationProperties, id:
         },
     ];
 
-    const previousColorMapping = get(properties, ["controls", "colorMapping"]) || [];
+    const previousColorMapping = properties?.controls?.colorMapping ?? [];
 
     const mergedMapping = compact(uniqBy([...colorMapping, ...previousColorMapping], "id"));
     const newProperties = cloneDeep(properties);

--- a/libs/sdk-ui-ext/src/internal/utils/controlsHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/controlsHelper.ts
@@ -1,5 +1,4 @@
 // (C) 2019-2020 GoodData Corporation
-import get from "lodash/get";
 import set from "lodash/set";
 import { WrappedComponentProps } from "react-intl";
 import { getTranslation } from "./translations";
@@ -32,9 +31,9 @@ export function maxInputValidateAndPushData(
     defaultState: IMinMaxControlState,
 ): void {
     const { basePath } = props;
-    const maxValue = get(data, `properties.controls.${basePath}.max`);
-    const incorrectMinValue = get(state, "minScale.incorrectValue", "");
-    const correctMinValue = get(props, `properties.controls.${basePath}.min`, "");
+    const maxValue = data?.properties?.controls?.[basePath]?.max;
+    const incorrectMinValue = state?.minScale?.incorrectValue ?? "";
+    const correctMinValue = props?.properties?.controls?.[basePath]?.min ?? "";
 
     const incorrectMinInvalid = isValueMinusOrEmpty(incorrectMinValue);
     const minNumberValue = incorrectMinInvalid
@@ -90,9 +89,9 @@ export function minInputValidateAndPushData(
     defaultState: IMinMaxControlState,
 ): void {
     const { basePath } = props;
-    const minValue = get(data, `properties.controls.${basePath}.min`);
-    const incorrectMaxValue = get(state, "maxScale.incorrectValue", "");
-    const correctMaxValue = get(props, `properties.controls.${basePath}.max`, "");
+    const minValue = data?.properties?.controls?.[basePath]?.min;
+    const incorrectMaxValue = state?.maxScale?.incorrectValue ?? "";
+    const correctMaxValue = props?.properties?.controls?.[basePath]?.max ?? "";
 
     const incorrectMaxInvalid = isValueMinusOrEmpty(incorrectMaxValue);
     const maxNumberValue = incorrectMaxInvalid

--- a/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
@@ -1,4 +1,5 @@
 // (C) 2019-2020 GoodData Corporation
+// eslint-disable-next-line no-restricted-imports -- unfortunately, the get syntax is used heavily here for the supported properties
 import get from "lodash/get";
 import has from "lodash/has";
 import set from "lodash/set";

--- a/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/propertiesHelper.ts
@@ -14,8 +14,7 @@ import {
     getMeasureItems,
     getAllMeasuresShowOnSecondaryAxis,
 } from "./bucketHelper";
-import { BUCKETS, SHOW_ON_SECONDARY_AXIS } from "../constants/bucket";
-import { PROPERTY_CONTROLS, PROPERTY_CONTROLS_DUAL_AXIS } from "../constants/properties";
+import { PROPERTY_CONTROLS } from "../constants/properties";
 import { UICONFIG_AXIS } from "../constants/uiConfig";
 import { AxisType, IAxisNameProperties } from "../interfaces/AxisType";
 import { OPTIONAL_STACKING_PROPERTIES } from "../constants/supportedProperties";
@@ -37,7 +36,7 @@ export function getSupportedPropertiesControls(
 }
 
 export function hasColorMapping(properties: IVisualizationProperties): boolean {
-    return !!get(properties, ["controls", "colorMapping"]);
+    return !!properties?.controls?.colorMapping;
 }
 
 export function setSecondaryMeasures(
@@ -50,8 +49,8 @@ export function setSecondaryMeasures(
 
     const newReferencePoint = cloneDeep(referencePoint);
     const path = `${PROPERTY_CONTROLS}.${axisName}`;
-    const secondaryAxisProperties = get(newReferencePoint, path);
-    const buckets = get(newReferencePoint, BUCKETS, []);
+    const secondaryAxisProperties = newReferencePoint?.properties?.controls?.[axisName];
+    const buckets = newReferencePoint?.buckets ?? [];
     const allMeasures = getMeasureItems(buckets);
     const secondaryMeasures = getAllMeasuresShowOnSecondaryAxis(buckets);
 
@@ -112,7 +111,7 @@ export function getReferencePointWithSupportedProperties(
             },
         };
     }
-    const buckets = get(referencePoint, BUCKETS, []);
+    const buckets = referencePoint?.buckets ?? [];
     const stackCount = getItemsCount(buckets, BucketNames.STACK);
     const stackMeasuresToPercent = Boolean(supportedControlsProperties.stackMeasuresToPercent);
 
@@ -130,11 +129,11 @@ export function getReferencePointWithSupportedProperties(
 }
 
 export function isStackingMeasure(properties: IVisualizationProperties): boolean {
-    return get(properties, ["controls", "stackMeasures"], false);
+    return properties?.controls?.stackMeasures ?? false;
 }
 
 export function isStackingToPercent(properties: IVisualizationProperties): boolean {
-    return get(properties, ["controls", "stackMeasuresToPercent"], false);
+    return properties?.controls?.stackMeasuresToPercent ?? false;
 }
 
 export function isDualAxisOrSomeSecondaryAxisMeasure(
@@ -142,8 +141,8 @@ export function isDualAxisOrSomeSecondaryAxisMeasure(
     secondaryMeasures: IBucketItem[],
 ): boolean {
     return (
-        get(extReferencePoint, PROPERTY_CONTROLS_DUAL_AXIS, true) ||
-        secondaryMeasures.some((item) => get(item, SHOW_ON_SECONDARY_AXIS))
+        (extReferencePoint?.properties?.controls?.dualAxis ?? true) ||
+        secondaryMeasures.some((item) => item?.showOnSecondaryAxis)
     );
 }
 
@@ -151,7 +150,7 @@ export function removeImmutableOptionalStackingProperties(
     referencePoint: IExtendedReferencePoint,
     supportedPropertiesList: string[],
 ): string[] {
-    const buckets = get(referencePoint, BUCKETS, []);
+    const buckets = referencePoint?.buckets ?? [];
     let immutableProperties: string[] = [];
 
     if (getItemsCount(buckets, BucketNames.MEASURES) <= 1) {
@@ -189,7 +188,7 @@ export function getHighchartsAxisNameConfiguration(
 ): IVisualizationProperties {
     const axisProperties: IVisualizationProperties = AXIS_TYPES.reduce(
         (result: IVisualizationProperties, axis: string) => {
-            const axisNameConfig: IAxisNameProperties = get(controlProperties, `${axis}.name`);
+            const axisNameConfig: IAxisNameProperties = controlProperties?.[axis]?.name;
 
             if (isEmpty(axisNameConfig)) {
                 return result;
@@ -241,5 +240,5 @@ export function getDataPointsConfiguration(
 export function getColumnWidthsFromProperties(
     visualizationProperties: IVisualizationProperties,
 ): ColumnWidthItem[] | undefined {
-    return get(visualizationProperties, "controls.columnWidths");
+    return visualizationProperties?.controls?.columnWidths;
 }

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -1,6 +1,5 @@
 // (C) 2019-2020 GoodData Corporation
 import every from "lodash/every";
-import get from "lodash/get";
 import includes from "lodash/includes";
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
@@ -152,9 +151,9 @@ export function createSorts(
 }
 
 export function getBucketItemIdentifiers(referencePoint: IExtendedReferencePoint): string[] {
-    const buckets: IBucketOfFun[] = get(referencePoint, "buckets", []);
+    const buckets = referencePoint?.buckets ?? [];
     return buckets.reduce((localIdentifiers: string[], bucket: IBucketOfFun): string[] => {
-        const items: IBucketItem[] = get(bucket, "items", []);
+        const items = bucket?.items ?? [];
         return localIdentifiers.concat(items.map((item: IBucketItem): string => item.localIdentifier));
     }, []);
 }
@@ -209,7 +208,7 @@ export function removeInvalidSort(
 
 export function setSortItems(referencePoint: IExtendedReferencePoint): IExtendedReferencePoint {
     const buckets = referencePoint.buckets;
-    const sortItems = get(referencePoint, ["properties", "sortItems"], []);
+    const sortItems = referencePoint?.properties?.sortItems ?? [];
 
     if (sortItems.length > 0) {
         return referencePoint;

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/areaChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/areaChartUiConfigHelper.ts
@@ -1,16 +1,10 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import { IntlShape } from "react-intl";
 
 import { BucketNames } from "@gooddata/sdk-ui";
-import {
-    IExtendedReferencePoint,
-    IBucketOfFun,
-    IUiConfig,
-    IBucketUiConfig,
-} from "../../interfaces/Visualization";
+import { IExtendedReferencePoint, IBucketOfFun, IUiConfig } from "../../interfaces/Visualization";
 
 import { UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
@@ -46,14 +40,14 @@ function setAreaChartBucketWarningMessages(
     messageConfig: { [bucketName: string]: string },
     intl?: IntlShape,
 ): IUiConfig {
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
-    const updatedUiConfig: IUiConfig = get(referencePoint, UICONFIG);
+    const buckets = referencePoint?.buckets ?? [];
+    const updatedUiConfig = referencePoint?.uiConfig;
 
     return buckets.reduce((uiConfig: IUiConfig, bucket: IBucketOfFun) => {
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
-        const bucketUiConfig: IBucketUiConfig = get(uiConfig, [BUCKETS, localIdentifier]);
-        const isEnabled: boolean = get(bucketUiConfig, "enabled", false);
-        const canAddItem: boolean = get(bucketUiConfig, "canAddItems");
+        const localIdentifier = bucket?.localIdentifier ?? "";
+        const bucketUiConfig = uiConfig?.buckets?.[localIdentifier];
+        const isEnabled = bucketUiConfig?.enabled ?? false;
+        const canAddItem = bucketUiConfig?.canAddItems;
 
         // skip disabled buckets
         if (canAddItem || !isEnabled) {
@@ -73,7 +67,7 @@ export function setAreaChartUiConfig(
     visualizationType: string,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const buckets: IBucketOfFun[] = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
     const categoriesCount = getItemsCount(buckets, BucketNames.VIEW);
     const measuresCount = getMasterMeasuresCount(buckets, BucketNames.MEASURES);
     const isStackEmpty = hasNoStacks(buckets);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/baseChartUiConfigHelper.ts
@@ -1,20 +1,14 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import forEach from "lodash/forEach";
 import { IntlShape } from "react-intl";
 
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
-import {
-    IExtendedReferencePoint,
-    IBucketOfFun,
-    IUiConfig,
-    IBucketUiConfig,
-} from "../../interfaces/Visualization";
+import { IExtendedReferencePoint, IBucketOfFun, IUiConfig } from "../../interfaces/Visualization";
 
 import { UICONFIG, RECOMMENDATIONS, OPEN_AS_REPORT, SUPPORTED } from "../../constants/uiConfig";
-import { BUCKETS, FILTERS } from "../../constants/bucket";
+import { BUCKETS } from "../../constants/bucket";
 
 import {
     comparisonAndTrendingRecommendationEnabled,
@@ -42,19 +36,19 @@ function setBaseChartBucketWarningMessages(
     referencePoint: IExtendedReferencePoint,
     intl?: IntlShape,
 ): IUiConfig {
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
-    const updatedUiConfig: IUiConfig = cloneDeep(get(referencePoint, UICONFIG));
+    const buckets = referencePoint?.buckets ?? [];
+    const updatedUiConfig = cloneDeep(referencePoint?.uiConfig);
 
     forEach(buckets, (bucket: IBucketOfFun) => {
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
-        const bucketUiConfig: IBucketUiConfig = get(updatedUiConfig, [BUCKETS, localIdentifier]);
+        const localIdentifier = bucket?.localIdentifier ?? "";
+        const bucketUiConfig = updatedUiConfig?.buckets?.[localIdentifier];
 
         // skip disabled buckets
-        if (!get(bucketUiConfig, "enabled", false)) {
+        if (!bucketUiConfig?.enabled) {
             return;
         }
 
-        if (!get(bucketUiConfig, "canAddItems")) {
+        if (!bucketUiConfig?.canAddItems) {
             let warningMessageId;
             if (bucket.localIdentifier === BucketNames.MEASURES) {
                 warningMessageId = "dashboard.bucket.metric_stack_by_warning";
@@ -78,7 +72,7 @@ export function setBaseChartUiConfig(
     visualizationType: string,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const buckets: IBucketOfFun[] = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
 
     const measuresCanAddItems = hasNoMeasures(buckets) || hasNoStacks(buckets);
     const stackCanAddItems = !hasMoreThanOneMasterMeasure(buckets, BucketNames.MEASURES);
@@ -113,17 +107,17 @@ export function setBaseChartUiConfig(
     set(
         referencePointConfigured,
         [UICONFIG, BUCKETS, BucketNames.MEASURES, "icon"],
-        get(iconsMap, [visualizationType, BucketNames.MEASURES]),
+        iconsMap[visualizationType]?.[BucketNames.MEASURES],
     );
     set(
         referencePointConfigured,
         [UICONFIG, BUCKETS, BucketNames.VIEW, "icon"],
-        get(iconsMap, [visualizationType, BucketNames.VIEW]),
+        iconsMap[visualizationType]?.[BucketNames.VIEW],
     );
     set(
         referencePointConfigured,
         [UICONFIG, BUCKETS, BucketNames.STACK, "icon"],
-        get(iconsMap, [visualizationType, BucketNames.STACK]),
+        iconsMap[visualizationType]?.[BucketNames.STACK],
     );
 
     set(
@@ -142,8 +136,8 @@ export function setBaseChartUiConfigRecommendations(
 ): IExtendedReferencePoint {
     if (visualizationType === VisualizationTypes.COLUMN) {
         const newReferencePoint = cloneDeep(referencePoint);
-        const buckets = get(newReferencePoint, BUCKETS);
-        const filters = get(newReferencePoint, FILTERS);
+        const buckets = newReferencePoint?.buckets;
+        const filters = newReferencePoint?.filters;
 
         const percentEnabled = percentRecommendationEnabled(buckets, filters);
         const comparisonAndTrending = comparisonAndTrendingRecommendationEnabled(buckets);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/bulletChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/bulletChartUiConfigHelper.ts
@@ -1,10 +1,8 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import { IntlShape } from "react-intl";
-import { IExtendedReferencePoint, IBucketOfFun } from "../../interfaces/Visualization";
+import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 import { UICONFIG } from "../../constants/uiConfig";
-import { BUCKETS } from "../../constants/bucket";
 import { setBucketTitles, getItemsCount } from "./../bucketHelper";
 import { getTranslation } from "../translations";
 
@@ -23,7 +21,7 @@ export function getBulletChartUiConfig(
 
     referencePointConfigured[UICONFIG] = setBucketTitles(referencePointConfigured, visualizationType, intl);
 
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
+    const buckets = referencePoint?.buckets ?? [];
 
     const primaryMeasuresCount = getItemsCount(buckets, BucketNames.MEASURES);
     const secondaryMeasuresCount = getItemsCount(buckets, BucketNames.SECONDARY_MEASURES);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/columnBarChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/columnBarChartUiConfigHelper.ts
@@ -1,7 +1,6 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
-import get from "lodash/get";
 import { BucketNames, OverTimeComparisonTypes } from "@gooddata/sdk-ui";
 import { getTranslation } from "../translations";
 
@@ -25,7 +24,7 @@ export function setColumnBarChartUiConfig(
         [OverTimeComparisonTypes.SAME_PERIOD_PREVIOUS_YEAR, OverTimeComparisonTypes.PREVIOUS_PERIOD],
     );
 
-    const buckets = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
     const measures = getMeasureItems(buckets);
 
     if (measures.length > 1) {

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/comboChartUiConfigHelper.ts
@@ -1,7 +1,6 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
-import get from "lodash/get";
 import { IntlShape } from "react-intl";
 
 import { isLineChart } from "@gooddata/sdk-ui-charts";
@@ -23,10 +22,6 @@ import columnViewIcon from "../../assets/column/bucket-title-view.svg";
 import lineViewIcon from "../../assets/combo/bucket-title-view-line-line.svg";
 import areaViewIcon from "../../assets/area/bucket-title-view.svg";
 
-import {
-    PROPERTY_CONTROLS_PRIMARY_CHART_TYPE,
-    PROPERTY_CONTROLS_SECONDARY_CHART_TYPE,
-} from "../../constants/properties";
 import { UICONFIG } from "../../constants/uiConfig";
 
 const { COLUMN, LINE, AREA } = VisualizationTypes;
@@ -62,23 +57,23 @@ export function setComboChartUiConfig(
     visualizationType: ChartType,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const measureBuckets: IBucketOfFun[] = getBucketsByNames(get(referencePointConfigured, BUCKETS), [
+    const measureBuckets = getBucketsByNames(referencePointConfigured?.buckets, [
         BucketNames.MEASURES,
         BucketNames.SECONDARY_MEASURES,
     ]);
     const chartTypes = [
-        get(referencePointConfigured, PROPERTY_CONTROLS_PRIMARY_CHART_TYPE, COLUMN),
-        get(referencePointConfigured, PROPERTY_CONTROLS_SECONDARY_CHART_TYPE, LINE),
+        referencePointConfigured?.properties?.controls?.primaryChartType ?? COLUMN,
+        referencePointConfigured?.properties?.controls?.secondaryChartType ?? LINE,
     ];
 
     const updatedUiConfig: IUiConfig = setBucketTitles(referencePointConfigured, visualizationType, intl);
 
-    const isDualAxis = get(referencePointConfigured, "properties.controls.dualAxis", true);
+    const isDualAxis = referencePointConfigured?.properties?.controls?.dualAxis ?? true;
     setCanStackInPercent(updatedUiConfig, chartTypes[1], isDualAxis);
 
     measureBuckets.forEach((bucket: IBucketOfFun, index: number) => {
         const type = chartTypes[index];
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
+        const localIdentifier = bucket?.localIdentifier ?? "";
         const subtitle = getTranslation(`dashboard.bucket.combo.subtitle.${type}`, intl);
 
         set(updatedUiConfig, [BUCKETS, localIdentifier, "subtitle"], subtitle);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/geoPushpinChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/geoPushpinChartUiConfigHelper.ts
@@ -2,7 +2,6 @@
 import { IntlShape } from "react-intl";
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
-import get from "lodash/get";
 
 import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 import { UICONFIG, OPEN_AS_REPORT, SUPPORTED } from "../../constants/uiConfig";
@@ -39,11 +38,11 @@ export function setGeoPushpinUiConfig(
 
     // only apply related bucket uiConfig
     set(referencePointConfigured, [UICONFIG, BUCKETS], {
-        [BucketNames.LOCATION]: get(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.LOCATION]),
-        [BucketNames.SIZE]: get(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.SIZE]),
-        [BucketNames.COLOR]: get(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.COLOR]),
-        [BucketNames.SEGMENT]: get(referencePointConfigured, [UICONFIG, BUCKETS, BucketNames.SEGMENT]),
-        ["filters"]: get(referencePointConfigured, [UICONFIG, BUCKETS, "filters"]),
+        [BucketNames.LOCATION]: referencePointConfigured?.uiConfig?.buckets?.[BucketNames.LOCATION],
+        [BucketNames.SIZE]: referencePointConfigured?.uiConfig?.buckets?.[BucketNames.SIZE],
+        [BucketNames.COLOR]: referencePointConfigured?.uiConfig?.buckets?.[BucketNames.COLOR],
+        [BucketNames.SEGMENT]: referencePointConfigured?.uiConfig?.buckets?.[BucketNames.SEGMENT],
+        filters: referencePointConfigured?.uiConfig?.buckets?.filters,
     });
 
     return referencePointConfigured;

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/headlineUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/headlineUiConfigHelper.ts
@@ -1,11 +1,10 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import { IntlShape } from "react-intl";
 
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
-import { IBucketOfFun, IUiConfig, IReferencePoint } from "../../interfaces/Visualization";
+import { IUiConfig, IReferencePoint } from "../../interfaces/Visualization";
 import { DEFAULT_HEADLINE_UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
 
@@ -24,7 +23,7 @@ export function getDefaultHeadlineUiConfig(): IUiConfig {
 export function getHeadlineUiConfig(referencePoint: IReferencePoint, intl: IntlShape): IUiConfig {
     let uiConfig = getDefaultHeadlineUiConfig();
 
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
+    const buckets = referencePoint?.buckets ?? [];
     const viewCanAddPrimaryItems = hasNoMeasures(buckets);
     const viewCanAddSecondaryItems = hasNoSecondaryMeasures(buckets);
 

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/lineChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/lineChartUiConfigHelper.ts
@@ -1,17 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import forEach from "lodash/forEach";
 import { IntlShape } from "react-intl";
 
 import { BucketNames } from "@gooddata/sdk-ui";
-import {
-    IExtendedReferencePoint,
-    IBucketOfFun,
-    IUiConfig,
-    IBucketUiConfig,
-} from "../../interfaces/Visualization";
+import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 
 import { UICONFIG, OPEN_AS_REPORT, SUPPORTED } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
@@ -27,19 +21,19 @@ import lineSegmentIcon from "../../assets/line/bucket-title-segment.svg";
 import { hasColorMapping } from "../propertiesHelper";
 
 function setLineChartBucketWarningMessages(referencePoint: IExtendedReferencePoint, intl?: IntlShape) {
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS);
-    const updatedUiConfig: IUiConfig = cloneDeep(get(referencePoint, UICONFIG));
+    const buckets = referencePoint?.buckets;
+    const updatedUiConfig = cloneDeep(referencePoint?.uiConfig);
 
-    forEach(buckets, (bucket: IBucketOfFun) => {
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
-        const bucketUiConfig: IBucketUiConfig = get(updatedUiConfig, [BUCKETS, localIdentifier]);
+    forEach(buckets, (bucket) => {
+        const localIdentifier = bucket?.localIdentifier ?? "";
+        const bucketUiConfig = updatedUiConfig?.buckets?.[localIdentifier];
 
         // skip disabled buckets
-        if (!get(bucketUiConfig, "enabled", false)) {
+        if (!bucketUiConfig?.enabled) {
             return;
         }
 
-        if (!get(bucketUiConfig, "canAddItems")) {
+        if (!bucketUiConfig?.canAddItems) {
             let warningMessageId;
             if (bucket.localIdentifier === BucketNames.MEASURES) {
                 warningMessageId = "dashboard.bucket.metric_segment_by_warning";
@@ -63,7 +57,7 @@ export function setLineChartUiConfig(
     visualizationType: string,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const buckets: IBucketOfFun[] = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
 
     const measuresCanAddItems = hasNoMeasures(buckets) || hasNoStacks(buckets);
     const segmentCanAddItems =

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pieChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/pieChartUiConfigHelper.ts
@@ -1,17 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import forEach from "lodash/forEach";
 import { IntlShape } from "react-intl";
 
 import { BucketNames } from "@gooddata/sdk-ui";
-import {
-    IExtendedReferencePoint,
-    IBucketOfFun,
-    IUiConfig,
-    IBucketUiConfig,
-} from "../../interfaces/Visualization";
+import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 
 import { UICONFIG, SUPPORTED, OPEN_AS_REPORT } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
@@ -26,19 +20,19 @@ import pieViewIcon from "../../assets/pie/bucket-title-view.svg";
 import { hasColorMapping } from "../propertiesHelper";
 
 function setPieChartBucketWarningMessages(referencePoint: IExtendedReferencePoint, intl?: IntlShape) {
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS);
-    const updatedUiConfig: IUiConfig = cloneDeep(get(referencePoint, UICONFIG));
+    const buckets = referencePoint?.buckets;
+    const updatedUiConfig = cloneDeep(referencePoint?.uiConfig);
 
-    forEach(buckets, (bucket: IBucketOfFun) => {
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
-        const bucketUiConfig: IBucketUiConfig = get(updatedUiConfig, [BUCKETS, localIdentifier]);
+    forEach(buckets, (bucket) => {
+        const localIdentifier = bucket?.localIdentifier ?? "";
+        const bucketUiConfig = updatedUiConfig?.buckets?.[localIdentifier];
 
         // skip disabled buckets
-        if (!get(bucketUiConfig, "enabled", false)) {
+        if (!bucketUiConfig?.enabled) {
             return;
         }
 
-        if (!get(bucketUiConfig, "canAddItems")) {
+        if (!bucketUiConfig?.canAddItems) {
             let warningMessageId;
             if (bucket.localIdentifier === BucketNames.VIEW) {
                 warningMessageId = "dashboard.bucket.category_category_by_warning";
@@ -60,7 +54,7 @@ export function setPieChartUiConfig(
     visualizationType: string,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const buckets: IBucketOfFun[] = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
 
     const measuresCanAddItems = !hasMoreThanOneCategory(buckets);
     const viewCanAddItems = !hasMoreThanOneMasterMeasure(buckets, BucketNames.MEASURES);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelper.test.ts
@@ -1,5 +1,4 @@
 // (C) 2019-2020 GoodData Corporation
-import get from "lodash/get";
 import { DefaultLocale, VisualizationTypes } from "@gooddata/sdk-ui";
 import * as referencePointMock from "../../../tests/mocks/referencePointMocks";
 import { setComboChartUiConfig } from "../comboChartUiConfigHelper";
@@ -17,9 +16,9 @@ describe("comboChartUiConfigHelper", () => {
 
         it("should set bucket titles", () => {
             const referencePoint = setComboChartUiConfig(refPointMock, intl, VisualizationTypes.COMBO);
-            const primaryMeasureBucket = get(referencePoint, "uiConfig.buckets.measures");
-            const secondaryMeasureBucket = get(referencePoint, "uiConfig.buckets.secondary_measures");
-            const viewBucket = get(referencePoint, "uiConfig.buckets.view");
+            const primaryMeasureBucket = referencePoint?.uiConfig?.buckets?.measures;
+            const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
+            const viewBucket = referencePoint?.uiConfig?.buckets?.view;
 
             expect(primaryMeasureBucket.title).toEqual("Measures");
             expect(secondaryMeasureBucket.title).toEqual("Measures");
@@ -43,8 +42,8 @@ describe("comboChartUiConfigHelper", () => {
                     },
                 };
                 const referencePoint = setComboChartUiConfig(refPoint, intl, VisualizationTypes.COMBO);
-                const primaryMeasureBucket = get(referencePoint, "uiConfig.buckets.measures");
-                const secondaryMeasureBucket = get(referencePoint, "uiConfig.buckets.secondary_measures");
+                const primaryMeasureBucket = referencePoint?.uiConfig?.buckets?.measures;
+                const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
 
                 expect(primaryMeasureBucket.icon).toBeDefined();
                 expect(secondaryMeasureBucket.icon).toBeDefined();
@@ -70,7 +69,7 @@ describe("comboChartUiConfigHelper", () => {
                     },
                 };
                 const referencePoint = setComboChartUiConfig(refPoint, intl, VisualizationTypes.COMBO);
-                const canStackInPercent = get(referencePoint, "uiConfig.optionalStacking.canStackInPercent");
+                const canStackInPercent = referencePoint?.uiConfig?.optionalStacking?.canStackInPercent;
                 expect(canStackInPercent).toBe(expectation);
             },
         );

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelperDeprecated.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/tests/comboChartUiConfigHelperDeprecated.test.ts
@@ -1,5 +1,4 @@
 // (C) 2019-2020 GoodData Corporation
-import get from "lodash/get";
 import { DefaultLocale, VisualizationTypes } from "@gooddata/sdk-ui";
 import * as referencePointMock from "../../../tests/mocks/referencePointMocks";
 import { setComboChartUiConfigDeprecated } from "../comboChartUiConfigHelperDeprecated";
@@ -20,9 +19,9 @@ describe("comboChartUiConfigHelper", () => {
                 intl,
                 VisualizationTypes.COMBO,
             );
-            const primaryMeasureBucket = get(referencePoint, "uiConfig.buckets.measures");
-            const secondaryMeasureBucket = get(referencePoint, "uiConfig.buckets.secondary_measures");
-            const viewBucket = get(referencePoint, "uiConfig.buckets.view");
+            const primaryMeasureBucket = referencePoint?.uiConfig?.buckets?.measures;
+            const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
+            const viewBucket = referencePoint?.uiConfig?.buckets?.view;
 
             expect(primaryMeasureBucket.title).toEqual("Measures");
             expect(secondaryMeasureBucket.title).toEqual("Measures");
@@ -35,8 +34,8 @@ describe("comboChartUiConfigHelper", () => {
                 intl,
                 VisualizationTypes.COMBO,
             );
-            const primaryMeasureBucket = get(referencePoint, "uiConfig.buckets.measures");
-            const secondaryMeasureBucket = get(referencePoint, "uiConfig.buckets.secondary_measures");
+            const primaryMeasureBucket = referencePoint?.uiConfig?.buckets?.measures;
+            const secondaryMeasureBucket = referencePoint?.uiConfig?.buckets?.secondary_measures;
 
             expect(primaryMeasureBucket.icon).toBeDefined();
             expect(secondaryMeasureBucket.icon).toBeDefined();

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/treemapUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/treemapUiConfigHelper.ts
@@ -1,17 +1,11 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import forEach from "lodash/forEach";
 import { IntlShape } from "react-intl";
 
 import { BucketNames } from "@gooddata/sdk-ui";
-import {
-    IExtendedReferencePoint,
-    IBucketOfFun,
-    IUiConfig,
-    IBucketUiConfig,
-} from "../../interfaces/Visualization";
+import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 
 import { UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
@@ -26,19 +20,19 @@ import treemapViewIcon from "../../assets/treemap/bucket-title-view.svg";
 import treemapSegmentIcon from "../../assets/treemap/bucket-title-segment.svg";
 
 function setTreemapBucketWarningMessages(referencePoint: IExtendedReferencePoint, intl?: IntlShape) {
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS);
-    const updatedUiConfig: IUiConfig = cloneDeep(get(referencePoint, UICONFIG));
+    const buckets = referencePoint?.buckets;
+    const updatedUiConfig = cloneDeep(referencePoint?.uiConfig);
 
-    forEach(buckets, (bucket: IBucketOfFun) => {
-        const localIdentifier: string = get(bucket, "localIdentifier", "");
-        const bucketUiConfig: IBucketUiConfig = get(updatedUiConfig, [BUCKETS, localIdentifier]);
+    forEach(buckets, (bucket) => {
+        const localIdentifier = bucket?.localIdentifier ?? "";
+        const bucketUiConfig = updatedUiConfig?.buckets?.[localIdentifier];
 
         // skip disabled buckets
-        if (!get(bucketUiConfig, "enabled", false)) {
+        if (!bucketUiConfig?.enabled) {
             return;
         }
 
-        if (!get(bucketUiConfig, "canAddItems")) {
+        if (!bucketUiConfig?.canAddItems) {
             let warningMessageId;
             if (bucket.localIdentifier === BucketNames.MEASURES) {
                 warningMessageId = "dashboard.bucket.metric_view_by_warning";
@@ -68,7 +62,7 @@ export function setTreemapUiConfig(
     visualizationType: string,
 ): IExtendedReferencePoint {
     const referencePointConfigured = cloneDeep(referencePoint);
-    const buckets: IBucketOfFun[] = get(referencePointConfigured, BUCKETS, []);
+    const buckets = referencePointConfigured?.buckets ?? [];
 
     const measuresCanAddItems = !hasOneCategory(buckets) || hasNoMeasures(buckets);
     const viewCanAddItems = !hasMoreThanOneMasterMeasure(buckets, BucketNames.MEASURES);

--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/xirrUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/xirrUiConfigHelper.ts
@@ -1,11 +1,10 @@
 // (C) 2019-2020 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
-import get from "lodash/get";
 import set from "lodash/set";
 import { IntlShape } from "react-intl";
 
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
-import { IReferencePoint, IUiConfig, ICustomError, IBucketOfFun } from "../../interfaces/Visualization";
+import { IReferencePoint, IUiConfig, ICustomError } from "../../interfaces/Visualization";
 import { DEFAULT_XIRR_UICONFIG } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
 import { hasNoMeasures, hasNoAttribute } from "../bucketRules";
@@ -40,7 +39,7 @@ export const getXirrUiConfig = (referencePoint: IReferencePoint, intl: IntlShape
         intl,
     );
 
-    const buckets: IBucketOfFun[] = get(referencePoint, BUCKETS, []);
+    const buckets = referencePoint?.buckets ?? [];
 
     const canAddMeasures = hasNoMeasures(buckets);
     const canAddAttribute = hasNoAttribute(buckets);


### PR DESCRIPTION
Remove `lodash/get` from `api-client-bear` and most of `sdk-ui-ext`.

Also add ESLint rule to improve the feedback in IDEs (they show ESLint errors, not dependabot ones).

Also fix one really old bug (see the second commit, this dates all the way back to app-components). 

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
