### PR TITLE
Chart's target attribute has just subset of attributes in intersection

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/drilling/drillTargets.ts
+++ b/libs/sdk-ui-pivot/src/impl/drilling/drillTargets.ts
@@ -1,23 +1,12 @@
 // (C) 2007-2021 GoodData Corporation
 import {
     DataViewFacade,
+    getIntersectionAttributes,
     IAvailableDrillTargetAttribute,
     IAvailableDrillTargetMeasure,
     IAvailableDrillTargets,
 } from "@gooddata/sdk-ui";
-import { IMeasureDescriptor, IAttributeDescriptor } from "@gooddata/sdk-backend-spi";
-import { areObjRefsEqual } from "@gooddata/sdk-model";
-
-function getIntersectionAttributes(
-    fromAttribute: IAttributeDescriptor,
-    attributes: IAttributeDescriptor[],
-): IAttributeDescriptor[] {
-    const indexOfFromAttribute = attributes.findIndex((attribute) =>
-        areObjRefsEqual(attribute.attributeHeader.ref, fromAttribute.attributeHeader.ref),
-    );
-
-    return attributes.slice(0, indexOfFromAttribute + 1);
-}
+import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 
 export function getAvailableDrillTargets(dv: DataViewFacade): IAvailableDrillTargets {
     const measureDescriptors = dv

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -411,6 +411,9 @@ export class GeoTokenMissingSdkError extends GoodDataSdkError {
 // @internal (undocumented)
 export function getDrillIntersection(drillItems: IMappingHeader[]): IDrillEventIntersectionElement[];
 
+// @internal
+export function getIntersectionAttributes(fromAttribute: IAttributeDescriptor, attributes: IAttributeDescriptor[]): IAttributeDescriptor[];
+
 // @internal (undocumented)
 export function getIntersectionPartAfter(intersection: IDrillEventIntersectionElement[], localIdentifier: string): IDrillEventIntersectionElement[];
 

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -134,6 +134,8 @@ export { withContexts } from "./react/withContexts";
 export { wrapDisplayName } from "./react/wrapDisplayName";
 export { CancelError, ICancelablePromise, makeCancelable, isCancelError } from "./react/CancelablePromise";
 export { withEntireDataView, ILoadingInjectedProps } from "./react/legacy/withEntireDataView";
+export { getIntersectionAttributes } from "./react/legacy/availableDrillTargets";
+
 export {
     resolveUseCancelablePromisesError,
     resolveUseCancelablePromisesStatus,

--- a/libs/sdk-ui/src/base/react/legacy/availableDrillTargets.ts
+++ b/libs/sdk-ui/src/base/react/legacy/availableDrillTargets.ts
@@ -1,13 +1,31 @@
 // (C) 2021 GoodData Corporation
 import uniqBy from "lodash/fp/uniqBy";
 import flatten from "lodash/flatten";
-import { IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
+import { IAttributeDescriptor, IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 import {
     IAvailableDrillTargetAttribute,
     IAvailableDrillTargetMeasure,
     IAvailableDrillTargets,
 } from "../../vis/Events";
 import { DataViewFacade } from "../../results/facade";
+import { areObjRefsEqual } from "@gooddata/sdk-model";
+
+/**
+ * @internal
+ * Provides the subset of attributes which consist from all attributes before given attribute and attribute itself.
+ * @param fromAttribute - attribute to which we want to get relevant intersection's attributes
+ * @param attributes - all attributes from the same dimension as fromAttribute
+ */
+export function getIntersectionAttributes(
+    fromAttribute: IAttributeDescriptor,
+    attributes: IAttributeDescriptor[],
+): IAttributeDescriptor[] {
+    const indexOfFromAttribute = attributes.findIndex((attribute) =>
+        areObjRefsEqual(attribute.attributeHeader.ref, fromAttribute.attributeHeader.ref),
+    );
+
+    return attributes.slice(0, indexOfFromAttribute + 1);
+}
 
 function getAvailableDrillAttributes(dv: DataViewFacade): IAvailableDrillTargetAttribute[] {
     return flatten(
@@ -20,7 +38,7 @@ function getAvailableDrillAttributes(dv: DataViewFacade): IAvailableDrillTargetA
                     .attributeDescriptorsForDim(index)
                     .map((attribute, _index, attributes) => ({
                         attribute,
-                        intersectionAttributes: attributes,
+                        intersectionAttributes: getIntersectionAttributes(attribute, attributes),
                     }));
             }),
     );

--- a/libs/sdk-ui/src/base/react/legacy/tests/__snapshots__/availableDrillTargets.test.ts.snap
+++ b/libs/sdk-ui/src/base/react/legacy/tests/__snapshots__/availableDrillTargets.test.ts.snap
@@ -1843,25 +1843,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
-          },
-        },
       ],
     },
     Object {
@@ -2665,25 +2646,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
-          },
-        },
       ],
     },
     Object {
@@ -2902,25 +2864,6 @@ Object {
               "uri": "/gdc/md/referenceworkspace/obj/1055",
             },
             "uri": "/gdc/md/referenceworkspace/obj/1055",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
           },
         },
       ],
