### PR TITLE
RELATED: RAIL-3560 - Sanitize ObjRefMap to better match expectations

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/metadata/tests/objRefMap.test.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/tests/objRefMap.test.ts
@@ -2,16 +2,6 @@
 import { newMapForObjectWithRef } from "../objRefMap";
 import { idRef, uriRef } from "@gooddata/sdk-model";
 
-const objWithIdRef = (id: number, obj: number = id) => ({
-    ref: idRef(`id${id}`),
-    value: obj,
-});
-
-const objWithUriRef = (id: number, obj: number = id) => ({
-    ref: uriRef(`uri${id}`),
-    value: obj,
-});
-
 const objWithBoth = (id: number, obj: number = id) => ({
     ref: {
         identifier: `id${id}`,
@@ -21,51 +11,7 @@ const objWithBoth = (id: number, obj: number = id) => ({
 });
 
 describe("ObjRefMap", () => {
-    describe("for objects that have mix of identifier and uri", () => {
-        const MixedTestData = [objWithIdRef(1), objWithUriRef(2), objWithBoth(3)];
-
-        it("should handle insert", () => {
-            const map = newMapForObjectWithRef(MixedTestData);
-
-            expect(Array.from(map.values())).toEqual(MixedTestData);
-        });
-
-        it("should handle insert of duplicates using first-win", () => {
-            const others = [objWithIdRef(1, 10), objWithUriRef(2, 20), objWithBoth(3, 30)];
-            const map = newMapForObjectWithRef([...others, ...MixedTestData]);
-
-            expect(Array.from(map.values())).toEqual(others);
-        });
-
-        it("should allow lookup by either id or uri if the stored object had both", () => {
-            const map = newMapForObjectWithRef(MixedTestData);
-
-            expect(map.get(idRef("id3"))).toBeDefined();
-            expect(map.get(uriRef("uri3"))).toBeDefined();
-        });
-
-        it("should allow lookup only by id if the stored object only has id", () => {
-            const map = newMapForObjectWithRef(MixedTestData);
-
-            expect(map.get(idRef("id1"))).toBeDefined();
-            expect(map.get(uriRef("uri1"))).toBeUndefined();
-        });
-
-        it("should allow lookup only by uri if the stored object only has uri", () => {
-            const map = newMapForObjectWithRef(MixedTestData);
-
-            expect(map.get(idRef("id2"))).toBeUndefined();
-            expect(map.get(uriRef("uri2"))).toBeDefined();
-        });
-
-        it("should bomb if trying to insert object that has both id&uri but previous item with same id and no uri was inserted ", () => {
-            expect(() => {
-                newMapForObjectWithRef([...MixedTestData, objWithBoth(1)]);
-            }).toThrow();
-        });
-    });
-
-    describe("for objects that have both identifier and uri", () => {
+    describe("for objects whose ref contains both identifier and uri", () => {
         const UnifiedTestData = [objWithBoth(1), objWithBoth(2), objWithBoth(3)];
 
         it("should handle insert", () => {
@@ -75,9 +21,9 @@ describe("ObjRefMap", () => {
             expect(Array.from(map.values())).toEqual(UnifiedTestData);
         });
 
-        it("should handle insert of duplicates using first-win", () => {
+        it("should handle insert of duplicates using last-win", () => {
             const others = [objWithBoth(1, 10), objWithBoth(2, 20), objWithBoth(3, 30)];
-            const map = newMapForObjectWithRef([...others, ...UnifiedTestData]);
+            const map = newMapForObjectWithRef([...UnifiedTestData, ...others]);
 
             expect(Array.from(map.values())).toEqual(others);
         });


### PR DESCRIPTION
-  Its nonsense to have entries that only have uri and not id; this was a miss in the previous PR
-  All entries must contain id, uri, and ref
-  The newMapForObjectWithRef has extractors that do invariant checks
-  This way, the expectation/contracts from ObjRefMap can be stable; otherwise stuff can enter the map
   but can never be looked up by both id or uri

JIRA: RAIL-3560

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
