### PR TITLE
Add context for workspaces provisioned via LCM

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1453,14 +1453,12 @@ export interface IDashboardProps {
     backend?: IAnalyticalBackend;
     // (undocumented)
     children?: JSX.Element | ((dashboard: any) => JSX.Element);
-    clientId?: string;
     config?: DashboardConfig;
     dashboardLayoutConfig?: {
         Component?: ComponentType<DashboardLayoutProps>;
         defaultComponentProps?: DashboardLayoutProps;
     };
     dashboardRef: ObjRef;
-    dataProductId?: string;
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;
     ErrorComponent?: ComponentType<IErrorProps>;
     eventHandlers?: DashboardEventHandler[];
@@ -1504,10 +1502,10 @@ export interface IDashboardQuery<_TResult = any> {
 // @internal (undocumented)
 export interface IDashboardStoreProviderProps {
     backend?: IAnalyticalBackend;
-    clientId?: string;
+    config?: DashboardConfig;
     dashboardRef: ObjRef;
-    dataProductId?: string;
     eventHandlers?: DashboardEventHandler[];
+    permissions?: IWorkspacePermissions;
     workspace?: string;
 }
 

--- a/libs/sdk-ui-dashboard/src/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useState } from "react";
 import invariant from "ts-invariant";
 import {
     FilterContextItem,
@@ -25,9 +25,6 @@ import {
     changeAttributeFilterSelection,
     changeDateFilterSelection,
     clearDateFilterSelection,
-    DashboardStoreProvider,
-    InitialLoadCorrelationId,
-    loadDashboard,
     renameDashboard,
     selectDashboardLoading,
     selectDashboardTitle,
@@ -35,6 +32,7 @@ import {
     selectLocale,
     useDashboardDispatch,
     useDashboardSelector,
+    DashboardStoreProvider,
 } from "../model";
 import { DefaultScheduledEmailDialog } from "../scheduledEmail";
 import { DefaultTopBar, IDefaultMenuButtonComponentCallbacks } from "../topBar";
@@ -209,15 +207,8 @@ const DashboardInner: React.FC<IDashboardProps> = (props: IDashboardProps) => {
 };
 
 const DashboardLoading: React.FC<IDashboardProps> = (props: IDashboardProps) => {
-    const dispatch = useDashboardDispatch();
     const { loading, error, result } = useDashboardSelector(selectDashboardLoading);
     const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
-
-    useEffect(() => {
-        if (!loading && result === undefined) {
-            dispatch(loadDashboard(props.config, props.permissions, InitialLoadCorrelationId));
-        }
-    }, [loading, result]);
 
     if (error) {
         return <ErrorComponent message={error.message} />;
@@ -239,8 +230,6 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
             dashboardRef={props.dashboardRef}
             backend={props.backend}
             workspace={props.workspace}
-            clientId={props.clientId}
-            dataProductId={props.dataProductId}
             eventHandlers={props.eventHandlers}
         >
             <ToastMessageContextProvider>

--- a/libs/sdk-ui-dashboard/src/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/dashboard/types.ts
@@ -45,26 +45,6 @@ export interface IDashboardProps {
     dashboardRef: ObjRef;
 
     /**
-     * Data product identifier.
-     * This property is required, if the current backend implementation allows usage of data product identifier
-     * and data product identifier is set (workspace is provisioned via LCM).
-     *
-     * It's used to resolve drill to custom url data product identifier parameter.
-     * For more details, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
-     */
-    dataProductId?: string;
-
-    /**
-     * Client identifier.
-     * This property is required, if current backend implementation allows usage of client identifier
-     * and client identifier is set (workspace is provisioned via LCM).
-     *
-     * It's used to resolve drill to custom url client identifier parameter.
-     * For more details, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
-     */
-    clientId?: string;
-
-    /**
      * Configuration that can be used to modify dashboard features, capabilities and behavior.
      *
      * If not specified, then the dashboard will retrieve and use the essential configuration from the backend.

--- a/libs/sdk-ui-dashboard/src/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/layout/DashboardLayoutWidget.tsx
@@ -72,6 +72,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
 
     const allowOverflow = !!currentSize.heightAsRatio;
 
+    const className = settings.enableKDWidgetCustomHeight ? "custom-height" : undefined;
+
     return (
         <DefaultWidgetRenderer
             DefaultWidgetRenderer={DefaultWidgetRenderer}
@@ -80,6 +82,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
             allowOverflow={allowOverflow}
             height={height}
             minHeight={minHeight}
+            className={className}
         >
             <RenderDashboardWidget
                 screen={screen}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
@@ -101,12 +101,12 @@ export function* rootCommandHandler(): SagaIterator<void> {
     const commandChannel = yield actionChannel((action: any) => action.type.startsWith("GDC.DASH/CMD"));
 
     while (true) {
-        const action: DashboardCommands = yield take(commandChannel);
+        const command: DashboardCommands = yield take(commandChannel);
         const dashboardContext: DashboardContext = yield getContext("dashboardContext");
-        const commandHandler = DefaultCommandHandlers[action.type] ?? unhandledCommand;
+        const commandHandler = DefaultCommandHandlers[command.type] ?? unhandledCommand;
 
         try {
-            const result = yield call(commandHandler, dashboardContext, action);
+            const result = yield call(commandHandler, dashboardContext, command);
 
             if (isDashboardEvent(result)) {
                 yield dispatchDashboardEvent(result);
@@ -121,9 +121,9 @@ export function* rootCommandHandler(): SagaIterator<void> {
                 yield dispatchDashboardEvent(
                     internalErrorOccurred(
                         dashboardContext,
-                        `Internal error has occurred while handling ${action.type}`,
+                        `Internal error has occurred while handling ${command.type}`,
                         e,
-                        action.correlationId,
+                        command.correlationId,
                     ),
                 );
             }

--- a/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
+++ b/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
@@ -2,15 +2,10 @@
 import React from "react";
 import { AnyAction, Dispatch } from "@reduxjs/toolkit";
 import { createDispatchHook, createSelectorHook, Provider, TypedUseSelectorHook } from "react-redux";
-import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
-import { ObjRef } from "@gooddata/sdk-model";
-import { useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
-
-import { DashboardEventHandler } from "../events/eventHandler";
-import { createDashboardStore } from "../state/dashboardStore";
 import { DashboardState } from "../state/types";
-
 import { DashboardEventsProvider } from "./DashboardEventsContext";
+import { useInitializeDashboardStore } from "./useInitializeDashboardStore";
+import { IDashboardStoreProviderProps } from "./types";
 
 /**
  * @internal
@@ -31,75 +26,12 @@ export const useDashboardSelector: TypedUseSelectorHook<DashboardState> =
 /**
  * @internal
  */
-export interface IDashboardStoreProviderProps {
-    /**
-     * Analytical backend from which the dashboard obtains data to render.
-     *
-     * If you do not specify instance of analytical backend using this prop, then you MUST have
-     * BackendProvider up in the component tree.
-     */
-    backend?: IAnalyticalBackend;
-
-    /**
-     * Identifier of analytical workspace, from which the dashboard obtains data to render.
-     *
-     * If you do not specify workspace identifier, then you MUST have WorkspaceProvider up in the
-     * component tree.
-     */
-    workspace?: string;
-
-    /**
-     * Reference of the persisted dashboard to render.
-     */
-    dashboardRef: ObjRef;
-
-    /**
-     * Data product identifier.
-     * This property is required, if the current backend implementation allows usage of data product identifier
-     * and data product identifier is set (workspace is provisioned via LCM).
-     *
-     * It's used to resolve drill to custom url data product identifier parameter.
-     * For more details, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
-     */
-    dataProductId?: string;
-
-    /**
-     * Client identifier.
-     * This property is required, if current backend implementation allows usage of client identifier
-     * and client identifier is set (workspace is provisioned via LCM).
-     *
-     * It's used to resolve drill to custom url client identifier parameter.
-     * For more details, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
-     */
-    clientId?: string;
-
-    /**
-     * Optionally specify event handlers to register at the dashboard creation time.
-     *
-     * Note: all events that will be emitted during the initial load processing will have the `initialLoad`
-     * correlationId.
-     *
-     * TODO: this needs more attention.
-     */
-    eventHandlers?: DashboardEventHandler[];
-}
-
-/**
- * @internal
- */
 export const DashboardStoreProvider: React.FC<IDashboardStoreProviderProps> = (props) => {
-    const backend = useBackendStrict(props.backend);
-    const workspace = useWorkspaceStrict(props.workspace);
-    const dashboardStore = createDashboardStore({
-        sagaContext: {
-            backend,
-            workspace,
-            dashboardRef: props.dashboardRef,
-            clientId: props.clientId,
-            dataProductId: props.dataProductId,
-        },
-        initialEventHandlers: props.eventHandlers,
-    });
+    const dashboardStore = useInitializeDashboardStore(props);
+
+    if (!dashboardStore) {
+        return null;
+    }
 
     return (
         <Provider store={dashboardStore.store} context={ReactDashboardContext}>

--- a/libs/sdk-ui-dashboard/src/model/react/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/index.ts
@@ -1,10 +1,6 @@
 // (C) 2021 GoodData Corporation
-export {
-    DashboardStoreProvider,
-    IDashboardStoreProviderProps,
-    useDashboardDispatch,
-    useDashboardSelector,
-} from "./DashboardStoreProvider";
+export { DashboardStoreProvider, useDashboardDispatch, useDashboardSelector } from "./DashboardStoreProvider";
 export { IDashboardEventsContext, useDashboardEventsContext } from "./DashboardEventsContext";
 export { useDashboardCommand } from "./useDashboardCommand";
 export { useDashboardCommandProcessing, CommandProcessingStatus } from "./useDashboardCommandProcessing";
+export { IDashboardStoreProviderProps } from "./types";

--- a/libs/sdk-ui-dashboard/src/model/react/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/types.ts
@@ -1,0 +1,57 @@
+// (C) 2021 GoodData Corporation
+import { IAnalyticalBackend, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
+import { ObjRef } from "@gooddata/sdk-model";
+import { DashboardEventHandler } from "../events/eventHandler";
+import { DashboardConfig } from "../types/commonTypes";
+
+/**
+ * @internal
+ */
+export interface IDashboardStoreProviderProps {
+    /**
+     * Analytical backend from which the dashboard obtains data to render.
+     *
+     * If you do not specify instance of analytical backend using this prop, then you MUST have
+     * BackendProvider up in the component tree.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Identifier of analytical workspace, from which the dashboard obtains data to render.
+     *
+     * If you do not specify workspace identifier, then you MUST have WorkspaceProvider up in the
+     * component tree.
+     */
+    workspace?: string;
+
+    /**
+     * Reference of the persisted dashboard to render.
+     */
+    dashboardRef: ObjRef;
+
+    /**
+     * Optionally specify event handlers to register at the dashboard creation time.
+     *
+     * Note: all events that will be emitted during the initial load processing will have the `initialLoad`
+     * correlationId.
+     *
+     * TODO: this needs more attention.
+     */
+    eventHandlers?: DashboardEventHandler[];
+
+    /**
+     * Configuration that can be used to modify dashboard features, capabilities and behavior.
+     *
+     * If not specified, then the dashboard will retrieve and use the essential configuration from the backend.
+     */
+    config?: DashboardConfig;
+
+    /**
+     * Optionally specify permissions to use when determining availability of the different features of
+     * the dashboard component.
+     *
+     * If you do not specify permissions, the dashboard component will load permissions for the currently
+     * logged-in user.
+     */
+    permissions?: IWorkspacePermissions;
+}

--- a/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
@@ -1,0 +1,64 @@
+// (C) 2021 GoodData Corporation
+import { useEffect, useState } from "react";
+import { usePrevious, useWorkspace } from "@gooddata/sdk-ui";
+import { createDashboardStore, ReduxedDashboardStore } from "../state/dashboardStore";
+import { InitialLoadCorrelationId, loadDashboard } from "../commands/dashboard";
+import { useBackendStrict, useClientWorkspaceIdentifiers } from "@gooddata/sdk-ui";
+import { objectUtils } from "@gooddata/util";
+import { IDashboardStoreProviderProps } from "./types";
+
+/**
+ * This hook is responsible for properly initializing and re-initializing the dashboard redux store,
+ * when the props of the Dashboard component change.
+ * It also cancels currently running sagas before the re-initialization.
+ *
+ * @internal
+ */
+export const useInitializeDashboardStore = (
+    props: IDashboardStoreProviderProps,
+): ReduxedDashboardStore | null => {
+    const { dashboardRef } = props;
+    const backend = useBackendStrict(props.backend);
+    const workspace = useWorkspace(props.workspace);
+    const { client: clientId, dataProduct: dataProductId } = useClientWorkspaceIdentifiers() ?? {};
+    const [dashboardStore, setDashboardStore] = useState<ReduxedDashboardStore | null>(null);
+
+    const currentInitProps = {
+        backend,
+        workspace,
+        dashboardRef,
+        clientId,
+        dataProductId,
+        initialEventHandlers: props.eventHandlers,
+    };
+
+    const previousInitProps = usePrevious(currentInitProps);
+
+    useEffect(() => {
+        if (!objectUtils.shallowEqualObjects(previousInitProps, currentInitProps) || !dashboardStore) {
+            if (dashboardStore) {
+                // When props are different and dashboardStore is already initialized or initializing,
+                // cancel all running sagas.
+                dashboardStore.rootSagaTask.cancel();
+            }
+
+            // Create new store and fire load dashboard command.
+            const dashStore = createDashboardStore({
+                sagaContext: {
+                    backend,
+                    workspace: workspace!,
+                    dashboardRef: currentInitProps.dashboardRef,
+                    clientId: currentInitProps.clientId,
+                    dataProductId: currentInitProps.dataProductId,
+                },
+                initialEventHandlers: props.eventHandlers,
+            });
+            dashStore.store.dispatch(
+                loadDashboard(props.config, props.permissions, InitialLoadCorrelationId),
+            );
+            return setDashboardStore(dashStore);
+        }
+    });
+
+    return dashboardStore;
+};

--- a/libs/sdk-ui-dashboard/src/widget/kpi/DashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/widget/kpi/DashboardKpi.tsx
@@ -18,7 +18,6 @@ export const DashboardKpi = (props: DashboardKpiProps): JSX.Element => {
         <KpiComponent
             {...props}
             onDrill={(event) => {
-                // TODO: RAIL-3533 correct Kpi drill typings
                 handleDrillToLegacyDashboard(event.drillDefinitions![0] as IDrillToLegacyDashboard, event);
             }}
         />

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -192,6 +192,9 @@ export type ChartElementType = "slice" | "bar" | "point" | "label" | "cell" | "t
 // @public (undocumented)
 export type ChartType = "bar" | "column" | "pie" | "line" | "area" | "donut" | "scatter" | "bubble" | "heatmap" | "geo" | "pushpin" | "combo" | "combo2" | "histogram" | "bullet" | "treemap" | "waterfall" | "funnel" | "pareto" | "alluvial";
 
+// @alpha
+export const ClientWorkspaceProvider: React_2.FC<IClientWorkspaceProviderProps>;
+
 // @public
 export function composedFromIdentifier(identifier: string): IHeaderPredicate;
 
@@ -546,6 +549,34 @@ export interface ICatalog {
     visualizations: {
         [key: string]: IIdentifierWithTags;
     };
+}
+
+// @alpha
+export interface IClientWorkspaceIdentifiers {
+    client?: string;
+    dataProduct?: string;
+    segment?: string;
+    workspace?: string;
+}
+
+// @alpha
+export interface IClientWorkspaceProviderCoreProps {
+    backend?: IAnalyticalBackend;
+    children: React_2.ReactNode;
+}
+
+// @alpha
+export type IClientWorkspaceProviderProps = IClientWorkspaceProviderWithWorkspaceProps | IClientWorkspaceProviderWithClientAndDataProductProps;
+
+// @alpha (undocumented)
+export interface IClientWorkspaceProviderWithClientAndDataProductProps extends IClientWorkspaceProviderCoreProps {
+    client: string;
+    dataProduct: string;
+}
+
+// @alpha (undocumented)
+export interface IClientWorkspaceProviderWithWorkspaceProps extends IClientWorkspaceProviderCoreProps {
+    workspace: string;
 }
 
 // @internal (undocumented)
@@ -1556,6 +1587,15 @@ export type UseCancelablePromiseSuccessState<TResult> = {
     status: "success";
 };
 
+// @alpha
+export const useClientWorkspaceError: () => GoodDataSdkError | undefined;
+
+// @alpha
+export const useClientWorkspaceIdentifiers: () => IClientWorkspaceIdentifiers;
+
+// @alpha
+export const useClientWorkspaceStatus: () => UseCancelablePromiseStatus;
+
 // @public
 export function useComposedPlaceholder<TContext, TPlaceholder extends IComposedPlaceholder<any, any, TContext>>(placeholder: TPlaceholder, resolutionContext?: TContext): PlaceholderResolvedValue<TPlaceholder>;
 
@@ -1603,6 +1643,9 @@ export function usePlaceholder<T extends IPlaceholder<any>>(placeholder?: T): [
 
 // @public
 export function usePlaceholders<T extends IPlaceholder<any>[]>(placeholders: [...T]): [PlaceholdersValues<T>, (valueOrUpdateCallback: ValueOrUpdateCallback<PlaceholdersValues<T>>) => void];
+
+// @internal
+export const usePrevious: <T>(props: T) => T;
 
 // @public
 export function useResolveValuesWithPlaceholders<T extends any[], C>(values: [...T], resolutionContext?: C): PlaceholdersResolvedValues<T>;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -138,7 +138,18 @@ export {
     resolveUseCancelablePromisesError,
     resolveUseCancelablePromisesStatus,
 } from "./react/useCancelablePromiseUtils";
-
+export {
+    IClientWorkspaceProviderProps,
+    IClientWorkspaceProviderCoreProps,
+    IClientWorkspaceProviderWithClientAndDataProductProps,
+    IClientWorkspaceProviderWithWorkspaceProps,
+    ClientWorkspaceProvider,
+    useClientWorkspaceIdentifiers,
+    useClientWorkspaceStatus,
+    useClientWorkspaceError,
+} from "./react/ClientWorkspaceContext/ClientWorkspaceContext";
+export { IClientWorkspaceIdentifiers } from "./react/ClientWorkspaceContext/interfaces";
+export { usePrevious } from "./react/usePrevious";
 /*
  * Localization exports
  */

--- a/libs/sdk-ui/src/base/react/ClientWorkspaceContext/ClientWorkspaceContext.tsx
+++ b/libs/sdk-ui/src/base/react/ClientWorkspaceContext/ClientWorkspaceContext.tsx
@@ -1,0 +1,180 @@
+// (C) 2019 GoodData Corporation
+import React from "react";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { useBackendStrict } from "../BackendContext";
+import {
+    useCancelablePromise,
+    UseCancelablePromiseState,
+    UseCancelablePromiseStatus,
+} from "../useCancelablePromise";
+import { GoodDataSdkError } from "../../errors/GoodDataSdkError";
+import isEmpty from "lodash/isEmpty";
+import { resolveLCMWorkspaceIdentifiers } from "./resolveLCMWorkspaceIdentifiers";
+import { IClientWorkspaceIdentifiers } from "./interfaces";
+import { useWorkspace, WorkspaceProvider } from "../WorkspaceContext";
+import invariant from "ts-invariant";
+
+/**
+ * @alpha
+ */
+export type IClientWorkspaceContext = UseCancelablePromiseState<
+    IClientWorkspaceIdentifiers,
+    GoodDataSdkError
+>;
+
+const ClientWorkspaceContext = React.createContext<IClientWorkspaceContext>({
+    status: "pending",
+    error: undefined,
+    result: undefined,
+});
+ClientWorkspaceContext.displayName = "ClientWorkspace";
+
+/**
+ * Common props of the {@link ClientWorkspaceProvider}.
+ *
+ * @alpha
+ */
+export interface IClientWorkspaceProviderCoreProps {
+    /**
+     * Optionally specify an instance of the analytical backend instance to work with.
+     *
+     * Note: if you do not have a BackendProvider above in the component tree, then you MUST specify the backend.
+     */
+    backend?: IAnalyticalBackend;
+
+    /**
+     * Wrapped React components that will have access to the LCMWorkspace context.
+     */
+    children: React.ReactNode;
+}
+
+/**
+ * @alpha
+ */
+export interface IClientWorkspaceProviderWithWorkspaceProps extends IClientWorkspaceProviderCoreProps {
+    /**
+     * Specify the workspace to use to obtain the LCM context.
+     *
+     * Note: another option is to specify dataProduct and client props, and then workspace will be resolved from them.
+     */
+    workspace: string;
+}
+
+/**
+ * @alpha
+ */
+export interface IClientWorkspaceProviderWithClientAndDataProductProps
+    extends IClientWorkspaceProviderCoreProps {
+    /**
+     * Specify the data product identifier to use to obtain the LCM context.
+     *
+     * Note: another option is to specify workspace prop, and then data product identifier will be resolved from it.
+     */
+    dataProduct: string;
+
+    /**
+     * Specify the client identifier to use to obtain the LCM context.
+     *
+     * Note: another option is to specify workspace prop, and then client identifier will be resolved from it.
+     */
+    client: string;
+}
+
+/**
+ * Props of the {@link ClientWorkspaceProvider} component.
+ * @alpha
+ */
+export type IClientWorkspaceProviderProps =
+    | IClientWorkspaceProviderWithWorkspaceProps
+    | IClientWorkspaceProviderWithClientAndDataProductProps;
+
+/**
+ * ClientWorkspaceProvider can be used as a replacement of the {@link WorkspaceProvider},
+ * if you want to work with the workspace in LCM context.
+ *
+ * It allows you to:
+ * - Use dataProduct and client identifier as a replacement of the workspace identifier.
+ *   Workspace identifier is resolved and provided to the {@link WorkspaceProvider} automatically.
+ *
+ * - Use workspace identifier to obtain dataProduct, client and segment identifiers by the {@link useClientWorkspaceIdentifiers} hooks.
+ *
+ * If the backend does not support clientId / dataProduct LCM provisioning,
+ * or the workspace is not provisioned via LCM, segment / client / dataProduct values will be undefined.
+ *
+ * To read more details about LCM, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86796865}
+ *
+ * @alpha
+ */
+export const ClientWorkspaceProvider: React.FC<IClientWorkspaceProviderProps> = (props) => {
+    const { children, backend: customBackend } = props;
+    const { client, dataProduct, workspace: customWorkspace } = getInputLCMIdentifiersFromProps(props);
+    const backend = useBackendStrict(customBackend, "ClientWorkspaceProvider");
+    const workspace = useWorkspace(customWorkspace);
+
+    const lcmIdentifiers = useCancelablePromise(
+        {
+            promise: () => resolveLCMWorkspaceIdentifiers(backend, { client, dataProduct, workspace }),
+        },
+        [client, dataProduct, workspace, backend],
+    );
+
+    const ws = lcmIdentifiers.result?.workspace;
+
+    return (
+        <ClientWorkspaceContext.Provider value={lcmIdentifiers}>
+            <WorkspaceProvider workspace={ws!}>{children}</WorkspaceProvider>
+        </ClientWorkspaceContext.Provider>
+    );
+};
+
+/**
+ * Hook to obtain loading status of the {@link ClientWorkspaceProvider} - "success", "error", "loading" or "pending".
+ * @alpha
+ */
+export const useClientWorkspaceStatus = (): UseCancelablePromiseStatus => {
+    const context = React.useContext(ClientWorkspaceContext);
+    return context.status;
+};
+
+/**
+ * Hook to obtain loading error of the {@link ClientWorkspaceProvider}.
+ * @alpha
+ */
+export const useClientWorkspaceError = (): GoodDataSdkError | undefined => {
+    const context = React.useContext(ClientWorkspaceContext);
+    return context.error;
+};
+
+/**
+ * Hook to obtain all resolved identifiers from the {@link ClientWorkspaceProvider} - workspace, segment, dataProduct and client.
+ * @alpha
+ */
+export const useClientWorkspaceIdentifiers = (): IClientWorkspaceIdentifiers => {
+    const context = React.useContext(ClientWorkspaceContext);
+    return context.result ?? {};
+};
+
+//
+//
+//
+
+function hasWorkspaceProp<T>(obj: T): obj is T & { workspace: string } {
+    return !isEmpty(obj) && !!(obj as Record<string, any>).workspace;
+}
+
+function getInputLCMIdentifiersFromProps(props: IClientWorkspaceProviderProps): IClientWorkspaceIdentifiers {
+    if (hasWorkspaceProp(props)) {
+        return {
+            workspace: props.workspace,
+        };
+    }
+
+    invariant(
+        props.client && props.dataProduct,
+        "ClientWorkspaceProvider: You must specify either - the workspace identifier, or the client and dataProduct identifier.",
+    );
+    return {
+        client: props.client,
+        dataProduct: props.dataProduct,
+    };
+}

--- a/libs/sdk-ui/src/base/react/ClientWorkspaceContext/interfaces.ts
+++ b/libs/sdk-ui/src/base/react/ClientWorkspaceContext/interfaces.ts
@@ -1,0 +1,28 @@
+// (C) 2019-2021 GoodData Corporation
+
+/**
+ * Resolved LCM identifiers of the workspace.
+ *
+ * @alpha
+ */
+export interface IClientWorkspaceIdentifiers {
+    /**
+     * Data product identifier.
+     */
+    dataProduct?: string;
+
+    /**
+     * Client identifier.
+     */
+    client?: string;
+
+    /**
+     * Segment identifier.
+     */
+    segment?: string;
+
+    /**
+     * Workspace identifier.
+     */
+    workspace?: string;
+}

--- a/libs/sdk-ui/src/base/react/ClientWorkspaceContext/resolveLCMWorkspaceIdentifiers.ts
+++ b/libs/sdk-ui/src/base/react/ClientWorkspaceContext/resolveLCMWorkspaceIdentifiers.ts
@@ -1,0 +1,80 @@
+// (C) 2019-2021 GoodData Corporation
+import { IClientWorkspaceIdentifiers } from "./interfaces";
+
+/**
+ * @internal
+ */
+export async function resolveLCMWorkspaceIdentifiers(
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    backend: any,
+    context: IClientWorkspaceIdentifiers,
+): Promise<IClientWorkspaceIdentifiers> {
+    const bootstrapResource = await getBootstrapResource(backend, {
+        clientId: context.client,
+        productId: context.dataProduct,
+        projectId: context.workspace,
+    });
+
+    return getLCMWorkspaceIdentifiersFromBootstrapResource(bootstrapResource);
+}
+
+function emptyPromise() {
+    return Promise.resolve();
+}
+
+function unwrapDecoratedBackend(backend: any): any {
+    if (backend?.decorated) {
+        return unwrapDecoratedBackend(backend.decorated);
+    }
+
+    return backend;
+}
+
+type AuthApiCall = (call: (client: any) => Promise<any>) => any;
+
+function getBackendAuthApiCallPrivateMethod(backend: any): AuthApiCall {
+    return backend.authApiCall ?? emptyPromise;
+}
+
+function getBearClientBootstrapResourceMethod(client: any): GetBootstrapResource {
+    const method = client?.user?.getBootstrapResource.bind(client?.user);
+
+    return method ?? emptyPromise;
+}
+
+type BootstrapResourceOptions = {
+    projectId?: string;
+    productId?: string;
+    clientId?: string;
+};
+type GetBootstrapResource = (options: BootstrapResourceOptions) => Promise<any>;
+
+async function getBootstrapResource(backend: any, options: BootstrapResourceOptions): Promise<any> {
+    const unwrappedBackend = unwrapDecoratedBackend(backend);
+    const authApiCall = getBackendAuthApiCallPrivateMethod(unwrappedBackend);
+
+    return authApiCall(async (client) => {
+        const getBootstrapResource = getBearClientBootstrapResourceMethod(client);
+
+        return getBootstrapResource(options);
+    });
+}
+
+function getLCMWorkspaceIdentifiersFromBootstrapResource(
+    bootstrapResource: any,
+): IClientWorkspaceIdentifiers {
+    const {
+        clientId: client,
+        dataProductId: dataProduct,
+        segmentId: segment,
+    } = bootstrapResource?.bootstrapResource.current.projectLcm ?? {};
+
+    const workspace = bootstrapResource?.bootstrapResource?.current?.project?.links?.self?.split?.("/").pop();
+
+    return {
+        dataProduct,
+        client,
+        segment,
+        workspace,
+    };
+}

--- a/libs/sdk-ui/src/base/react/usePrevious.ts
+++ b/libs/sdk-ui/src/base/react/usePrevious.ts
@@ -1,0 +1,18 @@
+// (C) 2021 GoodData Corporation
+import { useEffect, useRef } from "react";
+
+/**
+ * Hook for tracking the previous value of the React component prop.
+ * This is useful as a replacement for the componentWillReceiveProps lifecycle method.
+ * See: https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ * @internal
+ */
+export const usePrevious = <T>(props: T): T => {
+    const previousProps = useRef<T>(props);
+
+    useEffect(() => {
+        previousProps.current = props;
+    });
+
+    return previousProps.current;
+};

--- a/libs/util/src/index.ts
+++ b/libs/util/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 /**
  * This package contains utility functions used in production or test code of multiple different GoodData.UI packages.
@@ -13,5 +13,6 @@ import * as stringUtils from "./stringUtils";
 import * as testUtils from "./testUtils";
 import * as translationUtils from "./translationUtils";
 import * as arrayUtils from "./arrayUtils";
+import * as objectUtils from "./objectUtils";
 
-export { stringUtils, testUtils, translationUtils, arrayUtils };
+export { stringUtils, testUtils, translationUtils, arrayUtils, objectUtils };

--- a/libs/util/src/objectUtils.ts
+++ b/libs/util/src/objectUtils.ts
@@ -1,0 +1,33 @@
+// (C) 2021 GoodData Corporation
+// "Original" here: https://github.com/moroshko/shallow-equal/blob/master/src/objects.js
+
+/**
+ * @internal
+ */
+export function shallowEqualObjects(objA: Record<string, any>, objB: Record<string, any>): boolean {
+    if (objA === objB) {
+        return true;
+    }
+
+    if (!objA || !objB) {
+        return false;
+    }
+
+    const aKeys = Object.keys(objA);
+    const bKeys = Object.keys(objB);
+    const len = aKeys.length;
+
+    if (bKeys.length !== len) {
+        return false;
+    }
+
+    for (let i = 0; i < len; i++) {
+        const key = aKeys[i];
+
+        if (objA[key] !== objB[key] || !Object.prototype.hasOwnProperty.call(objB, key)) {
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/libs/util/src/tests/objectUtils.ts
+++ b/libs/util/src/tests/objectUtils.ts
@@ -1,0 +1,70 @@
+// (C) 2007-2021 GoodData Corporation
+import { shallowEqualObjects } from "./objectUtils";
+// "Original" here: https://github.com/moroshko/shallow-equal/blob/master/src/objects.test.js
+
+const obj1 = { game: "chess", year: "1979" };
+const obj2 = { language: "elm" };
+
+const tests: {
+    should: string;
+    objA: any;
+    objB: any;
+    result: boolean;
+}[] = [
+    {
+        should: "return false when A is falsy",
+        objA: null,
+        objB: {},
+        result: false,
+    },
+    {
+        should: "return false when B is falsy",
+        objA: {},
+        objB: undefined,
+        result: false,
+    },
+    {
+        should: "return true when objects are ===",
+        objA: obj1,
+        objB: obj1,
+        result: true,
+    },
+    {
+        should: "return true when both objects are empty",
+        objA: {},
+        objB: {},
+        result: true,
+    },
+    {
+        should: "return false when objects do not have the same amount of keys",
+        objA: { game: "chess", year: "1979", country: "Australia" },
+        objB: { game: "chess", year: "1979" },
+        result: false,
+    },
+    {
+        should: "return false when there corresponding values which are not ===",
+        objA: { first: obj1, second: obj2 },
+        objB: { first: obj1, second: { language: "elm" } },
+        result: false,
+    },
+    {
+        should: "return true when all values are ===",
+        objA: { first: obj1, second: obj2 },
+        objB: { second: obj2, first: obj1 },
+        result: true,
+    },
+    {
+        should: "return false when objectA contains undefined",
+        objA: { first: undefined },
+        objB: { second: "green" },
+        result: false,
+    },
+];
+
+describe("shallowEqualObjects", function () {
+    tests.forEach(function (test) {
+        it("should " + test.should, function () {
+            expect(shallowEqualObjects(test.objA, test.objB)).toEqual(test.result);
+        });
+    });
+});


### PR DESCRIPTION
- Add ability to use dataProduct / client identifiers instead of the workspace identifier itself
- Allow parsing of the workspace identifier to dataProduct / client / segment identifiers
- Add LCMProvisionedWorkspaceProvider and relevant hooks
- Add usePrevious hook
- Fix dashboard re-initializing - cancel running sagas and recreate store with the correct context.

JIRA: RAIL-3533

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
