### PR TITLE
RELATED: ONE-5099 Use dates when switching to column/bar charts

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -502,6 +502,29 @@ describe("PluggableColumnBarCharts", () => {
                     },
                 ],
                 [
+                    "from treemap to column chart: multiple measures and date in stack: should limit measures to one",
+                    referencePointMocks.onlyStackTreemapMultipleMeasures,
+                    {
+                        buckets: [
+                            {
+                                localIdentifier: "measures",
+                                items: referencePointMocks.onlyStackTreemapMultipleMeasures.buckets[0].items.slice(
+                                    0,
+                                    1,
+                                ),
+                            },
+                            {
+                                localIdentifier: "view",
+                                items: [],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: referencePointMocks.onlyStackTreemapMultipleMeasures.buckets[2].items,
+                            },
+                        ],
+                    },
+                ],
+                [
                     "Simulate adding pop measure:  With measure and derived measure and two date in view and date in stack",
                     referencePointMocks.measureWithDerivedAsFirstWithDateInStackRefPoint,
                     {

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -1488,6 +1488,27 @@ export const onlyStackColumnChart: IReferencePoint = {
     },
 };
 
+export const onlyStackTreemapMultipleMeasures: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems,
+        },
+        {
+            localIdentifier: "view",
+            items: [],
+        },
+        {
+            localIdentifier: "segment",
+            items: [dateItem],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
 export const multipleDatesInRowsOnly: IReferencePoint = {
     buckets: [
         {

--- a/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketHelper.ts
@@ -710,7 +710,7 @@ export function hasDerivedBucketItems(masterBucketItem: IBucketItem, buckets: IB
 }
 
 export function getFilteredMeasuresForStackedCharts(buckets: IBucketOfFun[]): IBucketItem[] {
-    const hasStacks = getStackItems(buckets).length > 0;
+    const hasStacks = getStackItems(buckets, [ATTRIBUTE, DATE]).length > 0;
     if (hasStacks) {
         const limitedBuckets = limitNumberOfMeasuresInBuckets(buckets, 1);
         return getMeasureItems(limitedBuckets);


### PR DESCRIPTION
JIRA: ONE-5099


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)