### PR TITLE
RELATED: RAIL-3450 avoid Partial in defaultProps typings

### DIFF
--- a/libs/sdk-ui-charts/src/charts/_base/BaseChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/_base/BaseChart.tsx
@@ -36,7 +36,10 @@ export interface IBaseChartProps extends ICoreChartProps {
 type Props = IBaseChartProps & ILoadingInjectedProps;
 
 class StatelessBaseChart extends React.Component<Props> {
-    public static defaultProps: Partial<Props> = {
+    public static defaultProps: Pick<
+        Partial<Props>,
+        keyof typeof defaultCoreChartProps | "onDataTooLarge" | "onLegendReady" | "config"
+    > = {
         ...defaultCoreChartProps,
         onDataTooLarge: noop,
         onLegendReady: noop,

--- a/libs/sdk-ui-charts/src/charts/_commons/defaultProps.ts
+++ b/libs/sdk-ui-charts/src/charts/_commons/defaultProps.ts
@@ -3,8 +3,19 @@ import noop from "lodash/noop";
 import { ErrorComponent, LoadingComponent, defaultErrorHandler } from "@gooddata/sdk-ui";
 import { ICoreChartProps } from "../../interfaces";
 
-export const defaultCoreChartProps: Partial<ICoreChartProps> = {
-    execution: undefined,
+export const defaultCoreChartProps: Pick<
+    ICoreChartProps,
+    | "locale"
+    | "drillableItems"
+    | "afterRender"
+    | "pushData"
+    | "onError"
+    | "onExportReady"
+    | "onLoadingChanged"
+    | "onDrill"
+    | "ErrorComponent"
+    | "LoadingComponent"
+> = {
     locale: "en-US",
     drillableItems: [],
     afterRender: noop,

--- a/libs/sdk-ui-charts/src/charts/headline/CoreHeadline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/CoreHeadline.tsx
@@ -11,13 +11,13 @@ import {
     ILoadingInjectedProps,
     withEntireDataView,
 } from "@gooddata/sdk-ui";
-import { ICommonChartProps, ICoreChartProps } from "../../interfaces";
+import { ICoreChartProps } from "../../interfaces";
 import HeadlineTransformation from "./internal/HeadlineTransformation";
 import { defaultCoreChartProps } from "../_commons/defaultProps";
 
 type Props = ICoreChartProps & ILoadingInjectedProps;
 export class HeadlineStateless extends React.Component<Props> {
-    public static defaultProps: Partial<ICommonChartProps> = defaultCoreChartProps;
+    public static defaultProps = defaultCoreChartProps;
 
     private errorMap: IErrorDescriptors;
 

--- a/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
@@ -39,7 +39,10 @@ export interface IHeadlineVisualizationProps {
  * The React component that renders the Headline visualisation.
  */
 export default class Headline extends React.Component<IHeadlineVisualizationProps> {
-    public static defaultProps: Partial<IHeadlineVisualizationProps> = {
+    public static defaultProps: Pick<
+        IHeadlineVisualizationProps,
+        "onDrill" | "onAfterRender" | "config" | "disableDrillUnderline"
+    > = {
         onDrill: () => true,
         onAfterRender: noop,
         config: {},

--- a/libs/sdk-ui-charts/src/charts/headline/internal/HeadlineTransformation.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/HeadlineTransformation.tsx
@@ -33,7 +33,10 @@ export interface IHeadlineTransformationProps {
  * and drill events out of it.
  */
 class HeadlineTransformation extends React.Component<IHeadlineTransformationProps & WrappedComponentProps> {
-    public static defaultProps: Partial<IHeadlineTransformationProps & WrappedComponentProps> = {
+    public static defaultProps: Pick<
+        IHeadlineTransformationProps,
+        "drillableItems" | "onDrill" | "onAfterRender"
+    > = {
         drillableItems: [],
         onDrill: () => true,
         onAfterRender: noop,

--- a/libs/sdk-ui-charts/src/charts/xirr/CoreXirr.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/CoreXirr.tsx
@@ -11,13 +11,13 @@ import {
     ILoadingInjectedProps,
     withEntireDataView,
 } from "@gooddata/sdk-ui";
-import { ICommonChartProps, ICoreChartProps } from "../../interfaces";
+import { ICoreChartProps } from "../../interfaces";
 import XirrTransformation from "./internal/XirrTransformation";
 import { defaultCoreChartProps } from "../_commons/defaultProps";
 
 type Props = ICoreChartProps & ILoadingInjectedProps;
 export class XirrStateless extends React.Component<Props> {
-    public static defaultProps: Partial<ICommonChartProps> = defaultCoreChartProps;
+    public static defaultProps = defaultCoreChartProps;
 
     private errorMap: IErrorDescriptors;
 

--- a/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
@@ -29,7 +29,10 @@ export interface IXirrTransformationProps {
  * and drill events out of it.
  */
 class XirrTransformation extends React.Component<IXirrTransformationProps & WrappedComponentProps> {
-    public static defaultProps: Partial<IXirrTransformationProps & WrappedComponentProps> = {
+    public static defaultProps: Pick<
+        IXirrTransformationProps,
+        "config" | "drillableItems" | "onDrill" | "onAfterRender"
+    > = {
         config: {},
         drillableItems: [],
         onDrill: () => true,

--- a/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
@@ -35,7 +35,7 @@ export interface IChartProps {
  * @internal
  */
 export class Chart extends React.Component<IChartProps> {
-    public static defaultProps: Partial<IChartProps> = {
+    public static defaultProps: Pick<IChartProps, "callback" | "domProps"> = {
         callback: noop,
         domProps: {},
     };

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiExecutor.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/KpiView/KpiExecutor.tsx
@@ -229,6 +229,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                  */
                 (isAlertBroken ? new NoDataSdkError() : undefined)
             }
+            isLoading={false /* content is always loaded at this point */}
             isAlertLoading={false /* alerts are always loaded at this point */}
             isAlertExecutionLoading={alertStatus === "loading"}
             isAlertBroken={isAlertBroken}

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -60,7 +60,10 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
     private visualization: IVisualization | undefined;
     private containerRef = React.createRef<HTMLDivElement>();
 
-    public static defaultProps: Partial<IInsightRendererProps & WrappedComponentProps> = {
+    public static defaultProps: Pick<
+        IInsightRendererProps,
+        "ErrorComponent" | "filters" | "drillableItems" | "LoadingComponent" | "pushData" | "locale"
+    > = {
         ErrorComponent,
         filters: [],
         drillableItems: [],

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -39,7 +39,10 @@ interface IInsightViewState {
 }
 
 class InsightViewCore extends React.Component<IInsightViewProps & WrappedComponentProps, IInsightViewState> {
-    public static defaultProps: Partial<IInsightViewProps & WrappedComponentProps> = {
+    public static defaultProps: Pick<
+        IInsightViewProps,
+        "ErrorComponent" | "filters" | "drillableItems" | "LoadingComponent" | "pushData" | "TitleComponent"
+    > = {
         ErrorComponent: DefaultError,
         filters: [],
         drillableItems: [],

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -40,7 +40,7 @@ export interface IBaseVisualizationProps extends IVisCallbacks {
     backend: IAnalyticalBackend;
     projectId: string;
     insight: IInsightDefinition;
-    insightPropertiesMeta: any;
+    insightPropertiesMeta?: any;
     config?: IGdcConfig;
     visualizationClass: IVisualizationClass;
     environment?: VisualizationEnvironment;
@@ -48,14 +48,14 @@ export interface IBaseVisualizationProps extends IVisCallbacks {
     height?: number;
     locale?: ILocale;
     dateFormat?: string;
-    drillableItems: Array<IDrillableItem | IHeaderPredicate>;
+    drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     totalsEditAllowed?: boolean;
     featureFlags?: ISettings;
     visualizationCatalog?: IVisualizationCatalog;
     newDerivedBucketItems?: IBucketItem[];
     referencePoint?: IReferencePoint;
     onError: OnError;
-    onExportReady: OnExportReady;
+    onExportReady?: OnExportReady;
     onLoadingChanged: OnLoadingChanged;
     isMdObjectValid?: boolean;
     configPanelClassName?: string;
@@ -68,7 +68,18 @@ export interface IBaseVisualizationProps extends IVisCallbacks {
 }
 
 export class BaseVisualization extends React.PureComponent<IBaseVisualizationProps> {
-    public static defaultProps: Partial<IBaseVisualizationProps> = {
+    public static defaultProps: Pick<
+        IBaseVisualizationProps,
+        | "visualizationCatalog"
+        | "newDerivedBucketItems"
+        | "referencePoint"
+        | "onExtendedReferencePointChanged"
+        | "onNewDerivedBucketItemsPlaced"
+        | "isMdObjectValid"
+        | "configPanelClassName"
+        | "featureFlags"
+        | "renderer"
+    > = {
         visualizationCatalog: FullVisualizationCatalog,
         newDerivedBucketItems: [],
         referencePoint: null,

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemsList.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemsList.tsx
@@ -29,7 +29,7 @@ export interface IColoredItemsListState {
 export type IColoredItemsListProps = IColoredItemsListOwnProps & WrappedComponentProps;
 
 class ColoredItemsList extends React.PureComponent<IColoredItemsListProps, IColoredItemsListState> {
-    public static defaultProps: Partial<IColoredItemsListProps> = {
+    public static defaultProps: Pick<IColoredItemsListProps, "disabled" | "isLoading"> = {
         disabled: false,
         isLoading: false,
     };

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/DashboardItemWithKpiAlert.tsx
@@ -9,7 +9,7 @@ import { GoodDataSdkError, isNoDataSdkError } from "@gooddata/sdk-ui";
 import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
 import React, { Component, MouseEvent } from "react";
-import { FormattedMessage, WrappedComponentProps } from "react-intl";
+import { FormattedMessage } from "react-intl";
 
 import { DashboardItemKpi } from "../DashboardItem/DashboardItemKpi";
 import { IKpiResult, IKpiAlertResult, KpiAlertOperationStatus } from "../types";
@@ -79,10 +79,19 @@ interface IDashboardItemWithKpiAlertState {
 }
 
 export class DashboardItemWithKpiAlert extends Component<
-    IDashboardItemWithKpiAlertProps & WrappedComponentProps,
+    IDashboardItemWithKpiAlertProps,
     IDashboardItemWithKpiAlertState
 > {
-    static defaultProps: Partial<IDashboardItemWithKpiAlertProps & WrappedComponentProps> = {
+    static defaultProps: Pick<
+        IDashboardItemWithKpiAlertProps,
+        | "isAlertHighlighted"
+        | "filters"
+        | "alertDeletingStatus"
+        | "alertSavingStatus"
+        | "alertUpdatingStatus"
+        | "suppressAlertTriggered"
+        | "isReadOnlyMode"
+    > = {
         isAlertHighlighted: false,
         filters: [],
         alertDeletingStatus: "idle",

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
@@ -87,7 +87,19 @@ export class KpiAlertDialog extends Component<
     IKpiAlertDialogProps & WrappedComponentProps,
     IKpiAlertDialogState
 > {
-    static defaultProps: Partial<IKpiAlertDialogProps & WrappedComponentProps> = {
+    static defaultProps: Pick<
+        IKpiAlertDialogProps,
+        | "isAlertLoading"
+        | "isKpiFormatLoading"
+        | "thresholdPlaceholder"
+        | "isDateFilterIgnored"
+        | "isThresholdRepresentingPercent"
+        | "filters"
+        | "isAlertDialogOpening"
+        | "alertDeletingStatus"
+        | "alertSavingStatus"
+        | "alertUpdatingStatus"
+    > = {
         isAlertLoading: false,
         isKpiFormatLoading: false,
         thresholdPlaceholder: "",

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiContent.tsx
@@ -30,7 +30,10 @@ export interface IKpiContentProps {
 }
 
 class KpiContent extends Component<IKpiContentProps & WrappedComponentProps> {
-    static defaultProps: Partial<IKpiContentProps & WrappedComponentProps> = {
+    static defaultProps: Pick<
+        IKpiContentProps,
+        "isKpiValueClickDisabled" | "filters" | "isKpiUnderlineHiddenWhenClickable"
+    > = {
         isKpiValueClickDisabled: false,
         filters: [],
         isKpiUnderlineHiddenWhenClickable: false,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiPop.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiPop.tsx
@@ -32,7 +32,10 @@ export interface IKpiPopProps {
 }
 
 class KpiPop extends PureComponent<IKpiPopProps & WrappedComponentProps> {
-    static defaultProps: Partial<IKpiPopProps & WrappedComponentProps> = {
+    static defaultProps: Pick<
+        IKpiPopProps,
+        "error" | "disabled" | "isLoading" | "previousPeriodName" | "clientWidth" | "clientHeight"
+    > = {
         error: null,
         disabled: false,
         isLoading: false,

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiValue.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/KpiContent/KpiValue.tsx
@@ -26,12 +26,13 @@ export interface IKpiValueProps {
 const SMALLEST_HEIGHT = 54;
 
 class KpiValue extends PureComponent<IKpiValueProps & WrappedComponentProps> {
-    static defaultProps: Partial<IKpiValueProps & WrappedComponentProps> = {
-        error: null,
-        value: "",
-        isLoading: false,
-        disableKpiDrillUnderline: false,
-    };
+    static defaultProps: Pick<IKpiValueProps, "error" | "value" | "isLoading" | "disableKpiDrillUnderline"> =
+        {
+            error: null,
+            value: "",
+            isLoading: false,
+            disableKpiDrillUnderline: false,
+        };
 
     getKpiValueClassNames() {
         return cx("kpi-value", {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
@@ -140,7 +140,7 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
     private emailSubject: string;
     private emailBody: string;
 
-    static defaultProps: Partial<IScheduledMailDialogRendererProps> = {
+    static defaultProps: Pick<IScheduledMailDialogRendererProps, "dateFormat"> = {
         dateFormat: "MM/dd/yyyy",
     };
 

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -46,7 +46,7 @@ export class DateFilter extends React_2.PureComponent<IDateFilterProps, IDateFil
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    static defaultProps: Partial<IDateFilterProps>;
+    static defaultProps: Pick<IDateFilterProps, "dateFormat" | "isEditMode" | "locale" | "onCancel" | "onOpen" | "onClose">;
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDateFilterProps, prevState: IDateFilterState): IDateFilterState;
     // (undocumented)
@@ -371,8 +371,6 @@ export type IWarningMessage = {
 // @beta (undocumented)
 export class MeasureValueFilter extends React_2.PureComponent<IMeasureValueFilterProps, IMeasureValueFilterState> {
     // (undocumented)
-    static defaultProps: Partial<IMeasureValueFilterProps>;
-    // (undocumented)
     render(): React_2.ReactNode;
     // (undocumented)
     state: IMeasureValueFilterState;
@@ -381,7 +379,7 @@ export class MeasureValueFilter extends React_2.PureComponent<IMeasureValueFilte
 // @beta (undocumented)
 export class MeasureValueFilterDropdown extends React_2.PureComponent<IMeasureValueFilterDropdownProps> {
     // (undocumented)
-    static defaultProps: Partial<IMeasureValueFilterDropdownProps>;
+    static defaultProps: Pick<IMeasureValueFilterDropdownProps, "displayTreatNullAsZeroOption" | "treatNullAsZeroDefaultValue" | "enableOperatorSelection">;
     // (undocumented)
     render(): React_2.ReactNode;
 }

--- a/libs/sdk-ui-filters/src/AttributeElements/AttributeElements.tsx
+++ b/libs/sdk-ui-filters/src/AttributeElements/AttributeElements.tsx
@@ -74,7 +74,7 @@ interface IAttributeElementsState {
 }
 
 class AttributeElementsCore extends React.PureComponent<IAttributeElementsProps, IAttributeElementsState> {
-    public static defaultProps: Partial<IAttributeElementsProps> = {
+    public static defaultProps: Pick<IAttributeElementsProps, "options" | "children" | "onError"> = {
         options: {},
         children: AttributeElementsDefaultChildren,
         onError: defaultErrorHandler,

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
@@ -81,7 +81,10 @@ export class AttributeDropdownCore extends React.PureComponent<
     IAttributeDropdownProps,
     IAttributeDropdownState
 > {
-    public static defaultProps: Partial<IAttributeDropdownProps> = {
+    public static defaultProps: Pick<
+        IAttributeDropdownProps,
+        "fullscreenOnMobile" | "isMobile" | "titleWithSelection" | "FilterLoading" | "isLoading"
+    > = {
         fullscreenOnMobile: false,
         isMobile: false,
         titleWithSelection: false,

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeFilterItem.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeFilterItem.tsx
@@ -15,16 +15,10 @@ export interface IAttributeElement {
 }
 
 export interface IAttributeFilterItemProps {
-    classname?: string;
     item?: IAttributeElement;
 }
 
 export class AttributeFilterItem extends React.PureComponent<IAttributeFilterItemProps> {
-    public static defaultProps: Partial<IAttributeFilterItemProps> = {
-        item: null,
-        classname: "",
-    };
-
     public render(): React.ReactNode {
         const { item } = this.props;
 

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -77,7 +77,10 @@ export interface IDateFilterState extends IDateFilterStatePropsIntersection {
  * @public
  */
 export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilterState> {
-    public static defaultProps: Partial<IDateFilterProps> = {
+    public static defaultProps: Pick<
+        IDateFilterProps,
+        "dateFormat" | "isEditMode" | "locale" | "onCancel" | "onOpen" | "onClose"
+    > = {
         dateFormat: DEFAULT_DATE_FORMAT,
         isEditMode: false,
         locale: "en-US",

--- a/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
@@ -51,13 +51,12 @@ export class DynamicSelect extends React.Component<IDynamicSelectProps, IDynamic
 
     public inputRef = React.createRef<HTMLDivElement>();
 
-    public static defaultProps: Partial<IDynamicSelectProps> = {
+    public static defaultProps: Pick<
+        IDynamicSelectProps,
+        "onChange" | "initialIsOpen" | "visibleItemsRange"
+    > = {
         onChange: noop,
         initialIsOpen: false,
-        placeholder: undefined,
-        value: undefined,
-        className: undefined,
-        style: undefined,
         visibleItemsRange: defaultVisibleItemsRange,
     };
 

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
@@ -37,7 +37,10 @@ interface IDropdownState {
 }
 
 class DropdownWrapped extends React.PureComponent<IDropdownProps, IDropdownState> {
-    public static defaultProps: Partial<IDropdownProps> = {
+    public static defaultProps: Pick<
+        IDropdownProps,
+        "value" | "operator" | "displayTreatNullAsZeroOption" | "treatNullAsZeroValue"
+    > = {
         value: {},
         operator: "ALL",
         displayTreatNullAsZeroOption: false,

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilter.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilter.tsx
@@ -1,7 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import { IMeasureValueFilter } from "@gooddata/sdk-model";
-import noop from "lodash/noop";
 
 import { MeasureValueFilterDropdown } from "./MeasureValueFilterDropdown";
 import MeasureValueFilterButton from "./MeasureValueFilterButton";
@@ -29,10 +28,6 @@ export class MeasureValueFilter extends React.PureComponent<
     IMeasureValueFilterProps,
     IMeasureValueFilterState
 > {
-    public static defaultProps: Partial<IMeasureValueFilterProps> = {
-        onCancel: noop,
-    };
-
     public state: IMeasureValueFilterState = {
         displayDropdown: false,
     };
@@ -90,7 +85,7 @@ export class MeasureValueFilter extends React.PureComponent<
 
     private onCancel = () => {
         this.closeDropdown();
-        this.props.onCancel();
+        this.props.onCancel?.();
     };
 
     private closeDropdown = () => {

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
@@ -58,7 +58,10 @@ const getTreatNullAsZeroValue = (
  * @beta
  */
 export class MeasureValueFilterDropdown extends React.PureComponent<IMeasureValueFilterDropdownProps> {
-    public static defaultProps: Partial<IMeasureValueFilterDropdownProps> = {
+    public static defaultProps: Pick<
+        IMeasureValueFilterDropdownProps,
+        "displayTreatNullAsZeroOption" | "treatNullAsZeroDefaultValue" | "enableOperatorSelection"
+    > = {
         displayTreatNullAsZeroOption: false,
         treatNullAsZeroDefaultValue: false,
         enableOperatorSelection: true,

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
@@ -56,7 +56,10 @@ export interface IGeoChartRendererProps extends WrappedComponentProps {
 }
 
 class GeoChartRenderer extends React.Component<IGeoChartRendererProps> {
-    public static defaultProps: Partial<IGeoChartRendererProps> = {
+    public static defaultProps: Pick<
+        IGeoChartRendererProps,
+        "config" | "afterRender" | "onZoomChanged" | "onCenterPositionChanged"
+    > = {
         config: {
             mapboxToken: "",
         },

--- a/libs/sdk-ui-geo/src/core/geoChart/tests/GeoChartRenderer.test.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/tests/GeoChartRenderer.test.tsx
@@ -5,9 +5,9 @@ import { shallow, ShallowWrapper } from "enzyme";
 import GeoChartRenderer, { IGeoChartRendererProps } from "../GeoChartRenderer";
 
 function createComponent(customProps: Partial<IGeoChartRendererProps> = {}): ShallowWrapper {
-    const chartProps: Partial<IGeoChartRendererProps> = {
+    const chartProps: IGeoChartRendererProps = {
         ...customProps,
-    };
+    } as any;
     return shallow(<GeoChartRenderer {...chartProps} />, { disableLifecycleMethods: true });
 }
 

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -26,7 +26,7 @@ export type Alignment = {
 };
 
 // @internal (undocumented)
-export const AppHeader: React_2.ComponentType<Pick<import("react-intl").WithIntlProps<IAppHeaderProps & WrappedComponentProps<"intl">>, "forwardedRef" | "className" | "onMenuItemClick" | "helpRedirectUrl" | "userName" | "onLogoClick" | "menuItemsGroups" | "accountMenuItems" | "helpMenuItems" | "badges" | "logoUrl" | "logoHref" | "logoTitle" | "documentationUrl" | "workspacePicker" | "headerColor" | "headerTextColor" | "activeColor" | "disableHelpDropdown" | "onHelpClick">>;
+export const AppHeader: React_2.ComponentType<Pick<import("react-intl").WithIntlProps<IAppHeaderProps & WrappedComponentProps<"intl">>, "forwardedRef" | "className" | "onMenuItemClick" | "helpRedirectUrl" | "userName" | "logoHref" | "accountMenuItems" | "helpMenuItems" | "menuItemsGroups" | "onLogoClick" | "badges" | "logoUrl" | "logoTitle" | "documentationUrl" | "workspacePicker" | "headerColor" | "headerTextColor" | "activeColor" | "disableHelpDropdown" | "onHelpClick">>;
 
 // @internal (undocumented)
 export type ArrowDirections = Record<string, string>;
@@ -96,7 +96,7 @@ export class Bubble extends React_2.Component<IBubbleProps, IBubbleState> {
 // @internal (undocumented)
 export class BubbleFocusTrigger extends BubbleTrigger<BubbleFocusTriggerProps> {
     // (undocumented)
-    static defaultProps: Partial<BubbleFocusTriggerProps>;
+    static defaultProps: BubbleFocusTriggerProps;
     // (undocumented)
     protected eventListeners(): any;
 }
@@ -109,7 +109,7 @@ export class BubbleHoverTrigger extends BubbleTrigger<IBubbleHoverTriggerProps> 
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    static defaultProps: Partial<IBubbleHoverTriggerProps>;
+    static defaultProps: IBubbleHoverTriggerProps;
     // (undocumented)
     protected eventListeners(): any;
     // (undocumented)
@@ -121,7 +121,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React_2.PureCo
     // (undocumented)
     protected changeBubbleVisibility(active: boolean): void;
     // (undocumented)
-    static defaultProps: Partial<IBubbleTriggerProps>;
+    static defaultProps: IBubbleTriggerProps;
     // (undocumented)
     protected eventListeners(): any;
     // (undocumented)
@@ -209,7 +209,7 @@ export class ConfirmDialog extends PureComponent<IConfirmDialogBaseProps> {
 // @internal (undocumented)
 export class ConfirmDialogBase extends DialogBase<IConfirmDialogBaseProps> {
     // (undocumented)
-    static defaultProps: Partial<IConfirmDialogBaseProps>;
+    static defaultProps: IConfirmDialogBaseProps;
     // (undocumented)
     render(): JSX.Element;
 }
@@ -241,7 +241,7 @@ export class Dialog extends Component<IDialogBaseProps> {
 // @internal (undocumented)
 export class DialogBase<P extends IDialogBaseProps> extends PureComponent<P> {
     // (undocumented)
-    static defaultProps: Partial<IDialogBaseProps>;
+    static defaultProps: IDialogBaseProps;
     // (undocumented)
     protected getDialogClasses(additionalClassName?: string): string;
     // (undocumented)
@@ -344,13 +344,13 @@ export enum ENUM_KEY_CODE {
 // @internal (undocumented)
 export const ExportDialog: {
     (props: IExportDialogBaseProps): JSX.Element;
-    defaultProps: Partial<IExportDialogBaseProps>;
+    defaultProps: IExportDialogBaseProps;
 };
 
 // @internal (undocumented)
 export class ExportDialogBase extends DialogBase<IExportDialogBaseProps> {
     // (undocumented)
-    static defaultProps: Partial<IExportDialogBaseProps>;
+    static defaultProps: IExportDialogBaseProps;
     // (undocumented)
     render(): JSX.Element;
     // (undocumented)
@@ -2124,7 +2124,7 @@ export interface InputWithNumberFormatState {
 }
 
 // @internal (undocumented)
-export const InsightListItem: React_2.ForwardRefExoticComponent<Pick<IInsightListItemProps & WrappedComponentProps<"intl">, "title" | "type" | "updated" | "width" | "onClick" | "isSelected" | "isLoading" | "isLocked" | "onDelete"> & {
+export const InsightListItem: React_2.ForwardRefExoticComponent<Pick<IInsightListItemProps & WrappedComponentProps<"intl">, "title" | "type" | "updated" | "width" | "isSelected" | "onClick" | "isLoading" | "isLocked" | "onDelete"> & {
     forwardedRef?: React_2.Ref<any>;
 } & React_2.RefAttributes<any>> & {
     WrappedComponent: React_2.ComponentType<IInsightListItemProps & WrappedComponentProps<"intl">>;
@@ -2480,7 +2480,7 @@ export class LegacyList extends Component<ILegacyListProps, ILegacyListState> {
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    static defaultProps: Partial<ILegacyListProps>;
+    static defaultProps: Pick<ILegacyListProps, "className" | "onScroll" | "onScrollStart" | "onSelect" | "width" | "height" | "itemHeight" | "compensateBorder" | "scrollToSelected">;
     // (undocumented)
     render(): JSX.Element;
     }
@@ -2724,7 +2724,7 @@ export class ShortenedText extends PureComponent<IShortenedTextProps, IShortened
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    static defaultProps: Partial<IShortenedTextProps>;
+    static defaultProps: Pick<IShortenedTextProps, "className" | "tagName" | "tooltipAlignPoints" | "tooltipVisibleOnMouseOver" | "getElement" | "displayTooltip">;
     // (undocumented)
     recomputeShortening(): void;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Bubble/BubbleFocusTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleFocusTrigger.tsx
@@ -10,7 +10,7 @@ export type BubbleFocusTriggerProps = IBubbleTriggerProps;
  * @internal
  */
 export class BubbleFocusTrigger extends BubbleTrigger<BubbleFocusTriggerProps> {
-    static defaultProps: Partial<BubbleFocusTriggerProps> = {
+    static defaultProps: BubbleFocusTriggerProps = {
         tagName: "span",
         eventsOnBubble: true,
     };

--- a/libs/sdk-ui-kit/src/Bubble/BubbleHoverTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleHoverTrigger.tsx
@@ -16,7 +16,7 @@ export interface IBubbleHoverTriggerProps extends IBubbleTriggerProps {
  * @internal
  */
 export class BubbleHoverTrigger extends BubbleTrigger<IBubbleHoverTriggerProps> {
-    public static defaultProps: Partial<IBubbleHoverTriggerProps> = {
+    public static defaultProps: IBubbleHoverTriggerProps = {
         showDelay: SHOW_DELAY,
         hideDelay: HIDE_DELAY,
         hoverHideDelay: 0,

--- a/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
@@ -28,7 +28,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
     P,
     IBubbleTriggerState
 > {
-    public static defaultProps: Partial<IBubbleTriggerProps> = {
+    public static defaultProps: IBubbleTriggerProps = {
         className: "",
         children: false,
         eventsOnBubble: false,

--- a/libs/sdk-ui-kit/src/ColorPicker/components/ColorsPreview.tsx
+++ b/libs/sdk-ui-kit/src/ColorPicker/components/ColorsPreview.tsx
@@ -12,7 +12,7 @@ export interface IColorsPreviewProps {
 }
 
 export class ColorsPreview extends PureComponent<IColorsPreviewProps> {
-    static defaultProps: Partial<IColorsPreviewProps> = {
+    static defaultProps: Pick<IColorsPreviewProps, "currentTextLabel" | "draftTextLabel"> = {
         currentTextLabel: "current",
         draftTextLabel: "new",
     };

--- a/libs/sdk-ui-kit/src/ColorPicker/components/HexColorInput.tsx
+++ b/libs/sdk-ui-kit/src/ColorPicker/components/HexColorInput.tsx
@@ -13,7 +13,7 @@ export interface IHexColorInputProps {
 }
 
 export class HexColorInput extends PureComponent<IHexColorInputProps> {
-    static defaultProps: Partial<IHexColorInputProps> = {
+    static defaultProps: Pick<IHexColorInputProps, "label" | "placeholder"> = {
         placeholder: "",
         label: "",
     };

--- a/libs/sdk-ui-kit/src/Dialog/ConfirmDialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ConfirmDialogBase.tsx
@@ -12,7 +12,7 @@ import { Bubble, BubbleHoverTrigger } from "../Bubble";
  * @internal
  */
 export class ConfirmDialogBase extends DialogBase<IConfirmDialogBaseProps> {
-    static defaultProps: Partial<IConfirmDialogBaseProps> = {
+    static defaultProps: IConfirmDialogBaseProps = {
         displayCloseButton: true,
         onCancel: noop,
         onSubmit: noop,

--- a/libs/sdk-ui-kit/src/Dialog/DialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/DialogBase.tsx
@@ -29,7 +29,7 @@ const shouldSubmitOnEnterPress = ({ target }: React.KeyboardEvent): boolean => {
  * @internal
  */
 export class DialogBase<P extends IDialogBaseProps> extends PureComponent<P> {
-    static defaultProps: Partial<IDialogBaseProps> = {
+    static defaultProps: IDialogBaseProps = {
         children: false,
         className: "",
         displayCloseButton: false,

--- a/libs/sdk-ui-kit/src/Dialog/ExportDialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/ExportDialogBase.tsx
@@ -10,7 +10,7 @@ import { ConfirmDialogBase } from "./ConfirmDialogBase";
  * @internal
  */
 export class ExportDialogBase extends DialogBase<IExportDialogBaseProps> {
-    static defaultProps: Partial<IExportDialogBaseProps> = {
+    static defaultProps: IExportDialogBaseProps = {
         displayCloseButton: true,
         isPositive: true,
         isSubmitDisabled: false,

--- a/libs/sdk-ui-kit/src/FilterLabel/FilterLabel.tsx
+++ b/libs/sdk-ui-kit/src/FilterLabel/FilterLabel.tsx
@@ -8,11 +8,10 @@ class WrappedFilterLabel extends React.PureComponent<
     IFilterLabelProps & WrappedComponentProps,
     IFilterLabelState
 > {
-    static defaultProps: Partial<IFilterLabelProps & WrappedComponentProps> = {
+    static defaultProps: Pick<IFilterLabelProps, "isAllSelected" | "isDate" | "selection" | "noData"> = {
         isAllSelected: false,
         isDate: false,
         selection: "",
-        selectionSize: null,
         noData: false,
     };
     private readonly labelRef: RefObject<HTMLSpanElement>;

--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -40,7 +40,10 @@ function getWidthOfChildren(element: HTMLDivElement, selector = "> *") {
 }
 
 class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, IAppHeaderState> {
-    public static defaultProps: Partial<IAppHeaderProps> = {
+    public static defaultProps: Pick<
+        IAppHeaderProps,
+        "logoHref" | "accountMenuItems" | "helpMenuItems" | "menuItemsGroups"
+    > = {
         logoHref: "/",
         accountMenuItems: [],
         helpMenuItems: [],

--- a/libs/sdk-ui-kit/src/Header/HeaderAccount.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderAccount.tsx
@@ -11,7 +11,7 @@ class WrappedHeaderAccount extends PureComponent<
     IHeaderAccountProps & WrappedComponentProps,
     IHeaderAccountState
 > {
-    static defaultProps: Partial<IHeaderAccountProps & WrappedComponentProps> = {
+    static defaultProps: Pick<IHeaderAccountProps, "className" | "items" | "userName"> = {
         className: "",
         items: [],
         userName: "",

--- a/libs/sdk-ui-kit/src/Header/HeaderMenu.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderMenu.tsx
@@ -8,7 +8,7 @@ import cx from "classnames";
 import { IHeaderMenuProps, IHeaderMenuItem } from "./typings";
 
 class WrappedHeaderMenu extends PureComponent<IHeaderMenuProps & WrappedComponentProps> {
-    static defaultProps: Partial<IHeaderMenuProps & WrappedComponentProps> = {
+    static defaultProps: Pick<IHeaderMenuProps, "className" | "onMenuItemClick" | "sections"> = {
         className: "",
         onMenuItemClick: identity,
         sections: [],

--- a/libs/sdk-ui-kit/src/List/LegacyList.tsx
+++ b/libs/sdk-ui-kit/src/List/LegacyList.tsx
@@ -43,7 +43,18 @@ export interface ILegacyListState {
  * @internal
  */
 export class LegacyList extends Component<ILegacyListProps, ILegacyListState> {
-    static defaultProps: Partial<ILegacyListProps> = {
+    static defaultProps: Pick<
+        ILegacyListProps,
+        | "className"
+        | "onScroll"
+        | "onScrollStart"
+        | "onSelect"
+        | "width"
+        | "height"
+        | "itemHeight"
+        | "compensateBorder"
+        | "scrollToSelected"
+    > = {
         className: "",
         onScroll: noop,
         onScrollStart: noop,
@@ -51,7 +62,6 @@ export class LegacyList extends Component<ILegacyListProps, ILegacyListState> {
         width: 200,
         height: 300,
         itemHeight: 28,
-        itemHeightGetter: null,
         compensateBorder: true,
         scrollToSelected: false,
     };

--- a/libs/sdk-ui-kit/src/List/tests/LegacyList.test.tsx
+++ b/libs/sdk-ui-kit/src/List/tests/LegacyList.test.tsx
@@ -129,7 +129,7 @@ interface IDummyRowItemProps {
 }
 
 class DummyRowItem extends React.Component<IDummyRowItemProps> {
-    static defaultProps: Partial<IDummyRowItemProps> = {
+    static defaultProps: Pick<IDummyRowItemProps, "isFirst" | "isLast" | "scrollToSelected"> = {
         isFirst: false,
         isLast: false,
         scrollToSelected: false,
@@ -151,7 +151,7 @@ interface IItemProps {
 
 describe("List", () => {
     const renderList = (options: Partial<ILegacyListProps>): ReactWrapper<LegacyList> => {
-        return mount(<LegacyList {...options} />);
+        return mount(<LegacyList {...(options as any)} />);
     };
 
     const dataSource = createDummyDataSource<IItemProps>([

--- a/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpener.tsx
+++ b/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpener.tsx
@@ -18,7 +18,10 @@ export interface IMenuOpenerProps extends Partial<IMenuPositionConfig> {
 }
 
 export class MenuOpener extends React.Component<IMenuOpenerProps> {
-    public static defaultProps: Partial<IMenuOpenerProps> = {
+    public static defaultProps: Pick<
+        IMenuOpenerProps,
+        "openAction" | "alignment" | "spacing" | "offset" | "portalTarget"
+    > = {
         openAction: "hover",
 
         alignment: ["right", "bottom"],

--- a/libs/sdk-ui-kit/src/ShortenedText/ShortenedText.tsx
+++ b/libs/sdk-ui-kit/src/ShortenedText/ShortenedText.tsx
@@ -63,7 +63,15 @@ export interface IShortenedTextState {
  * @internal
  */
 export class ShortenedText extends PureComponent<IShortenedTextProps, IShortenedTextState> {
-    static defaultProps: Partial<IShortenedTextProps> = {
+    static defaultProps: Pick<
+        IShortenedTextProps,
+        | "className"
+        | "tagName"
+        | "tooltipAlignPoints"
+        | "tooltipVisibleOnMouseOver"
+        | "getElement"
+        | "displayTooltip"
+    > = {
         className: "",
         tagName: "span",
         tooltipAlignPoints: [{ align: "cr cl" }],

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
@@ -34,7 +34,7 @@ export class CustomFormatDialog extends React.PureComponent<
     ICustomFormatDialogProps,
     ICustomFormatDialogState
 > {
-    public static defaultProps: Partial<ICustomFormatDialogProps> = {
+    public static defaultProps: Pick<ICustomFormatDialogProps, "positioning"> = {
         positioning: [
             { snapPoints: { parent: SnapPoint.CenterRight, child: SnapPoint.CenterLeft } },
             { snapPoints: { parent: SnapPoint.TopRight, child: SnapPoint.TopLeft } },

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
@@ -23,7 +23,7 @@ interface IMeasureNumberFormatDropdownOwnProps {
 type IMeasureNumberFormatDropdownProps = IMeasureNumberFormatDropdownOwnProps & WrappedComponentProps;
 
 export class PresetsDropdown extends React.PureComponent<IMeasureNumberFormatDropdownProps> {
-    public static defaultProps: Partial<IMeasureNumberFormatDropdownProps> = {
+    public static defaultProps: Pick<IMeasureNumberFormatDropdownProps, "positioning"> = {
         positioning: [
             { snapPoints: { parent: SnapPoint.BottomLeft, child: SnapPoint.TopLeft } },
             { snapPoints: { parent: SnapPoint.TopLeft, child: SnapPoint.BottomLeft } },

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdownItem.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdownItem.tsx
@@ -15,7 +15,7 @@ interface IMeasureNumberFormatDropdownItemProps {
 }
 
 export class PresetsDropdownItem extends React.PureComponent<IMeasureNumberFormatDropdownItemProps> {
-    public static defaultProps: Partial<IMeasureNumberFormatDropdownItemProps> = {
+    public static defaultProps: Pick<IMeasureNumberFormatDropdownItemProps, "isSelected"> = {
         isSelected: false,
     };
 

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -164,7 +164,22 @@ const AGGRID_ON_RESIZE_TIMEOUT = 300;
  * @internal
  */
 export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, ICorePivotTableState> {
-    public static defaultProps: Partial<ICorePivotTableProps> = {
+    public static defaultProps: Pick<
+        ICorePivotTableProps,
+        | "locale"
+        | "drillableItems"
+        | "afterRender"
+        | "pushData"
+        | "onExportReady"
+        | "onLoadingChanged"
+        | "onError"
+        | "onDrill"
+        | "ErrorComponent"
+        | "LoadingComponent"
+        | "pageSize"
+        | "config"
+        | "onColumnResized"
+    > = {
         locale: "en-US",
         drillableItems: [],
         afterRender: noop,

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsSubMenu.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsSubMenu.tsx
@@ -45,7 +45,7 @@ const HeaderIcon = () => {
 };
 
 export default class AggregationsSubMenu extends React.Component<IAggregationsSubMenuProps> {
-    public static defaultProps: Partial<IAggregationsSubMenuProps> = {
+    public static defaultProps: Pick<IAggregationsSubMenuProps, "isMenuOpened"> = {
         isMenuOpened: false,
     };
 

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/HeaderCell.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/HeaderCell.tsx
@@ -45,7 +45,17 @@ export interface IHeaderCellState {
 }
 
 export default class HeaderCell extends React.Component<IHeaderCellProps, IHeaderCellState> {
-    public static defaultProps: Partial<IHeaderCellProps> = {
+    public static defaultProps: Pick<
+        IHeaderCellProps,
+        | "sortDirection"
+        | "textAlign"
+        | "menuPosition"
+        | "defaultSortDirection"
+        | "menu"
+        | "enableSorting"
+        | "onMenuAggregationClick"
+        | "onSortClick"
+    > = {
         sortDirection: null,
         textAlign: ALIGN_LEFT,
         menuPosition: ALIGN_LEFT,

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/tests/HeaderCell.test.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/tests/HeaderCell.test.tsx
@@ -1,19 +1,37 @@
 // (C) 2007-2018 GoodData Corporation
 import React from "react";
 import { shallow, mount } from "enzyme";
+import { ReferenceRecordings } from "@gooddata/reference-workspace";
 
 import HeaderCell from "../HeaderCell";
+import { recordedDataFacade } from "../../../../../__mocks__/recordings";
+import { DataViewFirstPage } from "@gooddata/sdk-backend-mockingbird";
+import { TableDescriptor } from "../../tableDescriptor";
 
 describe("HeaderCell renderer", () => {
+    const fixture = recordedDataFacade(
+        ReferenceRecordings.Scenarios.PivotTable.SingleMeasureWithTwoRowAndOneColumnAttributes,
+        DataViewFirstPage,
+    );
+    const tableDescriptor = TableDescriptor.for(fixture);
+    const getTableDescriptor = () => tableDescriptor;
+
     it("should render text for the cell", () => {
-        const component = shallow(<HeaderCell displayText="Header" />);
+        const component = shallow(
+            <HeaderCell displayText="Header" getTableDescriptor={getTableDescriptor} />,
+        );
         expect(component.text()).toEqual("Header");
     });
 
     describe("Sorting in HeaderCell", () => {
         it("should render default sorting", () => {
             const component = mount(
-                <HeaderCell displayText="Header" enableSorting={true} defaultSortDirection={"asc"} />,
+                <HeaderCell
+                    displayText="Header"
+                    enableSorting={true}
+                    defaultSortDirection={"asc"}
+                    getTableDescriptor={getTableDescriptor}
+                />,
             );
             const headerCellLabel = component.find(".s-header-cell-label");
             expect(headerCellLabel).toHaveLength(1);
@@ -32,6 +50,7 @@ describe("HeaderCell renderer", () => {
                     enableSorting={true}
                     defaultSortDirection={"asc"}
                     onSortClick={onSortClick}
+                    getTableDescriptor={getTableDescriptor}
                 />,
             );
             const cellLabel = component.find(".s-header-cell-label");
@@ -48,6 +67,7 @@ describe("HeaderCell renderer", () => {
                     enableSorting={true}
                     sortDirection={"asc"}
                     onSortClick={onSortClick}
+                    getTableDescriptor={getTableDescriptor}
                 />,
             );
             const cellLabel = component.find(".s-header-cell-label");

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -502,7 +502,7 @@ export function shouldShowFluid(documentObj: Document): boolean;
 // @internal (undocumented)
 export class StaticLegend extends React_2.PureComponent<IStaticLegendProps> {
     // (undocumented)
-    static defaultProps: Partial<IStaticLegendProps>;
+    static defaultProps: Pick<IStaticLegendProps, "buttonOrientation" | "paginationHeight" | "onPageChanged">;
     // (undocumented)
     render(): React_2.ReactNode;
     // (undocumented)

--- a/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
@@ -31,7 +31,10 @@ export interface IStaticLegendProps {
  * @internal
  */
 export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
-    public static defaultProps: Partial<IStaticLegendProps> = {
+    public static defaultProps: Pick<
+        IStaticLegendProps,
+        "buttonOrientation" | "paginationHeight" | "onPageChanged"
+    > = {
         buttonOrientation: "upDown",
         paginationHeight: STATIC_PAGING_HEIGHT,
         onPageChanged: noop,

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -337,7 +337,7 @@ export const ErrorCodes: {
 // @public
 export class ErrorComponent extends React_2.Component<IErrorProps> {
     // (undocumented)
-    static defaultProps: Partial<IErrorProps>;
+    static defaultProps: Pick<IErrorProps, "icon" | "className" | "height" | "style">;
     // (undocumented)
     render(): React_2.ReactNode;
 }
@@ -1308,7 +1308,7 @@ export const Kpi: React_2.ComponentType<IKpiProps>;
 // @public
 export class LoadingComponent extends React_2.Component<ILoadingProps> {
     // (undocumented)
-    static defaultProps: Partial<ILoadingProps>;
+    static defaultProps: Pick<ILoadingProps, "className" | "color" | "inline" | "speed" | "height" | "imageHeight">;
     // (undocumented)
     render(): React_2.ReactNode;
 }

--- a/libs/sdk-ui/src/base/react/ErrorComponent.tsx
+++ b/libs/sdk-ui/src/base/react/ErrorComponent.tsx
@@ -56,10 +56,9 @@ export interface IErrorProps {
  * @public
  */
 export class ErrorComponent extends React.Component<IErrorProps> {
-    public static defaultProps: Partial<IErrorProps> = {
+    public static defaultProps: Pick<IErrorProps, "icon" | "className" | "height" | "style"> = {
         icon: "gd-icon-warning",
         className: "Error s-error",
-        width: undefined,
         height: "100%",
         style: {
             display: "flex",

--- a/libs/sdk-ui/src/base/react/LoadingComponent.tsx
+++ b/libs/sdk-ui/src/base/react/LoadingComponent.tsx
@@ -24,15 +24,16 @@ const baseAnimationDuration = 1.4;
  * @public
  */
 export class LoadingComponent extends React.Component<ILoadingProps> {
-    public static defaultProps: Partial<ILoadingProps> = {
+    public static defaultProps: Pick<
+        ILoadingProps,
+        "className" | "color" | "inline" | "speed" | "height" | "imageHeight"
+    > = {
         className: "s-loading",
         color: "var(--gd-palette-complementary-6, #94a1ad)",
         speed: 1,
         inline: false,
         height: "100%",
-        width: undefined,
         imageHeight: 8,
-        imageWidth: undefined,
     };
 
     public render(): React.ReactNode {

--- a/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
+++ b/libs/sdk-ui/src/base/react/legacy/withEntireDataView.tsx
@@ -102,7 +102,7 @@ export function withEntireDataView<T extends IDataVisualizationProps>(
     InnerComponent: React.ComponentClass<T & ILoadingInjectedProps>,
 ): React.ComponentClass<T> {
     class LoadingHOCWrapped extends React.Component<T & ILoadingInjectedProps, IDataViewLoadState> {
-        public static defaultProps: Partial<T & ILoadingInjectedProps> = InnerComponent.defaultProps || {};
+        public static defaultProps = InnerComponent.defaultProps || {};
 
         private hasUnmounted: boolean = false;
 


### PR DESCRIPTION
Using Partial when typing defaultProps makes all props optional,
even those specified as mandatory.

The correct way to explicitly type them is using the Pick type helper.
See https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-0.html#support-for-defaultprops-in-jsx
for details.

We found a missing prop passing in KpiExecutor this way and fixed it.
Also some BaseVisualization props were made optional as they can be omitted.

JIRA: RAIL-3450

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
