### PR TITLE
Remove availableDrillTargets attributes from XIRR visualisation

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
@@ -10,7 +10,7 @@ import {
     MeasureGroupIdentifier,
     newDimension,
 } from "@gooddata/sdk-model";
-import { BucketNames } from "@gooddata/sdk-ui";
+import { BucketNames, IPushData } from "@gooddata/sdk-ui";
 
 import { CoreXirr, updateConfigWithSettings } from "@gooddata/sdk-ui-charts";
 import React from "react";
@@ -20,6 +20,7 @@ import {
     IReferencePoint,
     IVisConstruct,
     IVisProps,
+    IVisualizationOptions,
     RenderFunction,
 } from "../../../interfaces/Visualization";
 import {
@@ -141,4 +142,27 @@ export class PluggableXirr extends AbstractPluggableVisualization {
 
         return [newDimension([MeasureGroupIdentifier])];
     }
+
+    private withEmptyAttributeTargets(data: IPushData) {
+        const dataWithEmptyAttributeTargets: IPushData = {
+            ...data,
+            availableDrillTargets: {
+                ...data?.availableDrillTargets,
+                attributes: [],
+            },
+        };
+
+        return dataWithEmptyAttributeTargets;
+    }
+
+    // This is effectively calling super.pushData()
+    // https://stackoverflow.com/questions/31088947/inheritance-method-call-triggers-typescript-compiler-error
+    // https://github.com/basarat/typescript-book/blob/master/docs/arrow-functions.md#tip-arrow-functions-and-inheritance
+    private superPushData = this.pushData;
+
+    protected pushData = (data: IPushData, options?: IVisualizationOptions): void => {
+        // For xirr chart we do not support drilling from attributes.
+        const filterAtrributes = this.withEmptyAttributeTargets(data);
+        this.superPushData(filterAtrributes, options);
+    };
 }


### PR DESCRIPTION
 - We do not suppor drill from XIRR Visualization
 - clear availableDrillTargets attributes in push data

JIRA: TNT-75

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
