### PR TITLE
#1626: remove no longer needed code handling local identifiers

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/availableItemsFactory.ts
@@ -138,7 +138,7 @@ export class TigerWorkspaceCatalogAvailableItemsFactory implements IWorkspaceCat
         const measures = relevantItems.filter(isMeasure);
         const filters = relevantItems.filter(isFilter);
 
-        const { filters: afmFilters, auxMeasures } = convertAfmFilters(attributes, measures, filters);
+        const { filters: afmFilters, auxMeasures } = convertAfmFilters(measures, filters);
 
         const afmValidObjectsQuery: AfmValidObjectsQuery = {
             types: relevantRestrictingTypes.map(mapToTigerType),

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/ObjRefConverter.ts
@@ -1,18 +1,7 @@
 // (C) 2007-2021 GoodData Corporation
 import { AfmObjectIdentifier, LocalIdentifier } from "@gooddata/api-client-tiger";
 import { NotSupported, UnexpectedError } from "@gooddata/sdk-backend-spi";
-import {
-    attributeDisplayFormRef,
-    attributesFind,
-    IAttribute,
-    isIdentifierRef,
-    isLocalIdRef,
-    isObjRef,
-    isUriRef,
-    ObjRef,
-    ObjRefInScope,
-} from "@gooddata/sdk-model";
-import { invariant } from "ts-invariant";
+import { isIdentifierRef, isLocalIdRef, isUriRef, ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
 import { TigerAfmType, TigerObjectType } from "../../types";
 import {
     isTigerCompatibleType,
@@ -86,41 +75,23 @@ export function toLocalIdentifier(localIdentifier: string): LocalIdentifier {
 /**
  * @internal
  */
-export function toMeasureValueFilterMeasureQualifier(
-    ref: ObjRefInScope,
-): LocalIdentifier | AfmObjectIdentifier {
+export function toAfmIdentifier(ref: ObjRefInScope): LocalIdentifier | AfmObjectIdentifier {
     if (isLocalIdRef(ref)) {
         return toLocalIdentifier(ref.localIdentifier);
     } else if (isIdentifierRef(ref)) {
         if (!ref.type) {
             throw new UnexpectedError(
-                "Please explicitly specify idRef for measure value filter. You must provide both identifier and type of object you want to reference.",
+                `Incomplete object specification in ${JSON.stringify(
+                    ref,
+                )}. You must provide both id and type of object you want to reference.`,
             );
         }
         return toObjQualifier(ref);
     } else {
         throw new UnexpectedError(
-            `The measure property of measure value filter must be either object reference or local identifier`,
+            `Invalid object specification in ${JSON.stringify(
+                ref,
+            )}. Must be either object identifier or local identifier.`,
         );
-    }
-}
-
-/**
- * @internal
- */
-export function toRankingFilterDimensionalityIdentifier(
-    ref: ObjRefInScope,
-    afmAttributes: IAttribute[],
-): AfmObjectIdentifier {
-    if (isObjRef(ref)) {
-        return toObjQualifier(ref);
-    } else {
-        invariant(afmAttributes.length > 0);
-
-        const attribute = attributesFind(afmAttributes, ref.localIdentifier);
-
-        invariant(attribute);
-
-        return toObjQualifier(attributeDisplayFormRef(attribute));
     }
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AfmFiltersConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/AfmFiltersConverter.ts
@@ -1,7 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import { FilterDefinition, MeasureItem } from "@gooddata/api-client-tiger";
 import {
-    IAttribute,
     Identifier,
     IFilter,
     IMeasure,
@@ -71,7 +70,6 @@ function determineComputeRatioMeasureNumerators(
  * being generated (intended to be used by the callers in crafting the final backend AFM).
  */
 export function convertAfmFilters(
-    afmAttributes: IAttribute[],
     afmMeasures: IMeasure[],
     afmFilters: IFilter[],
 ): { filters: FilterDefinition[]; auxMeasures: MeasureItem[] } {
@@ -101,7 +99,7 @@ export function convertAfmFilters(
         }
     });
     return {
-        filters: compact(transformedFilters.map((filter) => convertFilter(filter, afmAttributes))),
+        filters: compact(transformedFilters.map(convertFilter)),
         auxMeasures: Array.from(computeRatioMeasureNumerators.values()).map(convertMeasure),
     };
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/MeasureConverter.ts
@@ -104,9 +104,7 @@ function convertSimpleMeasureDefinition(definition: IMeasureDefinition): SimpleM
     const { measureDefinition } = definition;
 
     const filters: FilterDefinitionForSimpleMeasure[] = measureDefinition.filters
-        ? (compact(
-              measureDefinition.filters.map((filter) => convertFilter(filter)),
-          ) as FilterDefinitionForSimpleMeasure[]) // measureDefinition.filters is IMeasureFilter, it contains only date and attribute filter, equally result contains this subset, it corresponds to type FilterDefinitionForSimpleMeasure
+        ? (compact(measureDefinition.filters.map(convertFilter)) as FilterDefinitionForSimpleMeasure[]) // measureDefinition.filters is IMeasureFilter, it contains only date and attribute filter, equally result contains this subset, it corresponds to type FilterDefinitionForSimpleMeasure
         : [];
     const filtersProp = filters.length ? { filters } : {};
 

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AfmFilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/AfmFilterConverter.test.ts
@@ -15,7 +15,7 @@ describe("convertAfmFilters", () => {
 
     it("should transform measure based filter of ratio measure", () => {
         const ratioFilter = newMeasureValueFilter("ratio", "GREATER_THAN", 128);
-        expect(convertAfmFilters([], afmMeasures, [ratioFilter])).toMatchSnapshot();
+        expect(convertAfmFilters(afmMeasures, [ratioFilter])).toMatchSnapshot();
     });
 
     it("should not transform measure based filter of non-ratio measure", () => {
@@ -25,11 +25,11 @@ describe("convertAfmFilters", () => {
             "TOP",
             3,
         );
-        expect(convertAfmFilters([], afmMeasures, [nonRatioFilter])).toMatchSnapshot();
+        expect(convertAfmFilters(afmMeasures, [nonRatioFilter])).toMatchSnapshot();
     });
 
     it("should keep non-measure based filter", () => {
         const positiveAttributeFilter = newPositiveAttributeFilter(ReferenceMd.Product.Name, ["value"]);
-        expect(convertAfmFilters([], afmMeasures, [positiveAttributeFilter])).toMatchSnapshot();
+        expect(convertAfmFilters(afmMeasures, [positiveAttributeFilter])).toMatchSnapshot();
     });
 });

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/FilterConverter.test.ts
@@ -14,7 +14,6 @@ import {
     uriRef,
 } from "@gooddata/sdk-model";
 import { ReferenceMd } from "@gooddata/reference-workspace";
-import { InvariantError } from "ts-invariant";
 
 describe("tiger filter converter from model to AFM", () => {
     describe("convert measure value filter", () => {
@@ -44,7 +43,7 @@ describe("tiger filter converter from model to AFM", () => {
         it("should throw exception if filter has idRef without type", () => {
             expect(() => {
                 convertFilter(newMeasureValueFilter(idRef("ambiguous"), "GREATER_THAN", 10));
-            }).toThrow();
+            }).toThrowErrorMatchingSnapshot();
         });
 
         it("should throw exception if filter is using uriRef", () => {
@@ -157,24 +156,6 @@ describe("tiger filter converter from model to AFM", () => {
 
             expect(convertFilter(emptyPositiveFilter)).toBeNull();
             expect(convertFilter(emptyNegativeFilter)).toBeNull();
-        });
-
-        it("should convert ranking filter when localIds used for attributes", () => {
-            const rankingFilter = newRankingFilter(ReferenceMd.Won, [ReferenceMd.IsActive], "TOP", 3);
-
-            expect(convertFilter(rankingFilter, [ReferenceMd.IsActive])).toMatchSnapshot();
-        });
-
-        it("should throw error when converting ranking filter with localIds used for attributes and no attribute list", () => {
-            const rankingFilter = newRankingFilter(ReferenceMd.Won, [ReferenceMd.IsActive], "TOP", 3);
-
-            expect(() => convertFilter(rankingFilter)).toThrow(InvariantError);
-        });
-
-        it("should throw error when converting ranking filter with localIds used for attributes and no matching attribute provided", () => {
-            const rankingFilter = newRankingFilter(ReferenceMd.Won, [ReferenceMd.IsActive], "TOP", 3);
-
-            expect(() => convertFilter(rankingFilter, [ReferenceMd.Product.Name])).toThrow(InvariantError);
         });
     });
 });

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/tests/__snapshots__/FilterConverter.test.ts.snap
@@ -19,28 +19,6 @@ exports[`tiger filter converter from model to AFM convert absolute date filter s
 
 exports[`tiger filter converter from model to AFM convert absolute date filter should convert absolute date filter without 'to' attribute 1`] = `null`;
 
-exports[`tiger filter converter from model to AFM convert filter should convert ranking filter when localIds used for attributes 1`] = `
-Object {
-  "rankingFilter": Object {
-    "dimensionality": Array [
-      Object {
-        "identifier": Object {
-          "id": "label.stage.isactive",
-          "type": "label",
-        },
-      },
-    ],
-    "measures": Array [
-      Object {
-        "localIdentifier": "m_acugFHNJgsBy",
-      },
-    ],
-    "operator": "TOP",
-    "value": 3,
-  },
-}
-`;
-
 exports[`tiger filter converter from model to AFM convert filter should return absolute date filter 1`] = `
 Object {
   "absoluteDateFilter": Object {
@@ -343,6 +321,8 @@ Object {
   },
 }
 `;
+
+exports[`tiger filter converter from model to AFM convert measure value filter should throw exception if filter has idRef without type 1`] = `"Incomplete object specification in {\\"identifier\\":\\"ambiguous\\"}. You must provide both id and type of object you want to reference."`;
 
 exports[`tiger filter converter from model to AFM convert relative date filter should return AFM relative date filter with date granularity 1`] = `
 Object {

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/toAfmResultSpec.ts
@@ -14,7 +14,7 @@ function convertAFM(def: IExecutionDefinition): AFM {
     const measures: MeasureItem[] = def.measures.map(convertMeasure);
     const measuresProp = { measures };
 
-    const { filters, auxMeasures } = convertAfmFilters(def.attributes, def.measures, def.filters || []);
+    const { filters, auxMeasures } = convertAfmFilters(def.measures, def.filters || []);
     const filtersProp = { filters };
     const auxMeasuresProp = { auxMeasures };
 


### PR DESCRIPTION
This is a partial revert of 03ce64e15195cd03. That functionality
is no longer needed in SDK as it was moved to tiger in #906.

On top of the revert there are changes in ObjRefConverter,
namely the code handling identifiers in measure and ranking
filters is now merged as it is just the same.


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)