### PR TITLE
Close menu when outside click cancels event bubble

### DIFF
--- a/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpenedByClick.tsx
+++ b/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpenedByClick.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2018 GoodData Corporation
-import React from "react";
+import React, { useRef } from "react";
 
 import { OutsideClickHandler } from "../utils/OutsideClickHandler";
 import { MenuPosition } from "../positioning/MenuPosition";
@@ -10,22 +10,23 @@ export const MenuOpenedByClick = (props: IMenuOpenedBySharedProps): JSX.Element 
     const outsideClick = () => props.onOpenedChange({ opened: false, source: "OUTSIDE_CLICK" });
     const togglerWrapperClick = () =>
         props.onOpenedChange({ opened: !props.opened, source: "TOGGLER_BUTTON_CLICK" });
+    const togglerRef = useRef<HTMLDivElement>(null);
 
     const OutsideClickHandlerWrapped = (props: { children: React.ReactNode }) => (
-        // UseCapture is set to false (default event bubbling). This has the disadvantage that we will not
+        // If UseCapture is set to false (default event bubbling), the disadvantage is that we will not
         // get notified of click events with preventDefault or stopPropagation methods called on them. On the
         // other hand it greatly simplifies event handling with toggler elements, for example if we have
-        // opened menu and we used useCapture=true, and somebody clicked togger element, OutsideClickHandler
-        // would get notified, he would set opened state from true to false, and then togger element click
+        // opened menu and we used useCapture=true, and somebody clicked toggler element, OutsideClickHandler
+        // would get notified, he would set opened state from true to false, and then toggler element click
         // handler would get notified, that would toggle it back to true, so menu would stay opened. This
-        // could be solved by OutsideClickHandler ignoring clicks that are inside togglerWrapped.
-        <OutsideClickHandler onOutsideClick={outsideClick} useCapture={false}>
+        // is be solved by OutsideClickHandler ignoring clicks that are inside of togglerWrapped.
+        <OutsideClickHandler onOutsideClick={outsideClick} useCapture={true} toggler={togglerRef.current}>
             {props.children}
         </OutsideClickHandler>
     );
 
     const togglerWrapped = (
-        <div onClick={togglerWrapperClick} className="gd-menuOpenedByClick-togglerWrapped">
+        <div onClick={togglerWrapperClick} className="gd-menuOpenedByClick-togglerWrapped" ref={togglerRef}>
             {props.toggler}
         </div>
     );

--- a/libs/sdk-ui-kit/src/Menu/tests/Menu.test.tsx
+++ b/libs/sdk-ui-kit/src/Menu/tests/Menu.test.tsx
@@ -70,8 +70,10 @@ describe("Menu toggling", () => {
         );
 
         expect(isContentRenderedInBody()).toBeFalsy();
+        wrapper.find(Toggler).simulate("mousedown");
         wrapper.find(Toggler).simulate("click");
         expect(isContentRenderedInBody()).toBeTruthy();
+        wrapper.find(Toggler).simulate("mousedown");
         wrapper.find(Toggler).simulate("click");
         expect(isContentRenderedInBody()).toBeFalsy();
 
@@ -89,9 +91,10 @@ describe("Menu toggling", () => {
         );
 
         expect(isContentRenderedInBody()).toBeFalsy();
+        wrapper.find(Toggler).simulate("mousedown");
         wrapper.find(Toggler).simulate("click");
         expect(isContentRenderedInBody()).toBeTruthy();
-        outsideElement.click();
+        outsideElement.dispatchEvent(new MouseEvent("mousedown"));
         expect(isContentRenderedInBody()).toBeFalsy();
 
         outsideElement.remove();

--- a/libs/sdk-ui-kit/src/Menu/utils/OutsideClickHandler.tsx
+++ b/libs/sdk-ui-kit/src/Menu/utils/OutsideClickHandler.tsx
@@ -3,6 +3,7 @@ import React, { createRef } from "react";
 
 export interface IOutsideClickHandlerProps {
     onOutsideClick: (e: MouseEvent) => void;
+    toggler: HTMLDivElement;
     useCapture?: boolean;
 }
 
@@ -43,7 +44,9 @@ export class OutsideClickHandler extends React.Component<IOutsideClickHandlerPro
             return;
         }
 
-        if (this.wrapperElRef.current.contains(e.target as HTMLElement)) {
+        const target = e.target as HTMLElement;
+
+        if (this.wrapperElRef.current.contains(target) || this.props.toggler?.contains(target)) {
             return;
         }
 
@@ -53,10 +56,10 @@ export class OutsideClickHandler extends React.Component<IOutsideClickHandlerPro
     };
 
     private addListeners = () => {
-        document.addEventListener("click", this.handleClick, this.props.useCapture);
+        document.addEventListener("mousedown", this.handleClick, this.props.useCapture);
     };
 
     private removeListeners = () => {
-        document.removeEventListener("click", this.handleClick, this.props.useCapture);
+        document.removeEventListener("mousedown", this.handleClick, this.props.useCapture);
     };
 }


### PR DESCRIPTION
The original solution was easier but failed when outside click stopped click event propagation. Menu was not closed in this case.

The comment in the code described alternative solution that handle it. The new reworked click handling should work now also in this rare case. The original explanation comment was left in place (and slightly altered to match the new situation) as it adds a lot of context and information for future component maintenance.

JIRA: BB-2940

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
