### PR TITLE
RELATED: TNT-74 TNT-102 TNT-105 Fix KPI dashboard schedule dialog

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/DateTime.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/DateTime.tsx
@@ -38,6 +38,7 @@ export class DateTime extends React.PureComponent<IDateTimeProps> {
                     <Timepicker
                         className="gd-schedule-email-dialog-datetime-time"
                         maxVisibleItemsCount={MAX_VISIBLE_ITEMS_COUNT}
+                        skipNormalizeTime
                         time={date}
                         onChange={this.timeChange}
                         overlayPositionType="sameAsTarget"

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -344,7 +344,9 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
             year: getYear(selectedDateObject),
         };
 
-        this.setState({ startDate: selectedDateObject });
+        this.setState({ startDate: selectedDateObject }, () => {
+            this.updateStartDateForRepeats(selectedDateObject);
+        });
     };
 
     private onTimeChange = (time: IScheduleEmailRepeatTime): void => {
@@ -364,6 +366,28 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
     private onMessageChange = (value: string): void => {
         this.emailBody = value;
     };
+
+    private updateStartDateForRepeats(startDate: Date) {
+        const repeatType = this.repeatData.repeatType;
+        const repeatFrequency = this.repeatData.repeatFrequency;
+        const repeatExecuteOn = this.repeatData.repeatExecuteOn;
+
+        if (repeatType === REPEAT_TYPES.CUSTOM) {
+            if (repeatFrequency === REPEAT_FREQUENCIES.MONTH) {
+                setMonthlyRepeat(this.repeatData, repeatExecuteOn, startDate);
+            } else if (repeatFrequency === REPEAT_FREQUENCIES.WEEK) {
+                setWeeklyRepeat(this.repeatData, startDate);
+            } else {
+                setDailyRepeat(this.repeatData);
+            }
+        } else if (repeatType === REPEAT_TYPES.MONTHLY) {
+            setMonthlyRepeat(this.repeatData, REPEAT_EXECUTE_ON.DAY_OF_WEEK, startDate);
+        } else if (repeatType === REPEAT_TYPES.WEEKLY) {
+            setWeeklyRepeat(this.repeatData, startDate);
+        } else {
+            setDailyRepeat(this.repeatData);
+        }
+    }
 
     private onRepeatsChange = (data: IRepeatSelectData): void => {
         const { repeatExecuteOn, repeatFrequency, repeatPeriod, repeatType } = data;

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -121,6 +121,7 @@ export type IScheduledMailDialogRendererProps = IScheduledMailDialogRendererOwnP
 type IScheduledMailDialogRendererState = {
     alignment: string;
     startDate: Date;
+    startTime: IScheduleEmailRepeatTime;
     isValidScheduleEmailData: boolean;
     selectedRecipients: IScheduleEmailRecipient[];
 };
@@ -148,14 +149,19 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         super(props);
 
         const now = new Date();
+        const normalizedTime = normalizeTime(now);
         this.state = {
             alignment: "cc cc",
             startDate: now,
+            startTime: {
+                hour: normalizedTime.getHours(),
+                minute: normalizedTime.getMinutes(),
+                second: 0,
+            },
             selectedRecipients: [userToRecipient(this.props.currentUser)],
             isValidScheduleEmailData: true,
         };
 
-        const normalizedTime = normalizeTime(now);
         this.repeatData = {
             date: {
                 day: getDate(now),
@@ -246,10 +252,12 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
 
     private renderDateTime = (): React.ReactNode => {
         const { dateFormat, intl, locale } = this.props;
-        const { startDate } = this.state;
+
+        const { date, time } = this.repeatData;
+        const sendDate = new Date(date.year, date.month - 1, date.day, time.hour, time.minute);
         return (
             <DateTime
-                date={startDate}
+                date={sendDate}
                 dateFormat={dateFormat}
                 label={intl.formatMessage({ id: "dialogs.schedule.email.time.label" })}
                 locale={locale}
@@ -351,6 +359,9 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
 
     private onTimeChange = (time: IScheduleEmailRepeatTime): void => {
         this.repeatData.time = time;
+        this.setState({
+            startTime: time,
+        });
     };
 
     private onRecipientsChange = (selectedRecipients: IScheduleEmailRecipient[]): void => {

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/datetime.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/datetime.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import isDate from "lodash/isDate";
 import format from "date-fns/format";
 
@@ -33,8 +33,12 @@ export function getDayName(date: Date): string {
     return format(date, "eeee");
 }
 
+export function convertSun2MonWeekday(dayIndex: number): number {
+    return dayIndex === 0 ? 7 : dayIndex;
+}
+
 export function getDay(date: Date): number {
-    return date.getDay();
+    return convertSun2MonWeekday(date.getDay());
 }
 
 export function getWeek(date: Date): number {

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/test/repeat.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/utils/test/repeat.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 
 import { generateRepeatString, setDailyRepeat, setMonthlyRepeat, setWeeklyRepeat } from "../repeat";
@@ -110,6 +110,25 @@ describe("RepeatGenerator", () => {
                 ).toBe(expectedRepeatString);
             },
         );
+    });
+
+    describe("getDay", () => {
+        it("should convert sunday correctly", () => {
+            const monthZeroBased = 7;
+            const monthOneBased = monthZeroBased + 1;
+
+            const sunday = new Date(2021, monthZeroBased, 22, 10, 30, 0, 0);
+            const sundayDate: IScheduleEmailRepeatDate = {
+                day: getDay(sunday),
+                month: getMonth(sunday),
+                year: getYear(sunday),
+            };
+            expect(sundayDate).toEqual({
+                day: 7,
+                month: monthOneBased,
+                year: 2021,
+            });
+        });
     });
 
     describe("setDailyRepeat", () => {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/DateTime.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/DateTime.tsx
@@ -38,6 +38,7 @@ export class DateTime extends React.PureComponent<IDateTimeProps> {
                     <Timepicker
                         className="gd-schedule-email-dialog-datetime-time"
                         maxVisibleItemsCount={MAX_VISIBLE_ITEMS_COUNT}
+                        skipNormalizeTime
                         time={date}
                         onChange={this.timeChange}
                         overlayPositionType="sameAsTarget"

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
@@ -344,7 +344,9 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
             year: getYear(selectedDateObject),
         };
 
-        this.setState({ startDate: selectedDateObject });
+        this.setState({ startDate: selectedDateObject }, () => {
+            this.updateStartDateForRepeats(selectedDateObject);
+        });
     };
 
     private onTimeChange = (time: IScheduleEmailRepeatTime): void => {
@@ -364,6 +366,28 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
     private onMessageChange = (value: string): void => {
         this.emailBody = value;
     };
+
+    private updateStartDateForRepeats(startDate: Date) {
+        const repeatType = this.repeatData.repeatType;
+        const repeatFrequency = this.repeatData.repeatFrequency;
+        const repeatExecuteOn = this.repeatData.repeatExecuteOn;
+
+        if (repeatType === REPEAT_TYPES.CUSTOM) {
+            if (repeatFrequency === REPEAT_FREQUENCIES.MONTH) {
+                setMonthlyRepeat(this.repeatData, repeatExecuteOn, startDate);
+            } else if (repeatFrequency === REPEAT_FREQUENCIES.WEEK) {
+                setWeeklyRepeat(this.repeatData, startDate);
+            } else {
+                setDailyRepeat(this.repeatData);
+            }
+        } else if (repeatType === REPEAT_TYPES.MONTHLY) {
+            setMonthlyRepeat(this.repeatData, REPEAT_EXECUTE_ON.DAY_OF_WEEK, startDate);
+        } else if (repeatType === REPEAT_TYPES.WEEKLY) {
+            setWeeklyRepeat(this.repeatData, startDate);
+        } else {
+            setDailyRepeat(this.repeatData);
+        }
+    }
 
     private onRepeatsChange = (data: IRepeatSelectData): void => {
         const { repeatExecuteOn, repeatFrequency, repeatPeriod, repeatType } = data;

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/ScheduledMailDialog/ScheduledMailDialogRenderer.tsx
@@ -121,6 +121,7 @@ export type IScheduledMailDialogRendererProps = IScheduledMailDialogRendererOwnP
 type IScheduledMailDialogRendererState = {
     alignment: string;
     startDate: Date;
+    startTime: IScheduleEmailRepeatTime;
     isValidScheduleEmailData: boolean;
     selectedRecipients: IScheduleEmailRecipient[];
 };
@@ -148,14 +149,19 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         super(props);
 
         const now = new Date();
+        const normalizedTime = normalizeTime(now);
         this.state = {
             alignment: "cc cc",
             startDate: now,
+            startTime: {
+                hour: normalizedTime.getHours(),
+                minute: normalizedTime.getMinutes(),
+                second: 0,
+            },
             selectedRecipients: [userToRecipient(this.props.currentUser)],
             isValidScheduleEmailData: true,
         };
 
-        const normalizedTime = normalizeTime(now);
         this.repeatData = {
             date: {
                 day: getDate(now),
@@ -246,10 +252,12 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
 
     private renderDateTime = (): React.ReactNode => {
         const { dateFormat, intl, locale } = this.props;
-        const { startDate } = this.state;
+
+        const { date, time } = this.repeatData;
+        const sendDate = new Date(date.year, date.month - 1, date.day, time.hour, time.minute);
         return (
             <DateTime
-                date={startDate}
+                date={sendDate}
                 dateFormat={dateFormat}
                 label={intl.formatMessage({ id: "dialogs.schedule.email.time.label" })}
                 locale={locale}
@@ -351,6 +359,9 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
 
     private onTimeChange = (time: IScheduleEmailRepeatTime): void => {
         this.repeatData.time = time;
+        this.setState({
+            startTime: time,
+        });
     };
 
     private onRecipientsChange = (selectedRecipients: IScheduleEmailRecipient[]): void => {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/datetime.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/datetime.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import isDate from "lodash/isDate";
 import format from "date-fns/format";
 
@@ -30,8 +30,12 @@ export function getDayName(date: Date): string {
     return format(date, "eeee");
 }
 
+export function convertSun2MonWeekday(dayIndex: number): number {
+    return dayIndex === 0 ? 7 : dayIndex;
+}
+
 export function getDay(date: Date): number {
-    return date.getDay();
+    return convertSun2MonWeekday(date.getDay());
 }
 
 export function getWeek(date: Date): number {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/test/repeat.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/ScheduledMail/utils/test/repeat.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 
 import { generateRepeatString, setDailyRepeat, setMonthlyRepeat, setWeeklyRepeat } from "../repeat";
@@ -99,6 +99,25 @@ describe("RepeatGenerator", () => {
                 ).toBe(expectedRepeatString);
             },
         );
+    });
+
+    describe("getDay", () => {
+        it("should convert sunday correctly", () => {
+            const monthZeroBased = 7;
+            const monthOneBased = monthZeroBased + 1;
+
+            const sunday = new Date(2021, monthZeroBased, 22, 10, 30, 0, 0);
+            const sundayDate: IScheduleEmailRepeatDate = {
+                day: getDay(sunday),
+                month: getMonth(sunday),
+                year: getYear(sunday),
+            };
+            expect(sundayDate).toEqual({
+                day: 7,
+                month: monthOneBased,
+                year: 2021,
+            });
+        });
     });
 
     describe("setDailyRepeat", () => {

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2434,6 +2434,8 @@ export interface ITimepickerOwnProps {
     // (undocumented)
     overlayZIndex?: number;
     // (undocumented)
+    skipNormalizeTime?: boolean;
+    // (undocumented)
     time: Date;
 }
 

--- a/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
+++ b/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
@@ -30,6 +30,7 @@ export interface ITimepickerOwnProps {
     overlayPositionType?: OverlayPositionType;
     overlayZIndex?: number;
     locale?: string;
+    skipNormalizeTime?: boolean;
 }
 
 export type TimePickerProps = ITimepickerOwnProps & WrappedComponentProps;
@@ -48,6 +49,7 @@ export class WrappedTimepicker extends React.PureComponent<TimePickerProps, ITim
         time: new Date(),
         onChange: noop,
         overlayZIndex: 0,
+        skipNormalizeTime: false,
     };
 
     constructor(props: TimePickerProps) {
@@ -55,16 +57,18 @@ export class WrappedTimepicker extends React.PureComponent<TimePickerProps, ITim
 
         this.updateLocaleForMoment();
 
+        const time = props.time || new Date();
         this.state = {
             dropdownWidth: DEFAULT_WIDTH,
-            selectedTime: normalizeTime(props.time || new Date()),
+            selectedTime: props.skipNormalizeTime ? time : normalizeTime(time),
         };
     }
 
     public UNSAFE_componentWillReceiveProps(newProps: TimePickerProps): void {
         if (newProps.time !== this.props.time) {
+            const updatedTime = newProps.time || new Date();
             this.setState({
-                selectedTime: normalizeTime(newProps.time || new Date()),
+                selectedTime: this.props.skipNormalizeTime ? updatedTime : normalizeTime(updatedTime),
             });
         }
     }

--- a/libs/sdk-ui-kit/src/Timepicker/tests/Timepicker.test.tsx
+++ b/libs/sdk-ui-kit/src/Timepicker/tests/Timepicker.test.tsx
@@ -58,12 +58,31 @@ describe("TimePicker", () => {
         });
 
         describe("props", () => {
-            it("should process time property", () => {
-                const component = mountComponent();
+            it.each([
+                [9, 15, false, "09:30 AM"],
+                [9, 30, false, "10:00 AM"],
+                [14, 29, false, "02:30 PM"],
+                [9, 15, true, "09:15 AM"],
+                [9, 30, true, "09:30 AM"],
+                [17, 0, true, "05:00 PM"],
+            ])(
+                "should processed time property (%s, %s) with skipNormalizeTime=%s be equal to %s",
+                (hours: number, mins: number, skipNormalizeTime: boolean, expected: string) => {
+                    const alignedTime = new Date();
+                    alignedTime.setHours(hours);
+                    alignedTime.setMinutes(mins);
+                    alignedTime.setSeconds(0);
+                    alignedTime.setMilliseconds(0);
 
-                const currentTime = getTimePickerValue(component);
-                expect(currentTime).toBe("09:30 AM");
-            });
+                    const component = mountComponent({
+                        time: alignedTime,
+                        skipNormalizeTime,
+                    });
+
+                    const currentTime = getTimePickerValue(component);
+                    expect(currentTime).toBe(expected);
+                },
+            );
 
             it("should pass overlayPositionType and overlayZIndex to Dropdown", () => {
                 const overlayPositionType = "sameAsTarget";


### PR DESCRIPTION
- Fix generating recurrency string for Sunday
- Fix recurrency string after changing date
- Fix dialog behaviour after changing time (time normalization)

Add `skipNormalizeTime` optional property for Timepicker component (default=false) which allows using values exactly as they were passed without using the normalization.

The state management of _ScheduledMailDialogRenderer_ component should probably be reworked so that recurrence data is not stored on `this`, separated to FET-794.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)