### PR TITLE
RELATED: RAIL-3492 - Tag public model types and functions as alpha

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -87,10 +87,10 @@ import { ScreenSize } from '@gooddata/sdk-backend-spi';
 import { TypedUseSelectorHook } from 'react-redux';
 import { VisualizationProperties } from '@gooddata/sdk-model';
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type ActionFailedErrorReason = "USER_ERROR" | "INTERNAL_ERROR";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface AddAttributeFilter extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -104,10 +104,10 @@ export interface AddAttributeFilter extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD";
 }
 
-// @internal
+// @alpha
 export function addAttributeFilter(displayForm: ObjRef, index: number, correlationId?: string): AddAttributeFilter;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface AddLayoutSection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -119,13 +119,13 @@ export interface AddLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.ADD_SECTION";
 }
 
-// @internal
+// @alpha
 export function addLayoutSection(index: number, initialHeader?: IDashboardLayoutSectionHeader, initialItems?: DashboardItemDefinition[], correlationId?: string): AddLayoutSection;
 
-// @internal
+// @alpha
 export function addSectionItem(sectionIndex: number, itemIndex: number, item: DashboardItemDefinition, correlationId?: string): AddSectionItems;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface AddSectionItems extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -140,23 +140,23 @@ export interface AddSectionItems extends IDashboardCommand {
 // @internal (undocumented)
 export type AlertsState = EntityState<IWidgetAlert>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface AttributeFilterSelection {
     readonly elements: IAttributeElements;
     readonly filterLocalId: string;
     readonly selectionType: AttributeFilterSelectionType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type AttributeFilterSelectionType = "IN" | "NOT_IN";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface BackendCapabilitiesState {
     // (undocumented)
     backendCapabilities?: IBackendCapabilities;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface CatalogState {
     // (undocumented)
     attributes?: ICatalogAttribute[];
@@ -168,7 +168,7 @@ export interface CatalogState {
     measures?: ICatalogMeasure[];
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeAttributeFilterSelection extends IDashboardCommand {
     // (undocumented)
     readonly payload: AttributeFilterSelection;
@@ -176,10 +176,10 @@ export interface ChangeAttributeFilterSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION";
 }
 
-// @internal
+// @alpha
 export function changeAttributeFilterSelection(filterLocalId: string, elements: IAttributeElements, selectionType: AttributeFilterSelectionType, correlationId?: string): ChangeAttributeFilterSelection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeDateFilterSelection extends IDashboardCommand {
     // (undocumented)
     readonly payload: DateFilterSelection;
@@ -187,10 +187,10 @@ export interface ChangeDateFilterSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.DATE_FILTER.CHANGE_SELECTION";
 }
 
-// @internal
+// @alpha
 export function changeDateFilterSelection(type: DateFilterType, granularity: DateFilterGranularity, from?: DateString | number, to?: DateString | number, correlationId?: string): ChangeDateFilterSelection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeFilterContextSelection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -200,10 +200,10 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.CHANGE_SELECTION";
 }
 
-// @internal
+// @alpha
 export function changeFilterContextSelection(filters: IDashboardFilter_2[], correlationId?: string): ChangeFilterContextSelection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -214,10 +214,10 @@ export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS";
 }
 
-// @internal
+// @alpha
 export function changeInsightWidgetFilterSettings(ref: ObjRef, settings: WidgetFilterSettings, correlationId?: string): ChangeInsightWidgetFilterSettings;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeInsightWidgetHeader extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -228,10 +228,10 @@ export interface ChangeInsightWidgetHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_HEADER";
 }
 
-// @internal
+// @alpha
 export function changeInsightWidgetHeader(ref: ObjRef, header: WidgetHeader, correlationId?: string): ChangeInsightWidgetHeader;
 
-// @internal
+// @alpha
 export interface ChangeInsightWidgetInsight extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -243,10 +243,10 @@ export interface ChangeInsightWidgetInsight extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT";
 }
 
-// @internal
+// @alpha
 export function changeInsightWidgetInsight(ref: ObjRef, insightRef: ObjRef, visualizationProperties?: VisualizationProperties, correlationId?: string): ChangeInsightWidgetInsight;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeInsightWidgetVisProperties extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -257,10 +257,10 @@ export interface ChangeInsightWidgetVisProperties extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES";
 }
 
-// @internal
+// @alpha
 export function changeInsightWidgetVisProperties(ref: ObjRef, properties: VisualizationProperties, correlationId?: string): ChangeInsightWidgetVisProperties;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeKpiWidgetComparison extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -271,10 +271,10 @@ export interface ChangeKpiWidgetComparison extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_COMPARISON";
 }
 
-// @internal
+// @alpha
 export function changeKpiWidgetComparison(ref: ObjRef, comparison: KpiWidgetComparison, correlationId?: string): ChangeKpiWidgetComparison;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeKpiWidgetFilterSettings extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -285,10 +285,10 @@ export interface ChangeKpiWidgetFilterSettings extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_FILTER_SETTINGS";
 }
 
-// @internal
+// @alpha
 export function changeKpiWidgetFilterSettings(ref: ObjRef, settings: WidgetFilterSettings, correlationId?: string): ChangeKpiWidgetFilterSettings;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeKpiWidgetHeader extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -299,10 +299,10 @@ export interface ChangeKpiWidgetHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_HEADER";
 }
 
-// @internal
+// @alpha
 export function changeKpiWidgetHeader(ref: ObjRef, header: WidgetHeader, correlationId?: string): ChangeKpiWidgetHeader;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeKpiWidgetMeasure extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -314,10 +314,10 @@ export interface ChangeKpiWidgetMeasure extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE";
 }
 
-// @internal
+// @alpha
 export function changeKpiWidgetMeasure(ref: ObjRef, measureRef: ObjRef, header?: WidgetHeader, correlationId?: string): ChangeKpiWidgetMeasure;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ChangeLayoutSectionHeader extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -329,13 +329,13 @@ export interface ChangeLayoutSectionHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.CHANGE_SECTION_HEADER";
 }
 
-// @internal
+// @alpha
 export function changeLayoutSectionHeader(index: number, header: IDashboardLayoutSectionHeader, merge?: boolean, correlationId?: string): ChangeLayoutSectionHeader;
 
-// @internal
+// @alpha
 export function clearDateFilterSelection(correlationId?: string): ChangeDateFilterSelection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type CommandProcessingMeta = {
     readonly uuid: string;
 };
@@ -343,13 +343,13 @@ export type CommandProcessingMeta = {
 // @internal (undocumented)
 export type CommandProcessingStatus = "running" | "success" | "error";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ConfigState {
     // (undocumented)
     config?: ResolvedDashboardConfig;
 }
 
-// @internal
+// @alpha
 export interface CreateAlert extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -359,13 +359,13 @@ export interface CreateAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.CREATE";
 }
 
-// @internal
+// @alpha
 export function createAlert(alert: IWidgetAlertDefinition, correlationId?: string): CreateAlert;
 
-// @internal
+// @alpha
 export const createDrillToSameDashboardHandler: (dashboardRef: ObjRef) => DashboardEventHandler<DashboardDrillToDashboardTriggered>;
 
-// @internal
+// @alpha
 export interface CreateScheduledEmail extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -376,7 +376,7 @@ export interface CreateScheduledEmail extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SCHEDULED_EMAIL.CREATE";
 }
 
-// @internal
+// @alpha
 export function createScheduledEmail(scheduledEmail: IScheduledMailDefinition, filterContext?: IFilterContextDefinition, correlationId?: string): CreateScheduledEmail;
 
 // @internal (undocumented)
@@ -418,7 +418,7 @@ export type CustomTopBarComponent = ComponentType<ITopBarCoreProps>;
 // @internal (undocumented)
 export const Dashboard: React_2.FC<IDashboardProps>;
 
-// @internal
+// @alpha
 export interface DashboardAlertCreated extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -428,7 +428,7 @@ export interface DashboardAlertCreated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.CREATED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAlertRemoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -438,7 +438,7 @@ export interface DashboardAlertRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.REMOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAlertUpdated extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -448,7 +448,7 @@ export interface DashboardAlertUpdated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.UPDATED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAttributeFilterAdded extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -459,7 +459,7 @@ export interface DashboardAttributeFilterAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADDED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAttributeFilterMoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -471,7 +471,7 @@ export interface DashboardAttributeFilterMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAttributeFilterParentChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -481,7 +481,7 @@ export interface DashboardAttributeFilterParentChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.PARENT_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAttributeFilterRemoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -492,7 +492,7 @@ export interface DashboardAttributeFilterRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardAttributeFilterSelectionChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -502,7 +502,7 @@ export interface DashboardAttributeFilterSelectionChanged extends IDashboardEven
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.SELECTION_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardCommandFailed extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -514,19 +514,19 @@ export interface DashboardCommandFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COMMAND.FAILED";
 }
 
