### PR TITLE
RELATED: ONE-5031 Fix geo legend title and paging

### DIFF
--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartLegendRenderer.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartLegendRenderer.tsx
@@ -274,6 +274,7 @@ function renderPushpinLegend(
             hasSizeLegend={hasSizeLegend}
             containerId={containerId}
             customComponent={renderPushpinSizeLegend(props, hasSizeLegend, true, true)}
+            customComponentName={props.geoData?.size?.name}
         />
     );
 }

--- a/libs/sdk-ui-geo/src/core/geoChart/legends/PushpinCategoryLegend.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/legends/PushpinCategoryLegend.tsx
@@ -24,6 +24,8 @@ export interface IPushpinCategoryLegendProps {
     position?: PositionType;
     responsive?: boolean | "autoPositionWithPopup";
     customComponent?: JSX.Element | null;
+    customComponentName?: string;
+    sizeLegendName?: string;
     maxRows?: number;
     name?: string;
     renderPopUp?: boolean;
@@ -35,7 +37,7 @@ export default function PushpinCategoryLegend(props: IPushpinCategoryLegendProps
     const { contentRect, hasSizeLegend, isFluidLegend, renderPopUp } = props;
 
     if (renderPopUp) {
-        return <React.Fragment>{renderPopUpLegend(props)}</React.Fragment>;
+        return <GeoPopUpLegend {...props} />;
     }
 
     return (
@@ -96,8 +98,16 @@ function renderStaticCategoryLegend(
     return <StaticLegend {...legendProps} containerHeight={usedHeight} />;
 }
 
-function renderPopUpLegend(props: IPushpinCategoryLegendProps): React.ReactNode {
-    const { containerId, categoryItems = [], onItemClick = noop, name, maxRows, customComponent } = props;
+function GeoPopUpLegend(props: IPushpinCategoryLegendProps): JSX.Element {
+    const {
+        containerId,
+        categoryItems = [],
+        onItemClick = noop,
+        name,
+        maxRows,
+        customComponent,
+        customComponentName,
+    } = props;
 
     return (
         <PopUpLegend
@@ -107,6 +117,7 @@ function renderPopUpLegend(props: IPushpinCategoryLegendProps): React.ReactNode 
             name={name}
             containerId={containerId}
             customComponent={customComponent}
+            customComponentName={customComponentName}
         />
     );
 }

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -368,6 +368,8 @@ export interface IPopUpLegendProps {
     // (undocumented)
     customComponent?: JSX.Element | null;
     // (undocumented)
+    customComponentName?: string;
+    // (undocumented)
     enableBorderRadius?: boolean | ItemBorderRadiusPredicate;
     // (undocumented)
     maxRows?: number;
@@ -418,6 +420,8 @@ export interface IStaticLegendProps {
     label?: string;
     // (undocumented)
     onItemClick?(item: IPushpinCategoryLegendItem): void;
+    // (undocumented)
+    onPageChanged?: (page: number) => void;
     // (undocumented)
     paginationHeight?: number;
     // (undocumented)

--- a/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/PopUpLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/PopUpLegend.tsx
@@ -22,20 +22,34 @@ export interface IPopUpLegendProps {
     containerId: string;
 
     customComponent?: JSX.Element | null;
+    customComponentName?: string;
 }
 
 /**
  * @internal
  */
 export const PopUpLegend: React.FC<IPopUpLegendProps> = (props) => {
-    const { name, maxRows, enableBorderRadius, series, onLegendItemClick, containerId, customComponent } =
-        props;
+    const {
+        name,
+        maxRows,
+        enableBorderRadius,
+        series,
+        onLegendItemClick,
+        containerId,
+        customComponent,
+        customComponentName,
+    } = props;
     const intl = useIntl();
     const [isDialogOpen, setDialogOpen] = useState(false);
+    const [page, setPage] = useState(1);
 
-    const dialogTitle = name || intl.formatMessage({ id: "properties.legend.title" });
+    const dialogTitle =
+        (page === 1 && customComponentName) || name || intl.formatMessage({ id: "properties.legend.title" });
 
-    const onCloseDialog = () => setDialogOpen(false);
+    const onCloseDialog = () => {
+        setDialogOpen(false);
+        setPage(1);
+    };
 
     return (
         <div>
@@ -67,6 +81,7 @@ export const PopUpLegend: React.FC<IPopUpLegendProps> = (props) => {
                     enableBorderRadius={enableBorderRadius}
                     paginationHeight={PAGINATION_HEIGHT}
                     customComponent={customComponent}
+                    onPageChanged={setPage}
                 />
             </LegendDialog>
         </div>

--- a/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
@@ -24,6 +24,7 @@ export interface IStaticLegendProps {
     onItemClick?(item: IPushpinCategoryLegendItem): void;
     paginationHeight?: number;
     customComponent?: JSX.Element | null;
+    onPageChanged?: (page: number) => void;
 }
 
 /**
@@ -33,6 +34,7 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
     public static defaultProps: Partial<IStaticLegendProps> = {
         buttonOrientation: "upDown",
         paginationHeight: STATIC_PAGING_HEIGHT,
+        onPageChanged: () => {},
     };
 
     public state = {
@@ -40,11 +42,15 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
     };
 
     public showNextPage = (): void => {
-        this.setState({ page: this.state.page + 1 });
+        const updatedPage = this.state.page + 1;
+        this.props.onPageChanged!(updatedPage);
+        this.setState({ page: updatedPage });
     };
 
     public showPrevPage = (): void => {
-        this.setState({ page: this.state.page - 1 });
+        const updatedPage = this.state.page - 1;
+        this.props.onPageChanged!(updatedPage);
+        this.setState({ page: updatedPage });
     };
 
     public renderPaging = (pagesCount: number): React.ReactNode => {
@@ -106,6 +112,7 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
             columnNum,
             paginationHeight,
         );
+        const usePaging = hasPaging || customComponent;
 
         const heightOfAvailableSpace = (visibleItemsCount / columnNum) * ITEM_HEIGHT;
         const heightOfVisibleItems = Math.min(visibleItemsCount / columnNum, seriesCount) * ITEM_HEIGHT;
@@ -121,7 +128,7 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
                         {labelComponent}
                         {customComponent}
                     </div>
-                    {hasPaging && this.renderPaging(pagesCount)}
+                    {usePaging && this.renderPaging(pagesCount)}
                 </div>
             );
         }
@@ -153,7 +160,7 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
                         onItemClick={onItemClick}
                     />
                 </div>
-                {hasPaging && this.renderPaging(pagesCount)}
+                {usePaging && this.renderPaging(pagesCount)}
             </div>
         );
     }


### PR DESCRIPTION
Popup legend shows different title for different content.
In case of geo chart with custom component, it's the size metric name.


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)