### PR TITLE
DashboardView - fix possible infinite height grow

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/InsightRenderer/InsightRenderer.tsx
@@ -10,7 +10,13 @@ import {
     ITempFilterContext,
     IInsightWidget,
 } from "@gooddata/sdk-backend-spi";
-import { IInsight, insightProperties, insightSetProperties, isDateFilter } from "@gooddata/sdk-model";
+import {
+    IInsight,
+    insightProperties,
+    insightSetProperties,
+    isDateFilter,
+    insightVisualizationUrl,
+} from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     IAvailableDrillTargetAttribute,
@@ -237,17 +243,20 @@ export const InsightRenderer: React.FC<IInsightRendererProps> = ({
      */
     const drillableItemsToUse = onDrill ? drillableItems ?? implicitDrills : undefined;
 
-    const insightPoisitionStyle: CSSProperties = useMemo(() => {
+    const insightPositionStyle: CSSProperties = useMemo(() => {
         return {
             width: "100%",
             height: "100%",
-            position: userWorkspaceSettings?.enableKDWidgetCustomHeight ? "absolute" : "relative",
+            position:
+                // Headline violates the layout contract.
+                // It should fit parent height and adapt to it as other visualizations.
+                // Now, it works differently for the Headline - parent container adapts to Headline size.
+                insight && insightVisualizationUrl(insight).includes("headline") ? "relative" : "absolute",
         };
-    }, [userWorkspaceSettings?.enableKDWidgetCustomHeight]);
-
+    }, [insight]);
     return (
         <div style={insightStyle}>
-            <div style={insightPoisitionStyle}>
+            <div style={insightPositionStyle}>
                 <IntlWrapper locale={locale}>
                     {(status === "loading" || status === "pending" || isVisualizationLoading) && (
                         <LoadingComponent />


### PR DESCRIPTION
- 2 insights rendered in 1 row caused DashboardView height to grow infinitely

JIRA: RAIL-3416

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
