### PR TITLE
RELATED: RAIL-3354 Adapt to the new logout flow in Tiger 1.1

### DIFF
--- a/common/scripts/ci/run_patch_release.sh
+++ b/common/scripts/ci/run_patch_release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# This script bumps from prerelease to real minor, creates release, makes commit, tags, updates changelogs.
+# This script bumps from prerelease to real patch, creates release, makes commit, tags, updates changelogs.
 #
 # See docs/releases.md for more information how rush version bump behaves
 #
@@ -15,7 +15,7 @@ version=$(get_current_version)
 is_prerelease=$(is_current_version_prerelease)
 
 if [ ! $is_prerelease -eq 0 ]; then
-  echo "You are attempting a bump to a minor version. However the current version (${version}) is not a pre-release."
+  echo "You are attempting a bump to a patch version. However the current version (${version}) is not a pre-release."
   echo "Normally, each release actually creates a new version and then establishes the new pre-release (alpha.0)."
   echo
   echo "It is likely something went wrong during the previous release job or that the scripts or Rush version bumps are "
@@ -30,9 +30,9 @@ ${_RUSH} install
 ${_RUSH} build
 
 #
-# First bump to the next minor
+# First bump to the next patch
 #
-${_RUSH} version --bump --override-bump minor
+${_RUSH} version --bump --override-bump patch
 bump_rc=$?
 
 if [ $bump_rc -ne 0 ]; then
@@ -42,7 +42,7 @@ if [ $bump_rc -ne 0 ]; then
 fi
 
 #
-# Perform release; this will create commits & tags with the minor release in it.
+# Perform release; this will create commits & tags with the patch release in it.
 #
 export TAG_VERSION=TRUE
 export TAG_NPM="latest"
@@ -50,5 +50,5 @@ ${DIR}/do_publish.sh
 publish_rc=$?
 
 if [ $publish_rc -ne 0 ]; then
-  echo "Publishing minor version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
+  echo "Publishing patch version failed. Please investigate the impact of this catastrophe and correct manually. Good luck."
 fi

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -49,6 +49,7 @@
         "@gooddata/sdk-model": "^8.3.1-alpha.0",
         "axios": "^0.21.1",
         "date-fns": "^2.8.1",
+        "http-status-codes": "^1.3.0",
         "lodash": "^4.17.19",
         "spark-md5": "^3.0.0",
         "ts-invariant": "^0.6.0",

--- a/libs/sdk-backend-tiger/src/auth.ts
+++ b/libs/sdk-backend-tiger/src/auth.ts
@@ -9,6 +9,9 @@ import {
     NotAuthenticatedHandler,
 } from "@gooddata/sdk-backend-spi";
 import { ITigerClient, setAxiosAuthorizationToken } from "@gooddata/api-client-tiger";
+import { AxiosError } from "axios";
+import HttpStatusCodes from "http-status-codes";
+
 import { convertApiError } from "./utils/errorHandling";
 
 type TigerUserProfile = {
@@ -33,6 +36,11 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
         try {
             await client.axios.post("/logout");
         } catch (error) {
+            if ((error as AxiosError).response?.status === HttpStatusCodes.METHOD_NOT_ALLOWED) {
+                // this means we are on tiger >= 1.1 -> we must redirect to the /logout resource instead of POSTing to it
+                return window.location.assign("/logout");
+            }
+
             // eslint-disable-next-line no-console
             console.debug("Error during logout", error);
 


### PR DESCRIPTION
This is done with backwards compatibility in mind.

Also add patch release job.

JIRA: RAIL-3354

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
