### PR TITLE
Proper drill styling of stacked attribute element and sticky row

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
+++ b/libs/sdk-ui-pivot/src/impl/cell/cellClass.ts
@@ -26,6 +26,12 @@ export function cellClassFactory(
         const isEmptyCell = !cellClassParams.value;
         // hide empty sticky cells
         const isTopPinned = cellClassParams.node.rowPinned === "top";
+        const isHiddenTopPinnedCell =
+            isTopPinned &&
+            cellClassParams.colDef.colId &&
+            (!cellClassParams.data.stickyHeaderItemMap ||
+                (cellClassParams.data.stickyHeaderItemMap &&
+                    !cellClassParams.data.stickyHeaderItemMap[cellClassParams.colDef.colId]));
 
         if (isEmpty(row)) {
             // ag-grid calls getCellClass before the data is available & rows are created - there will be no
@@ -35,7 +41,7 @@ export function cellClassFactory(
             // ag-grid may call this with either data undefined or data being empty object
 
             // empty row data are also possible for pinned row, when no cell should be visible
-            return cx(classList, isTopPinned && isEmptyCell ? "gd-hidden-sticky-column" : null);
+            return cx(classList, isHiddenTopPinnedCell ? "gd-hidden-sticky-column" : null);
         }
 
         const dv = table.getDrillDataContext();
@@ -70,7 +76,7 @@ export function cellClassFactory(
             subtotalStyle ? `gd-table-row-subtotal gd-table-row-subtotal-${subtotalStyle}` : null,
             hiddenCell ? "gd-cell-hide s-gd-cell-hide" : null,
             rowSeparator ? "gd-table-row-separator s-gd-table-row-separator" : null,
-            isTopPinned && isEmptyCell ? "gd-hidden-sticky-column" : null,
+            isHiddenTopPinnedCell ? "gd-hidden-sticky-column" : null,
         );
     };
 }

--- a/libs/sdk-ui-pivot/src/impl/stickyRowHandler.ts
+++ b/libs/sdk-ui-pivot/src/impl/stickyRowHandler.ts
@@ -110,19 +110,21 @@ export function updateStickyRowContentClassesAndData(
         }
     });
     const previousRowData = gridApi.getPinnedTopRow(0)?.data as IGridRow;
-    const {
-        headerItemMap: _ignoredHeaders,
-        type: _ignoredType,
-        subtotalStyle: _ignoredStyle,
-        ...previousData
-    } = previousRowData;
+    const previousStickyHeaderMap = previousRowData.stickyHeaderItemMap || {};
+    const previousStickyData = Object.keys(previousStickyHeaderMap).reduce((data, colId) => {
+        data[colId] = previousRowData[colId]; // get rid of irrelevant keys and keep just data for columns which need sticky cell
+        return data;
+    }, {});
     // set new rowData only if differen to avoid rerendering and flashing of the sticky row
-    if (areDataDifferent(previousData, stickyRowData)) {
-        const headerItemMapProp = isEmpty(headerItemMap) ? {} : { headerItemMap };
+    if (areDataDifferent(previousStickyData, stickyRowData)) {
+        const stickyHeaderItemMapProp = isEmpty(headerItemMap)
+            ? { stickyHeaderItemMap: {} }
+            : { stickyHeaderItemMap: headerItemMap };
         gridApi.setPinnedTopRowData([
             {
                 ...stickyRowData,
-                ...headerItemMapProp,
+                ...firstVisibleNodeData,
+                ...stickyHeaderItemMapProp,
             },
         ]);
     }

--- a/libs/sdk-ui-pivot/src/impl/tests/stickyRowHandler.test.ts
+++ b/libs/sdk-ui-pivot/src/impl/tests/stickyRowHandler.test.ts
@@ -21,6 +21,14 @@ describe("stickyRowHandler", () => {
                     },
                 },
             },
+            stickyHeaderItemMap: {
+                r_0: {
+                    attributeHeaderItem: {
+                        name: "Educationly",
+                        uri: "/gdc/md/referenceworkspace/obj/1054/elements?id=165847",
+                    },
+                },
+            },
         },
     };
 
@@ -303,8 +311,21 @@ describe("stickyRowHandler", () => {
                 fakeGridApiWrapper,
             );
 
-            it("should set empty sticky row data", () => {
-                expect(fakeGridApi.setPinnedTopRowData).toHaveBeenCalledWith([{}]);
+            it("should set empty stickyHeaderItemMap data", () => {
+                expect(fakeGridApi.setPinnedTopRowData).toHaveBeenCalledWith([
+                    {
+                        headerItemMap: {
+                            r_0: {
+                                attributeHeaderItem: {
+                                    name: "Educationly",
+                                    uri: "/gdc/md/referenceworkspace/obj/1054/elements?id=165847",
+                                },
+                            },
+                        },
+                        r_0: "123",
+                        stickyHeaderItemMap: {},
+                    },
+                ]);
             });
 
             it("should temporarily show table cell behind", () => {
@@ -340,8 +361,20 @@ describe("stickyRowHandler", () => {
                 fakeGridApiWrapper,
             );
 
-            it("should set correct sticky row data", () => {
-                expect(fakeGridApi.setPinnedTopRowData).toHaveBeenCalledWith([fakeRow.data]);
+            it("should set correct stickyHeaderItemMap data", () => {
+                const expectedData = {
+                    ...fakeRow.data,
+                    stickyHeaderItemMap: {
+                        headerItemMap: undefined,
+                        r_0: {
+                            attributeHeaderItem: {
+                                name: "Educationly",
+                                uri: "/gdc/md/referenceworkspace/obj/1054/elements?id=165847",
+                            },
+                        },
+                    },
+                };
+                expect(fakeGridApi.setPinnedTopRowData).toHaveBeenCalledWith([expectedData]);
             });
 
             it("should not temporarily show table cell behind", () => {

--- a/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
+++ b/libs/sdk-ui-pivot/styles/scss/pivotTable.scss
@@ -267,6 +267,7 @@ $subtotal-odd-background-color: var(
                 .ag-cell {
                     background-color: $custom-background-color;
                     border-top-color: $custom-background-color;
+                    pointer-events: auto;
 
                     // stylelint-disable-next-line max-nesting-depth
                     &.gd-hidden-sticky-column {
@@ -274,6 +275,7 @@ $subtotal-odd-background-color: var(
                         border-top-color: transparent;
                         // stylelint-disable-next-line declaration-no-important
                         background-color: transparent !important; // TODO: remove !important after IE11 deprecation
+                        pointer-events: none;
                     }
 
                     // stylelint-disable-next-line max-nesting-depth
@@ -291,7 +293,8 @@ $subtotal-odd-background-color: var(
             border-top: none;
         }
 
-        .gd-cell-drillable {
+        .gd-cell-drillable:not(.gd-cell-hide),
+        .gd-cell-drillable.gd-cell-show-hidden {
             font-weight: bold;
             cursor: pointer;
 
@@ -300,10 +303,11 @@ $subtotal-odd-background-color: var(
             }
         }
 
-        .gd-cell-hide {
+        .gd-cell-hide:not(.gd-cell-show-hidden) {
             color: transparent;
             border-top: 1px solid transparent;
             background-color: $custom-background-color;
+            pointer-events: none;
         }
 
         .gd-cell-show-hidden {


### PR DESCRIPTION
JIRA: TNT-42
When attribute is drillable only grouped element label has drill styling and is clickable. Hidden element copies beneath it are without mouse events. Drill event payload contains row corresponding to the currently first visible row (current scroll position) next to the clicked grouped element

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
