### PR TITLE
Add a new backend capability flag

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -61,6 +61,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsElementsQueryParentFiltering: true,
     supportsKpiWidget: true,
     supportsHyperlinkAttributeLabels: true,
+    supportsGenericDateAttributeElements: true,
 };
 
 /**

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -287,6 +287,7 @@ export interface IBackendCapabilities {
     supportsCsvUploader?: boolean;
     supportsElementsQueryParentFiltering?: boolean;
     supportsElementUris?: boolean;
+    supportsGenericDateAttributeElements?: boolean;
     supportsHyperlinkAttributeLabels?: boolean;
     supportsKpiWidget?: boolean;
     supportsObjectUris?: boolean;

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -98,6 +98,11 @@ export interface IBackendCapabilities {
     supportsHyperlinkAttributeLabels?: boolean;
 
     /**
+     * Indicates whether backend supports returning of the valid elements (values) for generic date attributes (Day of Week, Month of Year, etc.).
+     */
+    supportsGenericDateAttributeElements?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -59,6 +59,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsElementsQueryParentFiltering: false,
     supportsKpiWidget: false,
     supportsHyperlinkAttributeLabels: false,
+    supportsGenericDateAttributeElements: false,
 };
 
 /**


### PR DESCRIPTION
The flag `supportsGenericDateAttributeElements` indicates whether backend supports returning of the valid elements (values) for generic date attributes (Day of Week, Month of Year, etc.) or not.

JIRA: BB-2913

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
