### PR TITLE
RELATED: RAIL-3498 Migrate AttributeDropdown away from goodstrap

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/tests/AttributeDropdown.test.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/tests/AttributeDropdown.test.tsx
@@ -3,7 +3,7 @@ import { ReferenceLdm, ReferenceRecordings } from "@gooddata/reference-workspace
 import { attributeDisplayFormRef } from "@gooddata/sdk-model";
 import React from "react";
 import { mount } from "enzyme";
-import { DropdownButton } from "@gooddata/goodstrap/lib/Dropdown/Dropdown";
+import { DropdownButton } from "@gooddata/sdk-ui-kit";
 import { recordedBackend } from "@gooddata/sdk-backend-mockingbird";
 import noop from "lodash/noop";
 import { IntlWrapper } from "@gooddata/sdk-ui";

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -944,6 +944,7 @@ export interface IDropdownProps {
     closeOnOutsideClick?: boolean;
     // (undocumented)
     closeOnParentScroll?: boolean;
+    fullscreenOnMobile?: boolean;
     // (undocumented)
     ignoreClicksOnByClass?: string[];
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
+++ b/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
@@ -81,6 +81,11 @@ export interface IDropdownProps {
 
     overlayPositionType?: OverlayPositionType;
     overlayZIndex?: number;
+
+    /**
+     * Should the dropdown body be fullscreen on smaller screens? Defaults to true.
+     */
+    fullscreenOnMobile?: boolean;
 }
 
 /**
@@ -117,6 +122,8 @@ export const Dropdown: React.FC<IDropdownProps> = (props) => {
         renderButton,
 
         onOpenStateChanged,
+
+        fullscreenOnMobile = true,
     } = props;
     const [{ isOpen, dropdownId }, setState] = useState<IDropdownState>({
         isOpen: !!openOnInit,
@@ -169,7 +176,7 @@ export const Dropdown: React.FC<IDropdownProps> = (props) => {
 
     const renderDropdown =
         isOpen &&
-        (isMobileDevice ? (
+        (fullscreenOnMobile && isMobileDevice ? (
             <FullScreenOverlay alignTo="body" alignPoints={MOBILE_DROPDOWN_ALIGN_POINTS}>
                 <div className="gd-mobile-dropdown-overlay overlay gd-flex-row-container">
                     <div className="gd-mobile-dropdown-header gd-flex-item">


### PR DESCRIPTION
This fixes issues with missing icons and removes another goodstrap dep.

Dropdown in sdk-ui-kit was extended with a new prop with a default
that maintains the original behavior.

JIRA: RAIL-3498

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
