### PR TITLE
Responsive rule evaluate original size not the current one

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
@@ -53,17 +53,29 @@ const getResponsiveConfigOptions = (
                 condition: {
                     callback: function () {
                         // first rule needs to store original plot size to use it for rules in every other re-evaluation (eg. after zoom)
-                        if ((this as any).originalPlotWidth === undefined) {
-                            (this as any).originalPlotWidth = this.plotWidth;
+                        if (this.userOptions?.plotOptions?.series?.custom?.initialPlotWidth === undefined) {
+                            this.userOptions.plotOptions.series.custom = {
+                                ...this.userOptions?.plotOptions?.series?.custom,
+                                initialPlotWidth: this.plotWidth,
+                            };
                         }
-                        if ((this as any).originalPlotHeight === undefined) {
-                            (this as any).originalPlotHeight = this.plotHeight;
+                        if (this.userOptions?.plotOptions?.series?.custom?.initialPlotHeight === undefined) {
+                            this.userOptions.plotOptions.series.custom = {
+                                ...this.userOptions?.plotOptions?.series?.custom,
+                                initialPlotHeight: this.plotHeight,
+                            };
                         }
                         const heightRatio = Math.round(
-                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                            getRatio(
+                                this.chartHeight,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotHeight,
+                            ),
                         );
                         const widthRatio = Math.round(
-                            getRatio(this.chartWidth, (this as any).originalPlotWidth),
+                            getRatio(
+                                this.chartWidth,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotWidth,
+                            ),
                         );
                         const isZeroRatio =
                             (heightRatio === 0 && widthRatio < BOTTOM_LIMIT_WIDTH_RATIO) ||
@@ -84,10 +96,12 @@ const getResponsiveConfigOptions = (
                 condition: {
                     callback: function () {
                         const ratio = Math.round(
-                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                            getRatio(
+                                this.chartHeight,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotHeight,
+                            ),
                         );
                         const result = ratio < BOTTOM_LIMIT_HEIGHT_RATIO;
-                        result && console.log("ratio < BOTTOM_LIMIT_HEIGHT_RATIO");
                         return result;
                     },
                 },
@@ -99,11 +113,12 @@ const getResponsiveConfigOptions = (
                 condition: {
                     callback: function () {
                         const ratio = Math.round(
-                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                            getRatio(
+                                this.chartHeight,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotHeight,
+                            ),
                         );
                         const result = ratio > BOTTOM_LIMIT_HEIGHT_RATIO && ratio < UPPER_LIMIT_RATIO;
-                        result &&
-                            console.log("ratio > BOTTOM_LIMIT_HEIGHT_RATIO && ratio < UPPER_LIMIT_RATIO");
                         return result;
                     },
                 },
@@ -114,9 +129,13 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartWidth, (this as any).originalPlotWidth));
+                        const ratio = Math.round(
+                            getRatio(
+                                this.chartWidth,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotWidth,
+                            ),
+                        );
                         const result = ratio < BOTTOM_LIMIT_WIDTH_RATIO;
-                        result && console.log("ratio < BOTTOM_LIMIT_WIDTH_RATIO");
                         return result;
                     },
                 },
@@ -127,10 +146,13 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartWidth, (this as any).originalPlotWidth));
+                        const ratio = Math.round(
+                            getRatio(
+                                this.chartWidth,
+                                this.userOptions?.plotOptions?.series?.custom?.initialPlotWidth,
+                            ),
+                        );
                         const result = ratio > BOTTOM_LIMIT_WIDTH_RATIO && ratio < UPPER_LIMIT_RATIO;
-                        result &&
-                            console.log("ratio > BOTTOM_LIMIT_WIDTH_RATIO && ratio < UPPER_LIMIT_RATIO");
                         return result;
                     },
                 },

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/responsive.ts
@@ -52,8 +52,19 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const heightRatio = Math.round(getRatio(this.chartHeight, this.plotHeight));
-                        const widthRatio = Math.round(getRatio(this.chartWidth, this.plotWidth));
+                        // first rule needs to store original plot size to use it for rules in every other re-evaluation (eg. after zoom)
+                        if ((this as any).originalPlotWidth === undefined) {
+                            (this as any).originalPlotWidth = this.plotWidth;
+                        }
+                        if ((this as any).originalPlotHeight === undefined) {
+                            (this as any).originalPlotHeight = this.plotHeight;
+                        }
+                        const heightRatio = Math.round(
+                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                        );
+                        const widthRatio = Math.round(
+                            getRatio(this.chartWidth, (this as any).originalPlotWidth),
+                        );
                         const isZeroRatio =
                             (heightRatio === 0 && widthRatio < BOTTOM_LIMIT_WIDTH_RATIO) ||
                             (widthRatio === 0 && heightRatio < BOTTOM_LIMIT_HEIGHT_RATIO);
@@ -72,8 +83,12 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartHeight, this.plotHeight));
-                        return ratio < BOTTOM_LIMIT_HEIGHT_RATIO;
+                        const ratio = Math.round(
+                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                        );
+                        const result = ratio < BOTTOM_LIMIT_HEIGHT_RATIO;
+                        result && console.log("ratio < BOTTOM_LIMIT_HEIGHT_RATIO");
+                        return result;
                     },
                 },
                 chartOptions: {
@@ -83,8 +98,13 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartHeight, this.plotHeight));
-                        return ratio > BOTTOM_LIMIT_HEIGHT_RATIO && ratio < UPPER_LIMIT_RATIO;
+                        const ratio = Math.round(
+                            getRatio(this.chartHeight, (this as any).originalPlotHeight),
+                        );
+                        const result = ratio > BOTTOM_LIMIT_HEIGHT_RATIO && ratio < UPPER_LIMIT_RATIO;
+                        result &&
+                            console.log("ratio > BOTTOM_LIMIT_HEIGHT_RATIO && ratio < UPPER_LIMIT_RATIO");
+                        return result;
                     },
                 },
                 chartOptions: {
@@ -94,8 +114,10 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartWidth, this.plotWidth));
-                        return ratio < BOTTOM_LIMIT_WIDTH_RATIO;
+                        const ratio = Math.round(getRatio(this.chartWidth, (this as any).originalPlotWidth));
+                        const result = ratio < BOTTOM_LIMIT_WIDTH_RATIO;
+                        result && console.log("ratio < BOTTOM_LIMIT_WIDTH_RATIO");
+                        return result;
                     },
                 },
                 chartOptions: {
@@ -105,8 +127,11 @@ const getResponsiveConfigOptions = (
             {
                 condition: {
                     callback: function () {
-                        const ratio = Math.round(getRatio(this.chartWidth, this.plotWidth));
-                        return ratio > BOTTOM_LIMIT_WIDTH_RATIO && ratio < UPPER_LIMIT_RATIO;
+                        const ratio = Math.round(getRatio(this.chartWidth, (this as any).originalPlotWidth));
+                        const result = ratio > BOTTOM_LIMIT_WIDTH_RATIO && ratio < UPPER_LIMIT_RATIO;
+                        result &&
+                            console.log("ratio > BOTTOM_LIMIT_WIDTH_RATIO && ratio < UPPER_LIMIT_RATIO");
+                        return result;
                     },
                 },
                 chartOptions: {


### PR DESCRIPTION
eg. after Zoom reset responsive rules are evaluated in moment, when chart is rendered with previous rule applied and so the same rule as before is no more triggered
JIRA: ONE-5021

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
