### PR TITLE
RELATED: RAIL-3488 Avoid changing visualization-uri-root div

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -33,14 +33,17 @@ import { IInsightViewProps } from "./types";
 /**
  * @internal
  */
-export interface IInsightRendererProps extends Omit<IInsightViewProps, "insight"> {
+export interface IInsightRendererProps
+    extends Omit<
+        IInsightViewProps,
+        "insight" | "TitleComponent" | "onInsightLoaded" | "showTitle" | "afterRender"
+    > {
     insight: IInsightDefinition | undefined;
     locale: ILocale;
     settings: IUserWorkspaceSettings | undefined;
     colorPalette: IColorPalette | undefined;
     onError?: OnError;
     theme?: ITheme;
-    isVisualisationLoading?: boolean;
 }
 
 const getElementId = () => `gd-vis-${uuidv4()}`;
@@ -228,11 +231,13 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
 
     public render(): React.ReactNode {
         return (
+            // never ever dynamically change the props of this div, otherwise bad things will happen
+            // e.g. visualization being rendered multiple times, etc.
             <div
                 className="visualization-uri-root"
                 id={this.elementId}
                 ref={this.containerRef}
-                style={this.props.isVisualisationLoading ? null : visualizationUriRootStyle}
+                style={visualizationUriRootStyle}
             />
         );
     }

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -245,26 +245,42 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         const { error, isDataLoading, isVisualizationLoading } = this.state;
 
         const resolvedTitle = this.resolveInsightTitle(this.state.insight);
+        const isLoadingShown = isDataLoading || isVisualizationLoading;
 
         return (
             <div className="insight-view-container">
                 {resolvedTitle && <TitleComponent title={resolvedTitle} />}
-                {(isDataLoading || isVisualizationLoading) && (
-                    <LoadingComponent className="insight-view-loader" />
-                )}
+                {isLoadingShown && <LoadingComponent className="insight-view-loader" />}
                 {error && !isDataLoading && (
                     <InsightError error={error} ErrorComponent={this.props.ErrorComponent} />
                 )}
-                <InsightRenderer
-                    {...this.props}
-                    colorPalette={this.props.colorPalette ?? this.state.colorPalette}
-                    insight={this.state.insight}
-                    locale={this.props.locale || (this.state.settings?.locale as ILocale) || DefaultLocale}
-                    settings={this.state.settings}
-                    onLoadingChanged={this.handleLoadingChanged}
-                    onError={this.handleError}
-                    isVisualisationLoading={isVisualizationLoading || isDataLoading}
-                />
+                <div
+                    className="insight-view-visualization"
+                    // make the visualization div 0 height so that the loading component can take up the whole area
+                    style={isLoadingShown ? { height: 0 } : undefined}
+                >
+                    <InsightRenderer
+                        insight={this.state.insight}
+                        workspace={this.props.workspace}
+                        backend={this.props.backend}
+                        colorPalette={this.props.colorPalette ?? this.state.colorPalette}
+                        config={this.props.config}
+                        drillableItems={this.props.drillableItems}
+                        executeByReference={this.props.executeByReference}
+                        filters={this.props.filters}
+                        locale={
+                            this.props.locale || (this.state.settings?.locale as ILocale) || DefaultLocale
+                        }
+                        settings={this.state.settings}
+                        ErrorComponent={this.props.ErrorComponent}
+                        LoadingComponent={this.props.LoadingComponent}
+                        onDrill={this.props.onDrill}
+                        onError={this.handleError}
+                        onExportReady={this.props.onExportReady}
+                        onLoadingChanged={this.handleLoadingChanged}
+                        pushData={this.props.pushData}
+                    />
+                </div>
             </div>
         );
     }

--- a/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
+++ b/libs/sdk-ui-ext/styles/internal/scss/dashboard_embedding.scss
@@ -341,6 +341,11 @@
     height: 100%;
 }
 
+.insight-view-visualization {
+    flex: 1 1 auto;
+    height: 100%;
+}
+
 .insight-view-container {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
Changing the div can have unforeseen consequences like the visualization
rendering multiple times. So we avoid it and implement the concern
this was introduced for in the parent component (making sure that
loading component is 100% of the height if shown).

Also, avoid passing irrelevant props to InsightRenderer from InsightView.
This makes the InsightRenderer re-render only if needed.

JIRA: RAIL-3488

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
