### PR TITLE
RELATED: ONE-5045 ONE-5046 ONE-5047 Remove cloneDeep from charts

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -726,27 +726,28 @@ function getStackingConfiguration(
 
 function getSeries(series: any) {
     return series.map((seriesItem: any) => {
-        const item = cloneDeep(seriesItem);
-        // Escaping is handled by highcharts so we don't want to provide escaped input.
-        // With one exception, though. Highcharts supports defining styles via
-        // for example <b>...</b> and parses that from series name.
-        // So to avoid this parsing, escape only < and > to &lt; and &gt;
-        // which is understood by highcharts correctly
-        item.name = item.name && escapeAngleBrackets(item.name);
+        return {
+            ...seriesItem,
 
-        // Escape data items for pie chart
-        item.data = item.data.map((dataItem: any) => {
-            if (!dataItem) {
-                return dataItem;
-            }
+            // Escaping is handled by highcharts so we don't want to provide escaped input.
+            // With one exception, though. Highcharts supports defining styles via
+            // for example <b>...</b> and parses that from series name.
+            // So to avoid this parsing, escape only < and > to &lt; and &gt;
+            // which is understood by highcharts correctly
+            name: seriesItem?.name && escapeAngleBrackets(seriesItem?.name),
 
-            return {
-                ...dataItem,
-                name: escapeAngleBrackets(dataItem.name),
-            };
-        });
+            // Escape data items for pie chart
+            data: seriesItem?.data?.map((dataItem: any) => {
+                if (!dataItem) {
+                    return dataItem;
+                }
 
-        return item;
+                return {
+                    ...dataItem,
+                    name: escapeAngleBrackets(dataItem.name),
+                };
+            }),
+        };
     });
 }
 


### PR DESCRIPTION
Replace cloneDeep in chart config creation with spread operator
Fix types where possible

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)