### PR TITLE
RELATED: RAIL-3426 Allow edit measure identifier

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -952,6 +952,10 @@ export interface IMetadataObjectBase {
 }
 
 // @internal (undocumented)
+export interface IMetadataObjectDefinition extends Partial<IMetadataObjectBase>, Partial<Pick<IMetadataObject, "id">> {
+}
+
+// @internal (undocumented)
 export interface IMetadataObjectIdentity {
     id: string;
     ref: ObjRef;

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -935,7 +935,9 @@ export interface IMeasureMetadataObjectBase {
 }
 
 // @public
-export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase;
+export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase & {
+    id?: string;
+};
 
 // @public (undocumented)
 export interface IMetadataObject extends IMetadataObjectBase, IMetadataObjectIdentity {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -935,9 +935,7 @@ export interface IMeasureMetadataObjectBase {
 }
 
 // @public
-export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase & {
-    id?: string;
-};
+export type IMeasureMetadataObjectDefinition = IMetadataObjectDefinition & IMeasureMetadataObjectBase;
 
 // @public (undocumented)
 export interface IMetadataObject extends IMetadataObjectBase, IMetadataObjectIdentity {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -344,6 +344,7 @@ export {
     isVariableMetadataObject,
     IFactMetadataObject,
     isFactMetadataObject,
+    IMetadataObjectDefinition,
     IMeasureMetadataObject,
     IMeasureMetadataObjectBase,
     isMeasureMetadataObject,

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
@@ -10,6 +10,7 @@ import { IFactMetadataObject, isFactMetadataObject } from "./fact";
 import {
     IMeasureMetadataObject,
     IMeasureMetadataObjectBase,
+    IMetadataObjectDefinition,
     IMeasureMetadataObjectDefinition,
     isMeasureMetadataObject,
     isMeasureMetadataObjectDefinition,
@@ -30,6 +31,7 @@ export {
     isFactMetadataObject,
     IMeasureMetadataObject,
     IMeasureMetadataObjectBase,
+    IMetadataObjectDefinition,
     isMeasureMetadataObject,
     IMeasureMetadataObjectDefinition,
     isMeasureMetadataObjectDefinition,

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IMetadataObject, IMetadataObjectBase, isMetadataObject } from "../types";
 
 /**
@@ -36,7 +36,8 @@ export type IMeasureMetadataObject = IMetadataObject & IMeasureMetadataObjectBas
  *
  * @public
  */
-export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase & {id?: string};
+export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> &
+    IMeasureMetadataObjectBase & { id?: string };
 
 /**
  * Tests whether the provided object is of type {@link IMeasureMetadataObject}.

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
@@ -36,7 +36,7 @@ export type IMeasureMetadataObject = IMetadataObject & IMeasureMetadataObjectBas
  *
  * @public
  */
-export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase;
+export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> & IMeasureMetadataObjectBase & {id?: string};
 
 /**
  * Tests whether the provided object is of type {@link IMeasureMetadataObject}.

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
@@ -25,6 +25,13 @@ export interface IMeasureMetadataObjectBase {
 }
 
 /**
+ * @internal
+ */
+export interface IMetadataObjectDefinition
+    extends Partial<IMetadataObjectBase>,
+        Partial<Pick<IMetadataObject, "id">> {}
+
+/**
  * Measure metadata object
  *
  * @public
@@ -36,8 +43,7 @@ export type IMeasureMetadataObject = IMetadataObject & IMeasureMetadataObjectBas
  *
  * @public
  */
-export type IMeasureMetadataObjectDefinition = Partial<IMetadataObjectBase> &
-    IMeasureMetadataObjectBase & { id?: string };
+export type IMeasureMetadataObjectDefinition = IMetadataObjectDefinition & IMeasureMetadataObjectBase;
 
 /**
  * Tests whether the provided object is of type {@link IMeasureMetadataObject}.

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -99,7 +99,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
                     workspaceId: this.workspace,
                     jsonApiMetricInDocument: {
                         data: {
-                            id: uuidv4(),
+                            id: measure.id || uuidv4(),
                             type: JsonApiMetricInTypeEnum.Metric,
                             attributes: metricAttributes,
                         },


### PR DESCRIPTION
Allow to set measure id when creating.
[RAIL-3426](https://jira.intgdc.com/browse/RAIL-3426)

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
