### PR TITLE
RELATED: ONE-5096 Stacked: Cannot add both date and attribute in View by

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -205,16 +205,15 @@ describe("PluggableAreaChart", () => {
                                 items: [
                                     referencePointMocks
                                         .twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
-                                        .buckets[1].items[2],
+                                        .buckets[1].items[0],
+                                    referencePointMocks
+                                        .twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
+                                        .buckets[1].items[1],
                                 ],
                             },
                             {
                                 localIdentifier: "stack",
-                                items: [
-                                    referencePointMocks
-                                        .twoAttributesAndDateInRowsAndOneDateInColumnsReferencePoint
-                                        .buckets[1].items[0],
-                                ],
+                                items: [],
                             },
                         ],
                     },
@@ -250,7 +249,7 @@ describe("PluggableAreaChart", () => {
                                 localIdentifier: "view",
                                 items: [
                                     referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint
-                                        .buckets[1].items[1],
+                                        .buckets[1].items[0],
                                 ],
                             },
                             {
@@ -273,21 +272,20 @@ describe("PluggableAreaChart", () => {
                                 localIdentifier: "view",
                                 items: [
                                     referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[1]
+                                        .items[0],
+                                    referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[1]
                                         .items[1],
                                 ],
                             },
                             {
                                 localIdentifier: "stack",
-                                items: [
-                                    referencePointMocks.dateAsSecondViewByItemReferencePoint.buckets[1]
-                                        .items[0],
-                                ],
+                                items: [],
                             },
                         ],
                     },
                 ],
                 [
-                    "from colum chart to area chart: att1 and date1 in viewBy and empty stackBy",
+                    "from colum chart to area chart: date1 and att1 in viewBy and empty stackBy",
                     referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy,
                     {
                         buckets: [
@@ -297,14 +295,13 @@ describe("PluggableAreaChart", () => {
                                 items: [
                                     referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[1]
                                         .items[0],
+                                    referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[1]
+                                        .items[1],
                                 ],
                             },
                             {
                                 localIdentifier: "stack",
-                                items: [
-                                    referencePointMocks.dateAndAttributeInViewByAndEmptyStackBy.buckets[1]
-                                        .items[1],
-                                ],
+                                items: [],
                             },
                         ],
                     },


### PR DESCRIPTION
 - disable date priority while switching from any chart to area chart in getExtendedReferencePoint
 - bug fix create area chart with one date and one att

JIRA: ONE-5096

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
