### PR TITLE
RELATED: RAIL-3511 Add CI script for api docs build

### DIFF
--- a/common/scripts/ci/docker_apidocs_build.sh
+++ b/common/scripts/ci/docker_apidocs_build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Absolute root directory - for volumes
+ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
+
+# go one level up to "see" the gooddata-ui-apidocs too
+ROOT_DIR="$ROOT_DIR/.."
+
+IMAGE="node:12.20.1"
+
+echo "Running apidocs build using ${IMAGE} in root directory ${ROOT_DIR}"
+
+#
+# Environment variables to propagate to docker
+#
+export CI=true
+
+
+echo "-----------------------------------------------------------------------"
+echo "--- starting: apidocs build"
+echo "-----------------------------------------------------------------------"
+
+
+if [ -z $API_DOCS_VERSION ]; then
+  echo "You did not specify api docs version to create."
+  exit 1
+fi
+
+#
+# Execute apidocs build using dockerized node - all heavy lifting is done against SDK sources mounted as a volume onto the
+# /workspace directory
+#
+
+docker run \
+  --env CI \
+  --env HOME="/workspace" \
+  --env API_DOCS_VERSION="$API_DOCS_VERSION" \
+  --rm \
+  ${net_param} \
+  --volume ${ROOT_DIR}:/workspace:Z \
+  -u $(id -u ${USER}):$(id -g ${USER}) \
+  -w /workspace \
+  ${IMAGE} \
+  /bin/bash -c "cd gooddata-ui-sdk && ./common/scripts/build-docs.js -v $API_DOCS_VERSION"

--- a/common/scripts/ci/run_apidocs_build.sh
+++ b/common/scripts/ci/run_apidocs_build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#
+# This script orchestrates the apidocs build
+#
+
+DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}") && pwd -P))
+_RUSH="${DIR}/docker_rush.sh"
+
+source ${DIR}/utils.sh
+
+if [ -z $API_DOCS_VERSION ]; then
+  echo "You did not specify api docs version to create."
+  exit 1
+fi
+
+# first build the SDK to make sure the api files are up to date
+${_RUSH} install
+${_RUSH} build
+
+# then run the build script for the api docs
+${DIR}/docker_apidocs_build.sh


### PR DESCRIPTION
The meat of the work is running in docker because we need node and yarn.

Related PR to ci-infra: https://github.com/gooddata/ci-infra/pull/7548

JIRA: RAIL-3511

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
