### PR TITLE
RELATED: ONE-5015 ONE-5017 ONE-5022 Fix pop-up legend

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
@@ -301,6 +301,23 @@ function chartedAttributeDiscovery(dv: DataViewFacade, chartType: string): Chart
     return defaultChartedAttributeDiscovery(dv);
 }
 
+function getLegendLabel(
+    type: string,
+    viewByAttribute: IUnwrappedAttributeHeadersWithItems,
+    stackByAttribute: IUnwrappedAttributeHeadersWithItems,
+) {
+    let legendLabel;
+    if (isTreemap(type)) {
+        legendLabel = viewByAttribute?.formOf?.name;
+    } else if (isOneOfTypes(type, sortedByMeasureTypes) && viewByAttribute) {
+        legendLabel = viewByAttribute?.formOf?.name;
+    } else {
+        legendLabel = stackByAttribute?.formOf?.name;
+    }
+
+    return legendLabel;
+}
+
 export function getChartOptions(
     dataView: IDataView,
     chartConfig: IChartConfig,
@@ -526,13 +543,12 @@ export function getChartOptions(
             measures.push(null);
         }
 
-        const legendLabel = stackByAttribute?.formOf?.name;
         return {
             type,
             stacking,
             hasViewByAttribute: Boolean(stackByAttribute),
             legendLayout: "horizontal",
-            legendLabel,
+            legendLabel: getLegendLabel(type, viewByAttribute, stackByAttribute),
             yAxes,
             xAxes,
             data: {
@@ -564,18 +580,13 @@ export function getChartOptions(
         isDualAxis,
     );
 
-    const legendLabel =
-        isOneOfTypes(type, multiMeasuresAlternatingTypes) && viewByAttribute
-            ? viewByAttribute?.formOf?.name
-            : stackByAttribute?.formOf?.name;
-
     const chartOptions: IChartOptions = {
         type,
         stacking,
         hasStackByAttribute: Boolean(stackByAttribute),
         hasViewByAttribute: Boolean(viewByAttribute),
         legendLayout: config.legendLayout || "horizontal",
-        legendLabel,
+        legendLabel: getLegendLabel(type, viewByAttribute, stackByAttribute),
         xAxes,
         yAxes,
         data: {

--- a/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
@@ -16,13 +16,18 @@ interface ILegendDialogContent {
 const LegendDialogContent: React.FC<ILegendDialogContent> = (props) => {
     const { title, onCloseDialog, children } = props;
 
+    const onClose = (e: React.MouseEvent) => {
+        e.preventDefault();
+        onCloseDialog();
+    };
+
     return (
         <div className="legend-popup-dialog legend-popup-dialog-content">
             <div className="legend-header">
                 <div className="legend-header-title">{title}</div>
                 <div
                     className="s-legend-close legend-close gd-button-link gd-button-icon-only gd-icon-cross"
-                    onClick={onCloseDialog}
+                    onClick={onClose}
                 />
             </div>
             <div className="legend-content">{children}</div>

--- a/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/LegendDialog.tsx
@@ -21,7 +21,7 @@ const LegendDialogContent: React.FC<ILegendDialogContent> = (props) => {
             <div className="legend-header">
                 <div className="legend-header-title">{title}</div>
                 <div
-                    className="s-legend-close legend-close gd-button-link gd-button-icon-only icon-cross"
+                    className="s-legend-close legend-close gd-button-link gd-button-icon-only gd-icon-cross"
                     onClick={onCloseDialog}
                 />
             </div>

--- a/libs/sdk-ui-vis-commons/styles/scss/legend.scss
+++ b/libs/sdk-ui-vis-commons/styles/scss/legend.scss
@@ -496,7 +496,7 @@ $legend-content-background: var(--gd-chart-backgroundColor, var(--gd-palette-com
 
 .legend-popup-dialog-content {
     position: relative;
-    z-index: 1001;
+    z-index: 5002;
     min-height: 148px;
     border: 1px solid var(--gd-palette-complementary-3, transparentize($dialog-border, 0.5));
     border-radius: 5px;

--- a/libs/sdk-ui-vis-commons/styles/scss/legend.scss
+++ b/libs/sdk-ui-vis-commons/styles/scss/legend.scss
@@ -473,7 +473,11 @@ $legend-content-background: var(--gd-chart-backgroundColor, var(--gd-palette-com
 // legend dialog
 
 .legend-popup-dialog {
+    display: flex;
+    flex-direction: column;
+
     .legend-header {
+        flex: 0 0 auto;
         margin: 0 15px;
         .legend-header-title {
             font-family: $gd-font-primary;
@@ -484,6 +488,7 @@ $legend-content-background: var(--gd-chart-backgroundColor, var(--gd-palette-com
         }
     }
     .legend-content {
+        flex: 1 1 auto;
         background-color: $legend-content-background;
         padding: 15px;
     }

--- a/libs/sdk-ui-vis-commons/styles/scss/legend.scss
+++ b/libs/sdk-ui-vis-commons/styles/scss/legend.scss
@@ -527,7 +527,7 @@ $legend-content-background: var(--gd-chart-backgroundColor, var(--gd-palette-com
         width: 308px;
     }
 
-    .legend-close[class*="icon-"] {
+    .legend-close[class*="gd-icon-"] {
         position: absolute;
         top: 7px;
         right: 8px;


### PR DESCRIPTION
- legend label for treemap
- legend fills whole popup
- bring popup to the front
- avoid closing parent overlay

Also includes part of the fix for RAIL-2048 related to icons


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)