### PR TITLE
Allow one line less to attributes legend

### DIFF
--- a/libs/sdk-ui-geo/src/core/geoChart/legends/PushpinCategoryLegend.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/legends/PushpinCategoryLegend.tsx
@@ -107,13 +107,14 @@ function GeoPopUpLegend(props: IPushpinCategoryLegendProps): JSX.Element {
         maxRows,
         customComponent,
         customComponentName,
+        hasSizeLegend,
     } = props;
 
     return (
         <PopUpLegend
             series={categoryItems}
             onLegendItemClick={onItemClick}
-            maxRows={maxRows}
+            maxRows={hasSizeLegend && maxRows ? maxRows - 1 : maxRows}
             name={name}
             containerId={containerId}
             customComponent={customComponent}

--- a/libs/sdk-ui-geo/src/core/geoChart/legends/test/PushpinCategoryLegend.test.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/legends/test/PushpinCategoryLegend.test.tsx
@@ -63,6 +63,12 @@ describe("PushpinCategoryLegend", () => {
         expect(wrapper.find(PopUpLegend).exists()).toBe(true);
     });
 
+    it("should render PopUp legend component with correct maxRows prop when Size legend shown too", () => {
+        const wrapper = createComponent({ renderPopUp: true, hasSizeLegend: true, maxRows: 2 });
+        const popupLegend = wrapper.find(PopUpLegend);
+        expect(popupLegend.prop("maxRows")).toBe(1);
+    });
+
     it("should not render PopUp legend component if renderPopUp is false", () => {
         const wrapper = createComponent({ renderPopUp: false });
         expect(wrapper.find(PopUpLegend).exists()).toBe(false);


### PR DESCRIPTION
When there is also Size legend attribute legend has to have one line less
JIRA: ONE-5033

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
