### PR TITLE
RELATED: RAIL-3319 Fix pivot tables with multiple sorts

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
@@ -15,6 +15,7 @@ import {
     SortDirection,
 } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
+import findIndex from "lodash/findIndex";
 
 type SortKey = SortKeyAttribute | SortKeyValue;
 
@@ -103,7 +104,7 @@ function dimensionsWithSorts(dims: Dimension[], sorts: ISortItem[]): Dimension[]
         return dims;
     }
 
-    const nonMeasureDimIdx = dims.findIndex((dim) => !dim.itemIdentifiers.includes(MeasureGroupIdentifier));
+    const nonMeasureDimIdx = findIndex(dims, (dim) => !dim.itemIdentifiers.includes(MeasureGroupIdentifier));
     const measureDim = dims.find((dim) => dim.itemIdentifiers.includes(MeasureGroupIdentifier));
     const sorting: SortKey[][] = dims.map((_) => []);
 
@@ -118,7 +119,7 @@ function dimensionsWithSorts(dims: Dimension[], sorts: ISortItem[]): Dimension[]
                 },
             };
 
-            const dimIdx = dims.findIndex((dim) => dim.itemIdentifiers.includes(attributeIdentifier));
+            const dimIdx = findIndex(dims, (dim) => dim.itemIdentifiers.includes(attributeIdentifier));
 
             if (dimIdx < 0) {
                 // eslint-disable-next-line no-console

--- a/libs/sdk-model/src/execution/base/dimension.ts
+++ b/libs/sdk-model/src/execution/base/dimension.ts
@@ -4,6 +4,7 @@ import invariant from "ts-invariant";
 import { Identifier } from "../../objRef/index";
 import { isTotal, ITotal } from "./totals";
 import isEmpty from "lodash/isEmpty";
+import findIndex from "lodash/findIndex";
 import { attributeLocalId, IAttribute, isAttribute } from "../attribute";
 
 /**
@@ -195,7 +196,7 @@ export function dimensionsFindItem(dims: IDimension[], localId: string): ItemInD
 
     for (let dimIdx = 0; dimIdx < dims.length; dimIdx++) {
         const dim = dims[dimIdx];
-        const itemIdx = dim.itemIdentifiers.findIndex((i) => i === localId);
+        const itemIdx = findIndex(dim.itemIdentifiers, (i) => i === localId);
 
         if (itemIdx >= 0) {
             result.push({ dim, dimIdx, itemIdx });

--- a/libs/sdk-model/src/execution/buckets/bucketArray.ts
+++ b/libs/sdk-model/src/execution/buckets/bucketArray.ts
@@ -23,6 +23,7 @@ import { ITotal } from "../base/totals";
 import flatMap from "lodash/flatMap";
 import invariant from "ts-invariant";
 import identity from "lodash/identity";
+import findIndex from "lodash/findIndex";
 
 /**
  * Gets all attributes matching the provided predicate from a list of buckets.
@@ -123,7 +124,7 @@ export function bucketsFindAttribute(
     };
 
     for (const bucket of buckets) {
-        const idx = bucket.items.findIndex(typeAgnosticPredicate);
+        const idx = findIndex(bucket.items, typeAgnosticPredicate);
 
         if (idx >= 0) {
             const item = bucket.items[idx];
@@ -164,7 +165,7 @@ export function bucketsFindMeasure(
     };
 
     for (const bucket of buckets) {
-        const idx = bucket.items.findIndex(typeAgnosticPredicate);
+        const idx = findIndex(bucket.items, typeAgnosticPredicate);
 
         if (idx >= 0) {
             const item = bucket.items[idx];

--- a/libs/sdk-model/src/execution/buckets/index.ts
+++ b/libs/sdk-model/src/execution/buckets/index.ts
@@ -15,6 +15,7 @@ import invariant from "ts-invariant";
 import { modifySimpleMeasure } from "../measure/factory";
 import isArray from "lodash/isArray";
 import identity from "lodash/identity";
+import findIndex from "lodash/findIndex";
 
 /**
  * Type representing bucket items - which can be either measure or an attribute.
@@ -188,7 +189,7 @@ export function bucketAttributeIndex(
         return isAttribute(obj) && predicate(obj);
     };
 
-    return bucket.items.findIndex(compositeGuard);
+    return findIndex(bucket.items, compositeGuard);
 }
 
 /**
@@ -260,7 +261,7 @@ export function bucketMeasureIndex(bucket: IBucket, idOrFun: string | MeasurePre
         return isMeasure(obj) && predicate(obj);
     };
 
-    return bucket.items.findIndex(compositeGuard);
+    return findIndex(bucket.items, compositeGuard);
 }
 
 /**

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartAxes.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartAxes.ts
@@ -8,6 +8,7 @@ import { isBarChart, isBubbleChart, isHeatmap, isOneOfTypes, isScatterPlot, unwr
 import { supportedDualAxesChartTypes } from "./chartCapabilities";
 import isEmpty from "lodash/isEmpty";
 import compact from "lodash/compact";
+import findIndex from "lodash/findIndex";
 import range from "lodash/range";
 import includes from "lodash/includes";
 import { IUnwrappedAttributeHeadersWithItems } from "../../typings/mess";
@@ -235,7 +236,7 @@ function createYAxisItem(measuresInAxis: any[], opposite = false) {
 
 export function assignYAxes(series: ISeriesItem[], yAxes: IAxis[]): ISeriesItem[] {
     return series.reduce((result, item, index) => {
-        const yAxisIndex = yAxes.findIndex((axis: IAxis) => {
+        const yAxisIndex = findIndex(yAxes, (axis: IAxis) => {
             return includes(axis.seriesIndices ?? [], index);
         });
         // for case viewBy and stackBy have one attribute, and one measure is sliced to multiple series

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -3,6 +3,7 @@ import range from "lodash/range";
 import set from "lodash/set";
 import isNil from "lodash/isNil";
 import cloneDeep from "lodash/cloneDeep";
+import findIndex from "lodash/findIndex";
 import { DefaultColorPalette, VisualizationTypes, HeaderPredicates, DataViewFacade } from "@gooddata/sdk-ui";
 import Highcharts from "../../../lib";
 import { findMeasureGroupInDimensions } from "../../_util/executionResultHelper";
@@ -1537,7 +1538,7 @@ describe("chartOptionsBuilder", () => {
             const { measureGroup } = getMVS(dv);
             const heatmapSeries = getHeatmapSeries(dv, measureGroup);
             const heatmapDataPoints = heatmapSeries[0].data;
-            const firstEmptyCellIndex = heatmapDataPoints.findIndex((point) => isNil(point.value));
+            const firstEmptyCellIndex = findIndex(heatmapDataPoints, (point) => isNil(point.value));
 
             it("should return only one series", () => {
                 expect(heatmapSeries.length).toBe(1);

--- a/libs/sdk-ui-ext/src/dashboardView/contexts/DashboardAlertsContext.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/contexts/DashboardAlertsContext.tsx
@@ -1,6 +1,7 @@
 // (C) 2021 GoodData Corporation
 import React, { useReducer } from "react";
 import noop from "lodash/noop";
+import findIndex from "lodash/findIndex";
 import { IWidgetAlert } from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual } from "@gooddata/sdk-model";
 
@@ -56,7 +57,7 @@ function reducer(state: IAlertsState, action: AlertAction): IAlertsState {
                 alerts: state.alerts?.filter((alert) => alert !== action.payload),
             };
         case "update": {
-            const index = state.alerts?.findIndex((alert) => areObjRefsEqual(alert.ref, action.payload.ref));
+            const index = findIndex(state.alerts, (alert) => areObjRefsEqual(alert.ref, action.payload.ref));
             return {
                 ...state,
                 alerts: [...state.alerts.slice(0, index), action.payload, ...state.alerts.slice(index + 1)],

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
@@ -27,6 +27,7 @@ import {
     resultHeaderName,
 } from "@gooddata/sdk-backend-spi";
 import { IPushpinCategoryLegendItem } from "@gooddata/sdk-ui-vis-commons";
+import findIndex from "lodash/findIndex";
 
 interface IBucketItemInfo {
     uri?: Identifier;
@@ -145,7 +146,8 @@ function getBucketItemNameAndDataIndex(dv: DataViewFacade): IGeoData {
             if (!bucketItemInfo) {
                 return;
             }
-            const index = attributeDescriptors.findIndex(
+            const index = findIndex(
+                attributeDescriptors,
                 (desc: IAttributeDescriptor): boolean =>
                     desc.attributeHeader.localIdentifier === bucketItemInfo.localIdentifier &&
                     (desc.attributeHeader.uri === bucketItemInfo.uri ||
@@ -167,7 +169,8 @@ function getBucketItemNameAndDataIndex(dv: DataViewFacade): IGeoData {
         if (!bucketItemInfo) {
             return;
         }
-        const index = measureDescriptors.findIndex(
+        const index = findIndex(
+            measureDescriptors,
             (desc: IMeasureDescriptor): boolean =>
                 desc.measureHeaderItem.localIdentifier === bucketItemInfo.localIdentifier &&
                 (desc.measureHeaderItem.uri === bucketItemInfo.uri ||

--- a/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowFactory.ts
@@ -15,9 +15,10 @@ import { TableDescriptor } from "../structure/tableDescriptor";
 import { IAgGridPage, IGridRow, IGridTotalsRow } from "./resultTypes";
 import { getSubtotalStyles } from "./dataSourceUtils";
 import fill from "lodash/fill";
+import findIndex from "lodash/findIndex";
 
 function getSubtotalLabelCellIndex(resultHeaderItems: IResultHeader[][], rowIndex: number): number {
-    return resultHeaderItems.findIndex((headerItem) => isResultTotalHeader(headerItem[rowIndex]));
+    return findIndex(resultHeaderItems, (headerItem) => isResultTotalHeader(headerItem[rowIndex]));
 }
 
 function getMinimalRowData(dv: DataViewFacade): DataValue[][] {

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
@@ -27,13 +27,28 @@ type TransformState = {
     allColDefs: Array<ColDef | ColGroupDef>;
 };
 
+function getSortProp(
+    initialSorts: ISortItem[],
+    predicate: (sortItem: ISortItem) => boolean,
+): Partial<ColDef> {
+    const sortIndex = initialSorts.findIndex((s) => predicate(s));
+    const sort = initialSorts[sortIndex];
+
+    return sort
+        ? {
+              sort: sortDirection(sort),
+              // use sortedAt to make sure the order of sorts is the same as the order of columns
+              sortedAt: sortIndex,
+          }
+        : {};
+}
+
 function createAndAddSliceColDefs(rows: SliceCol[], state: TransformState) {
     for (const row of rows) {
-        const sort = state.initialSorts.find((s) => attributeSortMatcher(row, s));
-        const sortProp = sort ? { sort: sortDirection(sort) } : {};
+        const sortProp = getSortProp(state.initialSorts, (s) => attributeSortMatcher(row, s));
         const cellRendererProp = !state.cellRendererPlaced ? { cellRenderer: "loadingRenderer" } : {};
 
-        const colDef = {
+        const colDef: ColDef = {
             type: ROW_ATTRIBUTE_COLUMN,
             colId: row.id,
             field: row.id,
@@ -106,9 +121,9 @@ function createColumnHeadersFromDescriptors(
                 break;
             }
             case "seriesCol": {
-                const sort = state.initialSorts.find((s) => measureSortMatcher(col, s));
-                const sortProp = sort ? { sort: sortDirection(sort) } : {};
+                const sortProp = getSortProp(state.initialSorts, (s) => measureSortMatcher(col, s));
                 const cellRendererProp = !state.cellRendererPlaced ? { cellRenderer: "loadingRenderer" } : {};
+
                 const colDef: ColDef = {
                     type: MEASURE_COLUMN,
                     colId: col.id,

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import { ColDef, ColGroupDef } from "@ag-grid-community/all-modules";
+import findIndex from "lodash/findIndex";
 import {
     COLUMN_ATTRIBUTE_COLUMN,
     COLUMN_GROUPING_DELIMITER,
@@ -31,7 +32,7 @@ function getSortProp(
     initialSorts: ISortItem[],
     predicate: (sortItem: ISortItem) => boolean,
 ): Partial<ColDef> {
-    const sortIndex = initialSorts.findIndex((s) => predicate(s));
+    const sortIndex = findIndex(initialSorts, (s) => predicate(s));
     const sort = initialSorts[sortIndex];
 
     return sort

--- a/libs/sdk-ui-pivot/src/impl/structure/colSortItemMatching.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colSortItemMatching.ts
@@ -10,6 +10,7 @@ import {
     sortMeasureLocators,
 } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
+import findIndex from "lodash/findIndex";
 
 function attributeLocatorMatch(col: SeriesCol, locator: IAttributeLocatorItem): boolean {
     const { attributeDescriptors, attributeHeaders } = col.seriesDescriptor;
@@ -19,7 +20,8 @@ function attributeLocatorMatch(col: SeriesCol, locator: IAttributeLocatorItem): 
         return false;
     }
 
-    const attributeIdx = attributeDescriptors.findIndex(
+    const attributeIdx = findIndex(
+        attributeDescriptors,
         (d) => d.attributeHeader.localIdentifier === attributeIdentifier,
     );
 

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/aggregationsMenuHelper.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/aggregationsMenuHelper.ts
@@ -2,6 +2,7 @@
 import { ITotal, TotalType } from "@gooddata/sdk-model";
 
 import { AVAILABLE_TOTALS } from "../../base/constants";
+import findIndex from "lodash/findIndex";
 import intersection from "lodash/intersection";
 import isEqual from "lodash/isEqual";
 import sortBy from "lodash/sortBy";
@@ -114,7 +115,7 @@ export function getUpdatedColumnTotals(
         : excludeTotals(columnTotals, columnTotalsChanged);
 
     return sortBy(updatedColumnTotals, (total) =>
-        AVAILABLE_TOTALS.findIndex((rankedItem: string) => rankedItem === total.type),
+        findIndex(AVAILABLE_TOTALS, (rankedItem) => rankedItem === total.type),
     );
 }
 

--- a/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/tableDescriptor.ts
@@ -24,6 +24,7 @@ import { ISortItem } from "@gooddata/sdk-model";
 import { createSortIndicators, SortIndicator } from "./tableDescriptorSorting";
 import { createSortItemForCol } from "./colSortItemFactory";
 import keyBy from "lodash/keyBy";
+import findIndex from "lodash/findIndex";
 
 /**
  * Table Descriptor is the entry point to all table structure data and metadata. It contains exhaustive information
@@ -246,7 +247,7 @@ export class TableDescriptor {
             // a col that is not a leaf
             invariant(isEmptyScopeCol(col));
 
-            return this.sliceColCount() + this.headers.leafDataCols.findIndex((leaf) => leaf.id === col.id);
+            return this.sliceColCount() + findIndex(this.headers.leafDataCols, (leaf) => leaf.id === col.id);
         }
 
         return this.sliceColCount() + col.index;
@@ -317,7 +318,7 @@ export class TableDescriptor {
             return allSliceCols;
         }
 
-        const colAt = allSliceCols.findIndex((slice) => slice.id === col.id);
+        const colAt = findIndex(allSliceCols, (slice) => slice.id === col.id);
 
         // if this happens, then caller has mismatch of descriptor and cols
         invariant(colAt > -1);

--- a/libs/sdk-ui/src/base/results/internal/definitionMethods.ts
+++ b/libs/sdk-ui/src/base/results/internal/definitionMethods.ts
@@ -9,6 +9,7 @@ import {
     measureMasterIdentifier,
     bucketMeasures,
 } from "@gooddata/sdk-model";
+import findIndex from "lodash/findIndex";
 
 /**
  * Methods to work with execution definition.
@@ -188,7 +189,7 @@ class ExecutionDefinitonMethods implements IExecutionDefinitionMethods {
     }
 
     public measureIndex(localId: string): number {
-        return this.definition.measures.findIndex(idMatchMeasure(localId));
+        return findIndex(this.definition.measures, idMatchMeasure(localId));
     }
 
     public masterMeasureForDerived(localId: string): IMeasure | undefined {

--- a/libs/sdk-ui/src/base/results/internal/resultMetaMethods.ts
+++ b/libs/sdk-ui/src/base/results/internal/resultMetaMethods.ts
@@ -27,6 +27,7 @@ import {
     isPreviousPeriodMeasure,
     sortMeasureLocators,
 } from "@gooddata/sdk-model";
+import findIndex from "lodash/findIndex";
 
 /**
  * Methods to access result metadata - dimension descriptors and result headers.
@@ -274,7 +275,8 @@ class ResultMetaMethods implements IResultMetaMethods {
         }
 
         const attributeId = attributeLocatorIdentifier(locator);
-        const attributeIdx = this.dimensionItemDescriptors(this._measureGroupHeaderIdx).findIndex(
+        const attributeIdx = findIndex(
+            this.dimensionItemDescriptors(this._measureGroupHeaderIdx),
             (descriptor) => {
                 return (
                     isAttributeDescriptor(descriptor) &&

--- a/libs/sdk-ui/src/base/vis/drilling.ts
+++ b/libs/sdk-ui/src/base/vis/drilling.ts
@@ -6,6 +6,7 @@ import {
     isTotalDescriptor,
 } from "@gooddata/sdk-backend-spi";
 import CustomEventPolyfill from "custom-event";
+import findIndex from "lodash/findIndex";
 import { identifierMatch, uriMatch } from "../headerMatching/HeaderPredicateFactory";
 import {
     IDrillableItem,
@@ -57,7 +58,8 @@ export function getIntersectionPartAfter(
     intersection: IDrillEventIntersectionElement[],
     localIdentifier: string,
 ): IDrillEventIntersectionElement[] {
-    const index = intersection.findIndex(
+    const index = findIndex(
+        intersection,
         (item: IDrillEventIntersectionElement) =>
             isDrillIntersectionAttributeItem(item.header) &&
             item.header.attributeHeader.localIdentifier === localIdentifier,

--- a/tools/applink/src/devConsole/ui/packageList.ts
+++ b/tools/applink/src/devConsole/ui/packageList.ts
@@ -24,6 +24,7 @@ import {
     findDependingPackages,
     naiveFilterDependencyGraph,
 } from "../../base/dependencyGraph";
+import findIndex from "lodash/findIndex";
 import flatten from "lodash/flatten";
 import intersection from "lodash/intersection";
 import { ColorCodes } from "./colors";
@@ -308,7 +309,7 @@ export class PackageList extends AppPanel implements IEventListener {
         const filteredBuildOrder =
             this.buildOrder?.filter((g) => intersection(g, dependents).length > 0) ?? [];
         const selectedItemPosition =
-            filteredBuildOrder.findIndex((pkgs) => pkgs.includes(selectedItem.packageName)) ?? -1;
+            findIndex(filteredBuildOrder, (pkgs) => pkgs.includes(selectedItem.packageName)) ?? -1;
 
         this.listItems.forEach((item, idx) => {
             item.selected = false;
@@ -318,7 +319,7 @@ export class PackageList extends AppPanel implements IEventListener {
                 item.selected = true;
             } else if (dependents.includes(item.packageName)) {
                 const itemDistance =
-                    filteredBuildOrder.findIndex((pkgs) => pkgs.includes(item.packageName)) ?? -1;
+                    findIndex(filteredBuildOrder, (pkgs) => pkgs.includes(item.packageName)) ?? -1;
 
                 item.highlightLevel = itemDistance - selectedItemPosition - 1;
             }


### PR DESCRIPTION
If a pivot table has more than one sort and their order is different
than the order of columns, the mismatch triggers an infinite loop.

This makes sure the order of sorts is the same as the order of columns
(not the order in which the col defs were created).

Also, replace all the Array.prototype.findIndex calls with lodash version to keep IE compatibility.

JIRA: RAIL-3319

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
