### PR TITLE
DashboardView - align filtering logic with gdc-dashboards

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
@@ -10,7 +10,7 @@ import {
     ITempFilterContext,
     IInsightWidget,
 } from "@gooddata/sdk-backend-spi";
-import { IInsight, insightProperties, insightSetProperties } from "@gooddata/sdk-model";
+import { IInsight, insightProperties, insightSetProperties, isDateFilter } from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     IAvailableDrillTargetAttribute,
@@ -33,7 +33,7 @@ import {
 import { InsightRenderer as InsightRendererImpl } from "../../../insightView/InsightRenderer";
 import { InsightError } from "../../../insightView/InsightError";
 import { getImplicitDrillsWithPredicates } from "./drillingUtils";
-import { addImplicitAllTimeFilter } from "./utils";
+import { addImplicitAllTimeFilter, isDateFilterIgnoredForInsight } from "./utils";
 import { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "../../converters";
 import {
     useAttributesWithDrillDown,
@@ -116,7 +116,13 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
                     .dashboards()
                     .getResolvedFiltersForWidget(insightWidget, inputFilters);
 
-                const resolvedWithImplicitAllTime = addImplicitAllTimeFilter(insightWidget, resolvedFilters);
+                let resolvedWithImplicitAllTime = addImplicitAllTimeFilter(insightWidget, resolvedFilters);
+
+                if (isDateFilterIgnoredForInsight(insight)) {
+                    resolvedWithImplicitAllTime = resolvedWithImplicitAllTime.filter(
+                        (filter) => !isDateFilter(filter),
+                    );
+                }
 
                 return effectiveBackend
                     .workspace(effectiveWorkspace)

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/utils.ts
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/utils.ts
@@ -1,6 +1,14 @@
 // (C) 2020-2021 GoodData Corporation
 import { IWidgetDefinition } from "@gooddata/sdk-backend-spi";
-import { IFilter, newAllTimeFilter } from "@gooddata/sdk-model";
+import {
+    IFilter,
+    IInsight,
+    insightMeasures,
+    isDateFilter,
+    isSimpleMeasure,
+    measureFilters,
+    newAllTimeFilter,
+} from "@gooddata/sdk-model";
 import { hasDateFilterForDateDataset } from "../../../internal";
 
 export function addImplicitAllTimeFilter(widget: IWidgetDefinition, resolvedFilters: IFilter[]): IFilter[] {
@@ -11,4 +19,25 @@ export function addImplicitAllTimeFilter(widget: IWidgetDefinition, resolvedFilt
         return [...resolvedFilters, newAllTimeFilter(widget.dateDataSet)];
     }
     return resolvedFilters;
+}
+
+/**
+ * Tests whether dashboard's date filter should not be applied on the insight included in the provided widget.
+ *
+ * This should happen for insights whose simple measures are all already set up with date filters. I guess ignoring
+ * global date filter is desired because otherwise there is a large chance that the intersection of global date filter
+ * and measure's date filters would lead to empty set and no data shown for the insight?
+ */
+export function isDateFilterIgnoredForInsight(insight: IInsight): boolean {
+    const simpleMeasures = insightMeasures(insight, isSimpleMeasure);
+
+    if (simpleMeasures.length === 0) {
+        return false;
+    }
+
+    const simpleMeasuresWithDateFilter = simpleMeasures.filter((m) =>
+        (measureFilters(m) ?? []).some(isDateFilter),
+    );
+
+    return simpleMeasures.length === simpleMeasuresWithDateFilter.length;
 }


### PR DESCRIPTION
- ignore global date filters for insights with simple measures that have date filter(s) set

JIRA: RAIL-3339

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
