### PR TITLE
RELATED: RAIL-3560 - Expand ObjRefMap to allow storing any object that has `ref`

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2209,7 +2209,7 @@ export const selectInsightAttributesMeta: (query: QueryInsightAttributesMeta) =>
 } | undefined>;
 
 // @internal
-export const selectInsightByRef: ((ref: ObjRef) => import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").IInsight | undefined, (res: DashboardState) => import("@gooddata/sdk-model").IInsight | undefined>) & import("lodash").MemoizedFunction;
+export const selectInsightByRef: ((ref: ObjRef) => import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").IInsight | undefined, (res: import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>) => import("@gooddata/sdk-model").IInsight | undefined>) & import("lodash").MemoizedFunction;
 
 // @internal
 export const selectInsightRefs: import("@reduxjs/toolkit").OutputSelector<DashboardState, ObjRef[], (res: import("@gooddata/sdk-model").IInsight[]) => ObjRef[]>;
@@ -2218,7 +2218,7 @@ export const selectInsightRefs: import("@reduxjs/toolkit").OutputSelector<Dashbo
 export const selectInsights: (state: DashboardState) => import("@gooddata/sdk-model").IInsight[];
 
 // @internal
-export const selectInsightsById: (state: DashboardState) => import("@reduxjs/toolkit").Dictionary<import("@gooddata/sdk-model").IInsight>;
+export const selectInsightsMap: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>, (res1: import("@gooddata/sdk-model").IInsight[], res2: import("@gooddata/sdk-backend-spi").IBackendCapabilities) => import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>>;
 
 // @internal
 export const selectIsEmbedded: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("../..").ResolvedDashboardConfig) => boolean>;

--- a/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
@@ -7,7 +7,17 @@ import {
     ICatalogDateDataset,
     IMetadataObject,
 } from "@gooddata/sdk-backend-spi";
-import { Identifier, isIdentifierRef, isUriRef, ObjectType, ObjRef } from "@gooddata/sdk-model";
+import {
+    Identifier,
+    IInsight,
+    insightId,
+    insightRef,
+    insightUri,
+    isIdentifierRef,
+    isUriRef,
+    ObjectType,
+    ObjRef,
+} from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 
 /**
@@ -123,7 +133,7 @@ export class ObjRefMap<T> {
         }
 
         if (identifier) {
-            this.itemsByIdentifier[`${this.idRefToKey(identifier, this.config.type)}`] = item;
+            this.itemsByIdentifier[this.idRefToKey(identifier, this.config.type)] = item;
         }
 
         this.items.push([refExtract(item), item]);
@@ -159,6 +169,10 @@ export class ObjRefMap<T> {
         }
 
         return this.itemsByUri[key.uri];
+    }
+
+    public has(key: ObjRef): boolean {
+        return this.get(key) !== undefined;
     }
 
     public keys(): IterableIterator<ObjRef> {
@@ -280,6 +294,27 @@ export function newMapForObjectWithRef<T extends { ref: ObjRef }>(
         idExtract: (i) => (isIdentifierRef(i.ref) ? i.ref.identifier : undefined),
         uriExtract: (i) => (isUriRef(i.ref) ? i.ref.uri : undefined),
         refExtract: (i) => i.ref,
+    });
+
+    return map.fromItems(items);
+}
+
+/**
+ * Creates {@link ObjRefMap} for insights.
+ *
+ * @param items - items to add into mapping
+ * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ */
+export function newInsightMap(
+    items: ReadonlyArray<IInsight>,
+    strictTypeCheck: boolean = false,
+): ObjRefMap<IInsight> {
+    const map = new ObjRefMap<IInsight>({
+        type: "insight",
+        strictTypeCheck,
+        idExtract: insightId,
+        uriExtract: insightUri,
+        refExtract: insightRef,
     });
 
     return map.fromItems(items);

--- a/libs/sdk-ui-dashboard/src/_staging/metadata/tests/objRefMap.test.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/tests/objRefMap.test.ts
@@ -1,0 +1,96 @@
+// (C) 2021 GoodData Corporation
+import { newMapForObjectWithRef } from "../objRefMap";
+import { idRef, uriRef } from "@gooddata/sdk-model";
+
+const objWithIdRef = (id: number, obj: number = id) => ({
+    ref: idRef(`id${id}`),
+    value: obj,
+});
+
+const objWithUriRef = (id: number, obj: number = id) => ({
+    ref: uriRef(`uri${id}`),
+    value: obj,
+});
+
+const objWithBoth = (id: number, obj: number = id) => ({
+    ref: {
+        identifier: `id${id}`,
+        uri: `uri${id}`,
+    },
+    value: obj,
+});
+
+describe("ObjRefMap", () => {
+    describe("for objects that have mix of identifier and uri", () => {
+        const MixedTestData = [objWithIdRef(1), objWithUriRef(2), objWithBoth(3)];
+
+        it("should handle insert", () => {
+            const map = newMapForObjectWithRef(MixedTestData);
+
+            expect(Array.from(map.values())).toEqual(MixedTestData);
+        });
+
+        it("should handle insert of duplicates using first-win", () => {
+            const others = [objWithIdRef(1, 10), objWithUriRef(2, 20), objWithBoth(3, 30)];
+            const map = newMapForObjectWithRef([...others, ...MixedTestData]);
+
+            expect(Array.from(map.values())).toEqual(others);
+        });
+
+        it("should allow lookup by either id or uri if the stored object had both", () => {
+            const map = newMapForObjectWithRef(MixedTestData);
+
+            expect(map.get(idRef("id3"))).toBeDefined();
+            expect(map.get(uriRef("uri3"))).toBeDefined();
+        });
+
+        it("should allow lookup only by id if the stored object only has id", () => {
+            const map = newMapForObjectWithRef(MixedTestData);
+
+            expect(map.get(idRef("id1"))).toBeDefined();
+            expect(map.get(uriRef("uri1"))).toBeUndefined();
+        });
+
+        it("should allow lookup only by uri if the stored object only has uri", () => {
+            const map = newMapForObjectWithRef(MixedTestData);
+
+            expect(map.get(idRef("id2"))).toBeUndefined();
+            expect(map.get(uriRef("uri2"))).toBeDefined();
+        });
+
+        it("should bomb if trying to insert object that has both id&uri but previous item with same id and no uri was inserted ", () => {
+            expect(() => {
+                newMapForObjectWithRef([...MixedTestData, objWithBoth(1)]);
+            }).toThrow();
+        });
+    });
+
+    describe("for objects that have both identifier and uri", () => {
+        const UnifiedTestData = [objWithBoth(1), objWithBoth(2), objWithBoth(3)];
+
+        it("should handle insert", () => {
+            const map = newMapForObjectWithRef(UnifiedTestData);
+
+            expect(map.size).toEqual(3);
+            expect(Array.from(map.values())).toEqual(UnifiedTestData);
+        });
+
+        it("should handle insert of duplicates using first-win", () => {
+            const others = [objWithBoth(1, 10), objWithBoth(2, 20), objWithBoth(3, 30)];
+            const map = newMapForObjectWithRef([...others, ...UnifiedTestData]);
+
+            expect(Array.from(map.values())).toEqual(others);
+        });
+
+        it("should allow lookup by either id or uri if the stored object had both", () => {
+            const map = newMapForObjectWithRef(UnifiedTestData);
+
+            expect(map.get(idRef("id1"))).toBeDefined();
+            expect(map.get(uriRef("uri1"))).toBeDefined();
+            expect(map.get(idRef("id2"))).toBeDefined();
+            expect(map.get(uriRef("uri2"))).toBeDefined();
+            expect(map.get(idRef("id3"))).toBeDefined();
+            expect(map.get(uriRef("uri3"))).toBeDefined();
+        });
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
@@ -14,7 +14,7 @@ import { validateSectionPlacement } from "./validation/layoutValidation";
 import { StashValidationResult, validateAndResolveStashedItems } from "./validation/stashValidation";
 import { resolveIndexOfNewItem } from "../../utils/arrayOps";
 import { loadInsightsForDashboardItems } from "./common/loadMissingInsights";
-import { selectInsightRefs } from "../../state/insights/insightsSelectors";
+import { selectInsightsMap } from "../../state/insights/insightsSelectors";
 import { PromiseFnReturnType } from "../../types/sagas";
 import { batchActions } from "redux-batched-actions";
 import { insightsActions } from "../../state/insights";
@@ -24,7 +24,7 @@ type AddLayoutSectionContext = {
     readonly cmd: AddLayoutSection;
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
-    readonly insightRefs: ReturnType<typeof selectInsightRefs>;
+    readonly availableInsights: ReturnType<typeof selectInsightsMap>;
 };
 
 function validateAndResolve(commandCtx: AddLayoutSectionContext): StashValidationResult {
@@ -71,7 +71,7 @@ export function* addLayoutSectionHandler(
         cmd,
         layout: yield select(selectLayout),
         stash: yield select(selectStash),
-        insightRefs: yield select(selectInsightRefs),
+        availableInsights: yield select(selectInsightsMap),
     };
 
     const stashValidationResult = validateAndResolve(commandCtx);
@@ -88,7 +88,7 @@ export function* addLayoutSectionHandler(
     const insightsToAdd: PromiseFnReturnType<typeof loadInsightsForDashboardItems> = yield call(
         loadInsightsForDashboardItems,
         ctx,
-        commandCtx.insightRefs,
+        commandCtx.availableInsights,
         stashValidationResult.resolved,
     );
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
@@ -13,7 +13,7 @@ import isEmpty from "lodash/isEmpty";
 import { layoutActions } from "../../state/layout";
 import { layoutSectionItemsAdded } from "../../events/layout";
 import { resolveIndexOfNewItem } from "../../utils/arrayOps";
-import { selectInsightRefs } from "../../state/insights/insightsSelectors";
+import { selectInsightsMap } from "../../state/insights/insightsSelectors";
 import { PromiseFnReturnType } from "../../types/sagas";
 import { loadInsightsForDashboardItems } from "./common/loadMissingInsights";
 import { batchActions } from "redux-batched-actions";
@@ -24,7 +24,7 @@ type AddSectionItemsContext = {
     readonly cmd: AddSectionItems;
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
-    readonly insightRefs: ReturnType<typeof selectInsightRefs>;
+    readonly availableInsights: ReturnType<typeof selectInsightsMap>;
 };
 
 function validateAndResolve(commandCtx: AddSectionItemsContext) {
@@ -80,7 +80,7 @@ export function* addSectionItemsHandler(ctx: DashboardContext, cmd: AddSectionIt
         cmd,
         layout: yield select(selectLayout),
         stash: yield select(selectStash),
-        insightRefs: yield select(selectInsightRefs),
+        availableInsights: yield select(selectInsightsMap),
     };
 
     const { stashValidationResult, section } = validateAndResolve(commandCtx);
@@ -89,7 +89,7 @@ export function* addSectionItemsHandler(ctx: DashboardContext, cmd: AddSectionIt
     const insightsToAdd: PromiseFnReturnType<typeof loadInsightsForDashboardItems> = yield call(
         loadInsightsForDashboardItems,
         ctx,
-        commandCtx.insightRefs,
+        commandCtx.availableInsights,
         stashValidationResult.resolved,
     );
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/common/loadMissingInsights.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/common/loadMissingInsights.ts
@@ -1,10 +1,10 @@
 // (C) 2021 GoodData Corporation
 import { DashboardContext } from "../../../types/commonTypes";
-import { IInsight, ObjRef, serializeObjRef } from "@gooddata/sdk-model";
+import { IInsight, ObjRef } from "@gooddata/sdk-model";
 import { ExtendedDashboardItem } from "../../../types/layoutTypes";
 import { isInsightWidget } from "@gooddata/sdk-backend-spi";
-import differenceBy from "lodash/differenceBy";
 import isEmpty from "lodash/isEmpty";
+import { ObjRefMap } from "../../../../_staging/metadata/objRefMap";
 
 function getInsightRefsFromItems(items: ReadonlyArray<ExtendedDashboardItem>): ObjRef[] {
     const result: ObjRef[] = [];
@@ -20,11 +20,11 @@ function getInsightRefsFromItems(items: ReadonlyArray<ExtendedDashboardItem>): O
 
 export function loadInsightsForDashboardItems(
     ctx: DashboardContext,
-    availableInsights: ObjRef[],
+    availableInsights: ObjRefMap<IInsight>,
     items: ReadonlyArray<ExtendedDashboardItem>,
 ): Promise<IInsight[]> {
     const usedInsightRefs = getInsightRefsFromItems(items);
-    const missingInsightRefs = differenceBy(usedInsightRefs, availableInsights, serializeObjRef);
+    const missingInsightRefs = usedInsightRefs.filter((ref) => !availableInsights.has(ref));
 
     if (isEmpty(missingInsightRefs)) {
         return Promise.resolve([]);

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -71,7 +71,7 @@ export {
 export {
     selectInsights,
     selectInsightRefs,
-    selectInsightsById,
+    selectInsightsMap,
     selectInsightByRef,
 } from "./state/insights/insightsSelectors";
 export { CatalogState } from "./state/catalog/catalogState";


### PR DESCRIPTION
-  ObjRefMap can now handle cases when object being inserted has id, uri or both
-  the new factory function `newMapForObjectWithRef` allows simple creation of maps for arbitrary objects
   that contain just `ref` property. Such map will extract the essentials from the ref and is ready for
   refs that are both uriRef and identifierRef
-  Testing what insights are available was not correctly checking refs

JIRA: RAIL-3560

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
