### PR TITLE
Fix IE11 visible pivot table sticky header when it should not be

### DIFF
--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -260,7 +260,8 @@ $subtotal-odd-background-color: var(
             }
 
             .ag-row {
-                background-color: transparent;
+                // stylelint-disable-next-line declaration-no-important
+                background-color: transparent !important; // TODO: remove !important after IE11 deprecation
 
                 // stylelint-disable-next-line max-nesting-depth
                 .ag-cell {
@@ -271,7 +272,8 @@ $subtotal-odd-background-color: var(
                     &.gd-hidden-sticky-column {
                         color: transparent;
                         border-top-color: transparent;
-                        background-color: transparent;
+                        // stylelint-disable-next-line declaration-no-important
+                        background-color: transparent !important; // TODO: remove !important after IE11 deprecation
                     }
 
                     // stylelint-disable-next-line max-nesting-depth


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