-// @internal
+// @alpha
 export interface DashboardCommandRejected extends IDashboardEvent {
     // (undocumented)
     readonly type: "GDC.DASH/EVT.COMMAND.REJECTED";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardCommands = LogUserInteraction | LoadDashboard | SaveDashboard | SaveDashboardAs | RenameDashboard | ResetDashboard | ChangeFilterContextSelection | ChangeDateFilterSelection | AddAttributeFilter | RemoveAttributeFilters | MoveAttributeFilter | ChangeAttributeFilterSelection | SetAttributeFilterParent | AddLayoutSection | MoveLayoutSection | RemoveLayoutSection | ChangeLayoutSectionHeader | AddSectionItems | ReplaceSectionItem | MoveSectionItem | RemoveSectionItem | UndoLayoutChanges | ChangeKpiWidgetHeader | ChangeKpiWidgetMeasure | ChangeKpiWidgetFilterSettings | ChangeKpiWidgetComparison | RefreshKpiWidget | ChangeInsightWidgetHeader | ChangeInsightWidgetFilterSettings | ChangeInsightWidgetVisProperties | ChangeInsightWidgetInsight | ModifyDrillsForInsightWidget | RemoveDrillsForInsightWidget | RefreshInsightWidget | CreateAlert | UpdateAlert | RemoveAlert | CreateScheduledEmail | Drill | DrillDown | DrillToAttributeUrl | DrillToCustomUrl | DrillToDashboard | DrillToInsight | DrillToLegacyDashboard;
 
-// @internal
+// @alpha
 export type DashboardCommandType = "GDC.DASH/CMD.LOG_USER_INTERACTION" | "GDC.DASH/CMD.LOAD" | "GDC.DASH/CMD.SAVE" | "GDC.DASH/CMD.SAVEAS" | "GDC.DASH/CMD.RESET" | "GDC.DASH/CMD.RENAME" | "GDC.DASH/CMD.FILTER_CONTEXT.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.DATE_FILTER.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT" | "GDC.DASH/CMD.FLUID_LAYOUT.ADD_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.CHANGE_SECTION_HEADER" | "GDC.DASH/CMD.FLUID_LAYOUT.ADD_ITEMS" | "GDC.DASH/CMD.FLUID_LAYOUT.REPLACE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.UNDO" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_HEADER" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_FILTER_SETTINGS" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_COMPARISON" | "GDC.DASH/CMD.KPI_WIDGET.REFRESH" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_HEADER" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT" | "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS" | "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS" | "GDC.DASH/CMD.INSIGHT_WIDGET.REFRESH" | "GDC.DASH/CMD.ALERT.CREATE" | "GDC.DASH/CMD.ALERT.UPDATE" | "GDC.DASH/CMD.ALERT.REMOVE" | "GDC.DASH/CMD.SCHEDULED_EMAIL.CREATE" | "GDC.DASH/CMD.DRILL" | "GDC.DASH/CMD.DRILL.DRILL_DOWN" | "GDC.DASH/CMD.DRILL.DRILL_TO_INSIGHT" | "GDC.DASH/CMD.DRILL.DRILL_TO_DASHBOARD" | "GDC.DASH/CMD.DRILL.DRILL_TO_ATTRIBUTE_URL" | "GDC.DASH/CMD.DRILL.DRILL_TO_CUSTOM_URL" | "GDC.DASH/CMD.DRILL.DRILL_TO_LEGACY_DASHBOARD";
 
-// @internal
+// @alpha
 export type DashboardConfig = {
     locale?: ILocale;
     separators?: ISeparators;
@@ -539,7 +539,7 @@ export type DashboardConfig = {
     isEmbedded?: boolean;
 };
 
-// @internal
+// @alpha
 export type DashboardContext = {
     backend: IAnalyticalBackend;
     workspace: string;
@@ -548,7 +548,7 @@ export type DashboardContext = {
     dataProductId?: string;
 };
 
-// @internal
+// @alpha
 export interface DashboardCopySaved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -558,7 +558,7 @@ export interface DashboardCopySaved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COPY_SAVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDateFilterSelectionChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -571,7 +571,7 @@ export interface DashboardDateFilterSelectionChanged extends IDashboardEvent {
 // @internal
 export type DashboardDispatch = Dispatch<AnyAction>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DashboardDrillContext {
     insight?: IInsight;
     widget?: IInsightWidget;
@@ -580,7 +580,7 @@ export interface DashboardDrillContext {
 // @internal (undocumented)
 export type DashboardDrillDefinition = DrillDefinition | IDrillDownDefinition;
 
-// @internal
+// @alpha
 export interface DashboardDrillDownTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -592,7 +592,7 @@ export interface DashboardDrillDownTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_DOWN.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillToAttributeUrlTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -604,7 +604,7 @@ export interface DashboardDrillToAttributeUrlTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_ATTRIBUTE_URL.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillToCustomUrlTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -616,7 +616,7 @@ export interface DashboardDrillToCustomUrlTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_CUSTOM_URL.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillToDashboardTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -628,7 +628,7 @@ export interface DashboardDrillToDashboardTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_DASHBOARD.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillToInsightTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -640,7 +640,7 @@ export interface DashboardDrillToInsightTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_INSIGHT.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillToLegacyDashboardTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -651,7 +651,7 @@ export interface DashboardDrillToLegacyDashboardTriggered extends IDashboardEven
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_LEGACY_DASHBOARD.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export interface DashboardDrillTriggered extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -662,19 +662,19 @@ export interface DashboardDrillTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.TRIGGERED";
 }
 
-// @internal
+// @alpha
 export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
     eval: (event: DashboardEvents) => boolean;
     handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void) => void;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardEvents = DashboardUserInteractionLogged | DashboardLoaded | DateFilterValidationFailed | DashboardCommandFailed | DashboardCommandRejected | DashboardQueryFailed | DashboardQueryRejected | DashboardQueryStarted | DashboardQueryCompleted<any, any> | DashboardSaved | DashboardCopySaved | DashboardRenamed | DashboardWasReset | DashboardDateFilterSelectionChanged | DashboardAttributeFilterAdded | DashboardAttributeFilterRemoved | DashboardAttributeFilterMoved | DashboardAttributeFilterSelectionChanged | DashboardAttributeFilterParentChanged | DashboardFilterContextChanged | DashboardLayoutSectionAdded | DashboardLayoutSectionMoved | DashboardLayoutSectionRemoved | DashboardLayoutSectionHeaderChanged | DashboardLayoutSectionItemsAdded | DashboardLayoutSectionItemReplaced | DashboardLayoutSectionItemMoved | DashboardLayoutSectionItemRemoved | DashboardLayoutChanged | DashboardKpiWidgetHeaderChanged | DashboardKpiWidgetMeasureChanged | DashboardKpiWidgetFilterSettingsChanged | DashboardKpiWidgetComparisonChanged | DashboardKpiWidgetChanged | DashboardInsightWidgetHeaderChanged | DashboardInsightWidgetFilterSettingsChanged | DashboardInsightWidgetVisPropertiesChanged | DashboardInsightWidgetInsightSwitched | DashboardInsightWidgetDrillsModified | DashboardInsightWidgetDrillsRemoved | DashboardInsightWidgetChanged | DashboardAlertCreated | DashboardAlertRemoved | DashboardAlertUpdated | DashboardScheduledEmailCreated | DashboardDrillDownTriggered | DashboardDrillToAttributeUrlTriggered | DashboardDrillToCustomUrlTriggered | DashboardDrillToDashboardTriggered | DashboardDrillToInsightTriggered | DashboardDrillToLegacyDashboardTriggered | DashboardDrillTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardEventType = "GDC.DASH/EVT.COMMAND.FAILED" | "GDC.DASH/EVT.COMMAND.REJECTED" | "GDC.DASH/EVT.QUERY.FAILED" | "GDC.DASH/EVT.QUERY.REJECTED" | "GDC.DASH/EVT.QUERY.STARTED" | "GDC.DASH/EVT.QUERY.COMPLETED" | "GDC.DASH/EVT.USER_INTERACTION_LOGGED" | "GDC.DASH/EVT.LOADED" | "GDC.DASH/EVT.SAVED" | "GDC.DASH/EVT.COPY_SAVED" | "GDC.DASH/EVT.RENAMED" | "GDC.DASH/EVT.RESET" | "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.VALIDATION.FAILED" | "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.SELECTION_CHANGED" | "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADDED" | "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVED" | "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVED" | "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.SELECTION_CHANGED" | "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.PARENT_CHANGED" | "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED" | "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED" | "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_MOVED" | "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_REMOVED" | "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_HEADER_CHANGED" | "GDC.DASH/EVT.FLUID_LAYOUT.ITEMS_ADDED" | "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED" | "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_MOVED" | "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REMOVED" | "GDC.DASH/EVT.FLUID_LAYOUT.LAYOUT_CHANGED" | "GDC.DASH/EVT.KPI_WIDGET.HEADER_CHANGED" | "GDC.DASH/EVT.KPI_WIDGET.MEASURE_CHANGED" | "GDC.DASH/EVT.KPI_WIDGET.FILTER_SETTINGS_CHANGED" | "GDC.DASH/EVT.KPI_WIDGET.COMPARISON_CHANGED" | "GDC.DASH/EVT.KPI_WIDGET.WIDGET_CHANGED" | "GDC.DASH/EVT.INSIGHT_WIDGET.HEADER_CHANGED" | "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED" | "GDC.DASH/EVT.INSIGHT_WIDGET.PROPERTIES_CHANGED" | "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED" | "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_MODIFIED" | "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_REMOVED" | "GDC.DASH/EVT.INSIGHT_WIDGET.WIDGET_CHANGED" | "GDC.DASH/EVT.ALERT.CREATED" | "GDC.DASH/EVT.ALERT.UPDATED" | "GDC.DASH/EVT.ALERT.REMOVED" | "GDC.DASH/EVT.SCHEDULED_EMAIL.CREATED" | "GDC.DASH/EVT.DRILL.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_DOWN.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_TO_INSIGHT.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_TO_DASHBOARD.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_TO_ATTRIBUTE_URL.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_TO_CUSTOM_URL.TRIGGERED" | "GDC.DASH/EVT.DRILL.DRILL_TO_LEGACY_DASHBOARD.TRIGGERED";
 
-// @internal
+// @alpha
 export interface DashboardFilterContextChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -690,7 +690,7 @@ export const DashboardInsight: () => JSX.Element;
 // @internal (undocumented)
 export const DashboardInsightPropsProvider: React_2.FC<IDashboardInsightProps>;
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -700,7 +700,7 @@ export interface DashboardInsightWidgetChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.WIDGET_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetDrillsModified extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -712,7 +712,7 @@ export interface DashboardInsightWidgetDrillsModified extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_MODIFIED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetDrillsRemoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -723,7 +723,7 @@ export interface DashboardInsightWidgetDrillsRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_REMOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetFilterSettingsChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -734,7 +734,7 @@ export interface DashboardInsightWidgetFilterSettingsChanged extends IDashboardE
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetHeaderChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -745,7 +745,7 @@ export interface DashboardInsightWidgetHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.HEADER_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetInsightSwitched extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -756,7 +756,7 @@ export interface DashboardInsightWidgetInsightSwitched extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED";
 }
 
-// @internal
+// @alpha
 export interface DashboardInsightWidgetVisPropertiesChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -767,7 +767,7 @@ export interface DashboardInsightWidgetVisPropertiesChanged extends IDashboardEv
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.PROPERTIES_CHANGED";
 }
 
-// @internal
+// @alpha
 export type DashboardItemDefinition = ExtendedDashboardItem | StashedDashboardItemsId;
 
 // @internal (undocumented)
@@ -791,7 +791,7 @@ export interface DashboardKpiProps {
 // @internal (undocumented)
 export const DashboardKpiPropsProvider: React_2.FC<DashboardKpiProps>;
 
-// @internal
+// @alpha
 export interface DashboardKpiWidgetChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -801,7 +801,7 @@ export interface DashboardKpiWidgetChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.WIDGET_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardKpiWidgetComparisonChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -812,7 +812,7 @@ export interface DashboardKpiWidgetComparisonChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.COMPARISON_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardKpiWidgetFilterSettingsChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -823,7 +823,7 @@ export interface DashboardKpiWidgetFilterSettingsChanged extends IDashboardEvent
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.FILTER_SETTINGS_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardKpiWidgetHeaderChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -834,7 +834,7 @@ export interface DashboardKpiWidgetHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.HEADER_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardKpiWidgetMeasureChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -849,7 +849,7 @@ export interface DashboardKpiWidgetMeasureChanged extends IDashboardEvent {
 // @internal (undocumented)
 export const DashboardLayout: (props: DashboardLayoutProps) => JSX.Element;
 
-// @internal
+// @alpha
 export interface DashboardLayoutChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -859,7 +859,7 @@ export interface DashboardLayoutChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.LAYOUT_CHANGED";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardLayoutCommands = AddLayoutSection | MoveLayoutSection | RemoveLayoutSection | ChangeLayoutSectionHeader | AddSectionItems | MoveSectionItem | RemoveSectionItem;
 
 // @internal (undocumented)
@@ -878,7 +878,7 @@ export interface DashboardLayoutProps {
     onFiltersChange?: (filters: IDashboardFilter[]) => void;
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionAdded extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -889,7 +889,7 @@ export interface DashboardLayoutSectionAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionHeaderChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -900,7 +900,7 @@ export interface DashboardLayoutSectionHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_HEADER_CHANGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionItemMoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -914,7 +914,7 @@ export interface DashboardLayoutSectionItemMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_MOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionItemRemoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -927,7 +927,7 @@ export interface DashboardLayoutSectionItemRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REMOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionItemReplaced extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -941,7 +941,7 @@ export interface DashboardLayoutSectionItemReplaced extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionItemsAdded extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -954,7 +954,7 @@ export interface DashboardLayoutSectionItemsAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEMS_ADDED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionMoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -966,7 +966,7 @@ export interface DashboardLayoutSectionMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_MOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLayoutSectionRemoved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -979,7 +979,7 @@ export interface DashboardLayoutSectionRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_REMOVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardLoaded extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -992,19 +992,19 @@ export interface DashboardLoaded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.LOADED";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardMeta = Pick<IDashboard, "ref" | "title" | "description" | "created" | "updated" | "isLocked" | "uri" | "identifier">;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DashboardMetaState {
     // (undocumented)
     meta?: DashboardMeta;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta;
 
-// @internal
+// @alpha
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult> extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1015,7 +1015,7 @@ export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>
     readonly type: "GDC.DASH/EVT.QUERY.COMPLETED";
 }
 
-// @internal
+// @alpha
 export interface DashboardQueryFailed extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1027,22 +1027,22 @@ export interface DashboardQueryFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.FAILED";
 }
 
-// @internal
+// @alpha
 export interface DashboardQueryRejected extends IDashboardEvent {
     // (undocumented)
     readonly type: "GDC.DASH/EVT.QUERY.REJECTED";
 }
 
-// @internal
+// @alpha
 export interface DashboardQueryStarted extends IDashboardEvent {
     // (undocumented)
     readonly type: "GDC.DASH/EVT.QUERY.STARTED";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META";
 
-// @internal
+// @alpha
 export interface DashboardRenamed extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1052,7 +1052,7 @@ export interface DashboardRenamed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.RENAMED";
 }
 
-// @internal
+// @alpha
 export interface DashboardSaved extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1063,7 +1063,7 @@ export interface DashboardSaved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.SAVED";
 }
 
-// @internal
+// @alpha
 export interface DashboardScheduledEmailCreated extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1073,7 +1073,7 @@ export interface DashboardScheduledEmailCreated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.SCHEDULED_EMAIL.CREATED";
 }
 
-// @internal
+// @alpha
 export type DashboardState = {
     loading: LoadingState;
     backendCapabilities: BackendCapabilitiesState;
@@ -1096,7 +1096,7 @@ export type DashboardState = {
 // @internal (undocumented)
 export const DashboardStoreProvider: React_2.FC<IDashboardStoreProviderProps>;
 
-// @internal
+// @alpha
 export interface DashboardUserInteractionLogged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1106,7 +1106,7 @@ export interface DashboardUserInteractionLogged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.USER_INTERACTION_LOGGED";
 }
 
-// @internal
+// @alpha
 export interface DashboardWasReset extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1154,17 +1154,17 @@ export const DashboardWidgetPropsProvider: React_2.FC<DashboardWidgetProps>;
 // @internal (undocumented)
 export const DashboardWidgetRenderer: React_2.FC<IDashboardWidgetRendererProps>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DateFilterConfigState {
     dateFilterConfig?: IDashboardDateFilterConfig_2;
     effectiveDateFilterConfig?: IDateFilterConfig;
     isUsingDashboardOverrides?: boolean;
 }
 
-// @internal
+// @alpha
 export type DateFilterConfigValidationResult = "Valid" | "NoVisibleOptions" | "ConflictingIdentifiers" | "SelectedOptionInvalid";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DateFilterSelection {
     readonly from?: DateString | number;
     readonly granularity: DateFilterGranularity;
@@ -1172,7 +1172,7 @@ export interface DateFilterSelection {
     readonly type: DateFilterType;
 }
 
-// @internal
+// @alpha
 export interface DateFilterValidationFailed extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
@@ -1182,7 +1182,7 @@ export interface DateFilterValidationFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.VALIDATION.FAILED";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type DateFilterValidationResult = "TOO_MANY_CONFIGS" | "NO_CONFIG" | DateFilterConfigValidationResult;
 
 // @internal (undocumented)
@@ -1239,7 +1239,7 @@ export const DefaultTitle: React_2.FC<IDefaultTitleProps>;
 // @internal (undocumented)
 export const DefaultTopBar: React_2.FC<IDefaultTopBarProps>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface Drill extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1250,10 +1250,10 @@ export interface Drill extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL";
 }
 
-// @internal
+// @alpha
 export function drill(drillEvent: IDashboardDrillEvent, drillContext: DashboardDrillContext, correlationId?: string): Drill;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillDown extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1265,10 +1265,10 @@ export interface DrillDown extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_DOWN";
 }
 
-// @internal
+// @alpha
 export function drillDown(insight: IInsight, drillDefinition: IDrillDownDefinition, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillDown;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillDownTriggered(ctx: DashboardContext, insight: IInsight, drillDefinition: IDrillDownDefinition, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillDownTriggered;
 
 // @internal (undocumented)
@@ -1281,7 +1281,7 @@ export interface DrillStep {
     insight: IInsight;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillToAttributeUrl extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1292,13 +1292,13 @@ export interface DrillToAttributeUrl extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_ATTRIBUTE_URL";
 }
 
-// @internal
+// @alpha
 export function drillToAttributeUrl(drillDefinition: IDrillToAttributeUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillToAttributeUrl;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillToAttributeUrlTriggered(ctx: DashboardContext, url: string, drillDefinition: IDrillToAttributeUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToAttributeUrlTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillToCustomUrl extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1309,13 +1309,13 @@ export interface DrillToCustomUrl extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_CUSTOM_URL";
 }
 
-// @internal
+// @alpha
 export function drillToCustomUrl(drillDefinition: IDrillToCustomUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillToCustomUrl;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillToCustomUrlTriggered(ctx: DashboardContext, url: string, drillDefinition: IDrillToCustomUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToCustomUrlTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillToDashboard extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1326,13 +1326,13 @@ export interface DrillToDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_DASHBOARD";
 }
 
-// @internal
+// @alpha
 export function drillToDashboard(drillDefinition: IDrillToDashboard, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillToDashboard;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillToDashboardTriggered(ctx: DashboardContext, filters: IDashboardFilter[], drillDefinition: IDrillToDashboard, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToDashboardTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillToInsight extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1343,13 +1343,13 @@ export interface DrillToInsight extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_INSIGHT";
 }
 
-// @internal
+// @alpha
 export function drillToInsight(drillDefinition: IDrillToInsight, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillToInsight;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillToInsightTriggered(ctx: DashboardContext, insight: IInsight, drillDefinition: IDrillToInsight, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToInsightTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface DrillToLegacyDashboard extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1360,34 +1360,34 @@ export interface DrillToLegacyDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_LEGACY_DASHBOARD";
 }
 
-// @internal
+// @alpha
 export function drillToLegacyDashboard(drillDefinition: IDrillToLegacyDashboard, drillEvent: IDashboardDrillEvent, correlationId?: string): DrillToLegacyDashboard;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillToLegacyDashboardTriggered(ctx: DashboardContext, drillDefinition: IDrillToLegacyDashboard, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToLegacyDashboardTriggered;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function drillTriggered(ctx: DashboardContext, drillEvent: IDashboardDrillEvent, drillContext: DashboardDrillContext, correlationId?: string): DashboardDrillTriggered;
 
-// @internal
+// @alpha
 export function eagerRemoveSectionItem(sectionIndex: number, itemIndex: number, stashIdentifier?: StashedDashboardItemsId, correlationId?: string): RemoveSectionItem;
 
-// @internal
+// @alpha
 export type ExtendedDashboardItem = IDashboardLayoutItem<ExtendedDashboardWidget>;
 
-// @internal
+// @alpha
 export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDashboardWidget>;
 
-// @internal
+// @alpha
 export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface FilterContextSelection {
     readonly attributeFilters?: Array<AttributeFilterSelection>;
     readonly dateFilter?: DateFilterSelection;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface FilterContextState {
     // (undocumented)
     filterContext?: IFilterContextDefinition;
@@ -1427,7 +1427,7 @@ export interface IDashboardAttributeFilterCoreProps {
     onFilterChanged: (filter: IDashboardAttributeFilter) => void;
 }
 
-// @internal
+// @alpha
 export interface IDashboardCommand {
     readonly correlationId?: string;
     readonly meta?: CommandProcessingMeta;
@@ -1455,14 +1455,14 @@ export interface IDashboardDrillEvent extends IDrillEvent {
     widgetRef?: ObjRef;
 }
 
-// @internal
+// @alpha
 export interface IDashboardEvent {
     readonly correlationId?: string;
     readonly ctx: DashboardContext;
     readonly type: DashboardEventType;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface IDashboardEventsContext {
     // (undocumented)
     registerHandler: (handler: DashboardEventHandler) => void;
@@ -1547,7 +1547,7 @@ export interface IDashboardProps {
     workspace?: string;
 }
 
-// @internal
+// @alpha
 export interface IDashboardQuery<_TResult = any> {
     readonly correlationId?: string;
     readonly type: DashboardQueryType;
@@ -1684,17 +1684,17 @@ export interface IMenuButtonItem {
     type?: "separator" | "header";
 }
 
-// @internal
+// @alpha
 export const InitialLoadCorrelationId = "initialLoad";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type InsightAttributesMeta = {
     usage: InsightDisplayFormUsage;
     displayForms: ReadonlyArray<IAttributeDisplayFormMetadataObject>;
     attributes: ReadonlyArray<IAttributeMetadataObject>;
 };
 
-// @internal
+// @alpha
 export type InsightDateDatasets = {
     readonly dateDatasets: ReadonlyArray<ICatalogDateDataset>;
     readonly dateDatasetsOrdered: ReadonlyArray<ICatalogDateDataset>;
@@ -1705,7 +1705,7 @@ export type InsightDateDatasets = {
     readonly dateDatasetDisplayNames: Record<string, string>;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type InsightPlaceholderWidget = {
     readonly type: "insightPlaceholder";
 };
@@ -1719,13 +1719,13 @@ export interface IScheduledEmailDialogCoreProps {
     onSuccess?: (scheduledMail: IScheduledMail) => void;
 }
 
-// @internal
+// @alpha
 export function isDashboardCommandFailed(obj: unknown): obj is DashboardCommandFailed;
 
-// @internal
+// @alpha
 export function isDashboardEvent(obj: unknown): obj is IDashboardEvent;
 
-// @internal
+// @alpha
 export function isDashboardQueryFailed(obj: unknown): obj is DashboardQueryFailed;
 
 // @beta
@@ -1749,21 +1749,21 @@ export interface ITopBarCoreProps {
     titleProps: ITitleProps;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type KpiPlaceholderWidget = {
     readonly type: "kpiPlaceholder";
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type KpiWidgetComparison = {
     comparisonType?: ILegacyKpiComparisonTypeComparison;
     comparisonDirection?: ILegacyKpiComparisonDirection;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type LayoutStash = Record<string, ExtendedDashboardItem[]>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface LayoutState extends UndoEnhancedState<DashboardLayoutCommands> {
     // (undocumented)
     layout?: IDashboardLayout<ExtendedDashboardWidget>;
@@ -1771,7 +1771,7 @@ export interface LayoutState extends UndoEnhancedState<DashboardLayoutCommands> 
     stash: LayoutStash;
 }
 
-// @internal
+// @alpha
 export interface LoadDashboard extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1782,17 +1782,17 @@ export interface LoadDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.LOAD";
 }
 
-// @internal
+// @alpha
 export function loadDashboard(config?: DashboardConfig, permissions?: IWorkspacePermissions, correlationId?: string): LoadDashboard;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type LoadingState = {
     loading: boolean;
     result?: boolean;
     error?: Error;
 };
 
-// @internal
+// @alpha
 export interface LogUserInteraction extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1802,13 +1802,13 @@ export interface LogUserInteraction extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.LOG_USER_INTERACTION";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function logUserInteraction(interaction: UserInteraction, correlationId?: string): LogUserInteraction;
 
-// @internal
+// @alpha
 export function modifyDrillForInsightWidget(ref: ObjRef, drill: InsightDrillDefinition, correlationId?: string): ModifyDrillsForInsightWidget;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1819,7 +1819,7 @@ export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface MoveAttributeFilter extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1830,10 +1830,10 @@ export interface MoveAttributeFilter extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE";
 }
 
-// @internal
+// @alpha
 export function moveAttributeFilter(filterLocalId: string, index: number, correlationId?: string): MoveAttributeFilter;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface MoveLayoutSection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1844,10 +1844,10 @@ export interface MoveLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_SECTION";
 }
 
-// @internal
+// @alpha
 export function moveLayoutSection(sectionIndex: number, toIndex: number, correlationId?: string): MoveLayoutSection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface MoveSectionItem extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1860,10 +1860,10 @@ export interface MoveSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_ITEM";
 }
 
-// @internal
+// @alpha
 export function moveSectionItem(sectionIndex: number, itemIndex: number, toSectionIndex: number, toItemIndex: number, correlationId?: string): MoveSectionItem;
 
-// @internal
+// @alpha
 export type ObjectAvailabilityConfig = {
     excludeObjectsWithTags?: string[];
     includeObjectsWithTags?: string[];
@@ -1910,16 +1910,16 @@ export type OnDrillToInsight = (context: {
 // @beta
 export type OnFiredDashboardViewDrillEvent = (event: IDashboardDrillEvent) => ReturnType<OnFiredDrillEvent>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface PermissionsState {
     // (undocumented)
     permissions?: IWorkspacePermissions;
 }
 
-// @internal
+// @alpha
 export function queryDateDatasetsForInsight(insightRef: ObjRef, correlationId?: string): QueryInsightDateDatasets;
 
-// @internal
+// @alpha
 export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
     // (undocumented)
     readonly payload: {
@@ -1929,10 +1929,10 @@ export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttri
     readonly type: "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META";
 }
 
-// @internal
+// @alpha
 export function queryInsightAttributesMeta(insightRef: ObjRef, correlationId?: string): QueryInsightAttributesMeta;
 
-// @internal
+// @alpha
 export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDatasets> {
     // (undocumented)
     readonly payload: {
@@ -1942,7 +1942,7 @@ export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDat
     readonly type: "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RefreshInsightWidget extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1952,10 +1952,10 @@ export interface RefreshInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.REFRESH";
 }
 
-// @internal
+// @alpha
 export function refreshInsightWidget(ref: ObjRef, correlationId?: string): RefreshInsightWidget;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RefreshKpiWidget extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1965,13 +1965,13 @@ export interface RefreshKpiWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.REFRESH";
 }
 
-// @internal
+// @alpha
 export function refreshKpiWidget(ref: ObjRef, correlationId?: string): RefreshKpiWidget;
 
-// @internal
+// @alpha
 export type RelativeIndex = number;
 
-// @internal
+// @alpha
 export interface RemoveAlert extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1981,13 +1981,13 @@ export interface RemoveAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.REMOVE";
 }
 
-// @internal
+// @alpha
 export function removeAlert(alert: IWidgetAlert, correlationId?: string): RemoveAlert;
 
-// @internal
+// @alpha
 export function removeAttributeFilter(filterLocalId: string, correlationId?: string): RemoveAttributeFilters;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RemoveAttributeFilters extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -1997,10 +1997,10 @@ export interface RemoveAttributeFilters extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE";
 }
 
-// @internal
+// @alpha
 export function removeDrillForInsightWidget(ref: ObjRef, measure: ObjRef, correlationId?: string): RemoveDrillsForInsightWidget;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RemoveDrillsForInsightWidget extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2011,10 +2011,10 @@ export interface RemoveDrillsForInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type RemoveDrillsSelector = ObjRef[] | "*";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RemoveLayoutSection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2025,10 +2025,10 @@ export interface RemoveLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_SECTION";
 }
 
-// @internal
+// @alpha
 export function removeLayoutSection(index: number, stashIdentifier?: StashedDashboardItemsId, correlationId?: string): RemoveLayoutSection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RemoveSectionItem extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2041,7 +2041,7 @@ export interface RemoveSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_ITEM";
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface RenameDashboard extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2051,10 +2051,10 @@ export interface RenameDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.RENAME";
 }
 
-// @internal
+// @alpha
 export function renameDashboard(newTitle: string, correlationId?: string): RenameDashboard;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ReplaceSectionItem extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2067,28 +2067,28 @@ export interface ReplaceSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REPLACE_ITEM";
 }
 
-// @internal
+// @alpha
 export function replaceSectionItem(sectionIndex: number, itemIndex: number, item: DashboardItemDefinition, stashIdentifier?: StashedDashboardItemsId, correlationId?: string): ReplaceSectionItem;
 
-// @internal
+// @alpha
 export function resetAttributeFilterSelection(filterLocalId: string, correlationId?: string): ChangeAttributeFilterSelection;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface ResetDashboard extends IDashboardCommand {
     // (undocumented)
     readonly type: "GDC.DASH/CMD.RESET";
 }
 
-// @internal
+// @alpha
 export function resetDashboard(correlationId?: string): ResetDashboard;
 
-// @internal
+// @alpha
 export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken"> & DashboardConfig;
 
-// @internal
+// @alpha
 export function revertLastLayoutChange(correlationId?: string): UndoLayoutChanges;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface SaveDashboard extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2098,10 +2098,10 @@ export interface SaveDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVE";
 }
 
-// @internal
+// @alpha
 export function saveDashboard(identifier?: string, correlationId?: string): SaveDashboard;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface SaveDashboardAs extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2112,61 +2112,61 @@ export interface SaveDashboardAs extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVEAS";
 }
 
-// @internal
+// @alpha
 export function saveDashboardAs(identifier?: string, title?: string, correlationId?: string): SaveDashboardAs;
 
-// @internal
+// @alpha
 export const selectAlerts: (state: DashboardState) => import("@gooddata/sdk-backend-spi").IWidgetAlert[];
 
-// @internal
+// @alpha
 export const selectAllCatalogAttributesMap: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-backend-spi").ICatalogAttribute | import("@gooddata/sdk-backend-spi").ICatalogDateAttribute>, (res1: import("@gooddata/sdk-backend-spi").ICatalogAttribute[], res2: import("@gooddata/sdk-backend-spi").ICatalogDateDataset[], res3: import("@gooddata/sdk-backend-spi").IBackendCapabilities) => import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-backend-spi").ICatalogAttribute | import("@gooddata/sdk-backend-spi").ICatalogDateAttribute>>;
 
-// @internal
+// @alpha
 export const selectAllCatalogDisplayFormsMap: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-backend-spi").IAttributeDisplayFormMetadataObject>, (res1: import("@gooddata/sdk-backend-spi").ICatalogAttribute[], res2: import("@gooddata/sdk-backend-spi").ICatalogDateDataset[], res3: import("@gooddata/sdk-backend-spi").IBackendCapabilities) => import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-backend-spi").IAttributeDisplayFormMetadataObject>>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const selectAttributesWithDrillDown: import("@reduxjs/toolkit").OutputSelector<DashboardState, (import("@gooddata/sdk-backend-spi").ICatalogAttribute | import("@gooddata/sdk-backend-spi").ICatalogDateAttribute)[], (res1: import("@gooddata/sdk-backend-spi").ICatalogAttribute[], res2: import("@gooddata/sdk-backend-spi").ICatalogDateAttribute[]) => (import("@gooddata/sdk-backend-spi").ICatalogAttribute | import("@gooddata/sdk-backend-spi").ICatalogDateAttribute)[]>;
 
-// @internal
+// @alpha
 export const selectBackendCapabilities: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IBackendCapabilities, (res: import("./backendCapabilitiesState").BackendCapabilitiesState) => import("@gooddata/sdk-backend-spi").IBackendCapabilities>;
 
 // @internal
 export const selectBasicLayout: import("@reduxjs/toolkit").OutputSelector<DashboardState, IDashboardLayout<import("@gooddata/sdk-backend-spi").IDashboardWidget>, (res: IDashboardLayout<import("../../types/layoutTypes").ExtendedDashboardWidget>) => IDashboardLayout<import("@gooddata/sdk-backend-spi").IDashboardWidget>>;
 
-// @internal
+// @alpha
 export const selectCanListUsersInWorkspace: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("@gooddata/sdk-backend-spi").IWorkspacePermissions) => boolean>;
 
-// @internal
+// @alpha
 export const selectCanManageWorkspace: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("@gooddata/sdk-backend-spi").IWorkspacePermissions) => boolean>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const selectCatalogAttributes: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ICatalogAttribute[], (res: import("./catalogState").CatalogState) => import("@gooddata/sdk-backend-spi").ICatalogAttribute[]>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const selectCatalogDateDatasets: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ICatalogDateDataset[], (res: import("./catalogState").CatalogState) => import("@gooddata/sdk-backend-spi").ICatalogDateDataset[]>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const selectCatalogFacts: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ICatalogFact[], (res: import("./catalogState").CatalogState) => import("@gooddata/sdk-backend-spi").ICatalogFact[]>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const selectCatalogMeasures: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ICatalogMeasure[], (res: import("./catalogState").CatalogState) => import("@gooddata/sdk-backend-spi").ICatalogMeasure[]>;
 
-// @internal
+// @alpha
 export const selectColorPalette: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").IColorPalette, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-model").IColorPalette>;
 
-// @internal
+// @alpha
 export const selectConfig: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../..").ResolvedDashboardConfig, (res: import("./configState").ConfigState) => import("../..").ResolvedDashboardConfig>;
 
 // @internal (undocumented)
 export const selectDashboardLoading: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("./loadingState").LoadingState, (res: DashboardState) => import("./loadingState").LoadingState>;
 
-// @internal
+// @alpha
 export const selectDashboardRef: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").ObjRef, (res: Pick<import("@gooddata/sdk-backend-spi").IDashboard, "title" | "description" | "ref" | "uri" | "updated" | "identifier" | "isLocked" | "created">) => import("@gooddata/sdk-model").ObjRef>;
 
-// @internal
+// @alpha
 export const selectDashboardTitle: import("@reduxjs/toolkit").OutputSelector<DashboardState, string, (res: Pick<import("@gooddata/sdk-backend-spi").IDashboard, "title" | "description" | "ref" | "uri" | "updated" | "identifier" | "isLocked" | "created">) => string>;
 
-// @internal
+// @alpha
 export const selectDashboardUriRef: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").UriRef, (res: string) => import("@gooddata/sdk-model").UriRef>;
 
 // @internal
@@ -2180,49 +2180,49 @@ export const selectDateDatasetsForInsight: (query: QueryInsightDateDatasets) => 
     error?: string | undefined;
 } | undefined>;
 
-// @internal
+// @alpha
 export const selectDateFilterConfig: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IDateFilterConfig, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-backend-spi").IDateFilterConfig>;
 
-// @internal
+// @alpha
 export const selectDateFilterConfigOverrides: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IDashboardDateFilterConfig | undefined, (res: import("./dateFilterConfigState").DateFilterConfigState) => import("@gooddata/sdk-backend-spi").IDashboardDateFilterConfig | undefined>;
 
-// @internal
+// @alpha
 export const selectDateFormat: import("@reduxjs/toolkit").OutputSelector<DashboardState, string | undefined, (res: import("../..").ResolvedDashboardConfig) => string | undefined>;
 
-// @internal
+// @alpha
 export const selectEffectiveDateFilterAvailableGranularities: import("@reduxjs/toolkit").OutputSelector<DashboardState, DateFilterGranularity[], (res: import("@gooddata/sdk-backend-spi").IDateFilterConfig) => DateFilterGranularity[]>;
 
-// @internal
+// @alpha
 export const selectEffectiveDateFilterConfig: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IDateFilterConfig, (res: import("./dateFilterConfigState").DateFilterConfigState) => import("@gooddata/sdk-backend-spi").IDateFilterConfig>;
 
-// @internal
+// @alpha
 export const selectEffectiveDateFilterMode: import("@reduxjs/toolkit").OutputSelector<DashboardState, DashboardDateFilterConfigMode, (res: import("@gooddata/sdk-backend-spi").IDashboardDateFilterConfig | undefined) => DashboardDateFilterConfigMode>;
 
-// @internal
+// @alpha
 export const selectEffectiveDateFilterOptions: import("@reduxjs/toolkit").OutputSelector<DashboardState, IDateFilterOptionsByType, (res: import("@gooddata/sdk-backend-spi").IDateFilterConfig) => IDateFilterOptionsByType>;
 
-// @internal
+// @alpha
 export const selectEffectiveDateFilterTitle: import("@reduxjs/toolkit").OutputSelector<DashboardState, string | undefined, (res1: boolean, res2: import("@gooddata/sdk-backend-spi").IDashboardDateFilterConfig | undefined) => string | undefined>;
 
-// @internal
+// @alpha
 export const selectEnableCompanyLogoInEmbeddedUI: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("../..").ResolvedDashboardConfig) => boolean>;
 
-// @internal
+// @alpha
 export const selectEnableKPIDashboardSchedule: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean | undefined, (res: import("../..").ResolvedDashboardConfig) => boolean | undefined>;
 
-// @internal
+// @alpha
 export const selectEnableKPIDashboardScheduleRecipients: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean | undefined, (res: import("../..").ResolvedDashboardConfig) => boolean | undefined>;
 
-// @internal
+// @alpha
 export const selectFilterContext: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IFilterContextDefinition, (res: import("./filterContextState").FilterContextState) => import("@gooddata/sdk-backend-spi").IFilterContextDefinition>;
 
-// @internal
+// @alpha
 export const selectFilterContextAttributeFilters: import("@reduxjs/toolkit").OutputSelector<DashboardState, IDashboardAttributeFilter[], (res: FilterContextItem[]) => IDashboardAttributeFilter[]>;
 
-// @internal
+// @alpha
 export const selectFilterContextDateFilter: import("@reduxjs/toolkit").OutputSelector<DashboardState, IDashboardDateFilter | undefined, (res: FilterContextItem[]) => IDashboardDateFilter | undefined>;
 
-// @internal
+// @alpha
 export const selectFilterContextFilters: import("@reduxjs/toolkit").OutputSelector<DashboardState, FilterContextItem[], (res: import("@gooddata/sdk-backend-spi").IFilterContextDefinition) => FilterContextItem[]>;
 
 // @internal
@@ -2236,61 +2236,61 @@ export const selectInsightAttributesMeta: (query: QueryInsightAttributesMeta) =>
     error?: string | undefined;
 } | undefined>;
 
-// @internal
+// @alpha
 export const selectInsightByRef: ((ref: ObjRef) => import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-model").IInsight | undefined, (res: import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>) => import("@gooddata/sdk-model").IInsight | undefined>) & import("lodash").MemoizedFunction;
 
-// @internal
+// @alpha
 export const selectInsightRefs: import("@reduxjs/toolkit").OutputSelector<DashboardState, ObjRef[], (res: import("@gooddata/sdk-model").IInsight[]) => ObjRef[]>;
 
-// @internal
+// @alpha
 export const selectInsights: (state: DashboardState) => import("@gooddata/sdk-model").IInsight[];
 
-// @internal
+// @alpha
 export const selectInsightsMap: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>, (res1: import("@gooddata/sdk-model").IInsight[], res2: import("@gooddata/sdk-backend-spi").IBackendCapabilities) => import("../../../_staging/metadata/objRefMap").ObjRefMap<import("@gooddata/sdk-model").IInsight>>;
 
-// @internal
+// @alpha
 export const selectIsEmbedded: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("../..").ResolvedDashboardConfig) => boolean>;
 
-// @internal
+// @alpha
 export const selectIsReadOnly: import("@reduxjs/toolkit").OutputSelector<DashboardState, boolean, (res: import("../..").ResolvedDashboardConfig) => boolean>;
 
-// @internal
+// @alpha
 export const selectLayout: import("@reduxjs/toolkit").OutputSelector<DashboardState, IDashboardLayout<import("../../types/layoutTypes").ExtendedDashboardWidget>, (res: LayoutState) => IDashboardLayout<import("../../types/layoutTypes").ExtendedDashboardWidget>>;
 
-// @internal
+// @alpha
 export const selectListedDashboards: (state: DashboardState) => import("@gooddata/sdk-backend-spi").IListedDashboard[];
 
-// @internal
+// @alpha
 export const selectLocale: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-ui").ILocale, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-ui").ILocale>;
 
-// @internal
+// @alpha
 export const selectMapboxToken: import("@reduxjs/toolkit").OutputSelector<DashboardState, string | undefined, (res: import("../..").ResolvedDashboardConfig) => string | undefined>;
 
-// @internal
+// @alpha
 export const selectObjectAvailabilityConfig: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("../..").ObjectAvailabilityConfig, (res: import("../..").ResolvedDashboardConfig) => import("../..").ObjectAvailabilityConfig>;
 
-// @internal
+// @alpha
 export const selectPermissions: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IWorkspacePermissions, (res: import("./permissionsState").PermissionsState) => import("@gooddata/sdk-backend-spi").IWorkspacePermissions>;
 
-// @internal
+// @alpha
 export const selectPlatformEdition: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").PlatformEdition, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-backend-spi").PlatformEdition>;
 
-// @internal
+// @alpha
 export const selectSeparators: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ISeparators, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-backend-spi").ISeparators>;
 
-// @internal
+// @alpha
 export const selectSettings: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").ISettings, (res: import("../..").ResolvedDashboardConfig) => import("@gooddata/sdk-backend-spi").ISettings>;
 
 // @internal
 export const selectStash: import("@reduxjs/toolkit").OutputSelector<DashboardState, Record<string, import("../../types/layoutTypes").ExtendedDashboardItem[]>, (res: LayoutState) => Record<string, import("../../types/layoutTypes").ExtendedDashboardItem[]>>;
 
-// @internal
+// @alpha
 export const selectUser: import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IUser, (res: import("./userState").UserState) => import("@gooddata/sdk-backend-spi").IUser>;
 
-// @internal
+// @alpha
 export const selectWidgetByRef: ((ref: ObjRef | undefined) => import("@reduxjs/toolkit").OutputSelector<DashboardState, import("@gooddata/sdk-backend-spi").IKpiWidgetDefinition | import("@gooddata/sdk-backend-spi").IInsightWidgetDefinition | undefined, (res: IDashboardLayout<import("../../types/layoutTypes").ExtendedDashboardWidget>) => import("@gooddata/sdk-backend-spi").IKpiWidgetDefinition | import("@gooddata/sdk-backend-spi").IInsightWidgetDefinition | undefined>) & import("lodash").MemoizedFunction;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface SetAttributeFilterParent extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2301,13 +2301,13 @@ export interface SetAttributeFilterParent extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT";
 }
 
