### PR TITLE
RELATED: RAIL-3383 - Fix live reload issue

### DIFF
--- a/examples/playground/webpack.config.js
+++ b/examples/playground/webpack.config.js
@@ -87,7 +87,7 @@ module.exports = async (env, argv) => {
 
     return smp.wrap({
         entry: ["./src/index.tsx"],
-        target: ["web", "es5"], // support IE11
+        target: "web",
         mode: isProduction ? "production" : "development",
         plugins,
         output: {
@@ -162,7 +162,7 @@ module.exports = async (env, argv) => {
             compress: true,
             port: 8999,
             stats: "errors-only",
-            hot: true,
+            liveReload: true,
             proxy,
         },
         stats: "errors-only",


### PR DESCRIPTION
-  Due to bug in webpack dev server. See https://github.com/webpack/webpack-dev-server/pull/3271

JIRA: RAIL-3383

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
