### PR TITLE
Validate widget size on dashboard data load

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
@@ -51,6 +51,8 @@ import {
     DashboardLayoutItemModifications,
     getDashboardLayoutItemHeight,
     getDashboardLayoutItemHeightForRatioAndScreen,
+    DashboardLayoutItemsSelector,
+    validateDashboardLayoutWidgetSize,
 } from "../internal";
 import {
     DashboardWidgetRenderer,
@@ -80,7 +82,7 @@ interface IDashboardRendererProps {
 }
 
 /**
- * Ensure that areObjRefsEqual() and other predicates will be working with uncontrolled user ref inputs.
+ * Ensure that areObjRefsEqual() and other predicates will be working with uncontrolled user ref inputs in custom layout transformation and/or custom widget/item renderers
  */
 const polluteWidgetRefsWithBothIdAndUri = (
     getInsightByRef: (insightRef: ObjRef) => IInsight | undefined,
@@ -105,6 +107,43 @@ const polluteWidgetRefsWithBothIdAndUri = (
 
         return updatedContent;
     });
+
+const validateItemsSize = (
+    getInsightByRef: (insightRef: ObjRef) => IInsight | undefined,
+    enableKDWidgetCustomHeight: boolean,
+): DashboardLayoutItemModifications => (item) => {
+    const widget = item.facade().widget();
+    if (isInsightWidget(widget)) {
+        const insight = getInsightByRef(widget.insight);
+        const currentWidth = item.facade().size().xl.gridWidth;
+        const currentHeight = item.facade().size().xl.gridHeight;
+        const { validWidth, validHeight } = validateDashboardLayoutWidgetSize(
+            currentWidth,
+            currentHeight,
+            insight,
+            { enableKDWidgetCustomHeight },
+        );
+        let validatedItem = item;
+        if (currentWidth !== validWidth) {
+            validatedItem = validatedItem.size({
+                xl: {
+                    ...validatedItem.facade().size().xl,
+                    gridWidth: validWidth,
+                },
+            });
+        }
+        if (currentHeight !== validHeight) {
+            validatedItem = validatedItem.size({
+                xl: {
+                    ...validatedItem.facade().size().xl,
+                    gridHeight: validHeight,
+                },
+            });
+        }
+
+        return validatedItem;
+    }
+};
 
 export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(function DashboardRenderer({
     dashboardLayout,
@@ -139,18 +178,25 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
     const getWidgetAlert = (widgetRef: ObjRef) =>
         alerts?.find((alert) => areObjRefsEqual(alert.widget, widgetRef));
 
+    const selectAllItemsWithInsights: DashboardLayoutItemsSelector = (items) =>
+        items.filter((item) => item.isInsightWidgetItem());
+
+    const commonLayoutBuilder = DashboardLayoutBuilder.for(dashboardLayout).modifySections((section) =>
+        section
+            .modifyItems(polluteWidgetRefsWithBothIdAndUri(getInsightByRef))
+            .modifyItems(
+                validateItemsSize(getInsightByRef, userWorkspaceSettings.enableKDWidgetCustomHeight),
+                selectAllItemsWithInsights,
+            ),
+    );
+
     const transformedLayout = transformLayout
-        ? transformLayout(
-              DashboardLayoutBuilder.for(dashboardLayout).modifySections((section) =>
-                  section.modifyItems(polluteWidgetRefsWithBothIdAndUri(getInsightByRef)),
-              ),
-              {
-                  getWidgetAlert,
-                  getInsight: getInsightByRef,
-                  filters,
-              },
-          ).build()
-        : dashboardLayout;
+        ? transformLayout(commonLayoutBuilder, {
+              getWidgetAlert,
+              getInsight: getInsightByRef,
+              filters,
+          }).build()
+        : commonLayoutBuilder.build();
 
     return (
         <DashboardLayout

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/index.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/index.ts
@@ -48,6 +48,7 @@ export {
     getDashboardLayoutItemHeight,
     getDashboardLayoutWidgetMinGridHeight,
     getDashboardLayoutWidgetMaxGridHeight,
+    validateDashboardLayoutWidgetSize,
 } from "./utils/sizing";
 export { DashboardLayoutBuilder } from "./builder/layout";
 export { DashboardLayoutFacade } from "./facade/layout";

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/sizing.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/sizing.ts
@@ -3,6 +3,7 @@ import flatten from "lodash/flatten";
 import round from "lodash/round";
 import isNil from "lodash/isNil";
 import isEqual from "lodash/isEqual";
+import clamp from "lodash/clamp";
 import {
     IDashboardLayoutSizeByScreenSize,
     isDashboardLayout,
@@ -577,5 +578,27 @@ function removeGridHeightFromItemSize<TWidget>(item: IDashboardLayoutItem<TWidge
                 ...rest,
             },
         },
+    };
+}
+
+export function validateDashboardLayoutWidgetSize(
+    currentWidth: number,
+    currentHeight: number | undefined,
+    insight: IInsightDefinition,
+    settings: ISettings,
+): {
+    validWidth: number;
+    validHeight: number;
+} {
+    const minWidth = getDashboardLayoutWidgetMinGridWidth(settings, "insight", insight);
+    const maxWidth = fluidLayoutDescriptor.gridColumnsCount;
+    const minHeight = getDashboardLayoutWidgetMinGridHeight(settings, "insight", insight);
+    const maxHeight = getDashboardLayoutWidgetMaxGridHeight(settings, "insight", insight);
+    const validWidth = currentWidth !== undefined ? clamp(currentWidth, minWidth, maxWidth) : currentWidth;
+    const validHeight =
+        currentHeight !== undefined ? clamp(currentHeight, minHeight, maxHeight) : currentHeight;
+    return {
+        validWidth,
+        validHeight,
     };
 }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/sizing.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/sizing.test.ts
@@ -15,6 +15,7 @@ import {
     getLayoutWithoutGridHeights,
     getDashboardLayoutWidgetMinGridHeight,
     getDashboardLayoutWidgetMaxGridHeight,
+    validateDashboardLayoutWidgetSize,
 } from "../sizing";
 import { ALL_SCREENS } from "../..";
 import {
@@ -346,5 +347,39 @@ describe("sizing", () => {
             const actual = getDashboardLayoutItemMaxGridWidth(layoutFacade.section(1).item(1), "xl");
             expect(actual).toEqual(8);
         });
+    });
+
+    describe("validateDashboardLayoutWidgetSize", () => {
+        const settings = {
+            enableKDWidgetCustomHeight: true,
+        };
+        it.each([
+            ["Headline with too big height", DASHBOARD_LAYOUT_VIS_TYPE.headline, 2, 80, 2, 40],
+            ["Column Chart with too low width", DASHBOARD_LAYOUT_VIS_TYPE.column, 2, 14, 4, 14],
+            ["Table with too low height", DASHBOARD_LAYOUT_VIS_TYPE.table, 3, 10, 3, 12],
+            [
+                "Geochart with too big width and undefined height",
+                DASHBOARD_LAYOUT_VIS_TYPE.pushpin,
+                14,
+                undefined,
+                12,
+                undefined,
+            ],
+        ])(
+            "should get valid width and height for %s",
+            (_name, visType, currentWidth, currentHeight, validWidth, validHeight) => {
+                expect(
+                    validateDashboardLayoutWidgetSize(
+                        currentWidth,
+                        currentHeight,
+                        newInsightDefinition(`local:${visType}`),
+                        settings,
+                    ),
+                ).toEqual({
+                    validWidth,
+                    validHeight,
+                });
+            },
+        );
     });
 });


### PR DESCRIPTION
Because visualization type can be changed in AD for existing widget on dashboard we need to handle invalid sizes caused by this (eg. widget of minimal size for Headline displays Headmap after change in AD) to ensure proper UX
JIRA: ONE-4916

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