@@ -3658,25 +3601,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/515",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
       ],
     },
     Object {
@@ -3712,25 +3636,6 @@ Object {
             },
             "identifier": "closed.aag81lMifn6q",
             "localIdentifier": "a_closed.aag81lMifn6q",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
             "name": "Year (Closed)",
             "ref": Object {
               "uri": "/gdc/md/referenceworkspace/obj/515",
@@ -5358,25 +5263,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/515",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
       ],
     },
     Object {
@@ -5412,25 +5298,6 @@ Object {
             },
             "identifier": "closed.aag81lMifn6q",
             "localIdentifier": "a_closed.aag81lMifn6q",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
             "name": "Year (Closed)",
             "ref": Object {
               "uri": "/gdc/md/referenceworkspace/obj/515",
@@ -5571,25 +5438,6 @@ Object {
               "uri": "/gdc/md/referenceworkspace/obj/1055",
             },
             "uri": "/gdc/md/referenceworkspace/obj/1055",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
           },
         },
       ],
@@ -5862,25 +5710,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/515",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
       ],
     },
     Object {
@@ -5916,25 +5745,6 @@ Object {
             },
             "identifier": "closed.aag81lMifn6q",
             "localIdentifier": "a_closed.aag81lMifn6q",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
             "name": "Year (Closed)",
             "ref": Object {
               "uri": "/gdc/md/referenceworkspace/obj/515",
@@ -6733,25 +6543,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.opportunity.id",
-              "name": "Opportunity",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1066",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1066",
-            },
-            "identifier": "label.opportunity.id.name",
-            "localIdentifier": "a_label.opportunity.id.name",
-            "name": "Opportunity Name",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1067",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1067",
-          },
-        },
       ],
     },
     Object {
@@ -7124,25 +6915,6 @@ Object {
               "uri": "/gdc/md/referenceworkspace/obj/1055",
             },
             "uri": "/gdc/md/referenceworkspace/obj/1055",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
           },
         },
       ],
@@ -8103,25 +7875,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
-          },
-        },
       ],
     },
     Object {
@@ -8857,25 +8610,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/515",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
       ],
     },
     Object {
@@ -8911,25 +8645,6 @@ Object {
             },
             "identifier": "closed.aag81lMifn6q",
             "localIdentifier": "a_closed.aag81lMifn6q",
-            "name": "Year (Closed)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/515",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "closed.year",
-              "name": "Year (Closed)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/497",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/497",
-            },
-            "identifier": "closed.aag81lMifn6q",
-            "localIdentifier": "closed.second",
             "name": "Year (Closed)",
             "ref": Object {
               "uri": "/gdc/md/referenceworkspace/obj/515",
@@ -15390,25 +15105,6 @@ Object {
             "uri": "/gdc/md/referenceworkspace/obj/1055",
           },
         },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
-          },
-        },
       ],
     },
     Object {
@@ -15573,25 +15269,6 @@ Object {
               "uri": "/gdc/md/referenceworkspace/obj/1055",
             },
             "uri": "/gdc/md/referenceworkspace/obj/1055",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "attr.owner.region",
-              "name": "Region",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/1086",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/1086",
-            },
-            "identifier": "label.owner.region",
-            "localIdentifier": "a_label.owner.region",
-            "name": "Region",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/1087",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/1087",
           },
         },
       ],
@@ -16038,25 +15715,6 @@ Object {
               "uri": "/gdc/md/referenceworkspace/obj/515",
             },
             "uri": "/gdc/md/referenceworkspace/obj/515",
-          },
-        },
-        Object {
-          "attributeHeader": Object {
-            "formOf": Object {
-              "identifier": "created.year",
-              "name": "Year (Created)",
-              "ref": Object {
-                "uri": "/gdc/md/referenceworkspace/obj/332",
-              },
-              "uri": "/gdc/md/referenceworkspace/obj/332",
-            },
-            "identifier": "created.aag81lMifn6q",
-            "localIdentifier": "a_created.aag81lMifn6q",
-            "name": "Year (Created)",
-            "ref": Object {
-              "uri": "/gdc/md/referenceworkspace/obj/350",
-            },
-            "uri": "/gdc/md/referenceworkspace/obj/350",
           },
         },
       ],


### PR DESCRIPTION
JIRA: TNT-87
Even that charts currently support only drill from data point which offers full intersection it could lead to the invalid drill to uri definitions in future once the drill from axis label will be supported. From this reason we decided to provide only intersection attributes working also with drill from labels - attributes from same dimension as origin and limited to the origin itself and his parents. The same is already done for pivot table


---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
