### PR TITLE
RELATED: RAIL-3497, RAIL-3502, RAIL-3511 small tweaks and fixes

### DIFF
--- a/common/scripts/build-docs.sh
+++ b/common/scripts/build-docs.sh
@@ -28,7 +28,7 @@ jq --arg version ${VERSION} -n '{version: $version}' > $VERSION_FILE
 
 if [ $VERSION != "Next" ]
 then
-    cat ${APIDOCS_VERSION_LIST} | jq --arg version ${VERSION} 'if index( [$version] ) == null then . += [$version] else . end' $APIDOCS_VERSION_LIST > temp && mv temp $APIDOCS_VERSION_LIST  
+    cat ${APIDOCS_VERSION_LIST} | jq --arg version ${VERSION} 'if index( [$version] ) == null then . += [$version] else . end' $APIDOCS_VERSION_LIST > temp && mv temp $APIDOCS_VERSION_LIST
 fi
 
 cp ${ROOT_DIR}/libs/*/temp/*.api.json "${APIDOC_INPUT_DIR}"
@@ -40,7 +40,7 @@ for filename in $APIDOC_INPUT_DIR/*; do
      FILE_NAME_WITHOUT_EXTENSION=${FILE_NAME%.*}
      IFS='.' read -ra FILE_NAME_ARRAY <<< "$FILE_NAME_WITHOUT_EXTENSION"
      LIB=${FILE_NAME_ARRAY[0]}
-     LIBS_TO_BE_REMOVED=("sdk-ui-kit" "sdk-backend-base" "sdk-backend-bear" "sdk-backend-tiger" "api-model-bear" "api-client-tiger" "api-client-bear" "sdk-backend-mockingbird" "sdk-embedding" "sdk-ui-ext" "sdk-ui-all")
+     LIBS_TO_BE_REMOVED=("sdk-ui-kit" "sdk-backend-base" "sdk-backend-bear" "sdk-backend-tiger" "api-model-bear" "api-client-tiger" "api-client-bear" "sdk-backend-mockingbird" "sdk-embedding" "sdk-ui-ext" "sdk-ui-all" "sdk-ui-dashboard")
 
     if [[ " ${LIBS_TO_BE_REMOVED[@]} " =~ " ${LIB} " ]]
     then
@@ -71,9 +71,9 @@ for filename in $APIDOC_DIR_DOCS/*; do
     fi
 
     if [[ ${#FILE_NAME_ARRAY[@]} -eq 2 ]]
-    then 
+    then
         cat $SIDEBAR | jq --arg FIELD ${FILE_NAME_ARRAY[0]} 'if .Docs | has($FIELD) | not then .Docs += {($FIELD): [($FIELD)]} else . end' $SIDEBAR > temp && mv temp $SIDEBAR
-        cat $SIDEBAR | jq --arg FIELD ${FILE_NAME_ARRAY[0]} --arg FIELD_DATA $FILE_NAME_WITHOUT_EXTENSION 'if .Docs[$FIELD] | index( [$FIELD_DATA] ) == null then .Docs[$FIELD] += [$FIELD_DATA] else . end' $SIDEBAR > temp && mv temp $SIDEBAR    
+        cat $SIDEBAR | jq --arg FIELD ${FILE_NAME_ARRAY[0]} --arg FIELD_DATA $FILE_NAME_WITHOUT_EXTENSION 'if .Docs[$FIELD] | index( [$FIELD_DATA] ) == null then .Docs[$FIELD] += [$FIELD_DATA] else . end' $SIDEBAR > temp && mv temp $SIDEBAR
     fi
 
      if [[ ${#FILE_NAME_ARRAY[@]} -eq 1 ]]
@@ -92,6 +92,6 @@ done
 
 cd "${APIDOC_DIR_VERSIONED}/website" && yarn install && yarn build
 cd "${APIDOC_DIR_VERSIONED}/website" && mv build/* ../
-cd "${APIDOC_DIR_VERSIONED}" && shopt -s extglob 
+cd "${APIDOC_DIR_VERSIONED}" && shopt -s extglob
 cd "${APIDOC_DIR_VERSIONED}" && rm -rf !(gooddata-ui-apidocs)
 cd "${APIDOC_DIR_VERSIONED}" && mv gooddata-ui-apidocs/* . && rm -rf gooddata-ui-apidocs

--- a/examples/sdk-examples/src/examples/theming/index.tsx
+++ b/examples/sdk-examples/src/examples/theming/index.tsx
@@ -13,6 +13,12 @@ import ThemeProviderExampleSrcJS from "./ThemedComponentsExample?rawJS";
 
 export const ThemedComponents: React.FC = () => (
     <div>
+        <style jsx>{`
+            /* since the theme is applied to the whole page, we override the color of p tags to retain readability */
+            :global(p) {
+                color: rgb(70, 78, 86);
+            }
+        `}</style>
         <h1>Custom Themed components</h1>
         <p>
             These examples show how to use ThemeProvider component to theme the UI components which support

--- a/tools/catalog-export/package.json
+++ b/tools/catalog-export/package.json
@@ -45,6 +45,7 @@
         "@gooddata/api-client-bear": "^8.5.0-alpha.35",
         "@gooddata/api-client-tiger": "^8.5.0-alpha.35",
         "@gooddata/api-model-bear": "^8.5.0-alpha.35",
+        "@gooddata/sdk-model": "^8.5.0-alpha.35",
         "chalk": "^4.1.1",
         "commander": "^3.0.2",
         "inquirer": "^7.3.3",

--- a/tools/catalog-export/src/transform/tests/__snapshots__/toTypescript.test.ts.snap
+++ b/tools/catalog-export/src/transform/tests/__snapshots__/toTypescript.test.ts.snap
@@ -45,11 +45,6 @@ export const $MenuItemSales = { /**
     Sum: newMeasure(idRef('fact.salesdetailfact.menuitemsales', \\"fact\\"), m => m.aggregation('sum')),/** 
     * Fact Title: $ Menu Item Sales  
     * Fact ID: fact.salesdetailfact.menuitemsales
-     * Fact Aggregation: count
-    */
-    Count: newMeasure(idRef('fact.salesdetailfact.menuitemsales', \\"fact\\"), m => m.aggregation('count')),/** 
-    * Fact Title: $ Menu Item Sales  
-    * Fact ID: fact.salesdetailfact.menuitemsales
      * Fact Aggregation: avg
     */
     Avg: newMeasure(idRef('fact.salesdetailfact.menuitemsales', \\"fact\\"), m => m.aggregation('avg')),/** 
@@ -83,11 +78,6 @@ export const Cost = { /**
      * Fact Aggregation: sum
     */
     Sum: newMeasure(idRef('fact.restaurantcostsfact.cost', \\"fact\\"), m => m.aggregation('sum')),/** 
-    * Fact Title: Cost  
-    * Fact ID: fact.restaurantcostsfact.cost
-     * Fact Aggregation: count
-    */
-    Count: newMeasure(idRef('fact.restaurantcostsfact.cost', \\"fact\\"), m => m.aggregation('count')),/** 
     * Fact Title: Cost  
     * Fact ID: fact.restaurantcostsfact.cost
      * Fact Aggregation: avg

--- a/tools/catalog-export/src/transform/toTypescript.ts
+++ b/tools/catalog-export/src/transform/toTypescript.ts
@@ -8,6 +8,7 @@ import {
     VariableDeclarationKind,
     VariableStatementStructure,
 } from "ts-morph";
+import { MeasureAggregation } from "@gooddata/sdk-model";
 import { Attribute, DateDataSet, DisplayForm, Fact, Metric, WorkspaceMetadata } from "../base/types";
 import { createUniqueVariableName, TakenNamesSet } from "./titles";
 
@@ -25,7 +26,8 @@ const FILE_HEADER = `/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU
 const INSIGHT_MAP_VARNAME = "Insights";
 const ANALYTICAL_DASHBOARD_MAP_VARNAME = "Dashboards";
 const DATE_DATASETS_MAP_VARNAME = "DateDatasets";
