### PR TITLE
Fix placeholder type signatures

### DIFF
--- a/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
+++ b/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
@@ -4,26 +4,28 @@
 
 ```ts
 
-import { AnyMeasure } from '@gooddata/sdk-ui';
+import { AttributeMeasureOrPlaceholder } from '@gooddata/sdk-ui';
+import { AttributeOrPlaceholder } from '@gooddata/sdk-ui';
+import { AttributesMeasuresOrPlaceholders } from '@gooddata/sdk-ui';
+import { AttributesOrPlaceholders } from '@gooddata/sdk-ui';
 import { ChartType } from '@gooddata/sdk-ui';
 import { ColorUtils } from '@gooddata/sdk-ui-vis-commons';
+import { FiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
-import { IAttribute } from '@gooddata/sdk-model';
 import { IColorMapping } from '@gooddata/sdk-ui-vis-commons';
 import { IColorPalette } from '@gooddata/sdk-model';
 import { Identifier } from '@gooddata/sdk-model';
-import { IFilter } from '@gooddata/sdk-model';
-import { INullableFilter } from '@gooddata/sdk-model';
 import { IPreparedExecution } from '@gooddata/sdk-backend-spi';
 import { ISeparators } from '@gooddata/numberjs';
 import { ISettings } from '@gooddata/sdk-backend-spi';
-import { ISortItem } from '@gooddata/sdk-model';
 import { ITheme } from '@gooddata/sdk-backend-spi';
 import { IVisualizationCallbacks } from '@gooddata/sdk-ui';
 import { IVisualizationProps } from '@gooddata/sdk-ui';
+import { MeasureOrPlaceholder } from '@gooddata/sdk-ui';
+import { MeasuresOrPlaceholders } from '@gooddata/sdk-ui';
+import { NullableFiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { default as React_2 } from 'react';
-import { ValueOrPlaceholder } from '@gooddata/sdk-ui';
-import { ValuesOrPlaceholders } from '@gooddata/sdk-ui';
+import { SortsOrPlaceholders } from '@gooddata/sdk-ui';
 import { VisType } from '@gooddata/sdk-ui';
 
 // @public
@@ -78,12 +80,12 @@ export const Heatmap: (props: IHeatmapProps) => JSX.Element;
 
 // @public (undocumented)
 export interface IAreaChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    stackBy?: ValueOrPlaceholder<IAttribute>;
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    stackBy?: AttributeOrPlaceholder;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -109,12 +111,12 @@ export interface IAxisNameConfig {
 
 // @public (undocumented)
 export interface IBarChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    stackBy?: ValueOrPlaceholder<IAttribute>;
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    stackBy?: AttributeOrPlaceholder;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -133,13 +135,13 @@ export interface IBaseChartProps extends ICoreChartProps {
 
 // @public (undocumented)
 export interface IBubbleChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    size?: ValueOrPlaceholder<AnyMeasure>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    viewBy?: ValueOrPlaceholder<IAttribute>;
-    xAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
-    yAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    size?: MeasureOrPlaceholder;
+    sortBy?: SortsOrPlaceholders;
+    viewBy?: AttributeOrPlaceholder;
+    xAxisMeasure?: MeasureOrPlaceholder;
+    yAxisMeasure?: MeasureOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -154,13 +156,13 @@ export interface IBucketChartProps extends ICommonChartProps {
 
 // @public (undocumented)
 export interface IBulletChartBucketProps {
-    comparativeMeasure?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    comparativeMeasure?: AttributeMeasureOrPlaceholder;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    primaryMeasure: ValueOrPlaceholder<IAttribute | AnyMeasure>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    targetMeasure?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    primaryMeasure: AttributeMeasureOrPlaceholder;
+    sortBy?: SortsOrPlaceholders;
+    targetMeasure?: AttributeMeasureOrPlaceholder;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -226,12 +228,12 @@ export { IColorMapping }
 
 // @public (undocumented)
 export interface IColumnChartBucketProps {
-    filters?: ValuesOrPlaceholders<IFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: FiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    stackBy?: ValueOrPlaceholder<IAttribute>;
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    stackBy?: AttributeOrPlaceholder;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -240,12 +242,12 @@ export interface IColumnChartProps extends IBucketChartProps, IColumnChartBucket
 
 // @public (undocumented)
 export interface IComboChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    primaryMeasures?: ValuesOrPlaceholders<AnyMeasure>;
-    secondaryMeasures?: ValuesOrPlaceholders<AnyMeasure>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    primaryMeasures?: MeasuresOrPlaceholders;
+    secondaryMeasures?: MeasuresOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -284,11 +286,11 @@ export type IDataPointsVisible = boolean | "auto";
 
 // @public (undocumented)
 export interface IDonutChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValueOrPlaceholder<IAttribute | AnyMeasure> | ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributeMeasureOrPlaceholder | AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    viewBy?: AttributeOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -297,11 +299,11 @@ export interface IDonutChartProps extends IBucketChartProps, IDonutChartBucketPr
 
 // @public (undocumented)
 export interface IFunnelChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    viewBy?: AttributeOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -316,10 +318,10 @@ export interface IGridConfig {
 
 // @public (undocumented)
 export interface IHeadlineBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    primaryMeasure: ValueOrPlaceholder<AnyMeasure>;
-    secondaryMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    primaryMeasure: MeasureOrPlaceholder;
+    secondaryMeasure?: MeasureOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -328,12 +330,12 @@ export interface IHeadlineProps extends IBucketChartProps, IHeadlineBucketProps 
 
 // @public (undocumented)
 export interface IHeatmapBucketProps {
-    columns?: ValueOrPlaceholder<IAttribute>;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measure: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    columns?: AttributeOrPlaceholder;
+    filters?: NullableFiltersOrPlaceholders;
+    measure: AttributeMeasureOrPlaceholder;
     placeholdersResolutionContext?: any;
-    rows?: ValueOrPlaceholder<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    rows?: AttributeOrPlaceholder;
+    sortBy?: SortsOrPlaceholders;
 }
 
 // @public (undocumented)
@@ -365,12 +367,12 @@ export interface ILegendItem {
 
 // @public (undocumented)
 export interface ILineChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    trendBy?: ValueOrPlaceholder<IAttribute>;
+    segmentBy?: AttributeOrPlaceholder;
+    sortBy?: SortsOrPlaceholders;
+    trendBy?: AttributeOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -379,11 +381,11 @@ export interface ILineChartProps extends IBucketChartProps, ILineChartBucketProp
 
 // @public (undocumented)
 export interface IPieChartBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    sortBy?: SortsOrPlaceholders;
+    viewBy?: AttributeOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -404,12 +406,12 @@ export const isBulletChart: import("lodash/fp").LodashIsEqual1x1;
 
 // @public (undocumented)
 export interface IScatterPlotBucketProps {
-    attribute?: ValueOrPlaceholder<IAttribute>;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    attribute?: AttributeOrPlaceholder;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    xAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
-    yAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    sortBy?: SortsOrPlaceholders;
+    xAxisMeasure?: MeasureOrPlaceholder;
+    yAxisMeasure?: MeasureOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -450,11 +452,11 @@ export interface ITooltipConfig {
 
 // @public (undocumented)
 export interface ITreemapBucketProps {
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    filters?: NullableFiltersOrPlaceholders;
+    measures: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    segmentBy?: AttributeOrPlaceholder;
+    viewBy?: AttributeOrPlaceholder;
 }
 
 // @public (undocumented)
@@ -463,9 +465,9 @@ export interface ITreemapProps extends IBucketChartProps, ITreemapBucketProps {
 
 // @beta (undocumented)
 export interface IXirrBucketProps {
-    attribute?: ValueOrPlaceholder<IAttribute>;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measure: ValueOrPlaceholder<AnyMeasure>;
+    attribute?: AttributeOrPlaceholder;
+    filters?: NullableFiltersOrPlaceholders;
+    measure: MeasureOrPlaceholder;
     placeholdersResolutionContext?: any;
 }
 

--- a/libs/sdk-ui-charts/src/charts/areaChart/AreaChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/areaChart/AreaChart.tsx
@@ -11,11 +11,13 @@ import {
 import { truncate } from "../_commons/truncate";
 import { IBucketChartProps, IChartConfig, ViewByAttributesLimit } from "../../interfaces";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    AttributeOrPlaceholder,
+    AttributesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { stackedChartDimensions } from "../_commons/dimensions";
 import { CoreAreaChart } from "./CoreAreaChart";
@@ -146,7 +148,7 @@ export interface IAreaChartBucketProps {
      * Note: it is possible to also include an attribute object among measures. In that case cardinality of the
      * attribute elements will be charted.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify attributes to slice and optionally stack the area chart.
@@ -163,7 +165,7 @@ export interface IAreaChartBucketProps {
      * stackBy attribute. In either case, as soon as the area chart is stacked, only the first measure will be
      * calculated and charted.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 
     /**
      * Optionally specify attribute to stack by. This is only applicable if you specify at most single viewBy
@@ -172,17 +174,17 @@ export interface IAreaChartBucketProps {
      * Note: stacking area chart using attribute elements means only a single measure can be charted. The component
      * will take the first measure.
      */
-    stackBy?: ValueOrPlaceholder<IAttribute>;
+    stackBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/barChart/BarChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/barChart/BarChart.tsx
@@ -5,15 +5,16 @@ import {
     IAttribute,
     IAttributeOrMeasure,
     IFilter,
-    INullableFilter,
     ISortItem,
     newBucket,
 } from "@gooddata/sdk-model";
 import {
     BucketNames,
-    ValuesOrPlaceholders,
-    ValueOrPlaceholder,
-    AnyMeasure,
+    AttributesMeasuresOrPlaceholders,
+    AttributeOrPlaceholder,
+    AttributesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
     useResolveValuesWithPlaceholders,
 } from "@gooddata/sdk-ui";
 import { IBucketChartProps, ViewByAttributesLimit } from "../../interfaces";
@@ -73,7 +74,7 @@ export interface IBarChartBucketProps {
      * Note: it is possible to also include an attribute object among measures. In that case cardinality of the
      * attribute elements will be charted.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify one or two attributes to slice the measures along the Y axis.
@@ -82,22 +83,22 @@ export interface IBarChartBucketProps {
      * value of the first attribute there will be all applicable values of the second attribute. For each value of the
      * second attribute there will be a bar indicating the respective slice's value.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 
     /**
      * Optionally specify attribute to stack the bars by.
      */
-    stackBy?: ValueOrPlaceholder<IAttribute>;
+    stackBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/bubbleChart/BubbleChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/bubbleChart/BubbleChart.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { IAttribute, IMeasure, INullableFilter, ISortItem, newBucket } from "@gooddata/sdk-model";
 import { IBucketChartProps } from "../../interfaces";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    MeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { pointyChartDimensions } from "../_commons/dimensions";
 import { CoreBubbleChart } from "./CoreBubbleChart";
@@ -53,32 +54,32 @@ export interface IBubbleChartBucketProps {
     /**
      * Optionally specify measure which will be used to position bubbles on the X axis.
      */
-    xAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    xAxisMeasure?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify measure which will be used to position bubbles on the Y axis
      */
-    yAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    yAxisMeasure?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify measure which will be used to determine the size of each bubble.
      */
-    size?: ValueOrPlaceholder<AnyMeasure>;
+    size?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify attribute whose values will be used to create the bubbles.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    viewBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/bulletChart/BulletChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/bulletChart/BulletChart.tsx
@@ -9,11 +9,13 @@ import {
     newBucket,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    SortsOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    AttributesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { IBucketChartProps, ViewByAttributesLimit } from "../../interfaces";
 import { truncate } from "../_commons/truncate";
@@ -91,18 +93,18 @@ export interface IBulletChartBucketProps {
     /**
      * Specify primary measure. This will be charted as the primary bar.
      */
-    primaryMeasure: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    primaryMeasure: AttributeMeasureOrPlaceholder;
 
     /**
      * Optionally specify measure which contains the target/goal value. The value will be charted as the thick
      * line to reach.
      */
-    targetMeasure?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    targetMeasure?: AttributeMeasureOrPlaceholder;
 
     /**
      * Optionally specify measure to use for comparison. This will be charted as the secondary bar.
      */
-    comparativeMeasure?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    comparativeMeasure?: AttributeMeasureOrPlaceholder;
 
     /**
      * Optionally specify one or two attributes to use for slicing the measures.
@@ -111,17 +113,17 @@ export interface IBulletChartBucketProps {
      * value of the first attribute there will be all applicable values of the second attribute. For each value of the
      * second attribute, there will be a bullet.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/columnChart/ColumnChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/columnChart/ColumnChart.tsx
@@ -10,11 +10,13 @@ import {
 } from "@gooddata/sdk-model";
 import { truncate } from "../_commons/truncate";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributeOrPlaceholder,
+    AttributesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    FiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { stackedChartDimensions } from "../_commons/dimensions";
 import { IBucketChartProps, ViewByAttributesLimit } from "../../interfaces";
@@ -72,7 +74,7 @@ export interface IColumnChartBucketProps {
      * Note: it is possible to also include an attribute object among measures. In that case cardinality of the
      * attribute elements will be charted.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify one or two attributes to slice the measures along the X axis.
@@ -81,22 +83,22 @@ export interface IColumnChartBucketProps {
      * value of the first attribute there will be all applicable values of the second attribute. For each value of the
      * second attribute there will be a column indicating the respective slice's value.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 
     /**
      * Optionally specify attribute to stack the bars by.
      */
-    stackBy?: ValueOrPlaceholder<IAttribute>;
+    stackBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<IFilter>;
+    filters?: FiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/comboChart/ComboChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/comboChart/ComboChart.tsx
@@ -10,10 +10,12 @@ import {
     newBucket,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    MeasuresOrPlaceholders,
+    AttributeOrPlaceholder,
+    AttributesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
     useResolveValuesWithPlaceholders,
 } from "@gooddata/sdk-ui";
 import { defaultDimensions } from "../_commons/dimensions";
@@ -92,12 +94,12 @@ export interface IComboChartBucketProps {
     /**
      * Optionally specify primary measures to render using the primary chart type.
      */
-    primaryMeasures?: ValuesOrPlaceholders<AnyMeasure>;
+    primaryMeasures?: MeasuresOrPlaceholders;
 
     /**
      * Optionally specify secondary measures to render using the secondary chart type.
      */
-    secondaryMeasures?: ValuesOrPlaceholders<AnyMeasure>;
+    secondaryMeasures?: MeasuresOrPlaceholders;
 
     /**
      * Optionally specify one or two attributes to use for slicing the measure values along the
@@ -107,17 +109,17 @@ export interface IComboChartBucketProps {
      * value of the first attribute there will be all applicable values of the second attribute. For each value of the
      * second attribute there will be a point/column/area indicating the respective slice's value.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute> | ValuesOrPlaceholders<IAttribute>;
+    viewBy?: AttributeOrPlaceholder | AttributesOrPlaceholders;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/donutChart/DonutChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/donutChart/DonutChart.tsx
@@ -2,11 +2,13 @@
 import React from "react";
 import { IAttribute, IAttributeOrMeasure, INullableFilter, ISortItem, newBucket } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    AttributesMeasuresOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { roundChartDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -61,23 +63,23 @@ export interface IDonutChartBucketProps {
      * If you specify multiple measures, then there will be a donut slice for each measure value. You may not
      * specify the viewBy in this case.
      */
-    measures: ValueOrPlaceholder<IAttribute | AnyMeasure> | ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributeMeasureOrPlaceholder | AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify viewBy attribute that will be used to create the donut slices. There will be a slice
      * for each value of the attribute.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    viewBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/funnelChart/FunnelChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/funnelChart/FunnelChart.tsx
@@ -1,12 +1,13 @@
 // (C) 2007-2018 GoodData Corporation
 import React from "react";
-import { IAttribute, IAttributeOrMeasure, INullableFilter, ISortItem, newBucket } from "@gooddata/sdk-model";
+import { IAttribute, IAttributeOrMeasure, INullableFilter, newBucket } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    AttributeOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { roundChartDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -55,23 +56,23 @@ export interface IFunnelChartBucketProps {
      *
      * If you specify multiple measures, then those calculate measure values will be charted into a funnel.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify attribute that will be used to slice the single measure into multiple pieces that
      * will be charted into a funnel.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    viewBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/headline/Headline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/Headline.tsx
@@ -3,13 +3,12 @@ import React from "react";
 import { IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { IBucket, IMeasure, INullableFilter, newBucket } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     Subtract,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
     withContexts,
+    MeasureOrPlaceholder,
+    NullableFiltersOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { IBucketChartProps, ICoreChartProps } from "../../interfaces";
 import { CoreHeadline } from "./CoreHeadline";
@@ -27,18 +26,18 @@ export interface IHeadlineBucketProps {
     /**
      * Specify the measure whose value will be shown as the headline.
      */
-    primaryMeasure: ValueOrPlaceholder<AnyMeasure>;
+    primaryMeasure: MeasureOrPlaceholder;
 
     /**
      * Optionally specify secondary measure whose value will be shown for comparison with the primary measure.
      * The change in percent between the two values will also be calculated and displayed.
      */
-    secondaryMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    secondaryMeasure?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/heatmap/Heatmap.tsx
+++ b/libs/sdk-ui-charts/src/charts/heatmap/Heatmap.tsx
@@ -12,11 +12,12 @@ import {
     newBucket,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { heatmapDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -63,27 +64,27 @@ export interface IHeatmapBucketProps {
     /**
      * Specify measure whose values will be charted on the heatmap.
      */
-    measure: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    measure: AttributeMeasureOrPlaceholder;
 
     /**
      * Optionally specify attribute, whose values will be used to create rows in the heatmap.
      */
-    rows?: ValueOrPlaceholder<IAttribute>;
+    rows?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify attribute, whose values will be used to create columns in the heatmap.
      */
-    columns?: ValueOrPlaceholder<IAttribute>;
+    columns?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/lineChart/LineChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/lineChart/LineChart.tsx
@@ -9,11 +9,12 @@ import {
     newBucket,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
+    AttributeOrPlaceholder,
+    AttributesMeasuresOrPlaceholders,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 
 import { stackedChartDimensions } from "../_commons/dimensions";
@@ -66,28 +67,28 @@ export interface ILineChartBucketProps {
      *
      * If you specify two or more measures, values of each measure will have their own line.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify single attribute whose values will be used to slice the lines along the X axis.
      */
-    trendBy?: ValueOrPlaceholder<IAttribute>;
+    trendBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify single attribute whose values will be used to segment the measure values. The line
      * chart will display one line per measure values pertaining to the segmentBy attribute values.
      */
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
+    segmentBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/pieChart/PieChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/pieChart/PieChart.tsx
@@ -2,11 +2,12 @@
 import React from "react";
 import { IAttribute, IAttributeOrMeasure, INullableFilter, ISortItem, newBucket } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    AttributeOrPlaceholder,
+    AttributesMeasuresOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { roundChartDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -57,23 +58,23 @@ export interface IPieChartBucketProps {
      * If you specify multiple measures, then there will be a pie slice for each measure value. You may not
      * specify the viewBy in this case.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify viewBy attribute that will be used to create the pie slices. There will be a slice
      * for each value of the attribute.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    viewBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/scatterPlot/ScatterPlot.tsx
+++ b/libs/sdk-ui-charts/src/charts/scatterPlot/ScatterPlot.tsx
@@ -2,11 +2,12 @@
 import React from "react";
 import { IAttribute, IMeasure, INullableFilter, ISortItem, newBucket } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
     useResolveValuesWithPlaceholders,
+    MeasureOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    AttributeOrPlaceholder,
 } from "@gooddata/sdk-ui";
 import { pointyChartDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -52,27 +53,27 @@ export interface IScatterPlotBucketProps {
     /**
      * Optionally specify measure which will be used to position data points on the X axis.
      */
-    xAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    xAxisMeasure?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify measure which will be used to position data points on the Y axis.
      */
-    yAxisMeasure?: ValueOrPlaceholder<AnyMeasure>;
+    yAxisMeasure?: MeasureOrPlaceholder;
 
     /**
      * Optionally specify attribute whose values will be used to create data points.
      */
-    attribute?: ValueOrPlaceholder<IAttribute>;
+    attribute?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/treemap/Treemap.tsx
+++ b/libs/sdk-ui-charts/src/charts/treemap/Treemap.tsx
@@ -14,11 +14,11 @@ import {
     newMeasureSort,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    AttributeOrPlaceholder,
+    NullableFiltersOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { treemapDimensions } from "../_commons/dimensions";
 import { IBucketChartProps } from "../../interfaces";
@@ -65,7 +65,7 @@ export interface ITreemapBucketProps {
     /**
      * Specify one or more measures whose values will be used to create the treemap rectangles.
      */
-    measures: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify an attribute whose values will be used to slice the measure. Treemap will chart one
@@ -74,19 +74,19 @@ export interface ITreemapBucketProps {
      *
      * Note: treemap only supports viewBy only when `measures` contains a single measure.
      */
-    viewBy?: ValueOrPlaceholder<IAttribute>;
+    viewBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify an attribute, whose values will be used to segment the rectangles created for
      * the measures or the combination of measure and viewBy attribute values. Segmenting essentially adds
      * another level into the hierarchy.
      */
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
+    segmentBy?: AttributeOrPlaceholder;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-charts/src/charts/xirr/Xirr.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/Xirr.tsx
@@ -12,12 +12,12 @@ import {
     newDimension,
 } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     BucketNames,
     Subtract,
     useResolveValuesWithPlaceholders,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    MeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    NullableFiltersOrPlaceholders,
     withContexts,
 } from "@gooddata/sdk-ui";
 import { IBucketChartProps, ICoreChartProps } from "../../interfaces";
@@ -36,15 +36,15 @@ export interface IXirrBucketProps {
      * The measure to calculate the Internal Rate of Return for.
      * For the result to make sense, the measure should start with a negative value at some point in time (the investment) followed by other values (the returns).
      */
-    measure: ValueOrPlaceholder<AnyMeasure>;
+    measure: MeasureOrPlaceholder;
     /**
      * The date dimension to use for the computation. This allows you to set the granularity (day, month, etc.) for the IRR calculation.
      */
-    attribute?: ValueOrPlaceholder<IAttribute>;
+    attribute?: AttributeOrPlaceholder;
     /**
      * Optionally specify filters to apply on the data to compute with.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { AttributeFiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { DashboardDateFilterConfigMode } from '@gooddata/sdk-backend-spi';
 import { DateFilterGranularity } from '@gooddata/sdk-backend-spi';
 import { DateString } from '@gooddata/sdk-backend-spi';
@@ -27,7 +28,6 @@ import { ObjRefInScope } from '@gooddata/sdk-model';
 import { OnError } from '@gooddata/sdk-ui';
 import { default as React_2 } from 'react';
 import { RelativeGranularityOffset } from '@gooddata/sdk-backend-spi';
-import { ValuesOrPlaceholders } from '@gooddata/sdk-ui';
 import { WrappedComponentProps } from 'react-intl';
 
 // @public
@@ -137,7 +137,7 @@ export interface IAttributeFilterButtonOwnProps {
     onApply?: (filter: IAttributeFilter, isInverted: boolean) => void;
     onError?: (error: any) => void;
     parentFilterOverAttribute?: ObjRef;
-    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
+    parentFilters?: AttributeFiltersOrPlaceholders;
     title?: string;
     workspace?: string;
 }
@@ -161,7 +161,7 @@ export interface IAttributeFilterProps {
     onApply: (filter: IAttributeFilter) => void;
     onError?: OnError;
     parentFilterOverAttribute?: ObjRef;
-    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
+    parentFilters?: AttributeFiltersOrPlaceholders;
     title?: string;
     titleWithSelection?: boolean;
     workspace?: string;

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
@@ -15,6 +15,7 @@ import { IAnalyticalBackend, IAttributeElement } from "@gooddata/sdk-backend-spi
 
 import { AttributeDropdown } from "./AttributeDropdown/AttributeDropdown";
 import {
+    AttributeFiltersOrPlaceholders,
     defaultErrorHandler,
     IntlTranslationsProvider,
     IntlWrapper,
@@ -24,7 +25,6 @@ import {
     useCancelablePromise,
     usePlaceholder,
     useResolveValueWithPlaceholders,
-    ValuesOrPlaceholders,
     withContexts,
 } from "@gooddata/sdk-ui";
 import { MediaQueries } from "../constants";
@@ -73,7 +73,7 @@ export interface IAttributeFilterProps {
      *
      * Parent filters elements must contain their URIs due to current backend limitations.
      */
-    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
+    parentFilters?: AttributeFiltersOrPlaceholders;
 
     /**
      * Specify {@link @gooddata/sdk-ui#IPlaceholder} to use to get and set the value of the attribute filter.

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -25,7 +25,7 @@ import {
     useCancelablePromise,
     usePlaceholder,
     useResolveValueWithPlaceholders,
-    ValuesOrPlaceholders,
+    AttributeFiltersOrPlaceholders,
     withContexts,
 } from "@gooddata/sdk-ui";
 import MediaQuery from "react-responsive";
@@ -83,7 +83,7 @@ export interface IAttributeFilterButtonOwnProps {
      *
      * Parent filters elements must contain their URIs due to current backend limitations.
      */
-    parentFilters?: ValuesOrPlaceholders<IAttributeFilter>;
+    parentFilters?: AttributeFiltersOrPlaceholders;
 
     /**
      * Specify {@link @gooddata/sdk-ui#IPlaceholder} to use to get and set the value of the attribute filter.

--- a/libs/sdk-ui-geo/api/sdk-ui-geo.api.md
+++ b/libs/sdk-ui-geo/api/sdk-ui-geo.api.md
@@ -4,7 +4,8 @@
 
 ```ts
 
