### PR TITLE
RELATED: ONE-5070 Chart contains stack by should not be added 2 measures

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
@@ -182,9 +182,7 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
     }
 
     private configureBucketsWithMultipleDates(extendedReferencePoint: IExtendedReferencePoint): void {
-        const buckets = extendedReferencePoint?.buckets ?? [];
-        const measures = getFilteredMeasuresForStackedCharts(buckets);
-        const [views, stacks] = this.getViewByAndStackByBucketItems(extendedReferencePoint);
+        const { measures, views, stacks } = this.getMeasuresViewStackBucketItems(extendedReferencePoint);
 
         set(extendedReferencePoint, BUCKETS, [
             {
@@ -218,8 +216,13 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
         );
     }
 
-    private getViewByAndStackByBucketItems(extendedReferencePoint: IExtendedReferencePoint): IBucketItem[][] {
+    private getMeasuresViewStackBucketItems(extendedReferencePoint: IExtendedReferencePoint): {
+        measures: IBucketItem[];
+        views: IBucketItem[];
+        stacks: IBucketItem[];
+    } {
         const buckets = extendedReferencePoint?.buckets ?? [];
+        const measures = getFilteredMeasuresForStackedCharts(buckets);
         const viewByMaxItemCount = this.getViewByMaxItemCount(extendedReferencePoint);
         const stackByMaxItemCount = this.getStackByMaxItemCount(extendedReferencePoint);
         const allAttributesWithoutStacks = getAllCategoriesAttributeItems(buckets);
@@ -245,8 +248,12 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
             }
         }
 
-        const finalStacks = [...stacks, ...possibleStacks].slice(0, stackByMaxItemCount);
-        return [views, finalStacks];
+        if (!stacks.length && measures.length <= 1) {
+            const finalStacks = [...stacks, ...possibleStacks].slice(0, stackByMaxItemCount);
+            return { measures, views, stacks: finalStacks };
+        }
+
+        return { measures, views, stacks };
     }
 
     private getViewByMaxItemCount(extendedReferencePoint: IExtendedReferencePoint): number {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -462,6 +462,49 @@ describe("PluggableColumnBarCharts", () => {
                         ],
                     },
                 ],
+                [
+                    "from table to column chart: multiple measures and date in stack",
+                    referencePointMocks.multipleMeasureAndDateInRowsAndColumReferencePoint,
+                    {
+                        buckets: [
+                            referencePointMocks.multipleMeasureAndDateInRowsAndColumReferencePoint.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: referencePointMocks.multipleMeasureAndDateInRowsAndColumReferencePoint
+                                    .buckets[1].items,
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "Simulate adding pop measure:  With measure and derived measure and two date in view and date in stack",
+                    referencePointMocks.measureWithDerivedAsFirstWithDateInStackRefPoint,
+                    {
+                        buckets: [
+                            {
+                                localIdentifier: "measures",
+                                items: [
+                                    referencePointMocks.measureWithDerivedAsFirstWithDateInStackRefPoint
+                                        .buckets[0].items[1],
+                                ],
+                            },
+                            {
+                                localIdentifier: "view",
+                                items: referencePointMocks.measureWithDerivedAsFirstWithDateInStackRefPoint
+                                    .buckets[1].items,
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: referencePointMocks.measureWithDerivedAsFirstWithDateInStackRefPoint
+                                    .buckets[2].items,
+                            },
+                        ],
+                    },
+                ],
             ];
             it.each(inputs)(
                 "should return correct extended reference (%s)",

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -859,6 +859,24 @@ export const measureWithDerivedAsFirstWithStackRefPoint: IReferencePoint = {
     filters: samePeriodPrevYearFiltersBucket,
 };
 
+export const measureWithDerivedAsFirstWithDateInStackRefPoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: [derivedMeasureItems[0], masterMeasureItems[0]],
+        },
+        {
+            localIdentifier: "view",
+            items: [dateItem, dateItem],
+        },
+        {
+            localIdentifier: "stack",
+            items: [dateItem2],
+        },
+    ],
+    filters: samePeriodPrevYearFiltersBucket,
+};
+
 export const samePeriodPreviousYearAndAttributesRefPoint: IReferencePoint = {
     buckets: [
         {
@@ -1075,7 +1093,7 @@ export const threeDifferentDatesReferencePoint: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
-            items: masterMeasureItems,
+            items: masterMeasureItems.slice(0, 1),
         },
         {
             localIdentifier: "rows",
@@ -1117,7 +1135,7 @@ export const twoIdenticalDatesInRows: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
-            items: masterMeasureItems,
+            items: masterMeasureItems.slice(0, 1),
         },
         {
             localIdentifier: "rows",
@@ -1138,7 +1156,7 @@ export const multipleDatesInRowsOnly: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
-            items: masterMeasureItems,
+            items: masterMeasureItems.slice(0, 1),
         },
         {
             localIdentifier: "rows",
@@ -1180,7 +1198,7 @@ export const multipleDatesNotAsFirstReferencePoint: IReferencePoint = {
     buckets: [
         {
             localIdentifier: "measures",
-            items: masterMeasureItems,
+            items: masterMeasureItems.slice(0, 1),
         },
         {
             localIdentifier: "rows",
@@ -1189,6 +1207,27 @@ export const multipleDatesNotAsFirstReferencePoint: IReferencePoint = {
         {
             localIdentifier: "columns",
             items: [],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const multipleMeasureAndDateInRowsAndColumReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 2),
+        },
+        {
+            localIdentifier: "rows",
+            items: [dateItem],
+        },
+        {
+            localIdentifier: "columns",
+            items: [dateItem2],
         },
     ],
     filters: {

--- a/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
@@ -214,7 +214,7 @@ export function isComparisonOverTimeAllowed(
     filters: IFilters,
     weekFiltersEnabled: boolean,
 ): boolean {
-    const rules = weekFiltersEnabled ? [hasNoStacks] : [hasNoStacks, hasNoWeekGranularity];
+    const rules = weekFiltersEnabled ? [hasNoStacksWithDate] : [hasNoStacksWithDate, hasNoWeekGranularity];
 
     return allRulesMet(rules, buckets, filters) && hasGlobalDateFilter(filters);
 }


### PR DESCRIPTION
JIRA: ONE-5070

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