-// @internal
+// @alpha
 export function setAttributeFilterParent(filterLocalId: string, parentFilter: IDashboardAttributeFilterParent, correlationId?: string): SetAttributeFilterParent;
 
-// @internal
+// @alpha
 export type StashedDashboardItemsId = string;
 
-// @internal
+// @alpha
 export type UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> = {
     _undo: {
         undoPointer: number;
@@ -2315,14 +2315,14 @@ export type UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> =
     };
 };
 
-// @internal
+// @alpha
 export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
     cmd: T;
     undoPatches: Patch[];
     redoPatches: Patch[];
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface UndoLayoutChanges extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2332,13 +2332,13 @@ export interface UndoLayoutChanges extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.UNDO";
 }
 
-// @internal
+// @alpha
 export function undoLayoutChanges(undoPointSelector?: UndoPointSelector, correlationId?: string): UndoLayoutChanges;
 
-// @internal
+// @alpha
 export type UndoPointSelector = (undoableCommands: ReadonlyArray<DashboardLayoutCommands>) => number;
 
-// @internal
+// @alpha
 export interface UpdateAlert extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
@@ -2348,10 +2348,10 @@ export interface UpdateAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.UPDATE";
 }
 
-// @internal
+// @alpha
 export function updateAlert(alert: IWidgetAlert, correlationId?: string): UpdateAlert;
 