-const FACT_AGGREGATIONS = ["sum", "count", "avg", "min", "max", "median", "runsum"];
+// "count" aggregation is not allowed for Facts, so do not generate code for that
+const FACT_AGGREGATIONS: MeasureAggregation[] = ["sum", "avg", "min", "max", "median", "runsum"];
 
 //
 // Variable naming support & strategies

--- a/tools/experimental-workspace/src/ldm/full.ts
+++ b/tools/experimental-workspace/src/ldm/full.ts
@@ -1,7 +1,6 @@
-// (C) 2020 GoodData Corporation
-
 /* eslint-disable */
-/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2020-11-20T08:11:45.022Z; */
+/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-06-21T15:35:37.369Z; */
+// @ts-ignore ignore unused imports here if they happen (e.g. when there is no measure in the workspace)
 import {
     newAttribute,
     newMeasure,
@@ -245,11 +244,6 @@ export const ActivityDate = {
     /**
      * Fact Title: Activity (Date)
      * Fact ID: dt.activity.activity
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.activity.activity", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Activity (Date)
-     * Fact ID: dt.activity.activity
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.activity.activity", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -287,11 +281,6 @@ export const Amount_1 = {
     /**
      * Fact Title: Amount
      * Fact ID: fact.opportunitysnapshot.amount
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.amount", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Amount
-     * Fact ID: fact.opportunitysnapshot.amount
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.opportunitysnapshot.amount", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -326,13 +315,6 @@ export const DaysToClose = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.opportunitysnapshot.daystoclose", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Days to Close
-     * Fact ID: fact.opportunitysnapshot.daystoclose
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.daystoclose", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Days to Close
      * Fact ID: fact.opportunitysnapshot.daystoclose
@@ -377,11 +359,6 @@ export const Duration = {
     /**
      * Fact Title: Duration
      * Fact ID: fact.stagehistory.duration
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.stagehistory.duration", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Duration
-     * Fact ID: fact.stagehistory.duration
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.stagehistory.duration", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -416,11 +393,6 @@ export const OppCloseDate = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("dt.opportunitysnapshot.closedate", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Opp. Close (Date)
-     * Fact ID: dt.opportunitysnapshot.closedate
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunitysnapshot.closedate", "fact"), (m) => m.aggregation("count")),
     /**
      * Fact Title: Opp. Close (Date)
      * Fact ID: dt.opportunitysnapshot.closedate
@@ -461,11 +433,6 @@ export const OppCreatedDate = {
     /**
      * Fact Title: Opp. Created (Date)
      * Fact ID: dt.opportunity.oppcreated
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunity.oppcreated", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Opp. Created (Date)
-     * Fact ID: dt.opportunity.oppcreated
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.opportunity.oppcreated", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -500,13 +467,6 @@ export const OppSnapshotDate = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("dt.opportunitysnapshot.snapshotdate", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Opp. Snapshot (Date)
-     * Fact ID: dt.opportunitysnapshot.snapshotdate
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunitysnapshot.snapshotdate", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Opp. Snapshot (Date)
      * Fact ID: dt.opportunitysnapshot.snapshotdate
@@ -551,13 +511,6 @@ export const Probability_1 = {
     /**
      * Fact Title: Probability
      * Fact ID: fact.opportunitysnapshot.probability
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.probability", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
-    /**
-     * Fact Title: Probability
-     * Fact ID: fact.opportunitysnapshot.probability
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.opportunitysnapshot.probability", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -599,11 +552,6 @@ export const TimelineDate = {
     /**
      * Fact Title: Timeline (Date)
      * Fact ID: dt.timeline.timeline
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.timeline.timeline", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Timeline (Date)
-     * Fact ID: dt.timeline.timeline
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.timeline.timeline", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -638,11 +586,6 @@ export const Velocity = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.stagehistory.velocity", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Velocity
-     * Fact ID: fact.stagehistory.velocity
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.stagehistory.velocity", "fact"), (m) => m.aggregation("count")),
     /**
      * Fact Title: Velocity
      * Fact ID: fact.stagehistory.velocity
@@ -1839,9 +1782,7 @@ export const TimelineDate_1 = {
      * Display Form ID: timeline.date.eddmmyyyy
      */ DdMmYyyy_1: newAttribute("timeline.date.eddmmyyyy"),
 };
-/**
- * Available Date Data Sets
- */
+/** Available Date Data Sets */
 export const DateDatasets = {
     /**
      * Date Data Set Title: Date (Created)
@@ -3297,3 +3238,4 @@ export const Insights = {
      */
     PivotTableWithNativeTotals: "aac5Bt1DibxY",
 };
+export const Dashboards = {};

--- a/tools/live-examples-workspace/src/ldm/full.ts
+++ b/tools/live-examples-workspace/src/ldm/full.ts
@@ -1,7 +1,6 @@
-// (C) 2020 GoodData Corporation
-
 /* eslint-disable */
-/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2020-11-20T08:11:25.058Z; */
+/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-06-21T15:13:14.446Z; */
+// @ts-ignore ignore unused imports here if they happen (e.g. when there is no measure in the workspace)
 import {
     newAttribute,
     newMeasure,
@@ -618,11 +617,6 @@ export const $MenuItemSales = {
     /**
      * Fact Title: $ Menu Item Sales
      * Fact ID: fact.salesdetailfact.menuitemsales
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.salesdetailfact.menuitemsales", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: $ Menu Item Sales
-     * Fact ID: fact.salesdetailfact.menuitemsales
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.salesdetailfact.menuitemsales", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -664,11 +658,6 @@ export const Cost = {
     /**
      * Fact Title: Cost
      * Fact ID: fact.restaurantcostsfact.cost
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.restaurantcostsfact.cost", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Cost
-     * Fact ID: fact.restaurantcostsfact.cost
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.restaurantcostsfact.cost", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -706,11 +695,6 @@ export const Density = {
     /**
      * Fact Title: Density
      * Fact ID: fact.uscities.density
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.uscities.density", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Density
-     * Fact ID: fact.uscities.density
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.uscities.density", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -745,13 +729,6 @@ export const MenuItemQuantity = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.salesdetailfact.menuitemquantity", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Menu Item Quantity
-     * Fact ID: fact.salesdetailfact.menuitemquantity
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.salesdetailfact.menuitemquantity", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Menu Item Quantity
      * Fact ID: fact.salesdetailfact.menuitemquantity
@@ -796,11 +773,6 @@ export const Population = {
     /**
      * Fact Title: Population
      * Fact ID: fact.uscities.population
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.uscities.population", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Population
-     * Fact ID: fact.uscities.population
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.uscities.population", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -835,13 +807,6 @@ export const ScheduledCost = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.restaurantcostsfact.scheduledcost", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Scheduled Cost
-     * Fact ID: fact.restaurantcostsfact.scheduledcost
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.restaurantcostsfact.scheduledcost", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Scheduled Cost
      * Fact ID: fact.restaurantcostsfact.scheduledcost
@@ -2510,9 +2475,7 @@ export const Date4Date = {
      * Display Form ID: date_4.date.eddmmyyyy
      */ DdMmYyyy_1: newAttribute("date_4.date.eddmmyyyy"),
 };
-/**
- * Available Date Data Sets
- */
+/** Available Date Data Sets */
 export const DateDatasets = {
     /**
      * Date Data Set Title: Date (Date)
@@ -4618,9 +4581,9 @@ export const Insights = {
      * Insight ID: aa0wmZDugnUX
      */ TestPzb: "aa0wmZDugnUX",
     /**
-     * Insight Title: # Checks viewed by City stacked by Location
+     * Insight Title: New Name of This Insight
      * Insight ID: aby6oS6DbpFX
-     */ NrChecksViewedByCityStackedByLocation: "aby6oS6DbpFX",
+     */ NewNameOfThisInsight: "aby6oS6DbpFX",
     /**
      * Insight Title: Kyle's Insight
      * Insight ID: aazlme4wcy3O
@@ -4937,4 +4900,111 @@ export const Insights = {
      * Insight Title: # Checks viewed by City stacked by Location - Table
      * Insight ID: aaJlFFkiaChA
      */ NrChecksViewedByCityStackedByLocationTable: "aaJlFFkiaChA",
+    /**
+     * Insight Title: DashboardEmbedding Insight
+     * Insight ID: abcolHjKeIB4
+     */ DashboardEmbeddingInsight: "abcolHjKeIB4",
+    /**
+     * Insight Title: Table applied measure format
+     * Insight ID: aajIe1OvcX5N
+     */ TableAppliedMeasureFormat: "aajIe1OvcX5N",
+    /**
+     * Insight Title: Column has measure format
+     * Insight ID: aafIHIqgireP
+     */ ColumnHasMeasureFormat: "aafIHIqgireP",
+    /**
+     * Insight Title: Example for Zach
+     * Insight ID: adLqfV3peeRI
+     */ ExampleForZach: "adLqfV3peeRI",
+    /**
+     * Insight Title: Seznam Příklad #1
+     * Insight ID: adotZaCGaEeP
+     */ SeznamPKladNr1: "adotZaCGaEeP",
+    /**
+     * Insight Title: sdfg
+     * Insight ID: ajhtO3DggLVY
+     */ Sdfg: "ajhtO3DggLVY",
+    /**
+     * Insight Title: Example #1
+     * Insight ID: adRuvTAwaTcq
+     */ ExampleNr1: "adRuvTAwaTcq",
+    /**
+     * Insight Title: New Table report Labor Costs Vs Scheduled Costs test
+     * Insight ID: abg18hRDbYS9
+     */ NewTableReportLaborCostsVsScheduledCostsTest: "abg18hRDbYS9",
+    /**
+     * Insight Title: My Insight
+     * Insight ID: afStbARxcOjh
+     */ MyInsight: "afStbARxcOjh",
+};
+export const Dashboards = {
+    /**
+     * Dashboard Title: KPIs
+     * Dashboard ID: afMA17GSbk31
+     */
+    KPIs: "afMA17GSbk31",
+    /**
+     * Dashboard Title: Store management KPIs
+     * Dashboard ID: abBJlnxrfEWH
+     */ StoreManagementKPIs: "abBJlnxrfEWH",
+    /**
+     * Dashboard Title: Untitled
+     * Dashboard ID: aa58UihrdgMg
+     */ Untitled: "aa58UihrdgMg",
+    /**
+     * Dashboard Title: KPIs Drill
+     * Dashboard ID: aby7cMBNeo0Y
+     */ KPIsDrill: "aby7cMBNeo0Y",
+    /**
+     * Dashboard Title: KPIs Embedded in React Native App
+     * Dashboard ID: abKH4eEFdBWS
+     */ KPIsEmbeddedInReactNativeApp: "abKH4eEFdBWS",
+    /**
+     * Dashboard Title: KPIs Underlined
+     * Dashboard ID: abTIt0ngdlUH
+     */ KPIsUnderlined: "abTIt0ngdlUH",
+    /**
+     * Dashboard Title: Untitled
+     * Dashboard ID: abpB9XpmbvjA
+     */ Untitled_1: "abpB9XpmbvjA",
+    /**
+     * Dashboard Title: KPIs Drill #2 - From
+     * Dashboard ID: abVweo3WfQgQ
+     */ KPIsDrillNr2From: "abVweo3WfQgQ",
+    /**
+     * Dashboard Title: KPIs Drill #2 - To
+     * Dashboard ID: aeRv67kib7Cg
+     */ KPIsDrillNr2To: "aeRv67kib7Cg",
+    /**
+     * Dashboard Title: Filter
+     * Dashboard ID: aaZ5WGrqfHsr
+     */ Filter: "aaZ5WGrqfHsr",
+    /**
+     * Dashboard Title: Dependent Filters
+     * Dashboard ID: aaBLkHnSfrBI
+     */ DependentFilters: "aaBLkHnSfrBI",
+    /**
+     * Dashboard Title: bar chart
+     * Dashboard ID: abHCFBGphqKh
+     */ BarChart_1: "abHCFBGphqKh",
+    /**
+     * Dashboard Title: DashboardEmbedding
+     * Dashboard ID: aeO5PVgShc0T
+     */ DashboardEmbedding: "aeO5PVgShc0T",
+    /**
+     * Dashboard Title: DashboardEmbedding-geo
+     * Dashboard ID: adsENtJ9e8ov
+     */ DashboardEmbeddingGeo: "adsENtJ9e8ov",
+    /**
+     * Dashboard Title: Untitled
+     * Dashboard ID: aesp8GtihI8o
+     */ Untitled_2: "aesp8GtihI8o",
+    /**
+     * Dashboard Title: Tu
+     * Dashboard ID: afGV15Ieg0Vr
+     */ Tu: "afGV15Ieg0Vr",
+    /**
+     * Dashboard Title: Untitled
+     * Dashboard ID: agAs5ICLaHEh
+     */ Untitled_3: "agAs5ICLaHEh",
 };

--- a/tools/reference-workspace/src/ldm/full.ts
+++ b/tools/reference-workspace/src/ldm/full.ts
@@ -1,7 +1,6 @@
-// (C) 2020 GoodData Corporation
-
 /* eslint-disable */
-/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2020-11-20T08:05:53.360Z; */
+/* THIS FILE WAS AUTO-GENERATED USING CATALOG EXPORTER; YOU SHOULD NOT EDIT THIS FILE; GENERATE TIME: 2021-06-21T15:11:23.718Z; */
+// @ts-ignore ignore unused imports here if they happen (e.g. when there is no measure in the workspace)
 import {
     newAttribute,
     newMeasure,
@@ -245,11 +244,6 @@ export const ActivityDate = {
     /**
      * Fact Title: Activity (Date)
      * Fact ID: dt.activity.activity
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.activity.activity", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Activity (Date)
-     * Fact ID: dt.activity.activity
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.activity.activity", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -287,11 +281,6 @@ export const Amount_1 = {
     /**
      * Fact Title: Amount
      * Fact ID: fact.opportunitysnapshot.amount
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.amount", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Amount
-     * Fact ID: fact.opportunitysnapshot.amount
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.opportunitysnapshot.amount", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -326,13 +315,6 @@ export const DaysToClose = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.opportunitysnapshot.daystoclose", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Days to Close
-     * Fact ID: fact.opportunitysnapshot.daystoclose
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.daystoclose", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Days to Close
      * Fact ID: fact.opportunitysnapshot.daystoclose
@@ -377,11 +359,6 @@ export const Duration = {
     /**
      * Fact Title: Duration
      * Fact ID: fact.stagehistory.duration
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.stagehistory.duration", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Duration
-     * Fact ID: fact.stagehistory.duration
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.stagehistory.duration", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -416,11 +393,6 @@ export const OppCloseDate = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("dt.opportunitysnapshot.closedate", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Opp. Close (Date)
-     * Fact ID: dt.opportunitysnapshot.closedate
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunitysnapshot.closedate", "fact"), (m) => m.aggregation("count")),
     /**
      * Fact Title: Opp. Close (Date)
      * Fact ID: dt.opportunitysnapshot.closedate
@@ -461,11 +433,6 @@ export const OppCreatedDate = {
     /**
      * Fact Title: Opp. Created (Date)
      * Fact ID: dt.opportunity.oppcreated
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunity.oppcreated", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Opp. Created (Date)
-     * Fact ID: dt.opportunity.oppcreated
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.opportunity.oppcreated", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -500,13 +467,6 @@ export const OppSnapshotDate = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("dt.opportunitysnapshot.snapshotdate", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Opp. Snapshot (Date)
-     * Fact ID: dt.opportunitysnapshot.snapshotdate
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.opportunitysnapshot.snapshotdate", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
     /**
      * Fact Title: Opp. Snapshot (Date)
      * Fact ID: dt.opportunitysnapshot.snapshotdate
@@ -551,13 +511,6 @@ export const Probability_1 = {
     /**
      * Fact Title: Probability
      * Fact ID: fact.opportunitysnapshot.probability
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.opportunitysnapshot.probability", "fact"), (m) =>
-        m.aggregation("count"),
-    ),
-    /**
-     * Fact Title: Probability
-     * Fact ID: fact.opportunitysnapshot.probability
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("fact.opportunitysnapshot.probability", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -599,11 +552,6 @@ export const TimelineDate = {
     /**
      * Fact Title: Timeline (Date)
      * Fact ID: dt.timeline.timeline
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("dt.timeline.timeline", "fact"), (m) => m.aggregation("count")),
-    /**
-     * Fact Title: Timeline (Date)
-     * Fact ID: dt.timeline.timeline
      * Fact Aggregation: avg
      */ Avg: newMeasure(idRef("dt.timeline.timeline", "fact"), (m) => m.aggregation("avg")),
     /**
@@ -638,11 +586,6 @@ export const Velocity = {
      * Fact Aggregation: sum
      */
     Sum: newMeasure(idRef("fact.stagehistory.velocity", "fact"), (m) => m.aggregation("sum")),
-    /**
-     * Fact Title: Velocity
-     * Fact ID: fact.stagehistory.velocity
-     * Fact Aggregation: count
-     */ Count: newMeasure(idRef("fact.stagehistory.velocity", "fact"), (m) => m.aggregation("count")),
     /**
      * Fact Title: Velocity
      * Fact ID: fact.stagehistory.velocity
@@ -1839,9 +1782,7 @@ export const TimelineDate_1 = {
      * Display Form ID: timeline.date.eddmmyyyy
      */ DdMmYyyy_1: newAttribute("timeline.date.eddmmyyyy"),
 };
-/**
- * Available Date Data Sets
- */
+/** Available Date Data Sets */
 export const DateDatasets = {
     /**
      * Date Data Set Title: Date (Created)
@@ -3348,4 +3289,39 @@ export const Insights = {
      * Insight Title: test insight
      * Insight ID: abkBnI1zd28W
      */ TestInsight_2: "abkBnI1zd28W",
+    /**
+     * Insight Title: table with multiple measures
+     * Insight ID: aegg7T2lgUh7
+     */ TableWithMultipleMeasures: "aegg7T2lgUh7",
+};
+export const Dashboards = {
+    /**
+     * Dashboard Title: simple dashboard
+     * Dashboard ID: aaRaEZRWdRpQ
+     */
+    SimpleDashboard: "aaRaEZRWdRpQ",
+    /**
+     * Dashboard Title: test
+     * Dashboard ID: aba3ZlEEgNsV
+     */ Test_3: "aba3ZlEEgNsV",
+    /**
+     * Dashboard Title: Kpi Export Test secure
+     * Dashboard ID: aaM7WfnqiukA
+     */ KpiExportTestSecure: "aaM7WfnqiukA",
+    /**
+     * Dashboard Title: Kpi Export Test secure 2
+     * Dashboard ID: adO7HK4vfVnf
+     */ KpiExportTestSecure2: "adO7HK4vfVnf",
+    /**
+     * Dashboard Title: test2
+     * Dashboard ID: acXeSCq5c0R7
+     */ Test2_1: "acXeSCq5c0R7",
+    /**
+     * Dashboard Title: test3
+     * Dashboard ID: afLe7WFTeYmc
+     */ Test3: "afLe7WFTeYmc",
+    /**
+     * Dashboard Title: Dashboard With 3 Sections
+     * Dashboard ID: aeis6NlXcL7X
+     */ DashboardWith3Sections: "aeis6NlXcL7X",
 };


### PR DESCRIPTION
* RAIL-3497 - do not generate "count" aggregations for Facts in catalog-export - it never made sense and would bomb
* RAIL-3502 - improve text legibility in Theme examples
* RAIL-3511 - exclude sdk-ui-dashboard from apidocs builds
---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
