### PR TITLE
RELATED: ONE-5048 Heatmap disable data labels for large series to improve performance

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -78,6 +78,9 @@ const BAR_COLUMN_TOOLTIP_LEFT_OFFSET = 5;
 const HIGHCHARTS_TOOLTIP_TOP_LEFT_OFFSET = 16;
 const MIN_RANGE = 2;
 
+// custom limit to hide data labels to improve performance
+const HEATMAP_DATA_LABELS_LIMIT = 150;
+
 // in viewport <= 480, tooltip width is equal to chart container width
 const TOOLTIP_FULLSCREEN_THRESHOLD = 480;
 
@@ -571,6 +574,10 @@ function getTreemapLabelsConfiguration(
     }
 }
 
+function shouldDisableHeatmapDataLabels(series: ISeriesItem[]): boolean {
+    return series.some((item) => item.data.length >= HEATMAP_DATA_LABELS_LIMIT);
+}
+
 function getLabelsConfiguration(chartOptions: IChartOptions, _config: any, chartConfig?: IChartConfig) {
     const { stacking, yAxes = [], type } = chartOptions;
 
@@ -603,6 +610,10 @@ function getLabelsConfiguration(chartOptions: IChartOptions, _config: any, chart
     // see https://github.com/highcharts/highcharts/issues/15145
     const dataLabelsBugWorkaround = stackMeasuresToPercent && canStackInPercent ? { inside: true } : {};
 
+    // only applied to heatmap chart
+    const areHeatmapDataLabelsDisabled = shouldDisableHeatmapDataLabels(series);
+    const heatmapLabelsConfig = areHeatmapDataLabelsDisabled ? { enabled: false } : labelsConfig;
+
     return {
         plotOptions: {
             gdcOptions: {
@@ -628,7 +639,7 @@ function getLabelsConfiguration(chartOptions: IChartOptions, _config: any, chart
                 dataLabels: {
                     formatter: labelFormatterHeatmap,
                     config: chartConfig,
-                    ...labelsConfig,
+                    ...heatmapLabelsConfig,
                 },
             },
             treemap: {


### PR DESCRIPTION
Disable data labels on Heatmap charts for big series.

JIRA: ONE-5048



---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
