### PR TITLE
Fix missing date attribute display forms on tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/datasetLoader.ts
@@ -108,7 +108,7 @@ function createDateDatasets(attributes: JsonApiAttributeOutList): ICatalogDateDa
             const labels = getAttributeLabels(attribute, attributes.included);
             const defaultLabel = labels[0];
 
-            return convertDateAttribute(attribute, defaultLabel);
+            return convertDateAttribute(attribute, defaultLabel, labels);
         });
 
         return convertDateDataset(dd.dataset, catalogDateAttributes);

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/CatalogConverter.ts
@@ -18,6 +18,7 @@ import {
     newCatalogMeasure,
 } from "@gooddata/sdk-backend-base";
 import {
+    IAttributeDisplayFormMetadataObject,
     ICatalogAttribute,
     ICatalogDateAttribute,
     ICatalogDateDataset,
@@ -37,6 +38,13 @@ const commonGroupableCatalogItemModifications =
         return builder.groups(tags);
     };
 
+const tigerLabelToDisplayFormMd = (label: JsonApiLabelOutWithLinks): IAttributeDisplayFormMetadataObject => {
+    return newAttributeDisplayFormMetadataObject(
+        idRef(label.id, "displayForm"),
+        commonMetadataObjectModifications(label),
+    );
+};
+
 export const convertAttribute = (
     attribute: JsonApiAttributeOutWithLinks,
     defaultLabel: JsonApiLabelOutWithLinks,
@@ -49,12 +57,7 @@ export const convertAttribute = (
             commonMetadataObjectModifications(label),
         );
     });
-    const displayForms = allLabels.map((label) => {
-        return newAttributeDisplayFormMetadataObject(
-            idRef(label.id, "displayForm"),
-            commonMetadataObjectModifications(label),
-        );
-    });
+    const displayForms = allLabels.map(tigerLabelToDisplayFormMd);
 
     return newCatalogAttribute((catalogA) =>
         catalogA
@@ -97,12 +100,15 @@ export const convertFact = (fact: JsonApiFactOutWithLinks): ICatalogFact => {
 export const convertDateAttribute = (
     attribute: JsonApiAttributeOutWithLinks,
     label: JsonApiLabelOutWithLinks,
+    allLabels: JsonApiLabelOutWithLinks[],
 ): ICatalogDateAttribute => {
+    const displayForms = allLabels.map(tigerLabelToDisplayFormMd);
+
     return newCatalogDateAttribute((dateAttribute) => {
         return dateAttribute
             .granularity(toSdkGranularity(attribute.attributes!.granularity!))
             .attribute(idRef(attribute.id, "attribute"), (a) =>
-                a.modify(commonMetadataObjectModifications(attribute)),
+                a.modify(commonMetadataObjectModifications(attribute)).displayForms(displayForms),
             )
             .defaultDisplayForm(idRef(label.id, "displayForm"), (df) =>
                 df.modify(commonMetadataObjectModifications(label)),


### PR DESCRIPTION
- This is causing blank screen for insights with date attribute buckets in AD as it implicitly depends on them

JIRA: NAS-149

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