-import { AnyMeasure } from '@gooddata/sdk-ui';
+import { AttributeMeasureOrPlaceholder } from '@gooddata/sdk-ui';
+import { AttributeOrPlaceholder } from '@gooddata/sdk-ui';
 import { ContentRect } from 'react-measure';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttribute } from '@gooddata/sdk-model';
@@ -18,17 +19,15 @@ import { IDrillConfig } from '@gooddata/sdk-ui';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IHeaderPredicate } from '@gooddata/sdk-ui';
 import { ILoadingInjectedProps } from '@gooddata/sdk-ui';
-import { INullableFilter } from '@gooddata/sdk-model';
 import { IPushpinCategoryLegendItem } from '@gooddata/sdk-ui-vis-commons';
 import { ISeparators } from '@gooddata/sdk-ui';
-import { ISortItem } from '@gooddata/sdk-model';
 import { ITheme } from '@gooddata/sdk-backend-spi';
 import { IVisualizationCallbacks } from '@gooddata/sdk-ui';
 import { IVisualizationProps } from '@gooddata/sdk-ui';
+import { NullableFiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { PositionType } from '@gooddata/sdk-ui-vis-commons';
 import { default as React_2 } from 'react';
-import { ValueOrPlaceholder } from '@gooddata/sdk-ui';
-import { ValuesOrPlaceholders } from '@gooddata/sdk-ui';
+import { SortsOrPlaceholders } from '@gooddata/sdk-ui';
 import { WrappedComponentProps } from 'react-intl';
 
 // @public (undocumented)
@@ -254,22 +253,22 @@ export interface IGeoPointsConfig {
 export interface IGeoPushpinChartProps extends IVisualizationProps, IVisualizationCallbacks {
     backend?: IAnalyticalBackend;
     // (undocumented)
-    color?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    color?: AttributeMeasureOrPlaceholder;
     // (undocumented)
     config?: IGeoConfig;
     // (undocumented)
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     // (undocumented)
-    location: ValueOrPlaceholder<IAttribute>;
+    location: AttributeOrPlaceholder;
     onCenterPositionChanged?: CenterPositionChangedCallback;
     onZoomChanged?: ZoomChangedCallback;
     placeholdersResolutionContext?: any;
     // (undocumented)
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
+    segmentBy?: AttributeOrPlaceholder;
     // (undocumented)
-    size?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
+    size?: AttributeMeasureOrPlaceholder;
     // (undocumented)
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
     workspace?: string;
 }
 

--- a/libs/sdk-ui-geo/src/GeoChart.ts
+++ b/libs/sdk-ui-geo/src/GeoChart.ts
@@ -1,13 +1,14 @@
 // (C) 2020-2021 GoodData Corporation
-import { IAttribute, IColorPalette, INullableFilter, ISortItem } from "@gooddata/sdk-model";
+import { IAttribute, IColorPalette } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
+    AttributeOrPlaceholder,
     IDrillEventContext,
     ISeparators,
     IVisualizationCallbacks,
     IVisualizationProps,
-    ValueOrPlaceholder,
-    ValuesOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IColorMapping, PositionType } from "@gooddata/sdk-ui-vis-commons";
@@ -211,13 +212,13 @@ export interface IGeoPushpinChartProps extends IVisualizationProps, IVisualizati
      */
     workspace?: string;
 
-    location: ValueOrPlaceholder<IAttribute>;
-    size?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
-    color?: ValueOrPlaceholder<IAttribute | AnyMeasure>;
-    segmentBy?: ValueOrPlaceholder<IAttribute>;
+    location: AttributeOrPlaceholder;
+    size?: AttributeMeasureOrPlaceholder;
+    color?: AttributeMeasureOrPlaceholder;
+    segmentBy?: AttributeOrPlaceholder;
 
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    filters?: NullableFiltersOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
+++ b/libs/sdk-ui-pivot/api/sdk-ui-pivot.api.md
@@ -4,23 +4,23 @@
 
 ```ts
 
-import { AnyMeasure } from '@gooddata/sdk-ui';
+import { AttributesMeasuresOrPlaceholders } from '@gooddata/sdk-ui';
+import { AttributesOrPlaceholders } from '@gooddata/sdk-ui';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttribute } from '@gooddata/sdk-model';
 import { IBackendCapabilities } from '@gooddata/sdk-backend-spi';
 import { Identifier } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
-import { INullableFilter } from '@gooddata/sdk-model';
 import { IPreparedExecution } from '@gooddata/sdk-backend-spi';
 import { ISeparators } from '@gooddata/numberjs';
-import { ISortItem } from '@gooddata/sdk-model';
 import { ITheme } from '@gooddata/sdk-backend-spi';
-import { ITotal } from '@gooddata/sdk-model';
 import { IVisualizationCallbacks } from '@gooddata/sdk-ui';
 import { IVisualizationProps } from '@gooddata/sdk-ui';
+import { NullableFiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { default as React_2 } from 'react';
+import { SortsOrPlaceholders } from '@gooddata/sdk-ui';
+import { TotalsOrPlaceholders } from '@gooddata/sdk-ui';
 import { TotalType } from '@gooddata/sdk-model';
-import { ValuesOrPlaceholders } from '@gooddata/sdk-ui';
 import { WrappedComponentProps } from 'react-intl';
 
 // @public (undocumented)
@@ -129,13 +129,13 @@ export interface IPivotTableBaseProps extends IVisualizationProps, IVisualizatio
 
 // @public (undocumented)
 export interface IPivotTableBucketProps {
-    columns?: ValuesOrPlaceholders<IAttribute>;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
-    measures?: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    columns?: AttributesOrPlaceholders;
+    filters?: NullableFiltersOrPlaceholders;
+    measures?: AttributesMeasuresOrPlaceholders;
     placeholdersResolutionContext?: any;
-    rows?: ValuesOrPlaceholders<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    totals?: ValuesOrPlaceholders<ITotal>;
+    rows?: AttributesOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
+    totals?: TotalsOrPlaceholders;
 }
 
 // @public (undocumented)

--- a/libs/sdk-ui-pivot/src/publicTypes.ts
+++ b/libs/sdk-ui-pivot/src/publicTypes.ts
@@ -1,12 +1,15 @@
 // (C) 2007-2021 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
 import { IAnalyticalBackend, IPreparedExecution, ITheme } from "@gooddata/sdk-backend-spi";
-import { IAttribute, INullableFilter, ISortItem, ITotal, TotalType } from "@gooddata/sdk-model";
+import { TotalType } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     IVisualizationCallbacks,
     IVisualizationProps,
-    ValuesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    TotalsOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    AttributesOrPlaceholders,
 } from "@gooddata/sdk-ui";
 import { WrappedComponentProps } from "react-intl";
 import { ColumnWidthItem } from "./columnWidths";
@@ -133,7 +136,7 @@ export interface IPivotTableBucketProps {
     /**
      * Optionally specify measures to create table columns from.
      */
-    measures?: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    measures?: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally specify one or more attributes to create table columns from. There will be a column for each
@@ -142,12 +145,12 @@ export interface IPivotTableBucketProps {
      * Note: you can specify column attributes in conjunction with one or more measures. In that case the table
      * will contain column for each combination of attribute values & measures.
      */
-    columns?: ValuesOrPlaceholders<IAttribute>;
+    columns?: AttributesOrPlaceholders;
 
     /**
      * Optionally specify attributes, whose elements will be used to populate table rows.
      */
-    rows?: ValuesOrPlaceholders<IAttribute>;
+    rows?: AttributesOrPlaceholders;
 
     /**
      * Optionally specify what totals should be calculated and included in the table.
@@ -156,17 +159,17 @@ export interface IPivotTableBucketProps {
      * Also note: the table will only include subtotals when in grouping mode and the grouping is effective = table
      * is sorted by the first row attribute.
      */
-    totals?: ValuesOrPlaceholders<ITotal>;
+    totals?: TotalsOrPlaceholders;
 
     /**
      * Optionally specify filters to apply on the data to chart.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optionally specify how to sort the data to chart.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -8,13 +8,16 @@ import { AuthenticationFlow } from '@gooddata/sdk-backend-spi';
 import { ComponentType } from 'react';
 import { DataValue } from '@gooddata/sdk-backend-spi';
 import { DependencyList } from 'react';
+import { IAbsoluteDateFilter } from '@gooddata/sdk-model';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttribute } from '@gooddata/sdk-model';
 import { IAttributeDescriptor } from '@gooddata/sdk-backend-spi';
+import { IAttributeFilter } from '@gooddata/sdk-model';
 import { IBucket } from '@gooddata/sdk-model';
 import { IColor } from '@gooddata/sdk-model';
 import { IColorPalette } from '@gooddata/sdk-model';
 import { IDataView } from '@gooddata/sdk-backend-spi';
+import { IDateFilter } from '@gooddata/sdk-model';
 import { IDimension } from '@gooddata/sdk-model';
 import { IDimensionDescriptor } from '@gooddata/sdk-backend-spi';
 import { IDimensionItemDescriptor } from '@gooddata/sdk-backend-spi';
@@ -22,15 +25,22 @@ import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IExportConfig } from '@gooddata/sdk-backend-spi';
 import { IExportResult } from '@gooddata/sdk-backend-spi';
+import { IFilter } from '@gooddata/sdk-model';
 import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
 import { IMeasureDefinitionType } from '@gooddata/sdk-model';
 import { IMeasureDescriptor } from '@gooddata/sdk-backend-spi';
+import { IMeasureFilter } from '@gooddata/sdk-model';
 import { IMeasureGroupDescriptor } from '@gooddata/sdk-backend-spi';
+import { IMeasureValueFilter } from '@gooddata/sdk-model';
+import { INegativeAttributeFilter } from '@gooddata/sdk-model';
 import { IntlShape } from 'react-intl';
 import { INullableFilter } from '@gooddata/sdk-model';
 import { IPagedResource } from '@gooddata/sdk-backend-spi';
+import { IPositiveAttributeFilter } from '@gooddata/sdk-model';
 import { IPreparedExecution } from '@gooddata/sdk-backend-spi';
+import { IRankingFilter } from '@gooddata/sdk-model';
+import { IRelativeDateFilter } from '@gooddata/sdk-model';
 import { IResultAttributeHeader } from '@gooddata/sdk-backend-spi';
 import { IResultHeader } from '@gooddata/sdk-backend-spi';
 import { IResultMeasureHeader } from '@gooddata/sdk-backend-spi';
@@ -68,7 +78,25 @@ export class ArithmeticMeasureTitleFactory {
 export type ArrayOf<T> = T extends any ? T[] : never;
 
 // @public
+export type AttributeFilterOrPlaceholder = ValueOrPlaceholder<IAttributeFilter> | ValueOrPlaceholder<IPositiveAttributeFilter> | ValueOrPlaceholder<INegativeAttributeFilter>;
+
+// @public
+export type AttributeFiltersOrPlaceholders = Array<ValueOrMultiValuePlaceholder<IAttributeFilter> | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter> | ValueOrMultiValuePlaceholder<INegativeAttributeFilter>>;
+
+// @public
 export function attributeItemNameMatch(name: string): IHeaderPredicate;
+
+// @public
+export type AttributeMeasureOrPlaceholder = ValueOrPlaceholder<IAttribute | AnyMeasure> | ValueOrPlaceholder<IAttribute> | ValueOrPlaceholder<AnyMeasure>;
+
+// @public
+export type AttributeOrPlaceholder = ValueOrPlaceholder<IAttribute>;
+
+// @public
+export type AttributesMeasuresOrPlaceholders = Array<ValueOrMultiValuePlaceholder<IAttribute | AnyMeasure> | ValueOrMultiValuePlaceholder<IAttribute> | ValueOrMultiValuePlaceholder<AnyMeasure>>;
+
+// @public
+export type AttributesOrPlaceholders = ValuesOrPlaceholders<IAttribute>;
 
 // @public
 export const BackendProvider: React_2.FC<IBackendProviderProps>;
@@ -350,6 +378,15 @@ export const ExecuteInsight: React_2.ComponentType<IExecuteInsightProps>;
 
 // @internal
 export function fillMissingTitles<T extends IInsightDefinition>(insight: T, locale: ILocale, maxArithmeticMeasureTitleLength?: number): T;
+
+// @public (undocumented)
+export type FilterOrMultiValuePlaceholder = ValueOrMultiValuePlaceholder<IFilter> | ValueOrMultiValuePlaceholder<IDateFilter> | ValueOrMultiValuePlaceholder<IMeasureFilter> | ValueOrMultiValuePlaceholder<IAttributeFilter> | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter> | ValueOrMultiValuePlaceholder<IRelativeDateFilter> | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter> | ValueOrMultiValuePlaceholder<INegativeAttributeFilter> | ValueOrMultiValuePlaceholder<IMeasureValueFilter> | ValueOrMultiValuePlaceholder<IRankingFilter>;
+
+// @public
+export type FilterOrPlaceholder = ValueOrPlaceholder<IFilter> | ValueOrPlaceholder<IDateFilter> | ValueOrPlaceholder<IMeasureFilter> | ValueOrPlaceholder<IAttributeFilter> | ValueOrPlaceholder<IAbsoluteDateFilter> | ValueOrPlaceholder<IRelativeDateFilter> | ValueOrPlaceholder<IPositiveAttributeFilter> | ValueOrPlaceholder<INegativeAttributeFilter> | ValueOrPlaceholder<IMeasureValueFilter> | ValueOrPlaceholder<IRankingFilter>;
+
+// @public
+export type FiltersOrPlaceholders = Array<FilterOrMultiValuePlaceholder>;
 
 // @internal
 export function fireDrillEvent(drillEventFunction: IDrillEventCallback, drillEventData: IDrillEvent, target: EventTarget): void;
@@ -828,14 +865,14 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
     componentName?: string;
     ErrorComponent?: IExecuteErrorComponent;
     exportTitle?: string;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     LoadingComponent?: IExecuteLoadingComponent;
     loadOnMount?: boolean;
     placeholdersResolutionContext?: any;
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    totals?: ValuesOrPlaceholders<ITotal>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
+    slicesBy?: AttributesOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
+    totals?: TotalsOrPlaceholders;
     window?: DataViewWindow;
     workspace?: string;
 }
@@ -843,12 +880,12 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
 // @beta (undocumented)
 export interface IExecutionConfiguration {
     componentName?: string;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    totals?: ValuesOrPlaceholders<ITotal>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
+    slicesBy?: AttributesOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
+    totals?: TotalsOrPlaceholders;
 }
 
 // @alpha
@@ -1198,12 +1235,12 @@ export type IUseComposedPlaceholderHook<T extends IComposedPlaceholder<any, any,
 export interface IUseExecutionConfig {
     backend?: IAnalyticalBackend;
     componentName?: string;
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
     placeholdersResolutionContext?: any;
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
-    totals?: ValuesOrPlaceholders<ITotal>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
+    slicesBy?: AttributesOrPlaceholders;
+    sortBy?: SortsOrPlaceholders;
+    totals?: TotalsOrPlaceholders;
     workspace?: string;
 }
 
@@ -1322,6 +1359,12 @@ export function makeCancelable<T>(promise: Promise<T>): ICancelablePromise<T>;
 // @public
 export type MeasureOf<T extends IMeasureDefinitionType> = T extends any ? IMeasure<T> : never;
 
+// @public
+export type MeasureOrPlaceholder = ValueOrPlaceholder<AnyMeasure>;
+
+// @public
+export type MeasuresOrPlaceholders = ValuesOrPlaceholders<AnyMeasure>;
+
 // @internal (undocumented)
 export const messagesMap: {
     [locale: string]: ITranslations;
@@ -1350,6 +1393,12 @@ export class NoDataSdkError extends GoodDataSdkError {
 export class NotFoundSdkError extends GoodDataSdkError {
     constructor(message?: string, cause?: Error);
 }
+
+// @public
+export type NullableFilterOrPlaceholder = FilterOrPlaceholder | ValueOrPlaceholder<INullableFilter> | ValueOrPlaceholder<IFilter | null> | ValueOrPlaceholder<IDateFilter | null> | ValueOrPlaceholder<IMeasureFilter | null> | ValueOrPlaceholder<IAttributeFilter | null> | ValueOrPlaceholder<IAbsoluteDateFilter | null> | ValueOrPlaceholder<IRelativeDateFilter | null> | ValueOrPlaceholder<IPositiveAttributeFilter | null> | ValueOrPlaceholder<INegativeAttributeFilter | null> | ValueOrPlaceholder<IMeasureValueFilter | null> | ValueOrPlaceholder<IRankingFilter | null>;
+
+// @public
+export type NullableFiltersOrPlaceholders = Array<FilterOrMultiValuePlaceholder | ValueOrMultiValuePlaceholder<INullableFilter> | ValueOrMultiValuePlaceholder<IFilter | null> | ValueOrMultiValuePlaceholder<IDateFilter | null> | ValueOrMultiValuePlaceholder<IMeasureFilter | null> | ValueOrMultiValuePlaceholder<IAttributeFilter | null> | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter | null> | ValueOrMultiValuePlaceholder<IRelativeDateFilter | null> | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter | null> | ValueOrMultiValuePlaceholder<INegativeAttributeFilter | null> | ValueOrMultiValuePlaceholder<IMeasureValueFilter | null> | ValueOrMultiValuePlaceholder<IRankingFilter | null>>;
 
 // @public (undocumented)
 export type OnError = (error: GoodDataSdkError) => void;
@@ -1414,6 +1463,9 @@ export function resolveUseCancelablePromisesStatus(cancelablePromisesStates: Use
 // @public (undocumented)
 export type SdkErrorType = keyof typeof ErrorCodes;
 
+// @public
+export type SortsOrPlaceholders = ValuesOrPlaceholders<ISortItem>;
+
 // @internal (undocumented)
 export type Subtract<T, K> = Pick<T, Exclude<keyof T, keyof K>>;
 
@@ -1422,6 +1474,9 @@ export type TableElementType = "cell";
 
 // @public (undocumented)
 export type TableType = "table";
+
+// @public
+export type TotalsOrPlaceholders = ValuesOrPlaceholders<ITotal>;
 
 // @internal (undocumented)
 export class TranslationsProvider extends React_2.PureComponent<ITranslationsProviderProps> {
@@ -1564,11 +1619,14 @@ export const useWorkspaceStrict: (workspace?: string | undefined, context?: stri
 // @public (undocumented)
 export type ValueFormatter = (value: DataValue, format: string) => string;
 
+// @public (undocumented)
+export type ValueOrMultiValuePlaceholder<T> = ValueOrPlaceholder<T> | AnyPlaceholderOf<T[]>;
+
 // @public
 export type ValueOrPlaceholder<T> = T | AnyPlaceholderOf<T>;
 
 // @public
-export type ValuesOrPlaceholders<T> = AnyArrayOf<ValueOrPlaceholder<T> | AnyPlaceholderOf<AnyArrayOf<T>>>;
+export type ValuesOrPlaceholders<T> = AnyArrayOf<ValueOrMultiValuePlaceholder<T>>;
 
 // @public (undocumented)
 export type VisElementType = ChartElementType | HeadlineElementType | TableElementType | "pushpin";

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -92,8 +92,26 @@ export {
     ComposedPlaceholderResolutionContext,
     IUseComposedPlaceholderHook,
     UnionToIntersection,
+    ValueOrMultiValuePlaceholder,
 } from "./react/placeholders/base";
 export { IPlaceholderOptions, newComposedPlaceholder, newPlaceholder } from "./react/placeholders/factory";
+export {
+    AttributeFilterOrPlaceholder,
+    AttributeFiltersOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    AttributesMeasuresOrPlaceholders,
+    AttributesOrPlaceholders,
+    FilterOrMultiValuePlaceholder,
+    FilterOrPlaceholder,
+    FiltersOrPlaceholders,
+    MeasureOrPlaceholder,
+    MeasuresOrPlaceholders,
+    NullableFilterOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    TotalsOrPlaceholders,
+} from "./react/placeholders/aliases";
 export {
     usePlaceholder,
     usePlaceholders,

--- a/libs/sdk-ui/src/base/react/placeholders/aliases.ts
+++ b/libs/sdk-ui/src/base/react/placeholders/aliases.ts
@@ -1,0 +1,213 @@
+// (C) 2019-2021 GoodData Corporation
+import {
+    IFilter,
+    IAttributeFilter,
+    INegativeAttributeFilter,
+    IPositiveAttributeFilter,
+    IAbsoluteDateFilter,
+    IMeasureFilter,
+    IDateFilter,
+    IRelativeDateFilter,
+    IMeasureValueFilter,
+    IRankingFilter,
+    INullableFilter,
+    IAttribute,
+    ISortItem,
+    ITotal,
+} from "@gooddata/sdk-model";
+import { ValueOrPlaceholder, ValuesOrPlaceholders, AnyMeasure, ValueOrMultiValuePlaceholder } from "./base";
+
+//
+// Due to the combination of TypeScript union merging and the lack of ability to specify
+// covariance / contravariance / bivariance of generic types,
+// the only possible solution to solve generics assignment issues in strict mode
+// (e.g. IPlaceholder<IAttributeFilter> is not assignable to IPlaceholder<IFilter>)
+// is to explicitly specify all type combinations that make sense.
+//
+
+///
+
+/**
+ * Alias for all possible filter or placeholder signatures.
+ *
+ * @public
+ */
+export type FilterOrPlaceholder =
+    | ValueOrPlaceholder<IFilter>
+    | ValueOrPlaceholder<IDateFilter>
+    | ValueOrPlaceholder<IMeasureFilter>
+    | ValueOrPlaceholder<IAttributeFilter>
+    //
+    | ValueOrPlaceholder<IAbsoluteDateFilter>
+    | ValueOrPlaceholder<IRelativeDateFilter>
+    | ValueOrPlaceholder<IPositiveAttributeFilter>
+    | ValueOrPlaceholder<INegativeAttributeFilter>
+    | ValueOrPlaceholder<IMeasureValueFilter>
+    | ValueOrPlaceholder<IRankingFilter>;
+
+///
+
+/**
+ * Alias for all possible nullable filter or placeholder signatures.
+ *
+ * @public
+ */
+export type NullableFilterOrPlaceholder =
+    | FilterOrPlaceholder
+    | ValueOrPlaceholder<INullableFilter>
+    | ValueOrPlaceholder<IFilter | null>
+    | ValueOrPlaceholder<IDateFilter | null>
+    | ValueOrPlaceholder<IMeasureFilter | null>
+    | ValueOrPlaceholder<IAttributeFilter | null>
+    //
+    | ValueOrPlaceholder<IAbsoluteDateFilter | null>
+    | ValueOrPlaceholder<IRelativeDateFilter | null>
+    | ValueOrPlaceholder<IPositiveAttributeFilter | null>
+    | ValueOrPlaceholder<INegativeAttributeFilter | null>
+    | ValueOrPlaceholder<IMeasureValueFilter | null>
+    | ValueOrPlaceholder<IRankingFilter | null>;
+
+///
+
+/**
+ *
+ * @public
+ */
+export type FilterOrMultiValuePlaceholder =
+    | ValueOrMultiValuePlaceholder<IFilter>
+    | ValueOrMultiValuePlaceholder<IDateFilter>
+    | ValueOrMultiValuePlaceholder<IMeasureFilter>
+    | ValueOrMultiValuePlaceholder<IAttributeFilter>
+    //
+    | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter>
+    | ValueOrMultiValuePlaceholder<IRelativeDateFilter>
+    | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter>
+    | ValueOrMultiValuePlaceholder<INegativeAttributeFilter>
+    | ValueOrMultiValuePlaceholder<IMeasureValueFilter>
+    | ValueOrMultiValuePlaceholder<IRankingFilter>;
+
+/**
+ * Alias for all possible filters or their placeholder signatures.
+ *
+ * @public
+ */
+export type FiltersOrPlaceholders = Array<FilterOrMultiValuePlaceholder>;
+
+///
+
+/**
+ * Alias for all possible nullable filters or their placeholder signatures.
+ *
+ * @public
+ */
+export type NullableFiltersOrPlaceholders = Array<
+    | FilterOrMultiValuePlaceholder
+    | ValueOrMultiValuePlaceholder<INullableFilter>
+    | ValueOrMultiValuePlaceholder<IFilter | null>
+    | ValueOrMultiValuePlaceholder<IDateFilter | null>
+    | ValueOrMultiValuePlaceholder<IMeasureFilter | null>
+    | ValueOrMultiValuePlaceholder<IAttributeFilter | null>
+    //
+    | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter | null>
+    | ValueOrMultiValuePlaceholder<IRelativeDateFilter | null>
+    | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter | null>
+    | ValueOrMultiValuePlaceholder<INegativeAttributeFilter | null>
+    | ValueOrMultiValuePlaceholder<IMeasureValueFilter | null>
+    | ValueOrMultiValuePlaceholder<IRankingFilter | null>
+>;
+
+///
+
+/**
+ * Alias for all possible attribute filter or placeholder signatures.
+ *
+ * @public
+ */
+export type AttributeFilterOrPlaceholder =
+    | ValueOrPlaceholder<IAttributeFilter>
+    | ValueOrPlaceholder<IPositiveAttributeFilter>
+    | ValueOrPlaceholder<INegativeAttributeFilter>;
+
+/**
+ * Alias for all possible attribute filters or their placeholder signatures.
+ *
+ * @public
+ */
+export type AttributeFiltersOrPlaceholders = Array<
+    | ValueOrMultiValuePlaceholder<IAttributeFilter>
+    | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter>
+    | ValueOrMultiValuePlaceholder<INegativeAttributeFilter>
+>;
+
+///
+
+/**
+ * Alias for all possible attribute or placeholder signatures.
+ *
+ * @public
+ */
+export type AttributeOrPlaceholder = ValueOrPlaceholder<IAttribute>;
+
+/**
+ * Alias for all possible attributes or their placeholder signatures.
+ *
+ * @public
+ */
+export type AttributesOrPlaceholders = ValuesOrPlaceholders<IAttribute>;
+
+///
+
+/**
+ * Alias for all possible measure or placeholder signatures.
+ *
+ * @public
+ */
+export type MeasureOrPlaceholder = ValueOrPlaceholder<AnyMeasure>;
+
+/**
+ * Alias for all possible measures or their placeholder signatures.
+ *
+ * @public
+ */
+export type MeasuresOrPlaceholders = ValuesOrPlaceholders<AnyMeasure>;
+
+///
+
+/**
+ * Alias for all possible attribute, measure or placeholder signatures.
+ *
+ * @public
+ */
+export type AttributeMeasureOrPlaceholder =
+    | ValueOrPlaceholder<IAttribute | AnyMeasure>
+    | ValueOrPlaceholder<IAttribute>
+    | ValueOrPlaceholder<AnyMeasure>;
+
+/**
+ * Alias for all possible attributes, measures or their placeholders signatures.
+ *
+ * @public
+ */
+export type AttributesMeasuresOrPlaceholders = Array<
+    | ValueOrMultiValuePlaceholder<IAttribute | AnyMeasure>
+    | ValueOrMultiValuePlaceholder<IAttribute>
+    | ValueOrMultiValuePlaceholder<AnyMeasure>
+>;
+
+///
+
+/**
+ * Alias for all possible sorts or their placeholders signatures.
+ *
+ * @public
+ */
+export type SortsOrPlaceholders = ValuesOrPlaceholders<ISortItem>;
+
+///
+
+/**
+ * Alias for all possible totals or their placeholders signatures.
+ *
+ * @public
+ */
+export type TotalsOrPlaceholders = ValuesOrPlaceholders<ITotal>;

--- a/libs/sdk-ui/src/base/react/placeholders/base.ts
+++ b/libs/sdk-ui/src/base/react/placeholders/base.ts
@@ -273,7 +273,7 @@ export type ValueOrPlaceholder<T> = T | AnyPlaceholderOf<T>;
  *
  * @public
  */
-export type ValuesOrPlaceholders<T> = AnyArrayOf<ValueOrPlaceholder<T> | AnyPlaceholderOf<AnyArrayOf<T>>>;
+export type ValuesOrPlaceholders<T> = AnyArrayOf<ValueOrMultiValuePlaceholder<T>>;
 
 /**
  * Generate union of measures from union of measure definitions.
@@ -292,3 +292,8 @@ export type MeasureOf<T extends IMeasureDefinitionType> = T extends any ? IMeasu
  * @public
  */
 export type AnyMeasure = IMeasure | MeasureOf<IMeasureDefinitionType>;
+
+/**
+ * @public
+ */
+export type ValueOrMultiValuePlaceholder<T> = ValueOrPlaceholder<T> | AnyPlaceholderOf<T[]>;

--- a/libs/sdk-ui/src/base/react/placeholders/tests/typeAliases.test.tsx
+++ b/libs/sdk-ui/src/base/react/placeholders/tests/typeAliases.test.tsx
@@ -1,0 +1,201 @@
+// (C) 2019-2021 GoodData Corporation
+import { expectType } from "tsd";
+import {
+    IFilter,
+    IAttributeFilter,
+    IAbsoluteDateFilter,
+    IMeasureFilter,
+    IDateFilter,
+    IMeasureValueFilter,
+    IRelativeDateFilter,
+    IPositiveAttributeFilter,
+    INegativeAttributeFilter,
+    IRankingFilter,
+    INullableFilter,
+    IMeasure,
+    IMeasureDefinition,
+    IArithmeticMeasureDefinition,
+    IPoPMeasureDefinition,
+    IPreviousPeriodMeasureDefinition,
+    IAttribute,
+    ISortItem,
+    IAttributeSortItem,
+    IMeasureSortItem,
+    ITotal,
+} from "@gooddata/sdk-model";
+import { newPlaceholder, newComposedPlaceholder } from "../factory";
+import { AttributeFilterOrPlaceholder, SortsOrPlaceholders, TotalsOrPlaceholders } from "../aliases";
+import {
+    AttributeFiltersOrPlaceholders,
+    AttributeMeasureOrPlaceholder,
+    AttributeOrPlaceholder,
+    AttributesMeasuresOrPlaceholders,
+    AttributesOrPlaceholders,
+    FilterOrPlaceholder,
+    FiltersOrPlaceholders,
+    MeasureOrPlaceholder,
+    MeasuresOrPlaceholders,
+    NullableFilterOrPlaceholder,
+    NullableFiltersOrPlaceholders,
+} from "../aliases";
+
+describe("Check assignability of filters and its placeholders to relevant aliases", () => {
+    const nullableFilter: INullableFilter = null as any;
+    const filter: IFilter = null as any;
+    const dateFilter: IDateFilter = null as any;
+    const measureFilter: IMeasureFilter = null as any;
+    const attributeFilter: IAttributeFilter = null as any;
+    const absoluteDateFilter: IAbsoluteDateFilter = null as any;
+    const relativeDateFilter: IRelativeDateFilter = null as any;
+    const positiveAttributeFilter: IPositiveAttributeFilter = null as any;
+    const negativeAttributeFilter: INegativeAttributeFilter = null as any;
+    const measureValueFilter: IMeasureValueFilter = null as any;
+    const rankingFilter: IRankingFilter = null as any;
+
+    const filters = [
+        filter,
+        dateFilter,
+        measureFilter,
+        attributeFilter,
+        absoluteDateFilter,
+        relativeDateFilter,
+        positiveAttributeFilter,
+        negativeAttributeFilter,
+        measureValueFilter,
+        rankingFilter,
+    ];
+    const nullableFilters = [...filters, null, nullableFilter];
+    const attributeFilters = [attributeFilter, positiveAttributeFilter, negativeAttributeFilter];
+
+    it("all filter and placeholder combinations should be assignable to FiltersOrPlaceholders / FilterOrPlaceholder", () => {
+        const placeholders = filters.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...filters, ...placeholders];
+
+        expectType<FiltersOrPlaceholders>(valuesOrPlaceholders);
+        expectType<FiltersOrPlaceholders>([composedPlaceholder]);
+
+        // This should be assignable as well
+        expectType<NullableFiltersOrPlaceholders>(valuesOrPlaceholders);
+        expectType<NullableFiltersOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<FilterOrPlaceholder>(v);
+        });
+    });
+
+    it("all nullable filter and placeholder combinations should be assignable to NullableFiltersOrPlaceholders / NullableFilterOrPlaceholder", () => {
+        const placeholders = nullableFilters.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...nullableFilters, ...placeholders];
+
+        // This should be assignable as well
+        expectType<NullableFiltersOrPlaceholders>(valuesOrPlaceholders);
+        expectType<NullableFiltersOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<NullableFilterOrPlaceholder>(v);
+        });
+    });
+
+    it("all attribute filter and placeholder combinations should be assignable to AttributeFiltersOrPlaceholders / AttributeFilterOrPlaceholder", () => {
+        const placeholders = attributeFilters.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...attributeFilters, ...placeholders];
+
+        expectType<AttributeFiltersOrPlaceholders>(valuesOrPlaceholders);
+        expectType<AttributeFiltersOrPlaceholders>([composedPlaceholder]);
+
+        // This should be assignable as well
+        expectType<NullableFiltersOrPlaceholders>(valuesOrPlaceholders);
+        expectType<NullableFiltersOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<AttributeFilterOrPlaceholder>(v);
+        });
+    });
+});
+
+describe("Check assignability of attributes, measures and its placeholders to relevant aliases", () => {
+    const attribute: IAttribute = null as any;
+    const measure: IMeasure = null as any;
+    const simpleMeasure: IMeasure<IMeasureDefinition> = null as any;
+    const arithmeticMeasure: IMeasure<IArithmeticMeasureDefinition> = null as any;
+    const popMeasure: IMeasure<IPoPMeasureDefinition> = null as any;
+    const previousPeriodMeasure: IMeasure<IPreviousPeriodMeasureDefinition> = null as any;
+
+    const attributes = [attribute];
+    const measures = [measure, simpleMeasure, arithmeticMeasure, popMeasure, previousPeriodMeasure];
+    const attributesOrMeasures = [...attributes, ...measures];
+
+    it("all attribute and placeholder combinations should be assignable to AttributesOrPlaceholders / AttributeOrPlaceholder", () => {
+        const placeholders = attributes.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...attributes, ...placeholders];
+
+        expectType<AttributesOrPlaceholders>(valuesOrPlaceholders);
+        expectType<AttributesOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<AttributeOrPlaceholder>(v);
+        });
+    });
+
+    it("all measure and placeholder combinations should be assignable to MeasuresOrPlaceholders / MeasureOrPlaceholder", () => {
+        const placeholders = measures.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...measures, ...placeholders];
+
+        expectType<MeasuresOrPlaceholders>(valuesOrPlaceholders);
+        expectType<MeasuresOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<MeasureOrPlaceholder>(v);
+        });
+    });
+
+    it("all attribute, measure and placeholder combinations should be assignable to AttributesMeasuresOrPlaceholders / AttributeMeasureOrPlaceholder", () => {
+        const placeholders = attributesOrMeasures.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...attributesOrMeasures, ...placeholders];
+
+        expectType<AttributesMeasuresOrPlaceholders>(valuesOrPlaceholders);
+        expectType<AttributesMeasuresOrPlaceholders>([composedPlaceholder]);
+
+        valuesOrPlaceholders.forEach((v) => {
+            expectType<AttributeMeasureOrPlaceholder>(v);
+        });
+    });
+});
+
+describe("Check assignability of sorts and its placeholders to relevant aliases", () => {
+    const sort: ISortItem = null as any;
+    const attributeSort: IAttributeSortItem = null as any;
+    const measureSort: IMeasureSortItem = null as any;
+
+    const sorts = [sort, attributeSort, measureSort];
+
+    it("all sort and placeholder combinations should be assignable to SortsOrPlaceholders", () => {
+        const placeholders = sorts.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...sorts, ...placeholders];
+
+        expectType<SortsOrPlaceholders>(valuesOrPlaceholders);
+        expectType<SortsOrPlaceholders>([composedPlaceholder]);
+    });
+});
+
+describe("Check assignability of totals and its placeholders to relevant aliases", () => {
+    const total: ITotal = null as any;
+
+    const totals = [total];
+
+    it("all total and placeholder combinations should be assignable to TotalsOrPlaceholders", () => {
+        const placeholders = totals.map((f) => newPlaceholder(f));
+        const composedPlaceholder = newComposedPlaceholder(placeholders);
+        const valuesOrPlaceholders = [...totals, ...placeholders];
+
+        expectType<TotalsOrPlaceholders>(valuesOrPlaceholders);
+        expectType<TotalsOrPlaceholders>([composedPlaceholder]);
+    });
+});

--- a/libs/sdk-ui/src/execution/Execute.tsx
+++ b/libs/sdk-ui/src/execution/Execute.tsx
@@ -5,7 +5,15 @@ import { DataViewWindow, IWithLoadingEvents, WithLoadingResult } from "./withExe
 import { IAttribute, IAttributeOrMeasure, INullableFilter, ISortItem, ITotal } from "@gooddata/sdk-model";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import isEqual from "lodash/isEqual";
-import { AnyMeasure, useResolveValuesWithPlaceholders, ValuesOrPlaceholders, withContexts } from "../base";
+import {
+    useResolveValuesWithPlaceholders,
+    withContexts,
+    AttributesMeasuresOrPlaceholders,
+    AttributesOrPlaceholders,
+    TotalsOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+} from "../base";
 import { createExecution } from "./createExecution";
 import { IExecuteErrorComponent, IExecuteLoadingComponent } from "./interfaces";
 
@@ -34,27 +42,27 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
      * Data series will be built using the provided measures that are optionally further scoped for
      * elements of the specified attributes.
      */
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally slice all data series by elements of these attributes.
      */
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
+    slicesBy?: AttributesOrPlaceholders;
 
     /**
      * Optionally include these totals among the data slices.
      */
-    totals?: ValuesOrPlaceholders<ITotal>;
+    totals?: TotalsOrPlaceholders;
 
     /**
      * Optional filters to apply on server side.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional sorting to apply on server side.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui/src/execution/useExecution.ts
+++ b/libs/sdk-ui/src/execution/useExecution.ts
@@ -1,12 +1,14 @@
 // (C) 2019-2021 GoodData Corporation
 import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
-import { IAttribute, ITotal, INullableFilter, ISortItem } from "@gooddata/sdk-model";
 import {
-    AnyMeasure,
     useBackend,
     useResolveValuesWithPlaceholders,
     useWorkspace,
-    ValuesOrPlaceholders,
+    AttributesMeasuresOrPlaceholders,
+    AttributesOrPlaceholders,
+    TotalsOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
 } from "../base";
 import { createExecution } from "./createExecution";
 
@@ -18,27 +20,27 @@ export interface IUseExecutionConfig {
      * Data series will be built using the provided measures that are optionally further scoped for
      * elements of the specified attributes.
      */
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally slice all data series by elements of these attributes.
      */
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
+    slicesBy?: AttributesOrPlaceholders;
 
     /**
      * Optionally include these totals among the data slices.
      */
-    totals?: ValuesOrPlaceholders<ITotal>;
+    totals?: TotalsOrPlaceholders;
 
     /**
      * Optional filters to apply on server side.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional sorting to apply on server side.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.

--- a/libs/sdk-ui/src/execution/useExecutionDataView.ts
+++ b/libs/sdk-ui/src/execution/useExecutionDataView.ts
@@ -1,6 +1,5 @@
 // (C) 2019-2021 GoodData Corporation
 import { IAnalyticalBackend, IPreparedExecution } from "@gooddata/sdk-backend-spi";
-import { IAttribute, INullableFilter, ISortItem, ITotal } from "@gooddata/sdk-model";
 import { DataViewWindow } from "./withExecutionLoading";
 import {
     DataViewFacade,
@@ -9,8 +8,11 @@ import {
     useWorkspaceStrict,
     UseCancelablePromiseState,
     useResolveValuesWithPlaceholders,
-    ValuesOrPlaceholders,
-    AnyMeasure,
+    AttributesMeasuresOrPlaceholders,
+    AttributesOrPlaceholders,
+    NullableFiltersOrPlaceholders,
+    SortsOrPlaceholders,
+    TotalsOrPlaceholders,
 } from "../base";
 import { useDataView } from "./useDataView";
 import isEmpty from "lodash/isEmpty";
@@ -24,27 +26,27 @@ export interface IExecutionConfiguration {
      * Data series will be built using the provided measures that are optionally further scoped for
      * elements of the specified attributes.
      */
-    seriesBy: ValuesOrPlaceholders<IAttribute | AnyMeasure>;
+    seriesBy: AttributesMeasuresOrPlaceholders;
 
     /**
      * Optionally slice all data series by elements of these attributes.
      */
-    slicesBy?: ValuesOrPlaceholders<IAttribute>;
+    slicesBy?: AttributesOrPlaceholders;
 
     /**
      * Optionally include these totals among the data slices.
      */
-    totals?: ValuesOrPlaceholders<ITotal>;
+    totals?: TotalsOrPlaceholders;
 
     /**
      * Optional filters to apply on server side.
      */
-    filters?: ValuesOrPlaceholders<INullableFilter>;
+    filters?: NullableFiltersOrPlaceholders;
 
     /**
      * Optional sorting to apply on server side.
      */
-    sortBy?: ValuesOrPlaceholders<ISortItem>;
+    sortBy?: SortsOrPlaceholders;
 
     /**
      * Optional resolution context for composed placeholders.


### PR DESCRIPTION
- Issue is that TypeScript has no option to define covariance/contravariance/bivariance of the generic types
- Example of the issue: `IPlaceholder<IAttributeFilter>` is not assignable to `IPlaceholder<IFilter>` (`ValuesOrPlaceholders<IFilter>`)
- Add type aliases for all placeholder combinations that make sense
- Cover proper assignability by the tests

JIRA: RAIL-3518

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
