### PR TITLE
RELATED: RAIL-2392 Validate localIds in execution definitions

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/__snapshots__/toAfmResultSpec.test.ts.snap
@@ -134,11 +134,11 @@ Object {
           "definition": Object {
             "measure": Object {
               "item": Object {
-                "identifier": "acugFHNJgsBy",
+                "identifier": "abZgFKGPaGYM",
               },
             },
           },
-          "localIdentifier": "m_acugFHNJgsBy",
+          "localIdentifier": "m_abZgFKGPaGYM",
         },
       ],
       "nativeTotals": Array [

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/toAfmResultSpec.test.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/tests/toAfmResultSpec.test.ts
@@ -44,7 +44,7 @@ describe("converts execution definition to AFM Execution", () => {
             defSetDimensions(
                 newDefForBuckets("test workspace", [
                     newBucket("mixedBucket1", ReferenceLdm.Activity.Default, ReferenceLdm.Won),
-                    newBucket("measureBucket1", ReferenceLdm.Won),
+                    newBucket("measureBucket1", ReferenceLdm.WinRate),
                     newBucket("attributeBucket1", ReferenceLdm.Account.Name),
                 ]),
                 newTwoDimensional(

--- a/libs/sdk-model/src/execution/executionDefinition/factory.ts
+++ b/libs/sdk-model/src/execution/executionDefinition/factory.ts
@@ -24,6 +24,7 @@ import {
 } from "./index";
 import isEmpty from "lodash/isEmpty";
 import invariant from "ts-invariant";
+import { defValidate } from "./validation";
 
 /**
  * Creates new, empty execution definition for the provided workspace.
@@ -70,6 +71,8 @@ export function newDefForItems(
         measures: items.filter(isMeasure),
     };
 
+    defValidate(def);
+
     return defWithFilters(def, filters);
 }
 
@@ -105,6 +108,8 @@ export function newDefForBuckets(
         measures: bucketsMeasures(buckets),
     };
 
+    defValidate(def);
+
     return defWithFilters(def, filters);
 }
 
@@ -138,6 +143,9 @@ export function newDefForInsight(
     invariant(insight, "insight to create exec def from must be specified");
 
     const def = newDefForBuckets(workspace, insightBuckets(insight));
+
+    defValidate(def);
+
     const extraFilters = filters ? filters : [];
     const filteredDef = defWithFilters(def, [...insightFilters(insight), ...extraFilters]);
 

--- a/libs/sdk-model/src/execution/executionDefinition/tests/__snapshots__/validation.test.ts.snap
+++ b/libs/sdk-model/src/execution/executionDefinition/tests/__snapshots__/validation.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defValidate should throw for execution definition with measure and an attribute with the same localId 1`] = `"There are 2 items with the same localId 'foo'. Please make sure the attributes and measures in the execution definition have unique localIds."`;
+
+exports[`defValidate should throw for execution definition with two attributes with the same localId 1`] = `"There are 2 items with the same localId 'foo'. Please make sure the attributes and measures in the execution definition have unique localIds."`;
+
+exports[`defValidate should throw for execution definition with two measures with the same localId 1`] = `"There are 2 items with the same localId 'foo'. Please make sure the attributes and measures in the execution definition have unique localIds."`;

--- a/libs/sdk-model/src/execution/executionDefinition/tests/validation.test.ts
+++ b/libs/sdk-model/src/execution/executionDefinition/tests/validation.test.ts
@@ -1,0 +1,49 @@
+// (C) 2021 GoodData Corporation
+
+import { IExecutionDefinition } from "../index";
+import { ActivityType, Department, Won, WinRate } from "../../../../__mocks__/model";
+import { modifyAttribute } from "../../attribute/factory";
+import { modifyMeasure } from "../../measure/factory";
+import { IAttribute } from "../../attribute";
+import { IMeasure } from "../../measure";
+import { emptyDef } from "../factory";
+import { defValidate } from "../validation";
+
+describe("defValidate", () => {
+    const Workspace = "testWorkspace";
+
+    it("should NOT throw for valid execution definition", () => {
+        const def: IExecutionDefinition = {
+            ...emptyDef(Workspace),
+            attributes: [ActivityType, Department],
+            measures: [WinRate, Won],
+        };
+        expect(() => defValidate(def)).not.toThrow();
+    });
+
+    const InvalidScenarios: Array<[string, IMeasure[], IAttribute[]]> = [
+        [
+            "two measures with the same localId",
+            [modifyMeasure(Won, (m) => m.localId("foo")), modifyMeasure(WinRate, (m) => m.localId("foo"))],
+            [],
+        ],
+        [
+            "two attributes with the same localId",
+            [],
+            [
+                modifyAttribute(ActivityType, (a) => a.localId("foo")),
+                modifyAttribute(Department, (a) => a.localId("foo")),
+            ],
+        ],
+        [
+            "measure and an attribute with the same localId",
+            [modifyMeasure(Won, (m) => m.localId("foo"))],
+            [modifyAttribute(Department, (a) => a.localId("foo"))],
+        ],
+    ];
+
+    it.each(InvalidScenarios)("should throw for execution definition with %s", (_, measures, attributes) => {
+        const def: IExecutionDefinition = { ...emptyDef(Workspace), attributes, measures };
+        expect(() => defValidate(def)).toThrowErrorMatchingSnapshot();
+    });
+});

--- a/libs/sdk-model/src/execution/executionDefinition/validation.ts
+++ b/libs/sdk-model/src/execution/executionDefinition/validation.ts
@@ -1,0 +1,29 @@
+// (C) 2021 GoodData Corporation
+import groupBy from "lodash/groupBy";
+import toPairs from "lodash/toPairs";
+import invariant from "ts-invariant";
+
+import { attributeLocalId, isAttribute } from "../attribute";
+import { measureLocalId } from "../measure";
+
+import { IExecutionDefinition } from "./index";
+
+/**
+ * Validates the {@link IExecutionDefinition} instance and throws if it is invalid.
+ * @param definition - the definition to validate
+ * @internal
+ */
+export function defValidate(definition: IExecutionDefinition): void {
+    const itemsWithLocalId = [...definition.attributes, ...definition.measures];
+
+    const groups = groupBy(itemsWithLocalId, (item) =>
+        isAttribute(item) ? attributeLocalId(item) : measureLocalId(item),
+    );
+
+    toPairs(groups).forEach(([localId, items]) => {
+        invariant(
+            items.length === 1,
+            `There are ${items.length} items with the same localId '${localId}'. Please make sure the attributes and measures in the execution definition have unique localIds.`,
+        );
+    });
+}

--- a/libs/sdk-ui-charts/src/charts/comboChart/tests/ComboChart.test.tsx
+++ b/libs/sdk-ui-charts/src/charts/comboChart/tests/ComboChart.test.tsx
@@ -6,7 +6,7 @@ import { IChartConfig } from "../../../interfaces";
 import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
 import { ReferenceLdm, ReferenceLdmExt } from "@gooddata/reference-workspace";
 import { CoreComboChart } from "../CoreComboChart";
-import { IMeasure, modifySimpleMeasure } from "@gooddata/sdk-model";
+import { IMeasure, measureLocalId, modifyMeasure, modifySimpleMeasure } from "@gooddata/sdk-model";
 
 // need to turn off ratio in the ReferenceLdmExt.AmountWithRatio
 describe("ComboChart", () => {
@@ -89,7 +89,11 @@ describe("ComboChart", () => {
         it("should ignore computeRatio when dual axis is OFF and # of measures > 1", () => {
             const wrapper = renderChart(
                 [ReferenceLdmExt.AmountWithRatio],
-                [ReferenceLdmExt.AmountWithRatio],
+                [
+                    modifyMeasure(ReferenceLdmExt.AmountWithRatio, (m) =>
+                        m.localId(`${measureLocalId(ReferenceLdmExt.AmountWithRatio)}_1`),
+                    ),
+                ],
                 {
                     ...config,
                     dualAxis: false,
@@ -98,7 +102,9 @@ describe("ComboChart", () => {
             const execution = wrapper.find(CoreComboChart).prop("execution");
             const expectedMeasures = [
                 modifySimpleMeasure(ReferenceLdmExt.AmountWithRatio, (m) => m.noRatio()),
-                modifySimpleMeasure(ReferenceLdmExt.AmountWithRatio, (m) => m.noRatio()),
+                modifySimpleMeasure(ReferenceLdmExt.AmountWithRatio, (m) =>
+                    m.noRatio().localId(`${measureLocalId(ReferenceLdmExt.AmountWithRatio)}_1`),
+                ),
             ];
 
             expect(execution.definition.measures).toEqual(expectedMeasures);


### PR DESCRIPTION
Currently just validates that the localIds are unique among measures and attributes.

This is to improve the error message (before, a generic 400 would be
thrown) and to not try to execute definitions that are certain to fail.

This helped us find a few test fixtures that were invalid, so they were fixed.

JIRA: RAIL-2392

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
