### PR TITLE
RELATED: RAIL-3464 Allow to customize measure number format button text

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2432,6 +2432,8 @@ export interface IToggleButtonProps {
     // (undocumented)
     isOpened: boolean;
     // (undocumented)
+    selectedPreset: IFormatPreset;
+    // (undocumented)
     text: string;
     // (undocumented)
     toggleDropdown: (e: React_2.SyntheticEvent) => void;

--- a/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
@@ -14,7 +14,7 @@ export const CUSTOM_FORMAT_PRESET_LOCAL_IDENTIFIER = "customFormat";
  * @internal
  */
 export interface IMeasureNumberFormatOwnProps {
-    toggleButton: React.ComponentType<IToggleButtonProps>;
+    toggleButton: React.ComponentType<IMeasureNumberFormatToggleButtonProps>;
     presets: ReadonlyArray<IFormatPreset>;
     separators: ISeparators;
     selectedFormat: string | null;
@@ -33,6 +33,10 @@ export type MeasureNumberFormatProps = IMeasureNumberFormatOwnProps & WrappedCom
 interface IMeasureNumberFormatState {
     showDropdown: boolean;
     showCustomFormatDialog: boolean;
+    selectedPreset: IFormatPreset;
+}
+
+interface IMeasureNumberFormatToggleButtonProps extends IToggleButtonProps {
     selectedPreset: IFormatPreset;
 }
 
@@ -81,6 +85,7 @@ class WrappedMeasureNumberFormat extends React.PureComponent<
                     text={buttonText}
                     isOpened={showDropdown || showCustomFormatDialog}
                     toggleDropdown={this.toggleDropdownOpened}
+                    selectedPreset={selectedPreset}
                 />
                 {showDropdown && (
                     <PresetsDropdown

--- a/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
@@ -14,7 +14,7 @@ export const CUSTOM_FORMAT_PRESET_LOCAL_IDENTIFIER = "customFormat";
  * @internal
  */
 export interface IMeasureNumberFormatOwnProps {
-    toggleButton: React.ComponentType<IMeasureNumberFormatToggleButtonProps>;
+    toggleButton: React.ComponentType<IToggleButtonProps>;
     presets: ReadonlyArray<IFormatPreset>;
     separators: ISeparators;
     selectedFormat: string | null;
@@ -33,10 +33,6 @@ export type MeasureNumberFormatProps = IMeasureNumberFormatOwnProps & WrappedCom
 interface IMeasureNumberFormatState {
     showDropdown: boolean;
     showCustomFormatDialog: boolean;
-    selectedPreset: IFormatPreset;
-}
-
-interface IMeasureNumberFormatToggleButtonProps extends IToggleButtonProps {
     selectedPreset: IFormatPreset;
 }
 

--- a/libs/sdk-ui-kit/src/measureNumberFormat/typings.ts
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/typings.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import React from "react";
 
 /**
@@ -27,6 +27,7 @@ export interface IToggleButtonProps {
     text: string;
     isOpened: boolean;
     toggleDropdown: (e: React.SyntheticEvent) => void;
+    selectedPreset: IFormatPreset;
 }
 
 /**


### PR DESCRIPTION
<!--

Description of changes.

-->
Allow to customize measure number format button text by adding selected option as property to toggle button

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
