### PR TITLE
RAIL-3406 attribute parent child filtering

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21661,6 +21661,7 @@ packages:
       stylelint: 13.13.0
       stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.0
+      ts-invariant: 0.7.3
       ts-jest: 26.5.5_jest@26.6.3+typescript@4.0.2
       tslib: 2.2.0
       typescript: 4.0.2

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonExample.tsx
@@ -1,0 +1,63 @@
+// (C) 2007-2020 GoodData Corporation
+import React, { useState } from "react";
+import { ErrorComponent, OnError, OnLoadingChanged } from "@gooddata/sdk-ui";
+import { AttributeFilterButton } from "@gooddata/sdk-ui-filters";
+import { BarChart } from "@gooddata/sdk-ui-charts";
+import {
+    attributeDisplayFormRef,
+    IAttributeFilter,
+    idRef,
+    newPositiveAttributeFilter,
+} from "@gooddata/sdk-model";
+import { Ldm, LdmExt } from "../../ldm";
+
+export const AttributeParentChildFilterButtonExample: React.FC = () => {
+    const [filter, setFilter] = useState<IAttributeFilter>();
+    const [parentFilter, setParentFilter] = useState<IAttributeFilter>();
+    const [error, setError] = useState<any>();
+
+    const onError: OnError = (...params) => {
+        setError(params);
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    const onLoadingChanged: OnLoadingChanged = (...params) => {
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    return (
+        <div className="s-attribute-filter">
+            <div style={{ display: "flex" }}>
+                <AttributeFilterButton
+                    filter={newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationState), {
+                        uris: [],
+                    })}
+                    onApply={setParentFilter}
+                />
+                <AttributeFilterButton
+                    filter={newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationCity), {
+                        uris: [],
+                    })}
+                    parentFilters={parentFilter ? [parentFilter] : []}
+                    parentFilterOverAttribute={idRef(LdmExt.locationIdAttributeIdentifier)}
+                    onApply={setFilter}
+                />
+            </div>
+            <div style={{ height: 300 }} className="s-line-chart">
+                {error ? (
+                    <ErrorComponent message={error} />
+                ) : (
+                    <BarChart
+                        measures={[LdmExt.TotalSales2]}
+                        viewBy={Ldm.LocationCity}
+                        filters={[filter, parentFilter]}
+                        onLoadingChanged={onLoadingChanged}
+                        onError={onError}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholder.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholder.tsx
@@ -1,0 +1,86 @@
+// (C) 2007-2020 GoodData Corporation
+import React, { useState } from "react";
+import {
+    ErrorComponent,
+    newPlaceholder,
+    OnError,
+    OnLoadingChanged,
+    PlaceholdersProvider,
+} from "@gooddata/sdk-ui";
+import { AttributeFilterButton } from "@gooddata/sdk-ui-filters";
+import { BarChart } from "@gooddata/sdk-ui-charts";
+import {
+    attributeDisplayFormRef,
+    IAttributeFilter,
+    idRef,
+    newPositiveAttributeFilter,
+} from "@gooddata/sdk-model";
+import { Ldm, LdmExt } from "../../ldm";
+import { newComposedPlaceholder } from "@gooddata/sdk-ui";
+import { IPlaceholder } from "@gooddata/sdk-ui";
+
+const stateFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+    newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationState), {
+        uris: [],
+    }),
+);
+
+const cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+    newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationCity), {
+        uris: [],
+    }),
+);
+
+const composedLocationFilterPlaceholder = newComposedPlaceholder<IPlaceholder<IAttributeFilter>[]>([
+    stateFilterPlaceholder,
+    cityFilterPlaceholder,
+]);
+
+const AttributeParentChildFilterButton: React.FC = () => {
+    const [error, setError] = useState<any>();
+
+    const onError: OnError = (...params) => {
+        setError(params);
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    const onLoadingChanged: OnLoadingChanged = (...params) => {
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    return (
+        <div className="s-attribute-filter">
+            <div style={{ display: "flex" }}>
+                <AttributeFilterButton connectToPlaceholder={stateFilterPlaceholder} />
+                <AttributeFilterButton
+                    parentFilters={[stateFilterPlaceholder]}
+                    parentFilterOverAttribute={idRef(LdmExt.locationIdAttributeIdentifier)}
+                    connectToPlaceholder={cityFilterPlaceholder}
+                />
+            </div>
+            <div style={{ height: 300 }} className="s-line-chart">
+                {error ? (
+                    <ErrorComponent message={error} />
+                ) : (
+                    <BarChart
+                        measures={[LdmExt.TotalSales2]}
+                        viewBy={Ldm.LocationCity}
+                        filters={[composedLocationFilterPlaceholder]}
+                        onLoadingChanged={onLoadingChanged}
+                        onError={onError}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const AttributeParentChildFilterButtonWithPlaceholder: React.FC = () => {
+    return (
+        <PlaceholdersProvider>
+            <AttributeParentChildFilterButton />
+        </PlaceholdersProvider>
+    );
+};

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterExample.tsx
@@ -1,0 +1,57 @@
+// (C) 2007-2020 GoodData Corporation
+import React, { useState } from "react";
+import { ErrorComponent, OnLoadingChanged, OnError } from "@gooddata/sdk-ui";
+import { AttributeFilter } from "@gooddata/sdk-ui-filters";
+import { BarChart } from "@gooddata/sdk-ui-charts";
+import { IAttributeFilter } from "@gooddata/sdk-model";
+import { Ldm, LdmExt } from "../../ldm";
+import { newPositiveAttributeFilter } from "@gooddata/sdk-model";
+import { attributeDisplayFormRef } from "@gooddata/sdk-model";
+import { idRef } from "@gooddata/sdk-model";
+
+export const AttributeParentChildFilterExample: React.FC = () => {
+    const [filter, setFilter] = useState<IAttributeFilter>();
+    const [parentFilter, setParentFilter] = useState<IAttributeFilter>();
+    const [error, setError] = useState<any>();
+
+    const onError: OnError = (...params) => {
+        setError(params);
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    const onLoadingChanged: OnLoadingChanged = (...params) => {
+        // eslint-disable-next-line no-console
+        console.info("AttributeFilterExample onLoadingChanged", ...params);
+    };
+
+    return (
+        <div className="s-attribute-filter">
+            <AttributeFilter
+                filter={newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationState), { uris: [] })}
+                fullscreenOnMobile={false}
+                onApply={setParentFilter}
+            />
+            <AttributeFilter
+                filter={newPositiveAttributeFilter(attributeDisplayFormRef(Ldm.LocationCity), { uris: [] })}
+                parentFilters={parentFilter ? [parentFilter] : []}
+                parentFilterOverAttribute={idRef(LdmExt.locationIdAttributeIdentifier)}
+                fullscreenOnMobile={false}
+                onApply={setFilter}
+            />
+            <div style={{ height: 300 }} className="s-line-chart">
+                {error ? (
+                    <ErrorComponent message={error} />
+                ) : (
+                    <BarChart
+                        measures={[LdmExt.TotalSales2]}
+                        viewBy={Ldm.LocationCity}
+                        filters={[filter, parentFilter]}
+                        onLoadingChanged={onLoadingChanged}
+                        onError={onError}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};

--- a/examples/sdk-examples/src/examples/attributeFilter/index.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/index.tsx
@@ -8,16 +8,25 @@ import AttributeFilterComponentExample from "./AttributeFilterComponentExample";
 import AttributeElementsExample from "./AttributeElementsExample";
 import AttributeFilterExample from "./AttributeFilterExample";
 import AttributeFilterButtonExample from "./AttributeFilterButtonExample";
+import { AttributeParentChildFilterExample } from "./AttributeParentChildFilterExample";
+import { AttributeParentChildFilterButtonExample } from "./AttributeParentChildFilterButtonExample";
+import { AttributeParentChildFilterButtonWithPlaceholder } from "./AttributeParentChildFilterButtonWithPlaceholder";
 
 import AttributeFilterComponentExampleSRC from "./AttributeFilterComponentExample?raw";
 import AttributeElementsExampleSRC from "./AttributeElementsExample?raw";
 import AttributeFilterExampleSRC from "./AttributeFilterExample?raw";
 import AttributeFilterButtonExampleSRC from "./AttributeFilterButtonExample?raw";
+import AttributeParentChildFilterExampleSRC from "./AttributeParentChildFilterExample?raw";
+import AttributeParentChildFilterButtonExampleSRC from "./AttributeParentChildFilterButtonExample?raw";
+import AttributeParentChildFilterButtonWithPlaceholderSRC from "./AttributeParentChildFilterButtonWithPlaceholder?raw";
 
 import AttributeFilterComponentExampleSRCJS from "./AttributeFilterComponentExample?rawJS";
 import AttributeElementsExampleSRCJS from "./AttributeElementsExample?rawJS";
 import AttributeFilterExampleSRCJS from "./AttributeFilterExample?rawJS";
 import AttributeFilterButtonExampleSRCJS from "./AttributeFilterButtonExample?rawJS";
+import AttributeParentChildFilterExampleSRCJS from "./AttributeParentChildFilterExample?rawJS";
+import AttributeParentChildFilterButtonExampleSRCJS from "./AttributeParentChildFilterButtonExample?rawJS";
+import AttributeParentChildFilterButtonWithPlaceholderSRCJS from "./AttributeParentChildFilterButtonWithPlaceholder?rawJS";
 
 export const AttributeFilter = (): JSX.Element => (
     <div>
@@ -83,6 +92,54 @@ export const AttributeFilter = (): JSX.Element => (
             for={AttributeFilterButtonExample}
             source={AttributeFilterButtonExampleSRC}
             sourceJS={AttributeFilterButtonExampleSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <h2>Parent-Child AttributeFilter</h2>
+
+        <p>
+            Pass parent filter via parentFilters property and attribute over which should be the child filter
+            reduced via parentFilterOverAttribute property to create parent-child dependency between filters.
+        </p>
+
+        <ExampleWithSource
+            for={AttributeParentChildFilterExample}
+            source={AttributeParentChildFilterExampleSRC}
+            sourceJS={AttributeParentChildFilterExampleSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <h2>Parent-Child AttributeFilterButton</h2>
+
+        <p>
+            Pass parent filter via parentFilters property and attribute over which should be the child filter
+            reduced via parentFilterOverAttribute property to create parent-child dependency between filters.
+        </p>
+
+        <ExampleWithSource
+            for={AttributeParentChildFilterButtonExample}
+            source={AttributeParentChildFilterButtonExampleSRC}
+            sourceJS={AttributeParentChildFilterButtonExampleSRCJS}
+        />
+
+        <hr className="separator" />
+
+        <h2>Parent-Child AttributeFilterButton with placeholders</h2>
+
+        <p>
+            Pass placeholder for parent filter via parentFilters property and attribute over which should be
+            the child filter reduced via parentFilterOverAttribute property to create parent-child dependency
+            between filters.
+        </p>
+
+        <p>Dependency implemented via Placeholders.</p>
+
+        <ExampleWithSource
+            for={AttributeParentChildFilterButtonWithPlaceholder}
+            source={AttributeParentChildFilterButtonWithPlaceholderSRC}
+            sourceJS={AttributeParentChildFilterButtonWithPlaceholderSRCJS}
         />
     </div>
 );

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -16,6 +16,7 @@ import { IElementsQueryAttributeFilter } from '@gooddata/sdk-backend-spi';
 import { IElementsQueryOptions } from '@gooddata/sdk-backend-spi';
 import { IElementsQueryResult } from '@gooddata/sdk-backend-spi';
 import { IMeasureValueFilter } from '@gooddata/sdk-model';
+import { IPlaceholder } from '@gooddata/sdk-ui';
 import { IRankingFilter } from '@gooddata/sdk-model';
 import { IRelativeDateFilterForm } from '@gooddata/sdk-backend-spi';
 import { IRelativeDateFilterPreset } from '@gooddata/sdk-backend-spi';
@@ -26,6 +27,7 @@ import { ObjRefInScope } from '@gooddata/sdk-model';
 import { OnError } from '@gooddata/sdk-ui';
 import { default as React_2 } from 'react';
 import { RelativeGranularityOffset } from '@gooddata/sdk-backend-spi';
+import { ValuesOrPlaceholders } from '@gooddata/sdk-ui';
 import { WrappedComponentProps } from 'react-intl';
 
 // @public
@@ -124,11 +126,17 @@ export interface IAttributeElementsProps {
 // @public (undocumented)
 export interface IAttributeFilterButtonOwnProps {
     backend?: IAnalyticalBackend;
+    connectToPlaceholder?: IPlaceholder<IAttributeFilter>;
     filter?: IAttributeFilter;
+    FilterError?: React_2.ComponentType<{
+        error?: any;
+    }>;
     // @deprecated
     identifier?: string;
-    onApply: (filter: IAttributeFilter, isInverted: boolean) => void;
+    onApply?: (filter: IAttributeFilter, isInverted: boolean) => void;
     onError?: (error: any) => void;
+    parentFilterOverAttribute?: ObjRef;
+    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
     title?: string;
     workspace?: string;
 }
@@ -150,6 +158,8 @@ export interface IAttributeFilterProps {
     locale?: string;
     onApply: (filter: IAttributeFilter) => void;
     onError?: OnError;
+    parentFilterOverAttribute?: ObjRef;
+    parentFilters?: IAttributeFilter[];
     title?: string;
     titleWithSelection?: boolean;
     workspace?: string;

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -77,7 +77,8 @@
         "react-responsive": "^8.0.1",
         "react-window": "^1.8.5",
         "tslib": "^2.0.0",
-        "date-fns": "^2.8.1"
+        "date-fns": "^2.8.1",
+        "ts-invariant": "^0.7.3"
     },
     "peerDependencies": {
         "react": "^16.10.0",

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -2,13 +2,19 @@
 import React, { useEffect, useRef, useState } from "react";
 import cx from "classnames";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { IAnalyticalBackend, IAttributeElement, IAttributeMetadataObject } from "@gooddata/sdk-backend-spi";
+import {
+    IAnalyticalBackend,
+    IAttributeElement,
+    IAttributeMetadataObject,
+    UnexpectedError,
+} from "@gooddata/sdk-backend-spi";
 import {
     filterAttributeElements,
     IAttributeFilter,
     isAttributeElementsByRef,
     newNegativeAttributeFilter,
     newPositiveAttributeFilter,
+    ObjRef,
 } from "@gooddata/sdk-model";
 import Dropdown from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
 import { AttributeDropdownBody } from "./AttributeDropdown/AttributeDropdownBody";
@@ -18,7 +24,14 @@ import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import { MAX_SELECTION_SIZE } from "./AttributeDropdown/AttributeDropdownList";
 import { mergeElementQueryResults } from "./AttributeDropdown/mergeElementQueryResults";
-import { IntlWrapper, useCancelablePromise, withContexts } from "@gooddata/sdk-ui";
+import {
+    IntlWrapper,
+    IPlaceholder,
+    useCancelablePromise,
+    useResolveValueWithPlaceholders,
+    ValuesOrPlaceholders,
+    withContexts,
+} from "@gooddata/sdk-ui";
 import MediaQuery from "react-responsive";
 import { MediaQueries } from "../constants";
 import {
@@ -28,9 +41,14 @@ import {
     getItemsTitles,
     getNoneTitleIntl,
     getObjRef,
+    getValidElementsFilters,
+    ILoadElementsResult,
+    isParentFilteringEnabled,
     updateSelectedOptionsWithData,
 } from "./utils/AttributeFilterUtils";
 import { stringUtils } from "@gooddata/util";
+import invariant from "ts-invariant";
+import stringify from "json-stable-stringify";
 
 /**
  * @public
@@ -53,13 +71,35 @@ export interface IAttributeFilterButtonOwnProps {
     /**
      * Specify an attribute filter that will be customized using this filter. The component will use content of the
      * filter and select the items that are already specified on the filter.
+     *
+     * Note: It's not possible to combine this property with "connectToPlaceholder" property. Either - provide a value, or a placeholder.
+     * The 'onApply' callback must be specified in order to handle filter changes.
      */
     filter?: IAttributeFilter;
 
     /**
+     * Specifies a parent attribute filter that will be used to reduce options for for current attribute filter.
+     */
+    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
+
+    /**
+     * Specify {@link @gooddata/sdk-ui#IPlaceholder} to use to get and set the value of the attribute filter.
+     *
+     * Note: It's not possible to combine this property with "filter" property. Either - provide a value, or a placeholder.
+     * There is no need to specify 'onApply' callback if 'connectToPlaceholder' property is used as the value of the filter
+     * is set via this placeholder.
+     */
+    connectToPlaceholder?: IPlaceholder<IAttributeFilter>;
+
+    /**
+     * Specify and parent filter attribute ref over which should be available options reduced.
+     */
+    parentFilterOverAttribute?: ObjRef;
+
+    /**
      * Specify identifier of attribute, for which you want to construct the filter.
      *
-     * Note: this is optional and deprecated. If you do not specify this, then you MUST specify the filter prop.
+     * Note: this is optional and deprecated. If you do not specify this, then you MUST specify the 'filter' prop or 'connectToPlaceholder' prop.
      *
      * @deprecated - use the filter prop instead
      */
@@ -76,13 +116,18 @@ export interface IAttributeFilterButtonOwnProps {
      *
      * @param filter - new value of the filter.
      */
-    onApply: (filter: IAttributeFilter, isInverted: boolean) => void;
+    onApply?: (filter: IAttributeFilter, isInverted: boolean) => void;
 
     /**
      * Optionally customize attribute filter with a callback function to trigger when an error occurs while
      * loading attribute elements.
      */
     onError?: (error: any) => void;
+
+    /**
+     * Optionally customize attribute filter with a component to be rendered if attribute elements loading fails
+     */
+    FilterError?: React.ComponentType<{ error?: any }>;
 }
 
 /**
@@ -119,6 +164,11 @@ const DropdownButton: React.FC<{
 const LIMIT = MAX_SELECTION_SIZE + 50;
 
 export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = (props) => {
+    invariant(
+        !(props.filter && props.connectToPlaceholder),
+        "It's not possible to combine 'filter' property with 'connectToPlaceholder' property. Either provide a value, or a placeholder.",
+    );
+
     const [validElements, setValidElements] = useState<IElementQueryResultWithEmptyItems>(null);
     const [selectedFilterOptions, setSelectedFilterOptions] = useState<Array<IAttributeElement>>([]);
     const [isInverted, setIsInverted] = useState(true);
@@ -131,22 +181,51 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     const [offset, setOffset] = useState(0);
     const [limit, setLimit] = useState(LIMIT);
     const [totalCount, setTotalCount] = useState(LIMIT);
-    const [filterOptions, setFilterOptions] = useState<Array<IAttributeElement>>([]);
     const [title, setTitle] = useState("");
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
     const dropdownRef = useRef<Dropdown>(null);
 
+    // TODO replace with non-conditional hook
+    const [placeholder, setPlaceholder] = props.connectToPlaceholder?.use() ?? [
+        undefined,
+        () => {
+            throw new UnexpectedError("No placeholder to be set with a filter value.");
+        },
+    ];
+
+    const resolvedParentFilters = useResolveValueWithPlaceholders(props.parentFilters);
+
     useEffect(() => {
         getElementTotalCount(
             props.workspace,
             getBackend(),
-            getObjRef(props.filter, props.identifier),
+            getObjRef(placeholder || props.filter, props.identifier),
             searchString,
         ).then((result) => {
             setTotalCount(result);
         });
     }, []);
+
+    useCancelablePromise(
+        {
+            promise: async () => getElements(validElements, offset, limit, loadElements, true),
+            onSuccess: (result) => {
+                setFirstLoad(false);
+                setIsLoading(false);
+                setSelectedFilterOptions(result.selectedOptions);
+                setValidElements(result.validOptions);
+                setTotalCount(result.totalCount);
+            },
+            onLoading: () => {
+                setIsLoading(true);
+            },
+            onError: (error) => {
+                setError(error);
+            },
+        },
+        [stringify(resolvedParentFilters)],
+    );
 
     useEffect(() => {
         setValidElements(null);
@@ -158,6 +237,10 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         getElements(validElements, offset, limit, loadElements);
     }, [props.workspace, searchString]);
 
+    // useDeepEffect(() => {
+    //     getElements(validElements, offset, limit, loadElements, true);
+    // }, [resolvedParentFilters]);
+
     useEffect(() => {
         closeDropdown();
     }, [prevIsInverted, prevSelectedFilterOptions]);
@@ -167,7 +250,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
             promise: async () => {
                 const attributes = getBackend().workspace(props.workspace).attributes();
                 const displayForm = await attributes.getAttributeDisplayForm(
-                    getObjRef(props.filter, props.identifier),
+                    getObjRef(placeholder || props.filter, props.identifier),
                 );
                 const attribute = await attributes.getAttribute(displayForm.attribute);
 
@@ -187,22 +270,29 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         [],
     );
 
-    const loadElements = async (offset: number, limit: number) => {
+    const loadElements = async (offset: number, limit: number): Promise<ILoadElementsResult> => {
         const { workspace } = props;
 
         setIsLoading(true);
 
-        const newElements = await getBackend()
+        const preparedElementQuery = getBackend()
             .workspace(workspace)
             .attributes()
             .elements()
-            .forDisplayForm(getObjRef(props.filter, props.identifier))
+            .forDisplayForm(getObjRef(placeholder || props.filter, props.identifier))
             .withOptions({
                 ...(searchString ? { filter: searchString } : {}),
             })
             .withOffset(offset)
-            .withLimit(limit)
-            .query();
+            .withLimit(limit);
+
+        if (isParentFilteringEnabled(getBackend())) {
+            preparedElementQuery.withAttributeFilters(
+                getValidElementsFilters(resolvedParentFilters, props.parentFilterOverAttribute),
+            );
+        }
+
+        const newElements = await preparedElementQuery.query();
 
         const mergedValidElements = mergeElementQueryResults(validElements, newElements);
         const { items } = mergedValidElements;
@@ -210,15 +300,12 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         // make sure that selected items have both title and uri, otherwise selection in InvertableList won't work
         // TODO we could maybe use the InvertableList's getItemKey and just use title or uri for example
         const updatedSelectedItems = updateSelectedOptionsWithData(selectedFilterOptions, items);
-        const updatedPrevSelectedItems = updateSelectedOptionsWithData(prevSelectedFilterOptions, items);
 
-        setSelectedFilterOptions(updatedSelectedItems);
-        setPrevSelectedFilterOptions(updatedPrevSelectedItems);
-        setIsLoading(false);
-        setValidElements(searchString ? newElements : mergedValidElements);
-        setTotalCount(firstLoad ? items.length : totalCount);
-        setFirstLoad(false);
-        setFilterOptions(items as Array<IAttributeElement>);
+        return {
+            selectedOptions: updatedSelectedItems,
+            validOptions: searchString || resolvedParentFilters ? newElements : mergedValidElements,
+            totalCount: firstLoad ? items.length : totalCount,
+        };
     };
 
     /**
@@ -229,7 +316,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     };
 
     const getSubtitle = () => {
-        const displayForm = getObjRef(props.filter, props.identifier);
+        const displayForm = getObjRef(placeholder || props.filter, props.identifier);
         if (totalCount && displayForm) {
             const empty = isEmpty(selectedFilterOptions);
             const equal = isEqual(totalCount, selectedFilterOptions?.length);
@@ -262,19 +349,24 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     }, 250);
 
     const onApply = () => {
+        const currentFilter = placeholder || props.filter;
         const useUriElements =
-            props.filter && isAttributeElementsByRef(filterAttributeElements(props.filter));
+            currentFilter && isAttributeElementsByRef(filterAttributeElements(currentFilter));
 
         const filterFactory = isInverted ? newNegativeAttributeFilter : newPositiveAttributeFilter;
 
         const filter = filterFactory(
-            getObjRef(props.filter, props.identifier),
+            getObjRef(currentFilter, props.identifier),
             useUriElements
                 ? { uris: selectedFilterOptions.map((item) => item.uri) }
                 : { values: selectedFilterOptions.map((item) => item.title) },
         );
 
-        return props.onApply(filter, isInverted);
+        if (props.connectToPlaceholder) {
+            setPlaceholder(filter);
+        }
+
+        return props.onApply && props.onApply(filter, isInverted);
     };
 
     const onSelect = (selectedFilterOptions: IAttributeElement[], isInverted: boolean) => {
@@ -360,7 +452,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 }
                 body={
                     <AttributeDropdownBody
-                        items={filterOptions}
+                        items={validElements?.items ?? []}
                         totalCount={totalCount}
                         selectedItems={selectedFilterOptions}
                         isInverted={isInverted}
@@ -380,7 +472,13 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         );
     };
 
-    return <>{error ? <DefaultFilterError /> : <>{renderAttributeDropdown()}</>}</>;
+    const { FilterError } = props;
+
+    return error ? <FilterError error={error} /> : renderAttributeDropdown();
+};
+
+AttributeFilterButtonCore.defaultProps = {
+    FilterError: DefaultFilterError,
 };
 
 const IntlAttributeFilterButton = withContexts(injectIntl(AttributeFilterButtonCore));

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -237,10 +237,6 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         getElements(validElements, offset, limit, loadElements);
     }, [props.workspace, searchString]);
 
-    // useDeepEffect(() => {
-    //     getElements(validElements, offset, limit, loadElements, true);
-    // }, [resolvedParentFilters]);
-
     useEffect(() => {
         closeDropdown();
     }, [prevIsInverted, prevSelectedFilterOptions]);


### PR DESCRIPTION
- add attribute parent child filtering suport to AttributeFilter component
- example with parent child filtering
- add parentFilters optional property
- add parentFilterOverAttribute optional property
- add FilterError optional property
- introduced useDeepEffect hook in SDK
- modified loadAttributes functuin to consider parent filters
- introduced default FilterError property value
- example with AttributeFilterButton parent-child filtering

JIRA: RAIL-3406
---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
