### PR TITLE
RELATED: RAIL-3580 Improve AttributeFilterButton empty attribute handling

### DIFF
--- a/libs/sdk-ui/src/base/localization/bundles/de-DE.json
+++ b/libs/sdk-ui/src/base/localization/bundles/de-DE.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Wenn mehrere Elemente den gleichen Wert haben, zeigt der Filter alle Elemente mit diesem Wert an. In diesem Fall kann die Einsicht mehr Elemente anzeigen als die eingestellte Zahl.",
     "attributesDropdown.allItemsFiltered": "Alle Elemente sind ausgefiltert.",
     "attributesDropdown.itemsFiltered.tooltip": "Elemente wurden nach: <strong>{filters}</strong> gefiltert",
-    "attributesDropdown.itemsFiltered": "Elemente wurden gefiltert"
+    "attributesDropdown.itemsFiltered": "Elemente wurden gefiltert",
+    "attributesDropdown.noData": "Dieses Attribut hat keinen Wert."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -1090,5 +1090,10 @@
         "value": "Items are filtered",
         "comment": "This message is displayed when attribute elements are being filtered out by parent filters",
         "limit": 0
+    },
+    "attributesDropdown.noData": {
+        "value": "This attribute does not have any value.",
+        "comment": "",
+        "limit": 0
     }
 }

--- a/libs/sdk-ui/src/base/localization/bundles/es-ES.json
+++ b/libs/sdk-ui/src/base/localization/bundles/es-ES.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Si varios elementos tienen el mismo valor, el filtro muestra todos los elementos con ese valor. Después, la perspectiva puede mostrar más elementos que el número establecido.",
     "attributesDropdown.allItemsFiltered": "Todos los elementos están filtrados",
     "attributesDropdown.itemsFiltered.tooltip": "Los elementos se han filtrado por: <strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "Los elementos se han filtrado"
+    "attributesDropdown.itemsFiltered": "Los elementos se han filtrado",
+    "attributesDropdown.noData": "Este atributo no tiene ningún valor."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui/src/base/localization/bundles/fr-FR.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Si plusieurs éléments ont la même valeur, le filtre affiche tous les éléments avec cette valeur. La perception peut alors montrer plus d'éléments que le nombre défini.",
     "attributesDropdown.allItemsFiltered": "Tous les éléments ont été filtrés.",
     "attributesDropdown.itemsFiltered.tooltip": "Les éléments sont filtrés par : <strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "Les éléments sont filtrés."
+    "attributesDropdown.itemsFiltered": "Les éléments sont filtrés.",
+    "attributesDropdown.noData": "Cet attribut ne possède aucune valeur."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui/src/base/localization/bundles/ja-JP.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "複数の項目に同じ値が設定されている場合は、この値を持つすべての項目がフィルターで表示されます。 インサイトには、設定数よりも多くのアイテムが表示される場合があります。",
     "attributesDropdown.allItemsFiltered": "すべてのアイテムはフィルター済み",
     "attributesDropdown.itemsFiltered.tooltip": "アイテムのフィルター：<strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "アイテムはフィルター済み"
+    "attributesDropdown.itemsFiltered": "アイテムはフィルター済み",
+    "attributesDropdown.noData": "この属性には値がありません。"
 }

--- a/libs/sdk-ui/src/base/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui/src/base/localization/bundles/nl-NL.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Als meerdere items dezelfde waarde hebben, toont het filter alle items met deze waarde. Het inzicht geeft dan mogelijk meer items weer dan het ingestelde aantal.",
     "attributesDropdown.allItemsFiltered": "Alle items zijn uitgefilterd",
     "attributesDropdown.itemsFiltered.tooltip": "Items zijn gefilterd op: <strong>{filters}</strong> ",
-    "attributesDropdown.itemsFiltered": "Items zijn gefilterd"
+    "attributesDropdown.itemsFiltered": "Items zijn gefilterd",
+    "attributesDropdown.noData": "Dit attribuut bevat geen enkele waarde."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui/src/base/localization/bundles/pt-BR.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Se vários itens tiverem o mesmo valor, o filtro mostrará todos os itens com esse valor. O insight poderá então exibir mais itens do que o número definido.",
     "attributesDropdown.allItemsFiltered": "Todos os itens estão filtrados",
     "attributesDropdown.itemsFiltered.tooltip": "Os itens estão filtrados por: <strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "Os itens estão filtrados"
+    "attributesDropdown.itemsFiltered": "Os itens estão filtrados",
+    "attributesDropdown.noData": "Este atributo não tem valor."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui/src/base/localization/bundles/pt-PT.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "Se vários itens tiverem o mesmo valor, o filtro apresenta todos os itens com este valor. O insight poderá então apresentar mais itens do que o número definido.",
     "attributesDropdown.allItemsFiltered": "Todos os itens foram filtrados",
     "attributesDropdown.itemsFiltered.tooltip": "Os itens foram filtrados por: <strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "Há itens filtrados"
+    "attributesDropdown.itemsFiltered": "Há itens filtrados",
+    "attributesDropdown.noData": "Este atributo não tem valores."
 }

--- a/libs/sdk-ui/src/base/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui/src/base/localization/bundles/zh-Hans.json
@@ -215,5 +215,6 @@
     "rankingFilter.valueTooltip": "如果有多项具有相同值，则筛选器将显示具有该值的所有项。洞察可显示比所设数量更多的项。",
     "attributesDropdown.allItemsFiltered": "所有各项都被筛选掉",
     "attributesDropdown.itemsFiltered.tooltip": "各项已筛选： <strong>{filters}</strong>",
-    "attributesDropdown.itemsFiltered": "各项已筛选"
+    "attributesDropdown.itemsFiltered": "各项已筛选",
+    "attributesDropdown.noData": "此属性没有任何值。"
 }


### PR DESCRIPTION
* Fix subtitle for empty attributes
* Display proper NoData message if opened

![image](https://user-images.githubusercontent.com/1748653/127141901-75dd5f5d-6248-4b59-b7e2-f7b836e9c49c.png)

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
