### PR TITLE
RELATED: RAIL-3383 - Add permissions to state & sanitize config resolution and loading

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -23,6 +23,7 @@ import { IInsight } from '@gooddata/sdk-model';
 import { ILocale } from '@gooddata/sdk-ui';
 import { ISeparators } from '@gooddata/sdk-backend-spi';
 import { ISettings } from '@gooddata/sdk-backend-spi';
+import { IWorkspacePermissions } from '@gooddata/sdk-backend-spi';
 import { ObjRef } from '@gooddata/sdk-model';
 import { default as React_2 } from 'react';
 import { TypedUseSelectorHook } from 'react-redux';
@@ -104,6 +105,7 @@ export interface DashboardLoaded extends IDashboardEvent {
         dashboard: IDashboard;
         insights: IInsight[];
         config: DashboardConfig;
+        permissions: IWorkspacePermissions;
     };
     // (undocumented)
     type: "GDC.DASHBOARD.EVT.LOADED";
@@ -119,6 +121,7 @@ export type DashboardMenuButtonComponent = ComponentType<IDashboardMenuButtonPro
 export type DashboardState = {
     loading: LoadingState;
     config: ConfigState;
+    permissions: PermissionsState;
     filterContext: FilterContextState;
     layout: LayoutState;
     dateFilterConfig: DateFilterConfigState;
@@ -247,6 +250,7 @@ export interface IDashboardProps {
         Component?: FilterBarComponent;
         defaultComponentProps?: IDefaultFilterBarProps;
     };
+    permissions?: IWorkspacePermissions;
     topBarConfig?: {
         Component?: TopBarComponent;
         defaultComponentProps?: IDefaultTopBarProps;
@@ -335,6 +339,7 @@ export interface LoadDashboard extends IDashboardCommand {
     // (undocumented)
     payload: {
         config?: DashboardConfig;
+        permissions?: IWorkspacePermissions;
     };
     // (undocumented)
     type: "GDC.DASHBOARD.CMD.LOAD";
@@ -365,6 +370,15 @@ export type MenuButtonItem = {
 
 // @internal (undocumented)
 export const NoTopBar: React_2.FC<ITopBarProps>;
+
+// @internal
+export const permissionsSelector: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IWorkspacePermissions, (res: import("./permissionsState").PermissionsState) => import("@gooddata/sdk-backend-spi").IWorkspacePermissions>;
+
+// @internal (undocumented)
+export interface PermissionsState {
+    // (undocumented)
+    permissions?: IWorkspacePermissions;
+}
 
 // @internal
 export type ResolvedDashboardConfig = Required<DashboardConfig>;

--- a/libs/sdk-ui-dashboard/src/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ import {
 } from "../model/state/dashboardStore";
 import { loadingSelector } from "../model";
 import { loadDashboard } from "../model/commands/dashboard";
-import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { IAnalyticalBackend, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 import { useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { DashboardEventHandler } from "../model/events/eventHandler";
@@ -48,6 +48,15 @@ export interface IDashboardProps {
      * If not specified, then the dashboard will retrieve and use the essential configuration from the backend.
      */
     config?: DashboardConfig;
+
+    /**
+     * Optionally specify permissions to use when determining availability of the different features of
+     * the dashboard component.
+     *
+     * If you do not specify permissions, the dashboard component will load permissions for the currently
+     * logged-in user.
+     */
+    permissions?: IWorkspacePermissions;
 
     /**
      * Optionally specify event handlers to register at the dashboard creation time.

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/loadDashboard/loadDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/loadDashboard/loadDashboardConfig.ts
@@ -1,6 +1,16 @@
 // (C) 2021 GoodData Corporation
-import { DashboardContext, ResolvedDashboardConfig } from "../../types/commonTypes";
-import { IDateFilterConfigsQueryResult, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import {
+    DashboardConfig,
+    DashboardContext,
+    isResolvedConfig,
+    ResolvedDashboardConfig,
+} from "../../types/commonTypes";
+import {
+    IDateFilterConfigsQueryResult,
+    ISeparators,
+    ISettings,
+    IUserWorkspaceSettings,
+} from "@gooddata/sdk-backend-spi";
 import { LoadDashboard } from "../../commands/dashboard";
 import { all, call } from "redux-saga/effects";
 import { dateFilterValidationFailed } from "../../events/dashboard";
@@ -38,6 +48,56 @@ function loadColorPalette(ctx: DashboardContext): Promise<IColorPalette> {
     return backend.workspace(workspace).styling().getColorPalette();
 }
 
+function* resolveDateFilterConfig(ctx: DashboardContext, config: DashboardConfig, cmd: LoadDashboard) {
+    if (config.dateFilterConfig !== undefined) {
+        return config.dateFilterConfig;
+    }
+
+    const result: PromiseFnReturnType<typeof loadDateFilterConfig> = yield call(loadDateFilterConfig, ctx);
+
+    if ((result?.totalCount ?? 0) > 1) {
+        yield call(eventDispatcher, dateFilterValidationFailed(ctx, "TOO_MANY_CONFIGS", cmd.correlationId));
+    }
+
+    const firstConfig = result?.items[0];
+
+    if (!firstConfig) {
+        yield call(eventDispatcher, dateFilterValidationFailed(ctx, "NO_CONFIG", cmd.correlationId));
+    }
+
+    return result?.items[0] ?? defaultDateFilterConfig;
+}
+
+type UserSettings = {
+    locale: ILocale;
+    separators: ISeparators;
+    settings: ISettings;
+};
+
+function resolveUserSettings(ctx: DashboardContext, config: DashboardConfig): Promise<UserSettings> {
+    if (config.settings && config.locale && config.separators) {
+        return Promise.resolve({
+            locale: config.locale,
+            separators: config.separators,
+            settings: config.settings,
+        });
+    }
+
+    return loadSettingsForCurrentUser(ctx).then((res) => ({
+        locale: config.locale ?? (res.locale as ILocale),
+        separators: config.separators ?? res.separators,
+        settings: config.settings ?? stripUserAndWorkspaceProps(res),
+    }));
+}
+
+function resolveColorPalette(ctx: DashboardContext, config: DashboardConfig): Promise<IColorPalette> {
+    if (config.colorPalette) {
+        return Promise.resolve(config.colorPalette);
+    }
+
+    return loadColorPalette(ctx);
+}
+
 /**
  * Loads all essential dashboard configuration from the backend if needed. The load command may specify their
  * own inline config - if that is the case the config is bounced back immediately. Otherwise the necessary
@@ -48,37 +108,35 @@ function loadColorPalette(ctx: DashboardContext): Promise<IColorPalette> {
  */
 export function* loadDashboardConfig(ctx: DashboardContext, cmd: LoadDashboard) {
     const {
-        payload: { config },
+        payload: { config = {} },
     } = cmd;
 
-    if (config) {
+    if (isResolvedConfig(config)) {
+        /*
+         * Config coming in props is fully specified. There is nothing to do. Bail out imediately.
+         */
         return config;
     }
 
-    const [dateFilterConfigResult, settings, colorPalette]: [
-        PromiseFnReturnType<typeof loadDateFilterConfig>,
-        PromiseFnReturnType<typeof loadSettingsForCurrentUser>,
-        PromiseFnReturnType<typeof loadColorPalette>,
+    /*
+     * Resolve the config values. The resolve* functions will take value from config if it is defined,
+     * otherwise they will obtain the config from backend.
+     *
+     * Note: the user settings include locale, separators and the ISettings that should be in effect
+     * for the current user in the context of the workspace.
+     */
+
+    const [dateFilterConfig, settings, colorPalette]: [
+        PromiseFnReturnType<typeof resolveDateFilterConfig>,
+        PromiseFnReturnType<typeof resolveUserSettings>,
+        PromiseFnReturnType<typeof resolveColorPalette>,
     ] = yield all([
-        call(loadDateFilterConfig, ctx),
-        call(loadSettingsForCurrentUser, ctx),
-        call(loadColorPalette, ctx),
+        call(resolveDateFilterConfig, ctx, config, cmd),
+        call(resolveUserSettings, ctx, config),
+        call(resolveColorPalette, ctx, config),
     ]);
 
-    if ((dateFilterConfigResult?.totalCount ?? 0) > 1) {
-        yield call(eventDispatcher, dateFilterValidationFailed(ctx, "TOO_MANY_CONFIGS", cmd.correlationId));
-    }
-
-    const firstConfig = dateFilterConfigResult?.items[0];
-
-    if (!firstConfig) {
-        yield call(eventDispatcher, dateFilterValidationFailed(ctx, "NO_CONFIG", cmd.correlationId));
-    }
-
-    const [dateFilterConfig, configValidation] = getValidDateFilterConfig(
-        firstConfig ?? defaultDateFilterConfig,
-        settings,
-    );
+    const [validDateFilterConfig, configValidation] = getValidDateFilterConfig(dateFilterConfig, settings);
 
     if (configValidation !== "Valid") {
         yield call(eventDispatcher, dateFilterValidationFailed(ctx, configValidation, cmd.correlationId));
@@ -87,8 +145,8 @@ export function* loadDashboardConfig(ctx: DashboardContext, cmd: LoadDashboard) 
     return {
         locale: settings.locale as ILocale,
         separators: settings.separators,
-        dateFilterConfig,
-        settings: stripUserAndWorkspaceProps(settings),
+        dateFilterConfig: validDateFilterConfig,
+        settings: settings.settings,
         colorPalette,
     } as ResolvedDashboardConfig;
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/loadDashboard/loadPermissions.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/loadDashboard/loadPermissions.ts
@@ -1,0 +1,27 @@
+// (C) 2021 GoodData Corporation
+import { DashboardContext } from "../../types/commonTypes";
+import { LoadDashboard } from "../../commands/dashboard";
+import { PromiseFnReturnType } from "../../types/sagas";
+import { call } from "redux-saga/effects";
+import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
+
+function loadPermissionsFromBackend(ctx: DashboardContext): Promise<IWorkspacePermissions> {
+    const { backend, workspace } = ctx;
+
+    return backend.workspace(workspace).permissions().getPermissionsForCurrentUser();
+}
+
+export function* loadPermissions(ctx: DashboardContext, cmd: LoadDashboard) {
+    const { permissions } = cmd.payload;
+
+    if (permissions) {
+        return permissions;
+    }
+
+    const result: PromiseFnReturnType<typeof loadPermissionsFromBackend> = yield call(
+        loadPermissionsFromBackend,
+        ctx,
+    );
+
+    return result;
+}

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -1,6 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 import { DashboardConfig } from "../types/commonTypes";
+import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 
 /**
  * All available command types.
@@ -46,6 +47,7 @@ export interface LoadDashboard extends IDashboardCommand {
     type: "GDC.DASHBOARD.CMD.LOAD";
     payload: {
         config?: DashboardConfig;
+        permissions?: IWorkspacePermissions;
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 
-import { IDashboard } from "@gooddata/sdk-backend-spi";
+import { IDashboard, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import { IInsight } from "@gooddata/sdk-model";
 import { DashboardConfig, DashboardContext } from "../types/commonTypes";
 import { DateFilterConfigValidationResult } from "../_staging/dateFilterConfig/validation";
@@ -56,9 +56,17 @@ export interface DashboardLoaded extends IDashboardEvent {
         insights: IInsight[];
 
         /**
-         * Configuration
+         * Configuration in effect for the dashboard. If the config was provided via props, then
+         * that same config is sent here. If there was no config in props, then the dashboard component load resolved
+         * all the config and includes it here.
          */
         config: DashboardConfig;
+
+        /**
+         * Permissions in effect for the dashboard. If the permissions were provided via props, then those
+         * same permissions are included here. Otherwise the dashboard will load the permissions and include it here.
+         */
+        permissions: IWorkspacePermissions;
     };
 }
 
@@ -67,6 +75,8 @@ export interface DashboardLoaded extends IDashboardEvent {
  * @param ctx
  * @param dashboard
  * @param insights
+ * @param config
+ * @param permissions
  * @param correlationId
  *
  */
@@ -75,6 +85,7 @@ export function dashboardLoaded(
     dashboard: IDashboard,
     insights: IInsight[],
     config: DashboardConfig,
+    permissions: IWorkspacePermissions,
     correlationId?: string,
 ): DashboardLoaded {
     return {
@@ -85,6 +96,7 @@ export function dashboardLoaded(
             dashboard,
             insights,
             config,
+            permissions,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -28,6 +28,8 @@ export {
     separatorsSelector,
     settingsSelector,
 } from "./state/config/configSelectors";
+export { PermissionsState } from "./state/permissions/permissionsState";
+export { permissionsSelector } from "./state/permissions/permissionsSelectors";
 export { FilterContextState } from "./state/filterContext/filterContextState";
 export { filterContextSelector } from "./state/filterContext/filterContextSelectors";
 export { LayoutState } from "./state/layout/layoutState";

--- a/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
@@ -26,6 +26,8 @@ import { ConfigState } from "./config/configState";
 import { configSliceReducer } from "./config";
 import { DateFilterConfigState } from "./dateFilterConfig/dateFilterConfigState";
 import { dateFilterConfigSliceReducer } from "./dateFilterConfig";
+import { PermissionsState } from "./permissions/permissionsState";
+import { permissionsSliceReducer } from "./permissions";
 
 /**
  * TODO: unfortunate. normally the typings get inferred from store. However since this code creates store
@@ -38,6 +40,7 @@ import { dateFilterConfigSliceReducer } from "./dateFilterConfig";
 export type DashboardState = {
     loading: LoadingState;
     config: ConfigState;
+    permissions: PermissionsState;
     filterContext: FilterContextState;
     layout: LayoutState;
     dateFilterConfig: DateFilterConfigState;
@@ -119,6 +122,7 @@ export function createDashboardStore(
         reducer: {
             loading: loadingSliceReducer,
             config: configSliceReducer,
+            permissions: permissionsSliceReducer,
             filterContext: filterContextSliceReducer,
             layout: layoutSliceReducer,
             dateFilterConfig: dateFilterConfigSliceReducer,

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/index.ts
@@ -1,0 +1,13 @@
+// (C) 2021 GoodData Corporation
+import { createSlice } from "@reduxjs/toolkit";
+import { permissionsReducers } from "./permissionsReducers";
+import { permissionsInitialState } from "./permissionsState";
+
+const permissionsSlice = createSlice({
+    name: "permissions",
+    initialState: permissionsInitialState,
+    reducers: permissionsReducers,
+});
+
+export const permissionsSliceReducer = permissionsSlice.reducer;
+export const permissionsActions = permissionsSlice.actions;

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsReducers.ts
@@ -1,0 +1,15 @@
+// (C) 2021 GoodData Corporation
+
+import { Action, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
+import { PermissionsState } from "./permissionsState";
+import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
+
+type PermissionsReducers<A extends Action> = CaseReducer<PermissionsState, A>;
+
+const setPermissions: PermissionsReducers<PayloadAction<IWorkspacePermissions>> = (state, action) => {
+    state.permissions = action.payload;
+};
+
+export const permissionsReducers = {
+    setPermissions,
+};

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsSelectors.ts
@@ -1,0 +1,21 @@
+// (C) 2021 GoodData Corporation
+import { createSelector } from "@reduxjs/toolkit";
+import { DashboardState } from "../dashboardStore";
+import invariant from "ts-invariant";
+
+const selectSelf = createSelector(
+    (state: DashboardState) => state,
+    (state) => state.permissions,
+);
+
+/**
+ * This selector returns user's permissions in the workspace where the dashboard is stored. It is expected that the
+ * selector is called only after the permission state is correctly initialized. Invocations before initialization lead to invariant errors.
+ *
+ * @internal
+ */
+export const permissionsSelector = createSelector(selectSelf, (filterContextState) => {
+    invariant(filterContextState.permissions, "attempting to access uninitialized permissions state");
+
+    return filterContextState.permissions!;
+});

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsState.ts
@@ -1,0 +1,12 @@
+// (C) 2021 GoodData Corporation
+
+import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
+
+/**
+ * @internal
+ */
+export interface PermissionsState {
+    permissions?: IWorkspacePermissions;
+}
+
+export const permissionsInitialState: PermissionsState = { permissions: undefined };

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -2,6 +2,8 @@
 import { IAnalyticalBackend, IDateFilterConfig, ISeparators, ISettings } from "@gooddata/sdk-backend-spi";
 import { IColorPalette, ObjRef } from "@gooddata/sdk-model";
 import { ILocale } from "@gooddata/sdk-ui";
+import keys from "lodash/keys";
+import includes from "lodash/includes";
 
 /**
  * Dashboard configuration can influence the available features, look and feel and behavior of the dashboard.
@@ -42,6 +44,30 @@ export type DashboardConfig = {
  * @internal
  */
 export type ResolvedDashboardConfig = Required<DashboardConfig>;
+
+type DashboardConfigKeys = keyof DashboardConfig;
+const RequiredConfigKeys: DashboardConfigKeys[] = [
+    "dateFilterConfig",
+    "locale",
+    "separators",
+    "colorPalette",
+    "settings",
+];
+
+/**
+ * Tests whether the provided config is fully resolved - it contains all the necessary values.
+ *
+ * @param config - config to test
+ */
+export function isResolvedConfig(config?: DashboardConfig): config is ResolvedDashboardConfig {
+    if (!config) {
+        return false;
+    }
+
+    const specifiedConfig = keys(config);
+
+    return RequiredConfigKeys.every((key) => includes(specifiedConfig, key));
+}
 
 /**
  * Values in this context will be available to all sagas.


### PR DESCRIPTION
-  Permissions can be provided on input (as optimization in multi-dashboard contexts)
-  The config loading now correctly identifies if the entire config has values resolved and if not fills in the gaps. the config values take precedence and will be kept, however whatever is missing will be loaded from backend

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
