### PR TITLE
RELATED: RAIL-3393 Add job for automatic creation of hotfix branches

### DIFF
--- a/common/scripts/ci/init_hotfix_branch.sh
+++ b/common/scripts/ci/init_hotfix_branch.sh
@@ -43,17 +43,20 @@ if [ -z $existing_branch ]; then
   commit_hash=$(get_release_commit_hash $VERSION_TO_HOTFIX)
 
   echo "Checking out the release commit $commit_hash"
-  git checkout $commit_hash
+  # git checkout $commit_hash
+  echo checkout $commit_hash
 
   echo "Creating the first hotfix branch for $VERSION_TO_HOTFIX"
-  git checkout -b $branch_base_name
+  # git checkout -b $branch_base_name
+  echo checkout -b $branch_base_name
 
   echo "Running the rush version bump"
   prerelease_id=$(echo "$VERSION_TO_HOTFIX" | sed 's/[0-9]*\.[0-9]*\.[0-9]*-\(.*\)/\1/').fix
-  ${_RUSH} version --bump --override-bump prerelease --override-prerelease-id $prerelease_id
+  # ${_RUSH} version --bump --override-bump prerelease --override-prerelease-id $prerelease_id
+  echo $prerelease_id
 
   echo "Commiting the results"
-  git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.0" -m "JIRA: $JIRA_TICKET"
+  # git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.0" -m "JIRA: $JIRA_TICKET"
 
   # set variables for the CI to push the branch to origin
   TARGET_BRANCH=$branch_base_name
@@ -62,18 +65,20 @@ else
   existing_fix_number=$(echo $existing_branch | sed 's/.*fix-\([0-9]*\)$/\1/')
 
   echo "Checking out the latest existing hotfix branch $existing_branch"
-  git checkout $existing_branch
+  # git checkout $existing_branch
+  echo checkout $existing_branch
 
   echo "Creating the next hotfix branch for $VERSION_TO_HOTFIX"
   new_fix_number=$(($existing_fix_number + 1))
   branch_name=$branch_base_name-$new_fix_number
-  git checkout -b $branch_name
+  # git checkout -b $branch_name
+  echo checkout -b $branch_name
 
   echo "Running the rush version bump"
-  ${_RUSH} version --bump --override-bump prerelease
+  # ${_RUSH} version --bump --override-bump prerelease
 
   echo "Commiting the results"
-  git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.$new_fix_number" -m "JIRA: $JIRA_TICKET"
+  # git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.$new_fix_number" -m "JIRA: $JIRA_TICKET"
 
   # set variables for the CI to push the branch to origin
   TARGET_BRANCH=$branch_name

--- a/common/scripts/ci/init_hotfix_branch.sh
+++ b/common/scripts/ci/init_hotfix_branch.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+#
+# This script prepares a new hotfix branch for a given prerelease version already released.
+#
+
+DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))
+_RUSH="${DIR}/docker_rush.sh"
+
+source ${DIR}/utils.sh
+
+version=$(get_current_version)
+is_prerelease=$(is_current_version_prerelease)
+
+if [ ! $is_prerelease -eq 0 ]; then
+  echo "You are attempting to create a hotfix branch for a pre-release version."
+  echo "However, the current version (${version}) is not a pre-release."
+  echo "Use the init_patch_branch job instead."
+  exit 1
+fi
+
+if [ -z $VERSION_TO_HOTFIX ]; then
+  echo "You did not specify the version to base the hotfix on."
+  exit 1
+fi
+
+if [ -z $JIRA_TICKET ]; then
+  echo "You did not specify the JIRA ticket for this hotfix."
+  exit 1
+fi
+
+# Find existing hotfix branches for this version and use the latest one
+
+# convert 8.1.0-alpha-26 to 810-alpha-26-fix
+branch_base_name=$(echo "$VERSION_TO_HOTFIX" | sed 's/\([0-9]*\)\.\([0-9]*\)\.\([0-9]*\)-\([a-z]*\)\.\([0-9]*\)/\1\2\3-\4-\5/')-fix
+
+existing_branch=$(git branch --all | grep -i $branch_base_name | tail -1)
+
+if [ -z $existing_branch ]; then
+  echo "Creating the first hotfix branch for $VERSION_TO_HOTFIX"
+
+  echo "Getting the hash of the given version release commit"
+  commit_hash=$(get_release_commit_hash $VERSION_TO_HOTFIX)
+
+  echo "Checking out the release commit $commit_hash"
+  git checkout $commit_hash
+
+  echo "Creating the first hotfix branch for $VERSION_TO_HOTFIX"
+  git checkout -b $branch_base_name
+
+  echo "Running the rush version bump"
+  prerelease_id=$(echo "$VERSION_TO_HOTFIX" | sed 's/[0-9]*\.[0-9]*\.[0-9]*-\(.*\)/\1/').fix
+  ${_RUSH} version --bump --override-bump prerelease --override-prerelease-id $prerelease_id
+
+  echo "Commiting the results"
+  git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.0" -m "JIRA: $JIRA_TICKET"
+
+  # set variables for the CI to push the branch to origin
+  TARGET_BRANCH=$branch_base_name
+  branching_rc=0
+else
+  existing_fix_number=$(echo $existing_branch | sed 's/.*fix-\([0-9]*\)$/\1/')
+
+  echo "Checking out the latest existing hotfix branch $existing_branch"
+  git checkout $existing_branch
+
+  echo "Creating the next hotfix branch for $VERSION_TO_HOTFIX"
+  new_fix_number=$(($existing_fix_number + 1))
+  branch_name=$branch_base_name-$new_fix_number
+  git checkout -b $branch_name
+
+  echo "Running the rush version bump"
+  ${_RUSH} version --bump --override-bump prerelease
+
+  echo "Commiting the results"
+  git commit -a -m "Initialize prerelease fix version" -m "- $VERSION_TO_HOTFIX.fix.$new_fix_number" -m "JIRA: $JIRA_TICKET"
+
+  # set variables for the CI to push the branch to origin
+  TARGET_BRANCH=$branch_name
+  branching_rc=0
+fi

--- a/common/scripts/ci/utils.sh
+++ b/common/scripts/ci/utils.sh
@@ -25,3 +25,9 @@ function is_current_version_prerelease {
 
   echo "$retval"
 }
+
+function get_release_commit_hash {
+  version=$1
+
+  echo $(git log --grep "^Release $version\$" | sed 's/commit //g' | head -1)
+}


### PR DESCRIPTION
Creates a branch for prerelease version hotfixes (prod patch release
job for this will come in a separate PR).

JIRA: RAIL-3393

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
