### PR TITLE
Added warnings property to decorated data view.

### DIFF
--- a/libs/sdk-backend-base/src/decoratedBackend/execution.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/execution.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import {
     IDataView,
     IDimensionDescriptor,
@@ -9,6 +9,7 @@ import {
     IPreparedExecution,
     IResultHeader,
     DataValue,
+    IResultWarning,
 } from "@gooddata/sdk-backend-spi";
 import {
     IAttributeOrMeasure,
@@ -184,6 +185,7 @@ export abstract class DecoratedDataView implements IDataView {
     public totals?: DataValue[][][];
     public definition: IExecutionDefinition;
     public result: IExecutionResult;
+    public warnings?: IResultWarning[];
 
     constructor(private readonly decorated: IDataView, result?: IExecutionResult) {
         this.result = result ?? decorated.result;
@@ -195,6 +197,7 @@ export abstract class DecoratedDataView implements IDataView {
         this.offset = decorated.offset;
         this.totalCount = decorated.totalCount;
         this.totals = decorated.totals;
+        this.warnings = decorated.warnings;
     }
 
     public equals(other: IDataView): boolean {


### PR DESCRIPTION
JIRA: ONE-4974

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
