### PR TITLE
Allow pass containerClassName to dialogs

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -817,6 +817,7 @@ export interface IDialogBaseProps {
     children?: React.ReactNode;
     // (undocumented)
     className?: string;
+    containerClassName?: string;
     // (undocumented)
     displayCloseButton?: boolean;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Dialog/ConfirmDialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ConfirmDialog.tsx
@@ -9,6 +9,8 @@ import { IConfirmDialogBaseProps } from "./typings";
  */
 export class ConfirmDialog extends PureComponent<IConfirmDialogBaseProps> {
     public render(): JSX.Element {
+        const { containerClassName, ...dialogProps } = this.props;
+
         return (
             <Overlay
                 alignPoints={[
@@ -18,8 +20,9 @@ export class ConfirmDialog extends PureComponent<IConfirmDialogBaseProps> {
                 ]}
                 isModal
                 positionType="fixed"
+                containerClassName={containerClassName}
             >
-                <ConfirmDialogBase {...this.props} />
+                <ConfirmDialogBase {...dialogProps} />
             </Overlay>
         );
     }

--- a/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
@@ -9,6 +9,8 @@ import { IDialogBaseProps } from "./typings";
  */
 export class Dialog extends Component<IDialogBaseProps> {
     public render(): JSX.Element {
+        const { containerClassName, ...dialogProps } = this.props;
+
         return (
             <Overlay
                 alignPoints={[
@@ -18,8 +20,9 @@ export class Dialog extends Component<IDialogBaseProps> {
                 ]}
                 isModal
                 positionType="fixed"
+                containerClassName={containerClassName}
             >
-                <DialogBase {...this.props} />
+                <DialogBase {...dialogProps} />
             </Overlay>
         );
     }

--- a/libs/sdk-ui-kit/src/Dialog/ExportDialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ExportDialog.tsx
@@ -12,6 +12,7 @@ export const ExportDialog = (props: IExportDialogBaseProps): JSX.Element => {
         displayCloseButton,
         isPositive,
         isSubmitDisabled,
+        containerClassName,
 
         headline,
         cancelButtonText,
@@ -39,6 +40,7 @@ export const ExportDialog = (props: IExportDialogBaseProps): JSX.Element => {
             ]}
             isModal
             positionType="fixed"
+            containerClassName={containerClassName}
         >
             <ExportDialogBase
                 displayCloseButton={displayCloseButton}

--- a/libs/sdk-ui-kit/src/Dialog/tests/ConfirmDialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/ConfirmDialog.test.tsx
@@ -1,16 +1,19 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { Overlay } from "../../Overlay";
 
 describe("ConfirmDialog", () => {
     it("should render content", () => {
-        const wrapper = shallow(
-            <ConfirmDialog className="confirmDialogTest">ReactConfirmDialog content</ConfirmDialog>,
+        const wrapper = mount(
+            <ConfirmDialog className="confirmDialogTest" containerClassName="containerTestClass">
+                ReactConfirmDialog content
+            </ConfirmDialog>,
         );
 
         expect(wrapper.find(Overlay)).toHaveLength(1);
-        expect(wrapper.find(".confirmDialogTest")).toHaveLength(1);
+        expect(wrapper.find(".confirmDialogTest").hostNodes()).toHaveLength(1);
+        expect(wrapper.find(".containerTestClass").hostNodes()).toHaveLength(1);
     });
 });

--- a/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
@@ -1,14 +1,19 @@
 // (C) 2007-2020 GoodData Corporation
 import React from "react";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import { Dialog } from "../Dialog";
 import { Overlay } from "../../Overlay";
 
 describe("Dialog", () => {
     it("should render content", () => {
-        const wrapper = shallow(<Dialog className="dialogTest">DialogTest content</Dialog>);
+        const wrapper = mount(
+            <Dialog className="dialogTest" containerClassName="containerTestClass">
+                DialogTest content
+            </Dialog>,
+        );
 
         expect(wrapper.find(Overlay)).toHaveLength(1);
-        expect(wrapper.find(".dialogTest")).toHaveLength(1);
+        expect(wrapper.find(".dialogTest").hostNodes()).toHaveLength(1);
+        expect(wrapper.find(".containerTestClass").hostNodes()).toHaveLength(1);
     });
 });

--- a/libs/sdk-ui-kit/src/Dialog/tests/ExportDialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/ExportDialog.test.tsx
@@ -6,9 +6,12 @@ import { Overlay } from "../../Overlay";
 
 describe("ExportDialog", () => {
     it("should render content", () => {
-        const wrapper = mount(<ExportDialog className="exportDialogTest" />);
+        const wrapper = mount(
+            <ExportDialog className="exportDialogTest" containerClassName="containerTestClass" />,
+        );
 
         expect(wrapper.find(Overlay)).toHaveLength(1);
         expect(wrapper.find(".exportDialogTest")).toHaveLength(1);
+        expect(wrapper.find(".containerTestClass").hostNodes()).toHaveLength(1);
     });
 });

--- a/libs/sdk-ui-kit/src/Dialog/typings.ts
+++ b/libs/sdk-ui-kit/src/Dialog/typings.ts
@@ -9,6 +9,10 @@ import { IAlignPoint } from "../typings/positioning";
 export interface IDialogBaseProps {
     children?: React.ReactNode;
     className?: string;
+    /**
+     * className will be placed to the container, which wraps overlay background and dialog content elements
+     */
+    containerClassName?: string;
     displayCloseButton?: boolean;
     submitOnEnterKey?: boolean;
     onCancel?: (data?: any) => void;


### PR DESCRIPTION
JIRA: RAIL-3365

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
