### PR TITLE
RELATED: ONE-5080 LineChart uiConfig: Correctly enable/disable adding of measures

### DIFF
--- a/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/lineChartUiConfigHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/uiConfigHelpers/lineChartUiConfigHelper.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
 import forEach from "lodash/forEach";
@@ -10,7 +10,7 @@ import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 import { UICONFIG, OPEN_AS_REPORT, SUPPORTED } from "../../constants/uiConfig";
 import { BUCKETS } from "../../constants/bucket";
 
-import { hasNoStacks, hasNoMeasures, hasOneMeasure, hasSomeSegmentByItems } from "./../bucketRules";
+import { hasNoMeasures, hasOneMeasure, hasSomeSegmentByItems, hasNoStacksWithDate } from "./../bucketRules";
 
 import { setBucketTitles } from "./../bucketHelper";
 import { getTranslation } from "./../translations";
@@ -59,7 +59,7 @@ export function setLineChartUiConfig(
     const referencePointConfigured = cloneDeep(referencePoint);
     const buckets = referencePointConfigured?.buckets ?? [];
 
-    const measuresCanAddItems = hasNoMeasures(buckets) || hasNoStacks(buckets);
+    const measuresCanAddItems = hasNoMeasures(buckets) || hasNoStacksWithDate(buckets);
     const segmentCanAddItems =
         hasSomeSegmentByItems(buckets) || hasNoMeasures(buckets) || hasOneMeasure(buckets);
 


### PR DESCRIPTION
- disallow adding measures when date is put in segment by


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)