### PR TITLE
Fix invisible Kpi components by adding missing CSS class

### DIFF
--- a/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
@@ -312,8 +312,12 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
                     alert,
                 };
 
+                const className = userWorkspaceSettings.enableKDWidgetCustomHeight
+                    ? "custom-height"
+                    : undefined;
+
                 return (
-                    <DefaultWidgetRenderer {...renderProps} {...computedRenderProps}>
+                    <DefaultWidgetRenderer {...renderProps} {...computedRenderProps} className={className}>
                         {widgetRenderer ? widgetRenderer(customWidgetRendererProps) : renderedWidget}
                     </DefaultWidgetRenderer>
                 );


### PR DESCRIPTION
Add same CSS class as in KD.
Without this class, nested CSS classes that depends on this "parent" class are not setting 100% height,
and without setting 100% height, react-measure does not work correctly - this is the root cause of the issue.

JIRA: RAIL-3531

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