-// @internal
+// @alpha
 export const useDashboardCommand: <TCommand extends DashboardCommands, TArgs extends any[]>(commandCreator: (...args: TArgs) => TCommand, eventHandlers: {
     "GDC.DASH/EVT.COMMAND.FAILED"?: ((event: import("../events").DashboardCommandFailed) => void) | undefined;
     "GDC.DASH/EVT.COMMAND.REJECTED"?: ((event: import("../events").DashboardCommandRejected) => void) | undefined;
@@ -2628,10 +2628,10 @@ export const useDashboardCommandProcessing: <TCommand extends DashboardCommands,
     status?: "error" | "running" | "success" | undefined;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const useDashboardDispatch: () => Dispatch<AnyAction>;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const useDashboardEventsContext: () => IDashboardEventsContext;
 
 // @internal (undocumented)
@@ -2640,7 +2640,7 @@ export const useDashboardInsightProps: () => IDashboardInsightProps;
 // @internal (undocumented)
 export const useDashboardKpiProps: () => DashboardKpiProps;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export const useDashboardSelector: TypedUseSelectorHook<DashboardState>;
 
 // @internal (undocumented)
@@ -2648,7 +2648,7 @@ export const useDashboardWidgetProps: () => DashboardWidgetProps;
 
 // @internal (undocumented)
 export const useDrill: ({ onSuccess, onError, onBeforeRun }?: UseDrillProps) => {
-    run: (drillEvent: import("../..").IDashboardDrillEvent, drillContext: import("..").DashboardDrillContext, correlationId?: string | undefined) => void;
+    run: (drillEvent: import("../..").IDashboardDrillEvent, drillContext: import("../..").DashboardDrillContext, correlationId?: string | undefined) => void;
     status?: "error" | "running" | "success" | undefined;
 };
 
@@ -2758,25 +2758,25 @@ export interface UseDrillToLegacyDashboardProps {
     onSuccess?: (event: DashboardDrillToLegacyDashboardTriggered) => void;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type UserInteraction = "poweredByGDLogoClicked";
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export function userInteractionLogged(ctx: DashboardContext, interaction: UserInteraction, correlationId?: string): DashboardUserInteractionLogged;
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export interface UserState {
     // (undocumented)
     user?: IUser;
 }
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type WidgetFilterSettings = {
     readonly ignoreDashboardFilters?: IDashboardFilterReference[];
     readonly dateDataSet?: ObjRef;
 };
 
-// @internal (undocumented)
+// @alpha (undocumented)
 export type WidgetHeader = {
     title?: string;
 };

--- a/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/validation.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/validation.ts
@@ -85,7 +85,7 @@ function isSelectedOptionValid(config: IDateFilterConfig): boolean {
 /**
  * Validation result.
  *
- * @internal
+ * @alpha
  */
 export type DateFilterConfigValidationResult =
     | "Valid"

--- a/libs/sdk-ui-dashboard/src/drill/DrillSelect/types.ts
+++ b/libs/sdk-ui-dashboard/src/drill/DrillSelect/types.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
-import { DashboardDrillContext, DashboardDrillDefinition } from "../types";
-import { IDashboardDrillEvent } from "../../types";
+import { DashboardDrillDefinition } from "../types";
+import { DashboardDrillContext, IDashboardDrillEvent } from "../../types";
 
 /**
  * These types are also used as s-classes for testing e.g. .s-drill-to-dashboard

--- a/libs/sdk-ui-dashboard/src/drill/index.ts
+++ b/libs/sdk-ui-dashboard/src/drill/index.ts
@@ -11,7 +11,6 @@ export {
     DashboardDrillDefinition,
     OnDashboardDrill,
     DrillStep,
-    DashboardDrillContext,
     OnDrillDown,
     OnDrillToAttributeUrl,
     OnDrillToCustomUrl,

--- a/libs/sdk-ui-dashboard/src/drill/types.ts
+++ b/libs/sdk-ui-dashboard/src/drill/types.ts
@@ -1,19 +1,23 @@
 // (C) 2019-2021 GoodData Corporation
-import { IAvailableDrillTargets, IAvailableDrillTargetMeasure } from "@gooddata/sdk-ui";
+import { IAvailableDrillTargetMeasure, IAvailableDrillTargets } from "@gooddata/sdk-ui";
 import isEmpty from "lodash/isEmpty";
 import { IInsight, ObjRef } from "@gooddata/sdk-model";
 import {
     DrillDefinition,
     IDrillToAttributeUrl,
     IDrillToCustomUrl,
-    IInsightWidget,
+    IDrillToDashboard,
+    IDrillToInsight,
+    IListedDashboard,
     isDrillToAttributeUrl,
     isDrillToCustomUrl,
-    IListedDashboard,
-    IDrillToInsight,
-    IDrillToDashboard,
 } from "@gooddata/sdk-backend-spi";
-import { IDashboardDrillEvent, IDrillDownDefinition, IDashboardFilter } from "../types";
+import {
+    DashboardDrillContext,
+    IDashboardDrillEvent,
+    IDashboardFilter,
+    IDrillDownDefinition,
+} from "../types";
 
 /**
  * @internal
@@ -72,21 +76,6 @@ export type OnDrillToCustomUrl = (context: {
     drillEvent: IDashboardDrillEvent;
     url: string;
 }) => void;
-
-/**
- * @internal
- */
-export interface DashboardDrillContext {
-    /**
-     * Particular insight that triggered the drill event.
-     */
-    insight?: IInsight;
-
-    /**
-     * Particular widget that triggered the drill event.
-     */
-    widget?: IInsightWidget;
-}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/commands/alerts.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/alerts.ts
@@ -6,7 +6,7 @@ import { IDashboardCommand } from "./base";
 /**
  * Creates Kpi alert.
  *
- * @internal
+ * @alpha
  */
 export interface CreateAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.CREATE";
@@ -21,7 +21,7 @@ export interface CreateAlert extends IDashboardCommand {
  * @param alert - specify alert to create.
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function createAlert(alert: IWidgetAlertDefinition, correlationId?: string): CreateAlert {
     return {
@@ -36,7 +36,7 @@ export function createAlert(alert: IWidgetAlertDefinition, correlationId?: strin
 /**
  *Updates Kpi alert.
  *
- * @internal
+ * @alpha
  */
 export interface UpdateAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.UPDATE";
@@ -52,7 +52,7 @@ export interface UpdateAlert extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
- * @internal
+ * @alpha
  */
 export function updateAlert(alert: IWidgetAlert, correlationId?: string): UpdateAlert {
     return {
@@ -71,7 +71,7 @@ export function updateAlert(alert: IWidgetAlert, correlationId?: string): Update
 /**
  * Removes Kpi alert.
  *
- * @internal
+ * @alpha
  */
 export interface RemoveAlert extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.ALERT.REMOVE";
@@ -87,7 +87,7 @@ export interface RemoveAlert extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
- * @internal
+ * @alpha
  */
 export function removeAlert(alert: IWidgetAlert, correlationId?: string): RemoveAlert {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/base.ts
@@ -2,7 +2,7 @@
 /**
  * All available command types.
  *
- * @internal
+ * @alpha
  */
 export type DashboardCommandType =
     | "GDC.DASH/CMD.LOG_USER_INTERACTION"
@@ -52,7 +52,7 @@ export type DashboardCommandType =
     | "GDC.DASH/CMD.DRILL.DRILL_TO_LEGACY_DASHBOARD";
 
 /**
- * @internal
+ * @alpha
  */
 export type CommandProcessingMeta = {
     /**
@@ -68,7 +68,7 @@ export type CommandProcessingMeta = {
  * they target backend, workspace and dashboard in depending on the Dashboard component tree from which the dispatch
  * is done.
  *
- * @internal
+ * @alpha
  */
 export interface IDashboardCommand {
     /**

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -7,14 +7,14 @@ import { IDashboardCommand } from "./base";
 /**
  * The initial load of the dashboard will use this correlation id.
  *
- * @internal
+ * @alpha
  */
 export const InitialLoadCorrelationId = "initialLoad";
 
 /**
  * Loads dashboard from analytical backend.
  *
- * @internal
+ * @alpha
  */
 export interface LoadDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.LOAD";
@@ -38,7 +38,7 @@ export interface LoadDashboard extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function loadDashboard(
     config?: DashboardConfig,
@@ -60,7 +60,7 @@ export function loadDashboard(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface SaveDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVE";
@@ -82,7 +82,7 @@ export interface SaveDashboard extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
- * @internal
+ * @alpha
  */
 export function saveDashboard(identifier?: string, correlationId?: string): SaveDashboard {
     return {
@@ -99,7 +99,7 @@ export function saveDashboard(identifier?: string, correlationId?: string): Save
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface SaveDashboardAs extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVEAS";
@@ -122,7 +122,7 @@ export interface SaveDashboardAs extends IDashboardCommand {
  * @param title - new title for the dashboard; if not specified, the title of original dashboard will be used
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function saveDashboardAs(
     identifier?: string,
@@ -144,7 +144,7 @@ export function saveDashboardAs(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RenameDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.RENAME";
@@ -160,7 +160,7 @@ export interface RenameDashboard extends IDashboardCommand {
  * @param newTitle - new dashboard title
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function renameDashboard(newTitle: string, correlationId?: string): RenameDashboard {
     return {
@@ -177,7 +177,7 @@ export function renameDashboard(newTitle: string, correlationId?: string): Renam
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ResetDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.RESET";
@@ -192,7 +192,7 @@ export interface ResetDashboard extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function resetDashboard(correlationId?: string): ResetDashboard {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/drill.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/drill.ts
@@ -7,12 +7,11 @@ import {
     IDrillToInsight,
     IDrillToLegacyDashboard,
 } from "@gooddata/sdk-backend-spi";
-import { DashboardDrillContext } from "../../drill/types";
 import { IInsight } from "@gooddata/sdk-model";
-import { IDashboardDrillEvent, IDrillDownDefinition } from "../../types";
+import { DashboardDrillContext, IDashboardDrillEvent, IDrillDownDefinition } from "../../types";
 
 /**
- * @internal
+ * @alpha
  */
 export interface Drill extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL";
@@ -43,7 +42,7 @@ export interface Drill extends IDashboardCommand {
  *   {@link DrillToCustomUrl}, {@link DrillToAttributeUrl}, {@link DrillToLegacyDashboard}
  *
  *
- * @internal
+ * @alpha
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param drillContext - context in which the drill interaction was triggered (widget and insight details - if available).
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
@@ -69,7 +68,7 @@ export function drill(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillDown extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_DOWN";
@@ -97,7 +96,7 @@ export interface DrillDown extends IDashboardCommand {
  * In the default dashboard implementation dispatching this command will also result into opening drill dialog with the insight
  * that has this particular drill down definition applied.
  *
- * @internal
+ * @alpha
  * @param insight - insight to which the drill down should be applied.
  * @param drillDefinition - drill definition to apply.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
@@ -126,7 +125,7 @@ export function drillDown(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillToInsight extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_INSIGHT";
@@ -150,7 +149,7 @@ export interface DrillToInsight extends IDashboardCommand {
  * In the default dashboard implementation this command will also result into opening the drill dialog with the target insight
  * that has the drill intersection filters applied.
  *
- * @internal
+ * @alpha
  * @param drillDefinition - drill definition with the target insight.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
@@ -176,7 +175,7 @@ export function drillToInsight(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillToDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_DASHBOARD";
@@ -197,7 +196,7 @@ export interface DrillToDashboard extends IDashboardCommand {
  * Dispatching this command will result into getting the drill intersection filters that can be applied to the target dashboard
  * and dispatching {@link DashboardDrillToDashboardTriggered} event that will contain them.
  *
- * @internal
+ * @alpha
  * @param drillDefinition - drill definition with the target dashboard.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
@@ -223,7 +222,7 @@ export function drillToDashboard(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillToCustomUrl extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_CUSTOM_URL";
@@ -247,12 +246,12 @@ export interface DrillToCustomUrl extends IDashboardCommand {
  * Custom url can contain various identifier or attribute title placeholders, see:
  * {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
  *
- * @internal
+ * @alpha
  * @param drillDefinition - drill definition with the target url to resolve.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns drill to custom url command
- * @internal
+ * @alpha
  */
 export function drillToCustomUrl(
     drillDefinition: IDrillToCustomUrl,
@@ -274,7 +273,7 @@ export function drillToCustomUrl(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillToAttributeUrl extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_ATTRIBUTE_URL";
@@ -297,12 +296,12 @@ export interface DrillToAttributeUrl extends IDashboardCommand {
  *
  * For more details, see: {@link https://help.gooddata.com/pages/viewpage.action?pageId=86794855}
  *
- * @internal
+ * @alpha
  * @param drillDefinition - drill definition with the target attribute url to resolve.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns drill to attribute url command
- * @internal
+ * @alpha
  */
 export function drillToAttributeUrl(
     drillDefinition: IDrillToAttributeUrl,
@@ -324,7 +323,7 @@ export function drillToAttributeUrl(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface DrillToLegacyDashboard extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.DRILL.DRILL_TO_LEGACY_DASHBOARD";
@@ -346,12 +345,12 @@ export interface DrillToLegacyDashboard extends IDashboardCommand {
  *
  * Drill to legacy dashboard can be configured for Kpi widgets only.
  *
- * @internal
+ * @alpha
  * @param drillDefinition - drill definition with the target dashboard.
  * @param drillEvent - original drill event, that triggered this particular drill interaction.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns drill to legacy dashboard command
- * @internal
+ * @alpha
  */
 export function drillToLegacyDashboard(
     drillDefinition: IDrillToLegacyDashboard,

--- a/libs/sdk-ui-dashboard/src/model/commands/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/filters.ts
@@ -10,7 +10,7 @@ import { IDashboardCommand } from "./base";
 import { IDashboardFilter } from "@gooddata/sdk-ui-ext";
 
 /**
- * @internal
+ * @alpha
  */
 export interface DateFilterSelection {
     /**
@@ -54,7 +54,7 @@ export interface DateFilterSelection {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeDateFilterSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.DATE_FILTER.CHANGE_SELECTION";
@@ -73,7 +73,7 @@ export interface ChangeDateFilterSelection extends IDashboardCommand {
  *  events that will be emitted during the command processing
  * @remarks see {@link ChangeDateFilterSelection} for a more complete description of the different parameters
  *
- * @internal
+ * @alpha
  */
 export function changeDateFilterSelection(
     type: DateFilterType,
@@ -101,7 +101,7 @@ export function changeDateFilterSelection(
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function clearDateFilterSelection(correlationId?: string): ChangeDateFilterSelection {
     return {
@@ -119,7 +119,7 @@ export function clearDateFilterSelection(correlationId?: string): ChangeDateFilt
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface AddAttributeFilter extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD";
@@ -166,7 +166,7 @@ export interface AddAttributeFilter extends IDashboardCommand {
  *  The index starts at zero and there is convenience that index of -1 would add the filter at the end.
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function addAttributeFilter(
     displayForm: ObjRef,
@@ -188,7 +188,7 @@ export function addAttributeFilter(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RemoveAttributeFilters extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE";
@@ -208,7 +208,7 @@ export interface RemoveAttributeFilters extends IDashboardCommand {
  * @param filterLocalId - dashboard attribute filter's local identifier
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function removeAttributeFilter(filterLocalId: string, correlationId?: string): RemoveAttributeFilters {
     return {
@@ -225,7 +225,7 @@ export function removeAttributeFilter(filterLocalId: string, correlationId?: str
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface MoveAttributeFilter extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE";
@@ -246,7 +246,7 @@ export interface MoveAttributeFilter extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function moveAttributeFilter(
     filterLocalId: string,
@@ -268,12 +268,12 @@ export function moveAttributeFilter(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export type AttributeFilterSelectionType = "IN" | "NOT_IN";
 
 /**
- * @internal
+ * @alpha
  */
 export interface AttributeFilterSelection {
     /**
@@ -291,7 +291,7 @@ export interface AttributeFilterSelection {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeAttributeFilterSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION";
@@ -314,7 +314,7 @@ export interface ChangeAttributeFilterSelection extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeAttributeFilterSelection(
     filterLocalId: string,
@@ -343,7 +343,7 @@ export function changeAttributeFilterSelection(
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function resetAttributeFilterSelection(
     filterLocalId: string,
@@ -365,7 +365,7 @@ export function resetAttributeFilterSelection(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface SetAttributeFilterParent extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT";
@@ -391,7 +391,7 @@ export interface SetAttributeFilterParent extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function setAttributeFilterParent(
     filterLocalId: string,
@@ -409,7 +409,7 @@ export function setAttributeFilterParent(
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface FilterContextSelection {
     /**
@@ -423,7 +423,7 @@ export interface FilterContextSelection {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeFilterContextSelection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.CHANGE_SELECTION";
@@ -442,7 +442,7 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
  * Only filters that are stored in the filter context can be applied (filters that are visible in the filter bar).
  * Filters will be matched via display form ref, duplicities will be omitted.
  *
- * @internal
+ * @alpha
  * @param selection - attribute filters and date filter to apply.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns change filter selection command

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -162,7 +162,7 @@ export {
 export { LogUserInteraction, UserInteraction, logUserInteraction } from "./logUserInteraction";
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardCommands =
     | LogUserInteraction

--- a/libs/sdk-ui-dashboard/src/model/commands/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/insight.ts
@@ -6,7 +6,7 @@ import { WidgetFilterSettings, WidgetHeader } from "../types/widgetTypes";
 import { InsightDrillDefinition } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeInsightWidgetHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_HEADER";
@@ -33,7 +33,7 @@ export interface ChangeInsightWidgetHeader extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeInsightWidgetHeader(
     ref: ObjRef,
@@ -55,7 +55,7 @@ export function changeInsightWidgetHeader(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS";
@@ -83,7 +83,7 @@ export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeInsightWidgetFilterSettings(
     ref: ObjRef,
@@ -105,7 +105,7 @@ export function changeInsightWidgetFilterSettings(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeInsightWidgetVisProperties extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES";
@@ -137,7 +137,7 @@ export interface ChangeInsightWidgetVisProperties extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeInsightWidgetVisProperties(
     ref: ObjRef,
@@ -162,7 +162,7 @@ export function changeInsightWidgetVisProperties(
  * XXX: don't think this is needed right away. should definitely allow such flexibility though. Would allow
  *  to switch between insights that are of different vis type but show same data.
  *
- * @internal
+ * @alpha
  */
 export interface ChangeInsightWidgetInsight extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT";
@@ -199,7 +199,7 @@ export interface ChangeInsightWidgetInsight extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeInsightWidgetInsight(
     ref: ObjRef,
@@ -223,7 +223,7 @@ export function changeInsightWidgetInsight(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS";
@@ -266,7 +266,7 @@ export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function modifyDrillForInsightWidget(
     ref: ObjRef,
@@ -288,12 +288,12 @@ export function modifyDrillForInsightWidget(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export type RemoveDrillsSelector = ObjRef[] | "*";
 
 /**
- * @internal
+ * @alpha
  */
 export interface RemoveDrillsForInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS";
@@ -320,7 +320,7 @@ export interface RemoveDrillsForInsightWidget extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function removeDrillForInsightWidget(
     ref: ObjRef,
@@ -342,7 +342,7 @@ export function removeDrillForInsightWidget(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RefreshInsightWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.INSIGHT_WIDGET.REFRESH";
@@ -362,7 +362,7 @@ export interface RefreshInsightWidget extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function refreshInsightWidget(ref: ObjRef, correlationId?: string): RefreshInsightWidget {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
@@ -6,7 +6,7 @@ import { ILegacyKpiComparisonDirection, ILegacyKpiComparisonTypeComparison } fro
 import { WidgetFilterSettings, WidgetHeader } from "../types/widgetTypes";
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeKpiWidgetHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_HEADER";
@@ -33,7 +33,7 @@ export interface ChangeKpiWidgetHeader extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeKpiWidgetHeader(
     ref: ObjRef,
@@ -55,7 +55,7 @@ export function changeKpiWidgetHeader(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeKpiWidgetMeasure extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE";
@@ -88,7 +88,7 @@ export interface ChangeKpiWidgetMeasure extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeKpiWidgetMeasure(
     ref: ObjRef,
@@ -112,7 +112,7 @@ export function changeKpiWidgetMeasure(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeKpiWidgetFilterSettings extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_FILTER_SETTINGS";
@@ -140,7 +140,7 @@ export interface ChangeKpiWidgetFilterSettings extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeKpiWidgetFilterSettings(
     ref: ObjRef,
@@ -162,7 +162,7 @@ export function changeKpiWidgetFilterSettings(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export type KpiWidgetComparison = {
     /**
@@ -183,7 +183,7 @@ export type KpiWidgetComparison = {
 };
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeKpiWidgetComparison extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.CHANGE_COMPARISON";
@@ -213,7 +213,7 @@ export interface ChangeKpiWidgetComparison extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeKpiWidgetComparison(
     ref: ObjRef,
@@ -235,7 +235,7 @@ export function changeKpiWidgetComparison(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RefreshKpiWidget extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.KPI_WIDGET.REFRESH";
@@ -254,7 +254,7 @@ export interface RefreshKpiWidget extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function refreshKpiWidget(ref: ObjRef, correlationId?: string): RefreshKpiWidget {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/layout.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/layout.ts
@@ -5,7 +5,7 @@ import { DashboardItemDefinition, RelativeIndex, StashedDashboardItemsId } from 
 import { IDashboardLayoutSectionHeader } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface AddLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.ADD_SECTION";
@@ -42,7 +42,7 @@ export interface AddLayoutSection extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function addLayoutSection(
     index: number,
@@ -66,7 +66,7 @@ export function addLayoutSection(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface MoveLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_SECTION";
@@ -96,7 +96,7 @@ export interface MoveLayoutSection extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function moveLayoutSection(
     sectionIndex: number,
@@ -118,7 +118,7 @@ export function moveLayoutSection(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RemoveLayoutSection extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_SECTION";
@@ -151,7 +151,7 @@ export interface RemoveLayoutSection extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function removeLayoutSection(
     index: number,
@@ -173,7 +173,7 @@ export function removeLayoutSection(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ChangeLayoutSectionHeader extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.CHANGE_SECTION_HEADER";
@@ -209,7 +209,7 @@ export interface ChangeLayoutSectionHeader extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function changeLayoutSectionHeader(
     index: number,
@@ -233,7 +233,7 @@ export function changeLayoutSectionHeader(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface AddSectionItems extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.ADD_ITEMS";
@@ -275,7 +275,7 @@ export interface AddSectionItems extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function addSectionItem(
     sectionIndex: number,
@@ -299,7 +299,7 @@ export function addSectionItem(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface ReplaceSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REPLACE_ITEM";
@@ -339,7 +339,7 @@ export interface ReplaceSectionItem extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function replaceSectionItem(
     sectionIndex: number,
@@ -365,7 +365,7 @@ export function replaceSectionItem(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface MoveSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_ITEM";
@@ -412,7 +412,7 @@ export interface MoveSectionItem extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function moveSectionItem(
     sectionIndex: number,
@@ -438,7 +438,7 @@ export function moveSectionItem(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export interface RemoveSectionItem extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_ITEM";
@@ -489,7 +489,7 @@ export interface RemoveSectionItem extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function removeSectionItem(
     sectionIndex: number,
@@ -521,7 +521,7 @@ export function removeSectionItem(
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function eagerRemoveSectionItem(
     sectionIndex: number,
@@ -546,7 +546,7 @@ export function eagerRemoveSectionItem(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardLayoutCommands =
     | AddLayoutSection
@@ -569,12 +569,12 @@ export type DashboardLayoutCommands =
  * The function must return index of command up to (and including) which the undo should be done. It is not possible
  * to undo just some command randomly.
  *
- * @internal
+ * @alpha
  */
 export type UndoPointSelector = (undoableCommands: ReadonlyArray<DashboardLayoutCommands>) => number;
 
 /**
- * @internal
+ * @alpha
  */
 export interface UndoLayoutChanges extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.FLUID_LAYOUT.UNDO";
@@ -616,7 +616,7 @@ export interface UndoLayoutChanges extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function undoLayoutChanges(
     undoPointSelector?: UndoPointSelector,
@@ -646,7 +646,7 @@ export function undoLayoutChanges(
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  *
- * @internal
+ * @alpha
  */
 export function revertLastLayoutChange(correlationId?: string): UndoLayoutChanges {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/logUserInteraction.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/logUserInteraction.ts
@@ -2,7 +2,7 @@
 import { IDashboardCommand } from "./base";
 
 /**
- * @internal
+ * @alpha
  */
 export type UserInteraction = "poweredByGDLogoClicked";
 
@@ -11,7 +11,7 @@ export type UserInteraction = "poweredByGDLogoClicked";
  *
  * Note that this command should be used purely for user interactions that cannot be tracked by other existing events.
  *
- * @internal
+ * @alpha
  */
 export interface LogUserInteraction extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.LOG_USER_INTERACTION";
@@ -21,7 +21,7 @@ export interface LogUserInteraction extends IDashboardCommand {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function logUserInteraction(interaction: UserInteraction, correlationId?: string): LogUserInteraction {
     return {

--- a/libs/sdk-ui-dashboard/src/model/commands/scheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/scheduledEmail.ts
@@ -6,7 +6,7 @@ import { IDashboardCommand } from "./base";
 /**
  * Creates scheduled email.
  *
- * @internal
+ * @alpha
  */
 export interface CreateScheduledEmail extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SCHEDULED_EMAIL.CREATE";
@@ -24,7 +24,7 @@ export interface CreateScheduledEmail extends IDashboardCommand {
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
 
- * @internal
+ * @alpha
  */
 export function createScheduledEmail(
     scheduledEmail: IScheduledMailDefinition,

--- a/libs/sdk-ui-dashboard/src/model/eventHandlers/createDrillToSameDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/eventHandlers/createDrillToSameDashboardHandler.ts
@@ -13,7 +13,7 @@ import { changeFilterContextSelection } from "../commands/filters";
  * Note that only filters that are already stored in the dashboard filter context will be applied
  * (attribute filters that are not visible in the filter bar will not be applied).
  *
- * @internal
+ * @alpha
  * @param dashboardRef - reference to the current dashboard
  * @returns event handler
  */

--- a/libs/sdk-ui-dashboard/src/model/events/alerts.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/alerts.ts
@@ -6,7 +6,7 @@ import { IDashboardEvent } from "./base";
 /**
  * This event is emitted after the Kpi alert is successfully saved.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAlertCreated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.CREATED";
@@ -37,7 +37,7 @@ export function alertCreated(
 /**
  * This event is emitted after the Kpi alert is successfully removed.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAlertRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.REMOVED";
@@ -68,7 +68,7 @@ export function alertRemoved(
 /**
  * This event is emitted after the Kpi alert is updated.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAlertUpdated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.ALERT.UPDATED";

--- a/libs/sdk-ui-dashboard/src/model/events/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/base.ts
@@ -3,7 +3,7 @@ import isEmpty from "lodash/isEmpty";
 import { DashboardContext } from "../types/commonTypes";
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardEventType =
     | "GDC.DASH/EVT.COMMAND.FAILED"
@@ -61,7 +61,7 @@ export type DashboardEventType =
 /**
  * Base type for all dashboard events.
  *
- * @internal
+ * @alpha
  */
 export interface IDashboardEvent {
     /**
@@ -84,7 +84,7 @@ export interface IDashboardEvent {
  * Tests whether object is an instance of {@link IDashboardEvent}.
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isDashboardEvent(obj: unknown): obj is IDashboardEvent {
     return !isEmpty(obj) && (obj as IDashboardEvent).type?.startsWith("GDC.DASH/EVT");

--- a/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
@@ -16,7 +16,7 @@ import { IDashboardEvent } from "./base";
  * This event is emitted when a dashboard is successfully loaded. It contains contextual information and then
  * the dashboard.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLoaded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.LOADED";
@@ -75,7 +75,7 @@ export function dashboardLoaded(
  * This event is emitted at the end of successful dashboard save command processing. At this point, the
  * dashboard state is persisted on the backend.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardSaved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.SAVED";
@@ -118,7 +118,7 @@ export function dashboardSaved(
  * This event is emitted at the end of successful 'dashboard save as' command processing. At this point, a new
  * dashboard exists on the backend.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardCopySaved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COPY_SAVED";
@@ -153,7 +153,7 @@ export function dashboardCopySaved(
  * This event is emitted at the end of successful 'dashboard rename' command processing. At this point, only the
  * in-memory title is changed and the changes are not saved on the backend.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardRenamed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.RENAMED";
@@ -188,7 +188,7 @@ export function dashboardRenamed(
  * This event is emitted at the end of successful 'dashboard reset' command processing. At this point, the
  * dashboard is reset to the state it was after initial load.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardWasReset extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.RESET";
@@ -217,7 +217,7 @@ export function dashboardWasReset(
 //
 
 /**
- * @internal
+ * @alpha
  */
 export type DateFilterValidationResult = "TOO_MANY_CONFIGS" | "NO_CONFIG" | DateFilterConfigValidationResult;
 
@@ -231,7 +231,7 @@ export type DateFilterValidationResult = "TOO_MANY_CONFIGS" | "NO_CONFIG" | Date
  * Note that this event is not a show stopper. The dashboard load will recover and fall back to a safe date
  * filter configuration.
  *
- * @internal
+ * @alpha
  */
 export interface DateFilterValidationFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.VALIDATION.FAILED";

--- a/libs/sdk-ui-dashboard/src/model/events/drill.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/drill.ts
@@ -2,7 +2,6 @@
 import { DashboardContext } from "../types/commonTypes";
 import { IDashboardEvent } from "./base";
 import { IInsight } from "@gooddata/sdk-model";
-import { DashboardDrillContext } from "../../drill/types";
 import {
     IDrillToDashboard,
     IDrillToInsight,
@@ -10,7 +9,12 @@ import {
     IDrillToCustomUrl,
     IDrillToLegacyDashboard,
 } from "@gooddata/sdk-backend-spi";
-import { IDashboardDrillEvent, IDrillDownDefinition, IDashboardFilter } from "../../types";
+import {
+    IDashboardDrillEvent,
+    IDrillDownDefinition,
+    IDashboardFilter,
+    DashboardDrillContext,
+} from "../../types";
 
 /**
  * A general drill event that is emitted each time any dashboard drill is triggered.
@@ -27,7 +31,7 @@ import { IDashboardDrillEvent, IDrillDownDefinition, IDashboardFilter } from "..
  * - Specific drill commands that can follow this general drill event are: {@link DrillDown}, {@link DrillToInsight}, {@link DrillToDashboard},
  *   {@link DrillToCustomUrl}, {@link DrillToAttributeUrl}, {@link DrillToLegacyDashboard}
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.TRIGGERED";
@@ -44,7 +48,7 @@ export interface DashboardDrillTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillTriggered(
     ctx: DashboardContext,
@@ -75,7 +79,7 @@ export function drillTriggered(
  * In the default dashboard implementation this event also opens drill dialog with the insight
  * that has this particular drill down definition applied.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillDownTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_DOWN.TRIGGERED";
@@ -96,7 +100,7 @@ export interface DashboardDrillDownTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillDownTriggered(
     ctx: DashboardContext,
@@ -128,7 +132,7 @@ export function drillDownTriggered(
  * In the default dashboard implementation this event also opens drill dialog with the insight
  * that has the drill intersection filters applied.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillToInsightTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_INSIGHT.TRIGGERED";
@@ -149,7 +153,7 @@ export interface DashboardDrillToInsightTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillToInsightTriggered(
     ctx: DashboardContext,
@@ -180,7 +184,7 @@ export function drillToInsightTriggered(
  *
  * There is a factory function to create default event handler for drill to same dashboard - see {@link createDrillToSameDashboardHandler}.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillToDashboardTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_DASHBOARD.TRIGGERED";
@@ -201,7 +205,7 @@ export interface DashboardDrillToDashboardTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillToDashboardTriggered(
     ctx: DashboardContext,
@@ -230,7 +234,7 @@ export function drillToDashboardTriggered(
  * This event is emitted as a result of the {@link DrillToCustomUrl} command.
  * It contains resolved custom url from the drill definition.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillToCustomUrlTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_CUSTOM_URL.TRIGGERED";
@@ -251,7 +255,7 @@ export interface DashboardDrillToCustomUrlTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillToCustomUrlTriggered(
     ctx: DashboardContext,
@@ -280,7 +284,7 @@ export function drillToCustomUrlTriggered(
  * This event is emitted as a result of the {@link DrillToAttributeUrl} command.
  * It contains resolved attribute url from the drill definition.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillToAttributeUrlTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_ATTRIBUTE_URL.TRIGGERED";
@@ -301,7 +305,7 @@ export interface DashboardDrillToAttributeUrlTriggered extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillToAttributeUrlTriggered(
     ctx: DashboardContext,
@@ -331,7 +335,7 @@ export function drillToAttributeUrlTriggered(
  *
  * Drill to legacy dashboard can be configured for Kpi widgets only.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDrillToLegacyDashboardTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_LEGACY_DASHBOARD.TRIGGERED";
@@ -342,7 +346,7 @@ export interface DashboardDrillToLegacyDashboardTriggered extends IDashboardEven
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function drillToLegacyDashboardTriggered(
     ctx: DashboardContext,

--- a/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
@@ -7,7 +7,7 @@ import { DashboardEvents } from "./index";
  * evaluated against all registered handlers and if evaluation succeeds they will be dispatched to the handler
  * function.
  *
- * @internal
+ * @alpha
  */
 export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
     /**

--- a/libs/sdk-ui-dashboard/src/model/events/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/filters.ts
@@ -10,7 +10,7 @@ import { DashboardContext } from "../types/commonTypes";
 /**
  * This event is emitted after the dashboard's date filter selection is changed.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardDateFilterSelectionChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.SELECTION_CHANGED";
@@ -44,7 +44,7 @@ export function dateFilterChanged(
  *
  * Each dashboard attribute filter has
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAttributeFilterAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADDED";
@@ -89,7 +89,7 @@ export function attributeFilterAdded(
  * If the removed filter figured as a parent to one or more child filters, then the removal
  * also cleaned up the parent relationship.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAttributeFilterRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVED";
@@ -135,7 +135,7 @@ export function attributeFilterRemoved(
  * This event is emitted after a dashboard attribute filter is moved from one position in the filter bar
  * to a new position
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAttributeFilterMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVED";
@@ -183,7 +183,7 @@ export function attributeFilterMoved(
 /**
  * This event is emitted after new elements are selected and applied in an attribute filter.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAttributeFilterSelectionChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.SELECTION_CHANGED";
@@ -219,7 +219,7 @@ export function attributeFilterSelectionChanged(
 /**
  * This event is emitted after the parent relationships of a filter change.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardAttributeFilterParentChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.PARENT_CHANGED";
@@ -259,7 +259,7 @@ export function attributeFilterParentChanged(
  * This is event is emitted as convenience - more granular events describe all the possible
  * changes to the dashboard filters and can be used to event source the state of filter context.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardFilterContextChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED";

--- a/libs/sdk-ui-dashboard/src/model/events/general.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/general.ts
@@ -6,7 +6,7 @@ import isEmpty from "lodash/isEmpty";
 import { IDashboardQuery } from "../queries";
 
 /**
- * @internal
+ * @alpha
  */
 export type ActionFailedErrorReason = "USER_ERROR" | "INTERNAL_ERROR";
 
@@ -18,7 +18,7 @@ export type ActionFailedErrorReason = "USER_ERROR" | "INTERNAL_ERROR";
  *
  * -  An internal error has occurred in the dashboard component - highly likely due to a bug.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardCommandFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COMMAND.FAILED";
@@ -78,7 +78,7 @@ export function invalidArgumentsProvided(
  * Tests whether the provided object is an instance of {@link DashboardCommandFailed}.
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isDashboardCommandFailed(obj: unknown): obj is DashboardCommandFailed {
     return !isEmpty(obj) && (obj as DashboardCommandFailed).type === "GDC.DASH/EVT.COMMAND.FAILED";
@@ -94,7 +94,7 @@ export function isDashboardCommandFailed(obj: unknown): obj is DashboardCommandF
  *
  * This typically indicates user error, perhaps a typo in the command type name.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardCommandRejected extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COMMAND.REJECTED";
@@ -116,7 +116,7 @@ export function commandRejected(ctx: DashboardContext, correlationId?: string): 
  * This event is emitted when the submitted query has been rejected by the dashboard component because it does
  * not know how to handle the query.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardQueryRejected extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.REJECTED";
@@ -142,7 +142,7 @@ export function queryRejected(ctx: DashboardContext, correlationId?: string): Da
  *
  * -  An internal error has occurred in the dashboard component - highly likely due to a bug.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardQueryFailed extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.FAILED";
@@ -202,7 +202,7 @@ export function invalidQueryArguments(
  * Tests whether the provided object is an instance of {@link DashboardCommandFailed}.
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isDashboardQueryFailed(obj: unknown): obj is DashboardQueryFailed {
     return !isEmpty(obj) && (obj as DashboardQueryFailed).type === "GDC.DASH/EVT.QUERY.FAILED";
@@ -215,7 +215,7 @@ export function isDashboardQueryFailed(obj: unknown): obj is DashboardQueryFaile
 /**
  * This event is emitted when query processing starts.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardQueryStarted extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.STARTED";
@@ -237,7 +237,7 @@ export function queryStarted(ctx: DashboardContext, correlationId?: string): Das
  * This event is emitted when query processing completes with success. Both the query payload and the result are
  * included.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult>
     extends IDashboardEvent {

--- a/libs/sdk-ui-dashboard/src/model/events/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/index.ts
@@ -146,7 +146,7 @@ export {
 export { DashboardUserInteractionLogged, userInteractionLogged } from "./logUserInteraction";
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardEvents =
     | DashboardUserInteractionLogged

--- a/libs/sdk-ui-dashboard/src/model/events/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/insight.ts
@@ -10,7 +10,7 @@ import { DrillDefinition, IInsightWidget, IInsightWidgetDefinition } from "@good
  * This event is emitted when the header of an insight widget changed. The new value of the header (title)
  * is included in the event.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.HEADER_CHANGED";
@@ -55,7 +55,7 @@ export function insightWidgetHeaderChanged(
  * should be used for the widget. A change of filter settings means the insight rendered in the widget will
  * be re-rendered.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetFilterSettingsChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED";
@@ -99,7 +99,7 @@ export function insightWidgetFilterSettingsChanged(
  * The properties specified influence how the insight rendered in the widget appears visually (legend, tooltips,
  * axes, etc)
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetVisPropertiesChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.PROPERTIES_CHANGED";
@@ -144,7 +144,7 @@ export function insightWidgetVisPropertiesChanged(
  *
  * That essentially means the insight widget now renders a different visualization
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetInsightSwitched extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.INSIGHT_SWITCHED";
@@ -186,7 +186,7 @@ export function insightWidgetInsightChanged(
  * This event is emitted when the insight widget's drill definitions change. The change may include
  * addition or change of drill definition for one or more drillable measures.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetDrillsModified extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_MODIFIED";
@@ -237,7 +237,7 @@ export function insightWidgetDrillsModified(
  * This event is emitted when the insight widget's drill definitions are removed. The measures for which
  * the drill definitions were set up will no longer be clickable.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetDrillsRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_REMOVED";
@@ -279,7 +279,7 @@ export function insightWidgetDrillsRemoved(
  * This event is emitted after any change to Insight Widget configuration. It contains the entire new state of the
  * Insight Widget.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardInsightWidgetChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.INSIGHT_WIDGET.WIDGET_CHANGED";

--- a/libs/sdk-ui-dashboard/src/model/events/kpi.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/kpi.ts
@@ -9,7 +9,7 @@ import { IKpiWidget, IKpiWidgetDefinition, ILegacyKpi } from "@gooddata/sdk-back
 /**
  * This event is emitted when the dashboard's KPI Widget header is modified.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardKpiWidgetHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.HEADER_CHANGED";
@@ -52,7 +52,7 @@ export function kpiWidgetHeaderChanged(
  * different measure. The change of measure to use may be accompanied with a change of the KPI header (change of
  * title). In that case new value of header is also included in the event.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardKpiWidgetMeasureChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.MEASURE_CHANGED";
@@ -105,7 +105,7 @@ export function kpiWidgetMeasureChanged(
 /**
  * This event is emitted when dashboard's KPI Widget filter settings are modified.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardKpiWidgetFilterSettingsChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.FILTER_SETTINGS_CHANGED";
@@ -148,7 +148,7 @@ export function kpiWidgetFilterSettingsChanged(
  * the new definition of the KPI that has uses same measure as before however has new setup of the over-time
  * comparison.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardKpiWidgetComparisonChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.COMPARISON_CHANGED";
@@ -193,7 +193,7 @@ export function kpiWidgetComparisonChanged(
  * This event is emitted after any change to KPI Widget configuration. It contains the entire new state of the
  * KPI Widget.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardKpiWidgetChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.KPI_WIDGET.WIDGET_CHANGED";

--- a/libs/sdk-ui-dashboard/src/model/events/layout.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/layout.ts
@@ -13,7 +13,7 @@ import { IDashboardLayout, IDashboardLayoutSectionHeader } from "@gooddata/sdk-b
 /**
  * This event is emitted when a new dashboard layout section is added.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED";
@@ -56,7 +56,7 @@ export function layoutSectionAdded(
 /**
  * This event is emitted when a dashboard layout section is moved from one place to another.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_MOVED";
@@ -97,7 +97,7 @@ export function layoutSectionMoved(
  * its items. E.g. item is removed, it is last item in the section, and the whole section is removed
  * as well.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_REMOVED";
@@ -155,7 +155,7 @@ export function layoutSectionRemoved(
 /**
  * This event is emitted when dashboard layout section changes.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionHeaderChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_HEADER_CHANGED";
@@ -196,7 +196,7 @@ export function layoutSectionHeaderChanged(
 /**
  * This event is emitted when items are added to a dashboard section.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionItemsAdded extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEMS_ADDED";
@@ -251,7 +251,7 @@ export function layoutSectionItemsAdded(
 
 /**
  * This event is emitted when an item in a dashboard section is replaced.
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionItemReplaced extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED";
@@ -314,7 +314,7 @@ export function layoutSectionItemReplaced(
 /**
  * This event is emitted when a dashboard item is moved between sections or within a section.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionItemMoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_MOVED";
@@ -378,7 +378,7 @@ export function layoutSectionItemMoved(
 /**
  * This event is emitted when an item is removed from dashboard layout section.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutSectionItemRemoved extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REMOVED";
@@ -435,7 +435,7 @@ export function layoutSectionItemRemoved(
 /**
  * This event is emitted after any change to the dashboard layout and will include the entire new layout.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardLayoutChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FLUID_LAYOUT.LAYOUT_CHANGED";

--- a/libs/sdk-ui-dashboard/src/model/events/logUserInteraction.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/logUserInteraction.ts
@@ -6,7 +6,7 @@ import { IDashboardEvent } from "./base";
 /**
  * This event is emitted after user interaction that can be logged.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardUserInteractionLogged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.USER_INTERACTION_LOGGED";
@@ -16,7 +16,7 @@ export interface DashboardUserInteractionLogged extends IDashboardEvent {
 }
 
 /**
- * @internal
+ * @alpha
  */
 export function userInteractionLogged(
     ctx: DashboardContext,

--- a/libs/sdk-ui-dashboard/src/model/events/scheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/scheduledEmail.ts
@@ -6,7 +6,7 @@ import { IDashboardEvent } from "./base";
 /**
  * This event is emitted after the scheduled email is successfully created.
  *
- * @internal
+ * @alpha
  */
 export interface DashboardScheduledEmailCreated extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.SCHEDULED_EMAIL.CREATED";

--- a/libs/sdk-ui-dashboard/src/model/queries/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/base.ts
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardQueryType =
     | "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS"
@@ -11,7 +11,7 @@ export type DashboardQueryType =
  * Base type for all dashboard queries. A dashboard query encapsulates how complex, read-only dashboard-specific logic
  * can be can be executed.
  *
- * @internal
+ * @alpha
  */
 export interface IDashboardQuery<_TResult = any> {
     /**

--- a/libs/sdk-ui-dashboard/src/model/queries/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/index.ts
@@ -13,6 +13,6 @@ export {
 } from "./insights";
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta;

--- a/libs/sdk-ui-dashboard/src/model/queries/insights.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/insights.ts
@@ -11,7 +11,7 @@ import {
  * Given a reference to an insight, this query will obtain list of all date datasets that may be used
  * to filter it.
  *
- * @internal
+ * @alpha
  */
 export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDatasets> {
     readonly type: "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS";
@@ -27,7 +27,7 @@ export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDat
  * @param insightRef - reference to insight
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function queryDateDatasetsForInsight(
     insightRef: ObjRef,
@@ -55,7 +55,7 @@ export function queryDateDatasetsForInsight(
  * it is not available (meaning the insight does not directly use anything related to date datasets) then the `dateDatasetsOrdered`
  * can be used to pick the date dataset for filtering.
  *
- * @internal
+ * @alpha
  */
 export type InsightDateDatasets = {
     /**
@@ -122,7 +122,7 @@ export type InsightDateDatasets = {
  * insight. For each display form, the result will also contain attribute to which the display form
  * belongs.
  *
- * @internal
+ * @alpha
  */
 export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
     readonly type: "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META";
@@ -132,7 +132,7 @@ export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttri
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type InsightAttributesMeta = {
     /**
@@ -158,7 +158,7 @@ export type InsightAttributesMeta = {
  * @param insightRef - reference to insight
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
- * @internal
+ * @alpha
  */
 export function queryInsightAttributesMeta(
     insightRef: ObjRef,

--- a/libs/sdk-ui-dashboard/src/model/react/DashboardEventsContext.tsx
+++ b/libs/sdk-ui-dashboard/src/model/react/DashboardEventsContext.tsx
@@ -5,7 +5,7 @@ import noop from "lodash/noop";
 import { DashboardEventHandler } from "../events/eventHandler";
 
 /**
- * @internal
+ * @alpha
  */
 export interface IDashboardEventsContext {
     registerHandler: (handler: DashboardEventHandler) => void;
@@ -13,7 +13,7 @@ export interface IDashboardEventsContext {
 }
 
 /**
- * @internal
+ * @alpha
  */
 const DashboardEventsContext = createContext<IDashboardEventsContext>({
     registerHandler: noop,
@@ -22,7 +22,7 @@ const DashboardEventsContext = createContext<IDashboardEventsContext>({
 DashboardEventsContext.displayName = "DashboardEventsContext";
 
 /**
- * @internal
+ * @alpha
  */
 export const useDashboardEventsContext = (): IDashboardEventsContext => useContext(DashboardEventsContext);
 

--- a/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
+++ b/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
@@ -10,15 +10,15 @@ import { IDashboardStoreProviderProps } from "./types";
 /**
  * @internal
  */
-export const ReactDashboardContext: any = React.createContext(null);
+const ReactDashboardContext: any = React.createContext(null);
 
 /**
- * @internal
+ * @alpha
  */
 export const useDashboardDispatch: () => Dispatch<AnyAction> = createDispatchHook(ReactDashboardContext);
 
 /**
- * @internal
+ * @alpha
  */
 export const useDashboardSelector: TypedUseSelectorHook<DashboardState> =
     createSelectorHook(ReactDashboardContext);

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardCommand.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardCommand.ts
@@ -20,7 +20,7 @@ import { useDashboardDispatch } from "./DashboardStoreProvider";
  * @param onBeforeRun - optionally provide callback that will be called before dispatching the command
  * @returns callback that dispatches the command, registers relevant event handlers and unregisters them
  *          when an event that matches the correlation ID and one of the specified event types occurs
- * @internal
+ * @alpha
  */
 export const useDashboardCommand = <TCommand extends DashboardCommands, TArgs extends any[]>(
     commandCreator: (...args: TArgs) => TCommand,

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/undoEnhancer.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/undoEnhancer.ts
@@ -13,7 +13,7 @@ enablePatches();
 /**
  * An entry on undo stack contains patches required
  *
- * @internal
+ * @alpha
  */
 export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
     /**
@@ -35,7 +35,7 @@ export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
 /**
  * Slice that can be undo-enabled needs to include the undo section which will contain the essential undo metadata.
  *
- * @internal
+ * @alpha
  */
 export type UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> = {
     _undo: {

--- a/libs/sdk-ui-dashboard/src/model/state/alerts/alertsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/alerts/alertsSelectors.ts
@@ -13,6 +13,6 @@ const adapterSelectors = alertsAdapter.getSelectors(selectSelf);
 /**
  * Selects all alerts used on the dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectAlerts = adapterSelectors.selectAll;

--- a/libs/sdk-ui-dashboard/src/model/state/backendCapabilities/backendCapabilitiesSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/backendCapabilities/backendCapabilitiesSelectors.ts
@@ -11,7 +11,7 @@ const selectSelf = createSelector(
 /**
  * This selector returns capabilities of the backend with which the dashboard works.
  *
- * @internal
+ * @alpha
  */
 export const selectBackendCapabilities = createSelector(selectSelf, (state) => {
     invariant(state.backendCapabilities, "attempting to access uninitialized backend capabilities");

--- a/libs/sdk-ui-dashboard/src/model/state/backendCapabilities/backendCapabilitiesState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/backendCapabilities/backendCapabilitiesState.ts
@@ -3,7 +3,7 @@
 import { IBackendCapabilities } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface BackendCapabilitiesState {
     backendCapabilities?: IBackendCapabilities;

--- a/libs/sdk-ui-dashboard/src/model/state/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/catalog/catalogSelectors.ts
@@ -20,42 +20,42 @@ const selectSelf = createSelector(
 );
 
 /**
- * @internal
+ * @alpha
  */
 export const selectCatalogAttributes = createSelector(selectSelf, (state) => {
     return state.attributes ?? [];
 });
 
 /**
- * @internal
+ * @alpha
  */
 export const selectCatalogMeasures = createSelector(selectSelf, (state) => {
     return state.measures ?? [];
 });
 
 /**
- * @internal
+ * @alpha
  */
 export const selectCatalogFacts = createSelector(selectSelf, (state) => {
     return state.facts ?? [];
 });
 
 /**
- * @internal
+ * @alpha
  */
 export const selectCatalogDateDatasets = createSelector(selectSelf, (state) => {
     return state.dateDatasets ?? [];
 });
 
 /**
- * @internal
+ * @alpha
  */
 export const selectCatalogDateAttributes = createSelector(selectCatalogDateDatasets, (dateDatasets) => {
     return flatMap(dateDatasets, (dd) => dd.dateAttributes);
 });
 
 /**
- * @internal
+ * @alpha
  */
 export const selectAttributesWithDrillDown = createSelector(
     [selectCatalogAttributes, selectCatalogDateAttributes],
@@ -66,6 +66,8 @@ export const selectAttributesWithDrillDown = createSelector(
 
 /**
  * Selects all date datasets in the catalog as a mapping of obj ref to date dataset.
+ *
+ * @alpha
  */
 export const selectAllCatalogDateDatasetsMap = createSelector(
     [selectCatalogDateDatasets, selectBackendCapabilities],
@@ -77,7 +79,7 @@ export const selectAllCatalogDateDatasetsMap = createSelector(
 /**
  * Selects all display forms in the catalog as a mapping of obj ref to display form
  *
- * @internal
+ * @alpha
  */
 export const selectAllCatalogDisplayFormsMap = createSelector(
     [selectCatalogAttributes, selectCatalogDateDatasets, selectBackendCapabilities],
@@ -99,7 +101,7 @@ export const selectAllCatalogDisplayFormsMap = createSelector(
  * will include both 'normal' attributes and attributes from date datasets.
  *
  * @remarks see `isCatalogAttribute` guard; this can be used to determine type of attribute
- * @internal
+ * @alpha
  */
 export const selectAllCatalogAttributesMap = createSelector(
     [selectCatalogAttributes, selectCatalogDateDatasets, selectBackendCapabilities],
@@ -118,7 +120,7 @@ export const selectAllCatalogAttributesMap = createSelector(
  * and the date dataset to which it belongs. The lookup is indexed by the date dataset attribute and entries can be obtained using
  * attribute refs.
  *
- * @internal
+ * @alpha
  */
 export const selectCatalogDateAttributeToDataset = createSelector(
     [selectCatalogDateDatasets, selectBackendCapabilities],

--- a/libs/sdk-ui-dashboard/src/model/state/catalog/catalogState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/catalog/catalogState.ts
@@ -7,7 +7,7 @@ import {
 } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface CatalogState {
     attributes?: ICatalogAttribute[];

--- a/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
@@ -12,7 +12,7 @@ const selectSelf = createSelector(
  * Returns dashboard's filter context. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectConfig = createSelector(selectSelf, (configState) => {
     invariant(configState.config, "attempting to access uninitialized filter context state");
@@ -26,7 +26,7 @@ export const selectConfig = createSelector(selectSelf, (configState) => {
  * Note: this configuration SHOULD be further augmented by the dashboard-level overrides to obtain
  * the effective date filter configuration.
  *
- * @internal
+ * @alpha
  */
 export const selectDateFilterConfig = createSelector(selectConfig, (state) => {
     return state.dateFilterConfig;
@@ -35,7 +35,7 @@ export const selectDateFilterConfig = createSelector(selectConfig, (state) => {
 /**
  * Returns settings that are in effect for the current dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectSettings = createSelector(selectConfig, (state) => {
     return state.settings;
@@ -44,7 +44,7 @@ export const selectSettings = createSelector(selectConfig, (state) => {
 /**
  * Returns locale to use for internationalization of the dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectLocale = createSelector(selectConfig, (state) => {
     return state.locale;
@@ -53,7 +53,7 @@ export const selectLocale = createSelector(selectConfig, (state) => {
 /**
  * Returns number separators to use when rendering numeric values on charts or KPIs.
  *
- * @internal
+ * @alpha
  */
 export const selectSeparators = createSelector(selectConfig, (state) => {
     return state.separators;
@@ -62,7 +62,7 @@ export const selectSeparators = createSelector(selectConfig, (state) => {
 /**
  * Returns the color palette for dashboard charts.
  *
- * @internal
+ * @alpha
  */
 export const selectColorPalette = createSelector(selectConfig, (state) => {
     return state.colorPalette;
@@ -73,7 +73,7 @@ export const selectColorPalette = createSelector(selectConfig, (state) => {
  * criteria can appear in selections where user has pick an object to use for some purpose (for instance metric for
  * KPI or date dataset to filter by).
  *
- * @internal
+ * @alpha
  */
 export const selectObjectAvailabilityConfig = createSelector(selectConfig, (state) => {
     return state.objectAvailability;
@@ -82,7 +82,7 @@ export const selectObjectAvailabilityConfig = createSelector(selectConfig, (stat
 /**
  * Returns Mapbox token.
  *
- * @internal
+ * @alpha
  */
 export const selectMapboxToken = createSelector(selectConfig, (state) => {
     return state.mapboxToken;
@@ -92,7 +92,7 @@ export const selectMapboxToken = createSelector(selectConfig, (state) => {
  * Returns whether the Dashboard is executed in read-only mode.
  * Read-only mode disables any interactions that can alter the backend data.
  *
- * @internal
+ * @alpha
  */
 export const selectIsReadOnly = createSelector(selectConfig, (state) => {
     return state.isReadOnly;
@@ -102,7 +102,7 @@ export const selectIsReadOnly = createSelector(selectConfig, (state) => {
  * Returns whether the Dashboard is executed in embedded context.
  * In embedded mode, some interactions may be disabled.
  *
- * @internal
+ * @alpha
  */
 export const selectIsEmbedded = createSelector(selectConfig, (state) => {
     return state.isEmbedded;
@@ -115,7 +115,7 @@ export const selectIsEmbedded = createSelector(selectConfig, (state) => {
 /**
  * Returns date format.
  *
- * @internal
+ * @alpha
  */
 export const selectDateFormat = createSelector(selectConfig, (state) => {
     return state.settings?.responsiveUiDateFormat;
@@ -124,7 +124,7 @@ export const selectDateFormat = createSelector(selectConfig, (state) => {
 /**
  * Returns whether the current user can schedule emails.
  *
- * @internal
+ * @alpha
  */
 export const selectEnableKPIDashboardSchedule = createSelector(selectConfig, (state) => {
     return state.settings?.enableKPIDashboardSchedule;
@@ -133,7 +133,7 @@ export const selectEnableKPIDashboardSchedule = createSelector(selectConfig, (st
 /**
  * Returns whether the current user can share scheduled email to other recipients.
  *
- * @internal
+ * @alpha
  */
 export const selectEnableKPIDashboardScheduleRecipients = createSelector(selectConfig, (state) => {
     return state.settings?.enableKPIDashboardScheduleRecipients;
@@ -142,7 +142,7 @@ export const selectEnableKPIDashboardScheduleRecipients = createSelector(selectC
 /**
  * Returns current platform edition.
  *
- * @internal
+ * @alpha
  */
 export const selectPlatformEdition = createSelector(selectConfig, (state) => {
     return state.settings?.platformEdition ?? "enterprise";
@@ -151,7 +151,7 @@ export const selectPlatformEdition = createSelector(selectConfig, (state) => {
 /**
  * Returns whether comapny logo should be visible in embedded dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectEnableCompanyLogoInEmbeddedUI = createSelector(selectConfig, (state) => {
     return state.settings?.enableCompanyLogoInEmbeddedUI ?? false;

--- a/libs/sdk-ui-dashboard/src/model/state/config/configState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/config/configState.ts
@@ -3,7 +3,7 @@
 import { ResolvedDashboardConfig } from "../../types/commonTypes";
 
 /**
- * @internal
+ * @alpha
  */
 export interface ConfigState {
     config?: ResolvedDashboardConfig;

--- a/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigSelectors.ts
@@ -23,7 +23,7 @@ const selectSelf = createSelector(
  *  date filter config that contains the final config obtained by merging the workspace-level config and the
  *  dashboard-level overrides.
  *
- * @internal
+ * @alpha
  */
 export const selectDateFilterConfigOverrides = createSelector(selectSelf, (dateFilterConfigState) => {
     return dateFilterConfigState.dateFilterConfig;
@@ -35,7 +35,7 @@ export const selectDateFilterConfigOverrides = createSelector(selectSelf, (dateF
  *
  * This is the configuration that the DateFilter SHOULD use when rendering filtering presets.
  *
- * @internal
+ * @alpha
  */
 export const selectEffectiveDateFilterConfig = createSelector(selectSelf, (dateFilterConfigState) => {
     invariant(
@@ -52,7 +52,7 @@ export const selectEffectiveDateFilterConfig = createSelector(selectSelf, (dateF
  *
  * These are the date filter options that the DateFilter SHOULD use when rendering filtering presets.
  *
- * @internal
+ * @alpha
  */
 export const selectEffectiveDateFilterOptions = createSelector(
     selectEffectiveDateFilterConfig,
@@ -66,7 +66,7 @@ export const selectEffectiveDateFilterOptions = createSelector(
  *
  * These are the date filter options that the DateFilter SHOULD use when rendering filtering presets.
  *
- * @internal
+ * @alpha
  */
 export const selectEffectiveDateFilterAvailableGranularities = createSelector(
     selectEffectiveDateFilterConfig,
@@ -91,7 +91,7 @@ const effectiveDateFilterConfigIsUsingOverrides = createSelector(selectSelf, (da
  * were defined OR the effective date filter config is not using them (because applying them means the final date filter config is invalid),
  * then no custom filter should be used.
  *
- * @internal
+ * @alpha
  */
 export const selectEffectiveDateFilterTitle = createSelector(
     effectiveDateFilterConfigIsUsingOverrides,
@@ -113,7 +113,7 @@ export const selectEffectiveDateFilterTitle = createSelector(
  * Returns display mode for the effective date filter. This always comes from the dashboard-level date filter config overrides - regardless whether
  * the rest of the overrides are actually used.
  *
- * @internal
+ * @alpha
  */
 export const selectEffectiveDateFilterMode = createSelector(
     selectDateFilterConfigOverrides,

--- a/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigState.ts
@@ -3,7 +3,7 @@
 import { IDashboardDateFilterConfig, IDateFilterConfig } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface DateFilterConfigState {
     /**

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
@@ -20,7 +20,7 @@ const selectSelf = createSelector(
  * This selector returns dashboard's filter context. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectFilterContext = createSelector(selectSelf, (filterContextState) => {
     invariant(filterContextState.filterContext, "attempting to access uninitialized filter context state");
@@ -32,7 +32,7 @@ export const selectFilterContext = createSelector(selectSelf, (filterContextStat
  * This selector returns dashboard's filter context filters. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectFilterContextFilters = createSelector(
     selectFilterContext,
@@ -43,7 +43,7 @@ export const selectFilterContextFilters = createSelector(
  * This selector returns dashboard's filter context attribute filters. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectFilterContextAttributeFilters = createSelector(
     selectFilterContextFilters,
@@ -54,7 +54,7 @@ export const selectFilterContextAttributeFilters = createSelector(
  * This selector returns dashboard's filter context date filter. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectFilterContextDateFilter = createSelector(
     selectFilterContextFilters,
@@ -64,7 +64,9 @@ export const selectFilterContextDateFilter = createSelector(
 /**
  * Creates a selector for selecting attribute filter by its displayForm {@link @gooddata/sdk-model#ObjRef}.
  *
- * @internal
+ * TODO: switch to select.. with memoize
+ *
+ * @alpha
  */
 export const makeSelectFilterContextAttributeFilterByDisplayForm = () =>
     createSelector(
@@ -79,7 +81,9 @@ export const makeSelectFilterContextAttributeFilterByDisplayForm = () =>
 /**
  * Creates a selector for selecting attribute filter by its localId.
  *
- * @internal
+ * TODO: switch to select.. with memoize
+ *
+ * @alpha
  */
 export const makeSelectFilterContextAttributeFilterByLocalId = () =>
     createSelector(
@@ -92,7 +96,9 @@ export const makeSelectFilterContextAttributeFilterByLocalId = () =>
 /**
  * Creates a selector for selecting attribute filter index by its localId.
  *
- * @internal
+ * TODO: switch to select.. with memoize
+ *
+ * @alpha
  */
 export const makeSelectFilterContextAttributeFilterIndexByLocalId = () =>
     createSelector(

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextState.ts
@@ -3,7 +3,7 @@
 import { IFilterContextDefinition } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface FilterContextState {
     filterContext?: IFilterContextDefinition;

--- a/libs/sdk-ui-dashboard/src/model/state/insights/insightsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/insights/insightsSelectors.ts
@@ -12,14 +12,14 @@ const entitySelectors = insightsAdapter.getSelectors((state: DashboardState) => 
 /**
  * Selects all insights used on the dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectInsights = entitySelectors.selectAll;
 
 /**
  * Selects refs of all insights used on the dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectInsightRefs = createSelector(selectInsights, (insights) => {
     return insights.map(insightRef);
@@ -28,7 +28,7 @@ export const selectInsightRefs = createSelector(selectInsights, (insights) => {
 /**
  * Selects all insights and returns them in a mapping of obj ref to the insight object.
  *
- * @internal
+ * @alpha
  */
 export const selectInsightsMap = createSelector(
     selectInsights,
@@ -41,7 +41,7 @@ export const selectInsightsMap = createSelector(
 /**
  * Selects insight used on a dashboard by its ref.
  *
- * @internal
+ * @alpha
  */
 export const selectInsightByRef = memoize((ref: ObjRef) => {
     return createSelector(selectInsightsMap, (insights) => {

--- a/libs/sdk-ui-dashboard/src/model/state/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/layoutSelectors.ts
@@ -38,7 +38,7 @@ export const selectUndoableLayoutCommands = createSelector(selectSelf, (layoutSt
  * This selector returns dashboard's layout. It is expected that the selector is called only after the layout state
  * is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectLayout = createSelector(selectSelf, (layoutState: LayoutState) => {
     invariant(layoutState.layout, "attempting to access uninitialized layout state");
@@ -77,7 +77,7 @@ export const selectBasicLayout = createSelector(selectLayout, (layout) => {
 /**
  * Selects widget by its ref.
  *
- * @internal
+ * @alpha
  */
 export const selectWidgetByRef = memoize(
     (ref: ObjRef | undefined) => {

--- a/libs/sdk-ui-dashboard/src/model/state/layout/layoutState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/layoutState.ts
@@ -6,12 +6,12 @@ import { ExtendedDashboardItem, ExtendedDashboardWidget } from "../../types/layo
 import { DashboardLayoutCommands } from "../../commands";
 
 /**
- * @internal
+ * @alpha
  */
 export type LayoutStash = Record<string, ExtendedDashboardItem[]>;
 
 /**
- * @internal
+ * @alpha
  */
 export interface LayoutState extends UndoEnhancedState<DashboardLayoutCommands> {
     layout?: IDashboardLayout<ExtendedDashboardWidget>;

--- a/libs/sdk-ui-dashboard/src/model/state/listedDashboards/listedDashboardsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/listedDashboards/listedDashboardsSelectors.ts
@@ -13,6 +13,6 @@ const adapterSelectors = listedDashboardsEntityAdapter.getSelectors(selectSelf);
 /**
  * Selects all alerts used on the dashboard.
  *
- * @internal
+ * @alpha
  */
 export const selectListedDashboards = adapterSelectors.selectAll;

--- a/libs/sdk-ui-dashboard/src/model/state/loading/loadingState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/loading/loadingState.ts
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 /**
- * @internal
+ * @alpha
  */
 export type LoadingState = {
     loading: boolean;

--- a/libs/sdk-ui-dashboard/src/model/state/meta/metaSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/meta/metaSelectors.ts
@@ -13,7 +13,7 @@ const selectSelf = createSelector(
  * Returns dashboard's metadata. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 const selectDashboardMetadata = createSelector(selectSelf, (state) => {
     invariant(state.meta, "attempting to access uninitialized meta state");
@@ -24,7 +24,7 @@ const selectDashboardMetadata = createSelector(selectSelf, (state) => {
 /**
  * Returns current dashboard ref.
  *
- * @internal
+ * @alpha
  */
 export const selectDashboardRef = createSelector(selectDashboardMetadata, (state) => {
     return state.ref;
@@ -33,7 +33,7 @@ export const selectDashboardRef = createSelector(selectDashboardMetadata, (state
 /**
  * Returns current dashboard identifier.
  *
- * @internal
+ * @alpha
  */
 export const selectDashboardId = createSelector(selectDashboardMetadata, (state) => {
     return state.identifier;
@@ -42,7 +42,7 @@ export const selectDashboardId = createSelector(selectDashboardMetadata, (state)
 /**
  * Returns current dashboard uri.
  *
- * @internal
+ * @alpha
  */
 const selectDashboardUri = createSelector(selectDashboardMetadata, (state) => {
     return state.uri;
@@ -51,7 +51,7 @@ const selectDashboardUri = createSelector(selectDashboardMetadata, (state) => {
 /**
  * Returns current dashboard uri ref.
  *
- * @internal
+ * @alpha
  */
 export const selectDashboardUriRef = createSelector(selectDashboardUri, (uri) => {
     return uriRef(uri);
@@ -60,7 +60,7 @@ export const selectDashboardUriRef = createSelector(selectDashboardUri, (uri) =>
 /**
  * Returns current dashboard title.
  *
- * @internal
+ * @alpha
  */
 export const selectDashboardTitle = createSelector(selectDashboardMetadata, (state) => {
     return state.title;

--- a/libs/sdk-ui-dashboard/src/model/state/meta/metaState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/meta/metaState.ts
@@ -3,7 +3,7 @@
 import { IDashboard } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export type DashboardMeta = Pick<
     IDashboard,
@@ -11,7 +11,7 @@ export type DashboardMeta = Pick<
 >;
 
 /**
- * @internal
+ * @alpha
  */
 export interface DashboardMetaState {
     meta?: DashboardMeta;

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsSelectors.ts
@@ -12,7 +12,7 @@ const selectSelf = createSelector(
  * This selector returns user's permissions in the workspace where the dashboard is stored. It is expected that the
  * selector is called only after the permission state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectPermissions = createSelector(selectSelf, (filterContextState) => {
     invariant(filterContextState.permissions, "attempting to access uninitialized permissions state");
@@ -23,7 +23,7 @@ export const selectPermissions = createSelector(selectSelf, (filterContextState)
 /**
  * Returns whether the current user has permissions to list other users in the workspace.
  *
- * @internal
+ * @alpha
  */
 export const selectCanListUsersInWorkspace = createSelector(selectPermissions, (state) => {
     return state?.canListUsersInProject;
@@ -32,7 +32,7 @@ export const selectCanListUsersInWorkspace = createSelector(selectPermissions, (
 /**
  * Returns whether the current user has permissions to manage current workspace.
  *
- * @internal
+ * @alpha
  */
 export const selectCanManageWorkspace = createSelector(selectPermissions, (state) => {
     return state?.canManageProject;

--- a/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/permissions/permissionsState.ts
@@ -3,7 +3,7 @@
 import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface PermissionsState {
     permissions?: IWorkspacePermissions;

--- a/libs/sdk-ui-dashboard/src/model/state/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/types.ts
@@ -19,7 +19,7 @@ import { BackendCapabilitiesState } from "./backendCapabilities/backendCapabilit
  *  will have problems if just the type gets exported unless the value from which it is inferred is exported
  *  as well.
  *
- * @internal
+ * @alpha
  */
 export type DashboardState = {
     loading: LoadingState;

--- a/libs/sdk-ui-dashboard/src/model/state/user/userSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/user/userSelectors.ts
@@ -12,7 +12,7 @@ const selectSelf = createSelector(
  * This selector returns current logged in user. It is expected that the
  * selector is called only after the permission state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
- * @internal
+ * @alpha
  */
 export const selectUser = createSelector(selectSelf, (state) => {
     invariant(state.user, "attempting to access uninitialized user state");

--- a/libs/sdk-ui-dashboard/src/model/state/user/userState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/user/userState.ts
@@ -3,7 +3,7 @@
 import { IUser } from "@gooddata/sdk-backend-spi";
 
 /**
- * @internal
+ * @alpha
  */
 export interface UserState {
     user?: IUser;

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -13,7 +13,7 @@ import includes from "lodash/includes";
  *
  * By default, all objects
  *
- * @internal
+ * @alpha
  */
 export type ObjectAvailabilityConfig = {
     /**
@@ -33,7 +33,7 @@ export type ObjectAvailabilityConfig = {
 /**
  * Dashboard configuration can influence the available features, look and feel and behavior of the dashboard.
  *
- * @internal
+ * @alpha
  */
 export type DashboardConfig = {
     /**
@@ -101,7 +101,7 @@ export type DashboardConfig = {
  * -  `mapboxToken` - has to be provided by the context
  * -  `isReadOnly` - is purely choice of context in which the dashboard is used
  *
- * @internal
+ * @alpha
  */
 export type ResolvedDashboardConfig = Omit<Required<DashboardConfig>, "mapboxToken"> & DashboardConfig;
 
@@ -132,7 +132,7 @@ export function isResolvedConfig(config?: DashboardConfig): config is ResolvedDa
 /**
  * Values in this context will be available to all sagas.
  *
- * @internal
+ * @alpha
  */
 export type DashboardContext = {
     /**

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -4,7 +4,7 @@ import { IDashboardLayoutItem, IDashboardLayoutSection, IDashboardWidget } from 
 import isEmpty from "lodash/isEmpty";
 
 /**
- * @internal
+ * @alpha
  */
 export type KpiPlaceholderWidget = {
     readonly type: "kpiPlaceholder";
@@ -14,14 +14,14 @@ export type KpiPlaceholderWidget = {
  * Tests whether an object is a {@link KpiPlaceholderWidget}.
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidget {
     return !isEmpty(obj) && (obj as KpiPlaceholderWidget).type === "kpiPlaceholder";
 }
 
 /**
- * @internal
+ * @alpha
  */
 export type InsightPlaceholderWidget = {
     readonly type: "insightPlaceholder";
@@ -31,7 +31,7 @@ export type InsightPlaceholderWidget = {
  * Tests whether an object is a {@link InsightPlaceholderWidget}.
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlaceholderWidget {
     return !isEmpty(obj) && (obj as InsightPlaceholderWidget).type === "insightPlaceholder";
@@ -41,7 +41,7 @@ export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlacehol
  * Extension of the default {@link @gooddata/sdk-backend-spi#DashboardWidget} type to also include view-only
  * widget types for KPI placeholder and Insight placeholder.
  *
- * @internal
+ * @alpha
  */
 export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
 
@@ -49,7 +49,7 @@ export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | 
  * Specialization of the IDashboardLayoutItem which also includes the extended dashboard widgets - KPI and
  * Insight placeholders.
  *
- * @internal
+ * @alpha
  */
 export type ExtendedDashboardItem = IDashboardLayoutItem<ExtendedDashboardWidget>;
 
@@ -58,7 +58,7 @@ export type ExtendedDashboardItem = IDashboardLayoutItem<ExtendedDashboardWidget
  * under some identifier. This stashed items can then be used in subsequent command that places items on the layout by
  * providing the stash identifier.
  *
- * @internal
+ * @alpha
  */
 export type StashedDashboardItemsId = string;
 
@@ -66,7 +66,7 @@ export type StashedDashboardItemsId = string;
  * Tests whether object is an instance of {@link StashedDashboardItemsId};
  *
  * @param obj - object to test
- * @internal
+ * @alpha
  */
 export function isStashedDashboardItemsId(obj: unknown): obj is StashedDashboardItemsId {
     return typeof obj === "string";
@@ -76,20 +76,20 @@ export function isStashedDashboardItemsId(obj: unknown): obj is StashedDashboard
  * This is a mark-up type that is used for properties and arguments that can contain relative index: a zero-based index
  * with added convenience of referencing last spot using index of `-1`.
  *
- * @internal
+ * @alpha
  */
 export type RelativeIndex = number;
 
 /**
  * Definition of items that may be placed into the dashboard sections.
  *
- * @internal
+ * @alpha
  */
 export type DashboardItemDefinition = ExtendedDashboardItem | StashedDashboardItemsId;
 
 /**
  * Dashboard layout section that can contain extended set of items - including KPI and Insight placeholders.
  *
- * @internal
+ * @alpha
  */
 export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDashboardWidget>;

--- a/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
@@ -4,7 +4,7 @@ import { IDashboardFilterReference } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 
 /**
- * @internal
+ * @alpha
  */
 export type WidgetHeader = {
     /**
@@ -14,7 +14,7 @@ export type WidgetHeader = {
 };
 
 /**
- * @internal
+ * @alpha
  */
 export type WidgetFilterSettings = {
     /**

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -1,14 +1,16 @@
 // (C) 2007-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-import { DrillDefinition } from "@gooddata/sdk-backend-spi";
-import { LocalIdRef, ObjRef } from "@gooddata/sdk-model";
+import { DrillDefinition, IInsightWidget } from "@gooddata/sdk-backend-spi";
 import {
     IAbsoluteDateFilter,
-    IRelativeDateFilter,
-    IPositiveAttributeFilter,
+    IInsight,
     INegativeAttributeFilter,
+    IPositiveAttributeFilter,
+    IRelativeDateFilter,
+    LocalIdRef,
+    ObjRef,
 } from "@gooddata/sdk-model";
-import { OnFiredDrillEvent, IDrillEvent } from "@gooddata/sdk-ui";
+import { IDrillEvent, OnFiredDrillEvent } from "@gooddata/sdk-ui";
 
 /**
  * Supported dashboard filter type.
@@ -76,4 +78,19 @@ export interface IDrillDownDefinition {
  */
 export function isDrillDownDefinition(obj: unknown): obj is IDrillDownDefinition {
     return !isEmpty(obj) && (obj as IDrillDownDefinition).type === "drillDown";
+}
+
+/**
+ * @alpha
+ */
+export interface DashboardDrillContext {
+    /**
+     * Particular insight that triggered the drill event.
+     */
+    insight?: IInsight;
+
+    /**
+     * Particular widget that triggered the drill event.
+     */
+    widget?: IInsightWidget;
 }


### PR DESCRIPTION
-  Until now everything was internal
-  It was hard to discern the intent - is this internal temporarily until we publish the component or will it be internal forever
-  Now everything that is supposed to be public API is alpha, and the stuff that should be internal is marked as internal

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
