### PR TITLE
TRIVIAL: Avoid named imports from JSON files

### DIFF
--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -5,9 +5,10 @@ import set from "lodash/set";
 import defaults from "lodash/defaults";
 import merge from "lodash/merge";
 import result from "lodash/result";
-import { name as pkgName, version as pkgVersion } from "../package.json";
+import pkgInfo from "../package.json";
 import { stringify } from "./utils/queryString";
 
+const { name: pkgName, version: pkgVersion } = pkgInfo;
 /**
  * Ajax wrapper around GDC authentication mechanisms, SST and TT token handling and polling.
  * Interface is the same as original jQuery.ajax.


### PR DESCRIPTION
This is not valid anymore and causes a warning in webpack 5, see [1].

[1] https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
