### PR TITLE
RELATED: ONE-5076 and ONE-5077 Stack area chart bug fixes and new switch rules implemented 

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -130,14 +130,14 @@ describe("PluggableAreaChart", () => {
         describe("with multiple dates", () => {
             const inputs: [string, IReferencePoint, Partial<IExtendedReferencePoint>][] = [
                 [
-                    "from table to area chart: date in rows only",
-                    referencePointMocks.dateAsFirstCategoryReferencePoint,
+                    "from table to area chart: date1 and date2 in rows ans date1 columns",
+                    referencePointMocks.twoDatesInRowsAndOneDateInColumnsReferencePoint,
                     {
                         buckets: [
-                            referencePointMocks.dateAsFirstCategoryReferencePoint.buckets[0],
+                            referencePointMocks.twoDatesInRowsAndOneDateInColumnsReferencePoint.buckets[0],
                             {
                                 localIdentifier: "view",
-                                items: referencePointMocks.dateAsFirstCategoryReferencePoint.buckets[1].items.slice(
+                                items: referencePointMocks.twoDatesInRowsAndOneDateInColumnsReferencePoint.buckets[1].items.slice(
                                     0,
                                     2,
                                 ),
@@ -150,42 +150,18 @@ describe("PluggableAreaChart", () => {
                     },
                 ],
                 [
-                    "from table to area chart: two identical dates in rows",
-                    referencePointMocks.twoIdenticalDatesInRowsWithSingleMeasure,
+                    "from table to area chart: date1 in rows ans date2 columns",
+                    referencePointMocks.oneDateInRowsAndOneDateInColumnsReferencePoint,
                     {
                         buckets: [
-                            referencePointMocks.twoIdenticalDatesInRowsWithSingleMeasure.buckets[0],
-                            {
-                                localIdentifier: "view",
-                                items: referencePointMocks.twoIdenticalDatesInRowsWithSingleMeasure.buckets[1].items.slice(
-                                    0,
-                                    1,
-                                ),
-                            },
-                            {
-                                localIdentifier: "stack",
-                                items: referencePointMocks.twoIdenticalDatesInRowsWithSingleMeasure.buckets[1].items.slice(
-                                    1,
-                                    2,
-                                ),
-                            },
-                        ],
-                    },
-                ],
-                [
-                    "from table to area chart: multiple dates in rows but not first (date should get preference, attribute should be put to view)",
-                    referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasure,
-                    {
-                        buckets: [
-                            referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasure
-                                .buckets[0],
+                            referencePointMocks.oneDateInRowsAndOneDateInColumnsReferencePoint.buckets[0],
                             {
                                 localIdentifier: "view",
                                 items: [
-                                    referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasure
-                                        .buckets[1].items[1],
-                                    referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasure
+                                    referencePointMocks.oneDateInRowsAndOneDateInColumnsReferencePoint
                                         .buckets[1].items[0],
+                                    referencePointMocks.oneDateInRowsAndOneDateInColumnsReferencePoint
+                                        .buckets[2].items[0],
                                 ],
                             },
                             {
@@ -196,17 +172,19 @@ describe("PluggableAreaChart", () => {
                     },
                 ],
                 [
-                    "from table to area chart: multiple dates in rows but not first, more measures",
-                    referencePointMocks.multipleDatesNotAsFirstReferencePoint,
+                    "from table to area chart: date1 in rows ans date1 columns",
+                    referencePointMocks.oneDateInRowsAndSameOneDateInColumnsReferencePoint,
                     {
                         buckets: [
-                            referencePointMocks.multipleDatesNotAsFirstReferencePoint.buckets[0],
+                            referencePointMocks.oneDateInRowsAndSameOneDateInColumnsReferencePoint.buckets[0],
                             {
                                 localIdentifier: "view",
-                                items: referencePointMocks.multipleDatesNotAsFirstReferencePoint.buckets[1].items.slice(
-                                    1,
-                                    2,
-                                ),
+                                items: [
+                                    referencePointMocks.oneDateInRowsAndSameOneDateInColumnsReferencePoint
+                                        .buckets[1].items[0],
+                                    referencePointMocks.oneDateInRowsAndSameOneDateInColumnsReferencePoint
+                                        .buckets[2].items[0],
+                                ],
                             },
                             {
                                 localIdentifier: "stack",
@@ -216,65 +194,140 @@ describe("PluggableAreaChart", () => {
                     },
                 ],
                 [
-                    "from column to area chart: two dates",
-                    referencePointMocks.twoDatesInColumnChart,
+                    "from table to area chart: att1 and att2 and date1 in rows ans date2 in columns",
+                    referencePointMocks.twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint,
                     {
                         buckets: [
-                            referencePointMocks.twoDatesInColumnChart.buckets[0],
-                            {
-                                localIdentifier: "view",
-                                items: referencePointMocks.twoDatesInColumnChart.buckets[1].items.slice(0, 1),
-                            },
-                            {
-                                localIdentifier: "stack",
-                                items: referencePointMocks.twoDatesInColumnChart.buckets[2].items.slice(0, 1),
-                            },
-                        ],
-                    },
-                ],
-                [
-                    "from column to area chart: three dates",
-                    referencePointMocks.threeDatesInColumnChart,
-                    {
-                        buckets: [
-                            referencePointMocks.threeDatesInColumnChart.buckets[0],
-                            {
-                                localIdentifier: "view",
-                                items: referencePointMocks.threeDatesInColumnChart.buckets[1].items.slice(
-                                    0,
-                                    1,
-                                ),
-                            },
-                            {
-                                localIdentifier: "stack",
-                                items: referencePointMocks.threeDatesInColumnChart.buckets[1].items.slice(
-                                    1,
-                                    2,
-                                ),
-                            },
-                        ],
-                    },
-                ],
-                [
-                    "from column to area chart: first attribute is not date (date should get preference)",
-                    referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasureColumn,
-                    {
-                        buckets: [
-                            referencePointMocks.multipleDatesNotAsFirstReferencePointWithSingleMeasureColumn
+                            referencePointMocks.twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
                                 .buckets[0],
                             {
                                 localIdentifier: "view",
                                 items: [
                                     referencePointMocks
-                                        .multipleDatesNotAsFirstReferencePointWithSingleMeasureColumn
+                                        .twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
+                                        .buckets[1].items[2],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [
+                                    referencePointMocks
+                                        .twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
+                                        .buckets[1].items[0],
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from table to area chart: date1 and date2 and date1 in columns",
+                    referencePointMocks.threeDatesInColumnsReferencePoint,
+                    {
+                        buckets: [
+                            referencePointMocks.threeDatesInColumnsReferencePoint.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.threeDatesInColumnsReferencePoint.buckets[2].items[0],
+                                    referencePointMocks.threeDatesInColumnsReferencePoint.buckets[2].items[1],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from colum chart to area chart: att1 and date1 in viewBy and date2 in stackBy",
+                    referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint,
+                    {
+                        buckets: [
+                            referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint
+                                .buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint
                                         .buckets[1].items[1],
                                 ],
                             },
                             {
                                 localIdentifier: "stack",
-                                items: referencePointMocks
-                                    .multipleDatesNotAsFirstReferencePointWithSingleMeasureColumn.buckets[2]
-                                    .items,
+                                items: [
+                                    referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint
+                                        .buckets[2].items[0],
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from colum chart to area chart: att1 and date1 in viewBy and empty stackBy",
+                    referencePointMocks.dateAsSecondViewByItemReferencePoint,
+                    {
+                        buckets: [
+                            referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[1]
+                                        .items[1],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [
+                                    referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[1]
+                                        .items[0],
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from colum chart to area chart: att1 and date1 in viewBy and empty stackBy",
+                    referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy,
+                    {
+                        buckets: [
+                            referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[1]
+                                        .items[0],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [
+                                    referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[1]
+                                        .items[1],
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from colum chart to area chart: att1 and att2 in viewBy and att3 stackBy",
+                    referencePointMocks.att1AndAtt2inViewByAndAtt3inStackBy,
+                    {
+                        buckets: [
+                            referencePointMocks.att1AndAtt2inViewByAndAtt3inStackBy.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.att1AndAtt2inViewByAndAtt3inStackBy.buckets[1]
+                                        .items[0],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [
+                                    referencePointMocks.att1AndAtt2inViewByAndAtt3inStackBy.buckets[2]
+                                        .items[0],
+                                ],
                             },
                         ],
                     },

--- a/libs/sdk-ui-ext/src/internal/constants/uiConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/uiConfig.ts
@@ -311,6 +311,9 @@ export const AREA_UICONFIG_WITH_MULTIPLE_DATES: IUiConfig = {
         },
         view: {
             ...viewBase,
+            itemsLimitByType: {
+                date: 2,
+            },
             allowsReordering: true,
             itemsLimit: MAX_VIEW_COUNT,
             allowsDuplicateDates: true,

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -1047,6 +1047,132 @@ export const dateAsFirstCategoryReferencePoint: IReferencePoint = {
     },
 };
 
+export const twoDatesInRowsAndOneDateInColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [{ ...dateItem }, { ...dateItem2 }],
+        },
+        {
+            localIdentifier: "columns",
+            items: [{ ...dateItem }],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const oneDateInRowsAndOneDateInColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [{ ...dateItem }],
+        },
+        {
+            localIdentifier: "columns",
+            items: [{ ...dateItem2 }],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const oneDateInRowsAndSameOneDateInColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [{ ...dateItem }],
+        },
+        {
+            localIdentifier: "columns",
+            items: [{ ...dateItem }],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [attributeItems[0], attributeItems[1], { ...dateItem }],
+        },
+        {
+            localIdentifier: "columns",
+            items: [{ ...dateItem2 }],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const threeDatesInColumnsReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "attribute",
+            items: [],
+        },
+        {
+            localIdentifier: "columns",
+            items: [{ ...dateItem }, { ...dateItem }, { ...dateItem2 }],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const attributeAndDateInViewByAndDateInStackByReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "view",
+            items: [attributeItems[1], dateItem],
+        },
+        {
+            localIdentifier: "stack",
+            items: [dateItem2],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
 export const dateAsSecondViewByItemReferencePoint: IReferencePoint = {
     buckets: [
         {
@@ -1060,6 +1186,48 @@ export const dateAsSecondViewByItemReferencePoint: IReferencePoint = {
         {
             localIdentifier: "stack",
             items: [],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const dateAndAttributeInViewByAndEmptyStackBy: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "view",
+            items: [dateItem, attributeItems[1]],
+        },
+        {
+            localIdentifier: "stack",
+            items: [],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const att1AndAtt2inViewByAndAtt3inStackBy: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "view",
+            items: [attributeItems[0], attributeItems[1]],
+        },
+        {
+            localIdentifier: "stack",
+            items: [attributeItems[2]],
         },
     ],
     filters: {
@@ -1306,7 +1474,7 @@ export const multipleDatesNotAsFirstReferencePointWithSingleMeasure: IReferenceP
             items: masterMeasureItems.slice(0, 1),
         },
         {
-            localIdentifier: "rows",
+            localIdentifier: "attribute",
             items: [attributeItems[0], dateItem, dateItem2],
         },
         {

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -537,9 +537,12 @@ export function getAttributeItems(buckets: IBucketOfFun[]): IBucketItem[] {
     ]);
 }
 
-export function getAttributeItemsWithoutStacks(buckets: IBucketOfFun[]): IBucketItem[] {
+export function getAttributeItemsWithoutStacks(
+    buckets: IBucketOfFun[],
+    itemTypes: string[] = [ATTRIBUTE],
+): IBucketItem[] {
     return getAttributeItems(buckets).filter((attribute) => {
-        return !includes(getStackItems(buckets), attribute);
+        return !includes(getStackItems(buckets, itemTypes), attribute);
     });
 }
 
@@ -581,6 +584,14 @@ export function getDateItems(buckets: IBucketOfFun[]): IBucketItem[] {
     return getAttributeItemsWithoutStacks(buckets).filter(isDateBucketItem);
 }
 
+export function getDateItemsWithMultipleDates(buckets: IBucketOfFun[]): IBucketItem[] {
+    return getAttributeItemsWithoutStacks(buckets, [ATTRIBUTE, DATE]).filter(isDateBucketItem);
+}
+
+export function getFistDateItemWithMultipleDates(buckets: IBucketOfFun[]): IBucketItem | undefined {
+    const dateItems = getDateItemsWithMultipleDates(buckets);
+    return dateItems[0];
+}
 export function getFistDateItem(buckets: IBucketOfFun[]): IBucketItem | undefined {
     const dateItems = getDateItems(buckets);
     return dateItems[0];


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
