### PR TITLE
RELATED: RAIL-3488 Fix InsightView styles when switching insights

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -250,9 +250,7 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
             <div className="insight-view-container">
                 {resolvedTitle && <TitleComponent title={resolvedTitle} />}
                 {(isDataLoading || isVisualizationLoading) && (
-                    <div className="insight-view-loader">
-                        <LoadingComponent />
-                    </div>
+                    <LoadingComponent className="insight-view-loader" />
                 )}
                 {error && !isDataLoading && (
                     <InsightError error={error} ErrorComponent={this.props.ErrorComponent} />

--- a/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
@@ -344,6 +344,7 @@
 .insight-view-container {
     display: flex;
     flex-direction: column;
+    overflow: hidden;
     height: 100%;
 }
 

--- a/libs/sdk-ui/src/base/react/LoadingComponent.tsx
+++ b/libs/sdk-ui/src/base/react/LoadingComponent.tsx
@@ -1,5 +1,5 @@
-// (C) 2007-2018 GoodData Corporation
-import React from "react";
+// (C) 2007-2021 GoodData Corporation
+import React, { CSSProperties } from "react";
 
 /**
  * @public
@@ -40,14 +40,14 @@ export class LoadingComponent extends React.Component<ILoadingProps> {
         const duration = baseAnimationDuration / speed;
         const delay = duration / -5;
 
-        const dotStyles = {
+        const dotStyles: CSSProperties = {
             transformOrigin: "4px 4px",
             animation: `GDC-pop ${duration}s infinite`,
             animationDelay: `${delay * 2}s`,
             fill: color,
         };
 
-        const wrapperStyles = {
+        const wrapperStyles: CSSProperties = {
             textAlign: "center",
             display: inline ? "inline-flex" : "flex",
             verticalAlign: "middle",
@@ -58,31 +58,27 @@ export class LoadingComponent extends React.Component<ILoadingProps> {
             height,
             width,
         };
-        const svgStyles = {
+        const svgStyles: CSSProperties = {
             maxHeight: "100%",
             maxWidth: "100%",
             flex: "0 1 auto",
             width: imageWidth,
             height: imageHeight,
         };
-        const dot1Styles = dotStyles;
-        const dot2Styles = {
+        const dot1Styles: CSSProperties = dotStyles;
+        const dot2Styles: CSSProperties = {
             ...dotStyles,
             transformOrigin: "18px 4px",
             animationDelay: `${delay}s`,
         };
-        const dot3Styles = {
+        const dot3Styles: CSSProperties = {
             ...dotStyles,
             transformOrigin: "32px 4px",
             animationDelay: "0",
         };
 
         return (
-            <div
-                className={className}
-                // this is intentional. Typescript complains about exact matching of css string values to enum.
-                style={wrapperStyles as any}
-            >
+            <div className={className} style={wrapperStyles}>
                 <svg style={svgStyles} version="1.1" x="0px" y="0px" viewBox="0 0 36 8">
                     <style scoped={true}>{`
                         @keyframes GDC-pop {


### PR DESCRIPTION
Now there is a loading shown properly over the "old" visualization.

Also prevent unnecessary any cast in LoadingComponent.

JIRA: RAIL-3488

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
