### PR TITLE
RELATED: RAIL-3511 Allow build-docs to take a CLI parameter

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -235,6 +235,15 @@
    * For example, you might define a "--production" parameter for the "rush build" command.
    */
   "parameters": [
+    {
+      "parameterKind": "string",
+      "longName": "--version",
+      "shortName": "-v",
+      "description": "Which version to create (e.g. 8.4.0 or Next for a prerelease version). This is case sensitive.",
+      "associatedCommands": ["build-docs"],
+      "required": false,
+      "argumentName": "VERSION"
+    }
     // {
     //   /**
     //    * (Required) Determines the type of custom parameter.

--- a/common/scripts/build-docs.sh
+++ b/common/scripts/build-docs.sh
@@ -1,6 +1,24 @@
 #!/bin/bash
-echo "Please input documentation version (ex. 8.4.0 or 'Next' for prerelease documentation):"
-read VERSION
+# parse cli arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+
+  case $key in
+    -v|--version)
+      VERSION="$2"
+      shift # past argument
+      shift # past value
+      ;;
+  esac
+done
+
+# if no version was provided via the command line, ask for it interactivelly
+if [ -z "$VERSION" ]
+then
+    echo "Please input documentation version (ex. 8.4.0 or 'Next' for prerelease documentation):"
+    read VERSION
+fi
+
 echo "Start creating docs v${VERSION}"
 
 DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))


### PR DESCRIPTION
To be able to run build-docs in a CI context, we need it to take
the version value from CLI (not interactively).

JIRA: RAIL-3511

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
