### PR TITLE
RELATED: RAIL-3511 Add rush start-doc command

### DIFF
--- a/common/config/rush/command-line.json
+++ b/common/config/rush/command-line.json
@@ -112,6 +112,13 @@
     },
     {
       "commandKind": "global",
+      "name": "start-docs",
+      "summary": "Builds API documentation for the entire SDK and runs it",
+      "shellCommand": "node common/scripts/build-docs.js -d",
+      "safeForSimultaneousRushProcesses": true
+    },
+    {
+      "commandKind": "global",
       "name": "populate-ref",
       "summary": "Makes projects populate reference workspace with recording definitions or recordings themselves.",
       "shellCommand": "bash common/scripts/populate-ref.sh",


### PR DESCRIPTION
This command builds hte apidocs and runs them making previews
of the doc changes easier when developing.

JIRA: RAIL-3511

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
