### PR TITLE
Table's attributes offer only limited set of intersection attributes

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/drilling/drillTargets.ts
+++ b/libs/sdk-ui-pivot/src/impl/drilling/drillTargets.ts
@@ -5,7 +5,19 @@ import {
     IAvailableDrillTargetMeasure,
     IAvailableDrillTargets,
 } from "@gooddata/sdk-ui";
-import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
+import { IMeasureDescriptor, IAttributeDescriptor } from "@gooddata/sdk-backend-spi";
+import { areObjRefsEqual } from "@gooddata/sdk-model";
+
+function getIntersectionAttributes(
+    fromAttribute: IAttributeDescriptor,
+    attributes: IAttributeDescriptor[],
+): IAttributeDescriptor[] {
+    const indexOfFromAttribute = attributes.findIndex((attribute) =>
+        areObjRefsEqual(attribute.attributeHeader.ref, fromAttribute.attributeHeader.ref),
+    );
+
+    return attributes.slice(0, indexOfFromAttribute + 1);
+}
 
 export function getAvailableDrillTargets(dv: DataViewFacade): IAvailableDrillTargets {
     const measureDescriptors = dv
@@ -23,7 +35,7 @@ export function getAvailableDrillTargets(dv: DataViewFacade): IAvailableDrillTar
         .attributeDescriptorsForDim(0)
         .map((attribute, _index, attributes) => ({
             attribute,
-            intersectionAttributes: attributes,
+            intersectionAttributes: getIntersectionAttributes(attribute, attributes),
         }));
 
     return {

--- a/libs/sdk-ui-pivot/src/impl/drilling/tests/__snapshots__/drillTargets.test.ts.snap
+++ b/libs/sdk-ui-pivot/src/impl/drilling/tests/__snapshots__/drillTargets.test.ts.snap
@@ -43,25 +43,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.department",
-              "name": "Department",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1088",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1088",
-            },
-            "identifier": "label.owner.department",
-            "localIdentifier": "a_label.owner.department",
-            "name": "Department",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1089",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1089",
-          },
-        },
       ],
     },
     Object {


### PR DESCRIPTION
JIRA: TNT-87
As tables fully support frill from attribute even on row attribute elements, drill intersection is not containing all attributes but only attribute itself and its parents
---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
