### PR TITLE
Do not generate BY ALL condition when attribute missing

### DIFF
--- a/libs/api-client-bear/src/execution/experimental-executions.ts
+++ b/libs/api-client-bear/src/execution/experimental-executions.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import SparkMD5 from "spark-md5";
 import invariant from "ts-invariant";
 import cloneDeep from "lodash/cloneDeep";
@@ -178,9 +178,10 @@ function getPercentMetricExpression(category: any, attributesMap: any, measure: 
         map(getMeasureFilters(measure), partial(getFilterExpression, attributesMap)),
         (e) => !!e,
     );
+    const byAllExpression = attributeUri ? ` BY ALL [${attributeUri}]` : "";
     const whereExpression = notEmpty(...whereFilters) ? ` WHERE ${whereFilters.join(" AND ")}` : "";
 
-    return `SELECT (${metricExpressionWithoutFilters}${whereExpression}) / (${metricExpressionWithoutFilters} BY ALL [${attributeUri}]${whereExpression})`;
+    return `SELECT (${metricExpressionWithoutFilters}${whereExpression}) / (${metricExpressionWithoutFilters}${byAllExpression}${whereExpression})`;
 }
 
 function getPoPExpression(attributeUri: string, metricExpression: string) {

--- a/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
+++ b/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import range from "lodash/range";
@@ -1176,6 +1176,83 @@ describe("execution", () => {
                                     "BY ALL [" +
                                     mdEndpoint +
                                     "/1027] " +
+                                    "WHERE [" +
+                                    mdEndpoint +
+                                    "/42] " +
+                                    "IN ([" +
+                                    mdEndpoint +
+                                    "/42/elements?id=61527])" +
+                                    ")",
+                                format: "#,##0.00%",
+                            },
+                            execConfig,
+                        );
+                    });
+            });
+
+            it("for generated measure with attribute filters without BY ALL expression", () => {
+                const mdObjContributionCloned = cloneDeep(mdObjContribution);
+                mdObjContributionCloned.buckets[0] = {
+                    localIdentifier: "measures",
+                    items: [
+                        {
+                            measure: {
+                                localIdentifier: "m1",
+                                definition: {
+                                    measureDefinition: {
+                                        item: {
+                                            uri: mdEndpoint + "/1",
+                                        },
+                                        computeRatio: true,
+                                        aggregation: "sum",
+                                        filters: [
+                                            {
+                                                positiveAttributeFilter: {
+                                                    displayForm: {
+                                                        uri: mdEndpoint + "/43",
+                                                    },
+                                                    in: [mdEndpoint + "/42/elements?id=61527"],
+                                                },
+                                            },
+                                        ],
+                                    },
+                                },
+                                title: "% Sum of Amount",
+                                format: "#,##0.00",
+                            },
+                        },
+                    ],
+                };
+                const missingAttr = "/gdc/md/qamfsd9cw85e53mcqs74k8a0mwbf5gc2/obj/1029";
+                mdObjContributionCloned.buckets[1].items[0].visualizationAttribute.displayForm.uri =
+                    missingAttr;
+
+                return createExecution()
+                    .mdToExecutionDefinitionsAndColumns(
+                        "qamfsd9cw85e53mcqs74k8a0mwbf5gc2",
+                        mdObjContributionCloned,
+                    )
+                    .then((execConfig: any) => {
+                        expectMetricDefinition(
+                            {
+                                title: "% Sum of Amount",
+                                identifier:
+                                    "fact_qamfsd9cw85e53mcqs74k8a0mwbf5gc2_1.generated.e37e27d5a6d61fe71d56d7ae7a7655ac_filtered_percent",
+                                expression:
+                                    "SELECT (" +
+                                    "SELECT SUM([" +
+                                    mdEndpoint +
+                                    "/1]) " +
+                                    "WHERE [" +
+                                    mdEndpoint +
+                                    "/42] " +
+                                    "IN ([" +
+                                    mdEndpoint +
+                                    "/42/elements?id=61527])" +
+                                    ") / (" +
+                                    "SELECT SUM([" +
+                                    mdEndpoint +
+                                    "/1]) " +
                                     "WHERE [" +
                                     mdEndpoint +
                                     "/42] " +


### PR DESCRIPTION
- applies during "show in percent"

JIRA: ONE-4983


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)