### PR TITLE
RELATED: NAS-156 Optimize availability queries on tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -32,6 +32,7 @@ import { convertAttribute } from "../../../convertors/toBackend/afm/AttributeCon
 import { jsonApiIdToObjRef } from "../../../convertors/fromBackend/ObjRefConverter";
 import { InvariantError } from "ts-invariant";
 import { convertAfmFilters } from "../../../convertors/toBackend/afm/AfmFiltersConverter";
+import { filterMeasuresForAvailabilityQuery } from "./availableItemsQueryUtils";
 
 const typesMatching: Partial<{ [T in CatalogItemType]: AfmValidObjectsQueryTypesEnum }> = {
     attribute: AfmValidObjectsQueryTypesEnum.Attributes,
@@ -137,7 +138,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
             ? [...insightMeasures(insight), ...insightAttributes(insight), ...insightFilters(insight)]
             : items;
         const attributes = relevantItems.filter(isAttribute);
-        const measures = relevantItems.filter(isMeasure);
+        const measures = filterMeasuresForAvailabilityQuery(relevantItems.filter(isMeasure));
         const filters = relevantItems.filter(isFilter);
 
         const { filters: afmFilters, auxMeasures } = convertAfmFilters(attributes, measures, filters);

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsQueryUtils.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsQueryUtils.ts
@@ -1,0 +1,47 @@
+// (C) 2021 GoodData Corporation
+import {
+    isMeasure,
+    isArithmeticMeasure,
+    measureLocalId,
+    isSimpleMeasure,
+    isPoPMeasure,
+    isPreviousPeriodMeasure,
+    measureMasterIdentifier,
+    IMeasure,
+} from "@gooddata/sdk-model";
+import { InvariantError } from "ts-invariant";
+
+/*
+ * Availability query measures do not need to contain arithmetic measures and measures derived from them:
+ * they cannot influence the item availability anyway.
+ */
+export function filterMeasuresForAvailabilityQuery(measures: IMeasure[]): IMeasure[] {
+    const arithmeticMeasuresIds = new Set<string>();
+    const otherMeasureIds = new Set<string>();
+
+    measures.forEach((measure) => {
+        if (isArithmeticMeasure(measure)) {
+            arithmeticMeasuresIds.add(measureLocalId(measure));
+        } else if (isMeasure(measure)) {
+            otherMeasureIds.add(measureLocalId(measure));
+        }
+    });
+
+    return measures.filter((measure) => {
+        if (isSimpleMeasure(measure)) {
+            return true;
+        } else if (isArithmeticMeasure(measure)) {
+            return false;
+        } else if (isPoPMeasure(measure) || isPreviousPeriodMeasure(measure)) {
+            const masterMeasure = measureMasterIdentifier(measure);
+
+            // remove derived measures which are either derived from arithmetic measure or which do
+            // not have their master among the items to query
+            return !arithmeticMeasuresIds.has(masterMeasure) && otherMeasureIds.has(masterMeasure);
+        }
+
+        throw new InvariantError(
+            "unexpected type of measure encountered while constructing items for availability query",
+        );
+    });
+}

--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/test/availableItemsQueryUtils.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/test/availableItemsQueryUtils.test.ts
@@ -1,0 +1,34 @@
+// (C) 2021 GoodData Corporation
+
+import { newArithmeticMeasure, newMeasure, newPopMeasure } from "@gooddata/sdk-model";
+import { filterMeasuresForAvailabilityQuery } from "../availableItemsQueryUtils";
+
+describe("filterMeasuresForAvailabilityQuery", () => {
+    const simpleMeasure1 = newMeasure("foo");
+    const simpleMeasure2 = newMeasure("bar");
+
+    const arithmeticMeasure = newArithmeticMeasure([simpleMeasure1, simpleMeasure2], "ratio");
+
+    it("should remove arithmetic measure", () => {
+        expect(
+            filterMeasuresForAvailabilityQuery([simpleMeasure1, simpleMeasure2, arithmeticMeasure]),
+        ).toEqual([simpleMeasure1, simpleMeasure2]);
+    });
+
+    it("should remove PoP measure derived from arithmetic measure", () => {
+        const derived = newPopMeasure(arithmeticMeasure, "some-attr");
+
+        expect(
+            filterMeasuresForAvailabilityQuery([simpleMeasure1, simpleMeasure2, arithmeticMeasure, derived]),
+        ).toEqual([simpleMeasure1, simpleMeasure2]);
+    });
+
+    it("should remove PoP measure derived from a measure that is not in the list", () => {
+        const derived = newPopMeasure("non-existent-local-id", "some-attr");
+
+        expect(filterMeasuresForAvailabilityQuery([simpleMeasure1, simpleMeasure2, derived])).toEqual([
+            simpleMeasure1,
+            simpleMeasure2,
+        ]);
+    });
+});


### PR DESCRIPTION
Similar to bear, arithmetic measures cannot influence item availability,
so filter them out to make the AFM simpler.

This also allows certain optimizations in user code (e.g. ignoring
arithmetic measures when reloading available items).

JIRA: NAS-156

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
