### PR TITLE
Change the way how axes options are modified to support multiple axes

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
-import { ResponsiveOptions } from "highcharts";
+import range from "lodash/range";
+import cloneDeep from "lodash/cloneDeep";
 import { HighchartsResponsiveOptions, XAxisOptions, YAxisOptions } from "../../../highcharts/lib";
 
 const UPPER_LIMIT_RATIO = 35;
@@ -30,7 +31,16 @@ const yAxisTitleDisabledOption: YAxisOptions = {
         text: undefined,
     },
 };
-const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOptions => {
+
+function forMultipleAxes<T>(count: number, options: T): Array<T> {
+    return range(count).map(() => cloneDeep(options));
+}
+
+const getResponsiveConfigOptions = (
+    inverted: boolean,
+    xAxesCount: number,
+    yAxesCount: number,
+): HighchartsResponsiveOptions => {
     const axisKeyX = inverted ? "yAxis" : "xAxis";
     const axisKeyY = inverted ? "xAxis" : "yAxis";
 
@@ -55,12 +65,8 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
                     },
                 },
                 chartOptions: {
-                    [axisKeyX]: {
-                        ...xAxisLabelsDisabledOption,
-                    },
-                    [axisKeyY]: {
-                        ...yAxisLabelsDisabledOption,
-                    },
+                    [axisKeyX]: forMultipleAxes(xAxesCount, xAxisLabelsDisabledOption),
+                    [axisKeyY]: forMultipleAxes(yAxesCount, yAxisLabelsDisabledOption),
                 },
             },
             {
@@ -71,9 +77,7 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
                     },
                 },
                 chartOptions: {
-                    [axisKeyX]: {
-                        ...xAxisLabelsDisabledOption,
-                    },
+                    [axisKeyX]: forMultipleAxes(xAxesCount, xAxisLabelsDisabledOption),
                 },
             },
             {
@@ -84,9 +88,7 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
                     },
                 },
                 chartOptions: {
-                    [axisKeyX]: {
-                        ...xAxisTitleDisabledOption,
-                    },
+                    [axisKeyX]: forMultipleAxes(xAxesCount, xAxisTitleDisabledOption),
                 },
             },
             {
@@ -97,9 +99,7 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
                     },
                 },
                 chartOptions: {
-                    [axisKeyY]: {
-                        ...yAxisLabelsDisabledOption,
-                    },
+                    [axisKeyY]: forMultipleAxes(yAxesCount, yAxisLabelsDisabledOption),
                 },
             },
             {
@@ -110,9 +110,7 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
                     },
                 },
                 chartOptions: {
-                    [axisKeyY]: {
-                        ...yAxisTitleDisabledOption,
-                    },
+                    [axisKeyY]: forMultipleAxes(yAxesCount, yAxisTitleDisabledOption),
                 },
             },
         ],
@@ -125,15 +123,19 @@ const getResponsiveConfigOptions = (inverted: boolean): HighchartsResponsiveOpti
  * therefore is possible to use the boolean parameter "inverted" to get inverted config.
  * @param {boolean} [inverted]
  */
