### PR TITLE
RELATED: ONE-5103 Prefer stacks over measures when switching to area

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -239,6 +239,52 @@ describe("PluggableAreaChart", () => {
                     },
                 ],
                 [
+                    "from table to area chart: multiple measures and date in columns",
+                    referencePointMocks.dateInColumnsAndMultipleMeasuresTable,
+                    {
+                        buckets: [
+                            referencePointMocks.dateInColumnsAndMultipleMeasuresTable.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: [
+                                    referencePointMocks.dateInColumnsAndMultipleMeasuresTable.buckets[2]
+                                        .items[0],
+                                ],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [],
+                            },
+                        ],
+                    },
+                ],
+                [
+                    "from treemap to area chart: multiple measures and date in segment",
+                    referencePointMocks.dateInColumnsAndMultipleMeasuresTreemap,
+                    {
+                        buckets: [
+                            {
+                                localIdentifier: "measures",
+                                items: referencePointMocks.dateInColumnsAndMultipleMeasuresTreemap.buckets[0].items.slice(
+                                    0,
+                                    1,
+                                ),
+                            },
+                            {
+                                localIdentifier: "view",
+                                items: [],
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [
+                                    referencePointMocks.dateInColumnsAndMultipleMeasuresTreemap.buckets[2]
+                                        .items[0],
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                [
                     "from colum chart to area chart: att1 and date1 in viewBy and date2 in stackBy",
                     referencePointMocks.attributeAndDateInViewByAndDateInStackByReferencePoint,
                     {

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -1236,6 +1236,48 @@ export const dateAndAttributeInViewByAndEmptyStackBy: IReferencePoint = {
     },
 };
 
+export const dateInColumnsAndMultipleMeasuresTable: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems,
+        },
+        {
+            localIdentifier: "attributes",
+            items: [],
+        },
+        {
+            localIdentifier: "columns",
+            items: [dateItem],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const dateInColumnsAndMultipleMeasuresTreemap: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems,
+        },
+        {
+            localIdentifier: "view",
+            items: [],
+        },
+        {
+            localIdentifier: "segment",
+            items: [dateItem],
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
 export const datesInViewByAndAttributeInStackBy: IReferencePoint = {
     buckets: [
         {


### PR DESCRIPTION
JIRA: ONE-5103


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)