### PR TITLE
Handle undefined point in Zoomed chart

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/setupDrilldownToParentAttribute.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/setupDrilldownToParentAttribute.ts
@@ -12,8 +12,8 @@ export function getDDPointsInParentTick(axis: any, tick: IHighchartsParentTick):
     const ddPoints: IHighchartsPointObject[] = []; // drilldown points
 
     for (let i = startAt; i < startAt + leaves; i++) {
-        const currentDDPoints = axis.getDDPoints(i);
-        ddPoints.push(...currentDDPoints);
+        const currentDDPoints: IHighchartsPointObject[] = axis.getDDPoints(i);
+        ddPoints.push(...currentDDPoints.filter((point) => !!point));
     }
 
     // replace y value by target value for bullet chart target


### PR DESCRIPTION
JIRA: ONE-5030

During zooming to the chart, some of datapoints are undefined and needs to be skipped

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