-export const getCommonResponsiveConfig = (inverted: boolean = false): HighchartsResponsiveOptions => {
-    return getResponsiveConfigOptions(inverted);
+export const getCommonResponsiveConfig = (
+    inverted: boolean = false,
+    xAxesCount: number = 1,
+    yAxesCount: number = 1,
+): HighchartsResponsiveOptions => {
+    return getResponsiveConfigOptions(inverted, xAxesCount, yAxesCount);
 };
 
 /**
  * Special responsive config is applicable for Pie chart and Donut chart.
  * Pie chart config is implicitly called from Donut chart config, therefore these configs are same.
  */
-export const getPieResponsiveConfig = (): ResponsiveOptions => ({
+export const getPieResponsiveConfig = (): HighchartsResponsiveOptions => ({
     rules: [
         {
             condition: {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import clone from "lodash/clone";
 import includes from "lodash/includes";
 import isNil from "lodash/isNil";
@@ -9,6 +9,7 @@ import isEqual from "lodash/fp/isEqual";
 import unescape from "lodash/unescape";
 import { VisualizationTypes } from "@gooddata/sdk-ui";
 import { IChartOptions, ISeriesItem } from "../../typings/unsafe";
+import { IChartConfig } from "../../../interfaces";
 
 export function parseValue(value: string): number | null {
     const parsedValue = parseFloat(value);
@@ -161,3 +162,9 @@ export const isCssMultiLineTruncationSupported = (): boolean => {
     return "webkitLineClamp" in document.body.style;
 };
 export const customEscape = (str: string): string => str && escape(unescape(str));
+
+export const getAxesCounts = (config: IChartConfig): [number, number] => {
+    const hasSecondaryXAxis = config.secondary_xaxis && config.secondary_xaxis?.measures?.length !== 0;
+    const hasSecondaryYAxis = config.secondary_yaxis && config.secondary_yaxis?.measures?.length !== 0;
+    return [hasSecondaryXAxis ? 2 : 1, hasSecondaryYAxis ? 2 : 1];
+};

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/common.test.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/test/common.test.tsx
@@ -8,6 +8,7 @@ import {
     getPrimaryChartType,
     unwrap,
     percentFormatter,
+    getAxesCounts,
 } from "../common";
 
 describe("Common utils", () => {
@@ -146,6 +147,32 @@ describe("Common utils", () => {
             ["", null],
         ])('should return "%s" when input is %s', (formattedValue: string, value: number) => {
             expect(percentFormatter(value)).toEqual(formattedValue);
+        });
+    });
+
+    describe("getAxesCounts", () => {
+        it("should return both axes as singles for empty secondary config", () => {
+            expect(getAxesCounts({})).toEqual([1, 1]);
+        });
+
+        it("should return dual x axes", () => {
+            expect(
+                getAxesCounts({
+                    secondary_xaxis: {
+                        measures: ["m1"],
+                    },
+                }),
+            ).toEqual([2, 1]);
+        });
+
+        it("should return dual y axes", () => {
+            expect(
+                getAxesCounts({
+                    secondary_yaxis: {
+                        measures: ["m1"],
+                    },
+                }),
+            ).toEqual([1, 2]);
         });
     });
 });

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/barChart/barConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/barChart/barConfiguration.ts
@@ -4,6 +4,7 @@ import { HighchartsOptions } from "../../../highcharts/lib";
 import { MAX_POINT_WIDTH } from "../_chartCreators/commonConfiguration";
 import { IChartConfig } from "../../../interfaces";
 import { getCommonResponsiveConfig } from "../_chartCreators/responsive";
+import { getAxesCounts } from "../_util/common";
 
 const BAR_TEMPLATE = {
     chart: {
@@ -39,9 +40,10 @@ export function getBarConfiguration(config: IChartConfig): HighchartsOptions {
 
     if (config?.enableCompactSize) {
         const reversed = true;
+        const [xAxesCount, yAxesCount] = getAxesCounts(config);
         return {
             ...barConfiguration,
-            responsive: getCommonResponsiveConfig(reversed),
+            responsive: getCommonResponsiveConfig(reversed, xAxesCount, yAxesCount),
         };
     }
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/columnChart/columnConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/columnChart/columnConfiguration.ts
@@ -6,6 +6,7 @@ import { getCommonResponsiveConfig } from "../_chartCreators/responsive";
 import { HighchartsOptions } from "../../../highcharts/lib";
 
 import { MAX_POINT_WIDTH } from "../_chartCreators/commonConfiguration";
+import { getAxesCounts } from "../_util/common";
 
 export function getColumnConfiguration(
     config: IChartConfig,
@@ -50,9 +51,10 @@ export function getColumnConfiguration(
     };
 
     if (config?.enableCompactSize) {
+        const [xAxesCount, yAxesCount] = getAxesCounts(config);
         return {
             ...columnConfiguration,
-            responsive: getCommonResponsiveConfig(),
+            responsive: getCommonResponsiveConfig(false, xAxesCount, yAxesCount),
         };
     }
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/lineChart/lineConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/lineChart/lineConfiguration.ts
@@ -5,6 +5,7 @@ import { ITheme } from "@gooddata/sdk-backend-spi";
 import { styleVariables } from "../_chartCreators/styles/variables";
 import { getCommonResponsiveConfig } from "../_chartCreators/responsive";
 import { HighchartsOptions } from "../../../highcharts/lib";
+import { getAxesCounts } from "../_util/common";
 
 export const LINE_WIDTH = 3;
 
@@ -57,9 +58,10 @@ export function getLineConfiguration(
     };
 
     if (config?.enableCompactSize) {
+        const [xAxesCount, yAxesCount] = getAxesCounts(config);
         return {
             ...lineConfiguration,
-            responsive: getCommonResponsiveConfig(),
+            responsive: getCommonResponsiveConfig(false, xAxesCount, yAxesCount),
         };
     }
 


### PR DESCRIPTION
Both single and dual axes charts options use notation with array as value not an object
JIRA: ONE-5021

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
