### PR TITLE
RELATED: TNT-1 Transform table data also when requesting additional rows

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
@@ -233,7 +233,8 @@ export class AgGridDatasource implements IDatasource {
             result
                 .readWindow([startRow, 0], [endRow - startRow, COLS_PER_PAGE])
                 .then((data) => {
-                    this.processData(DataViewFacade.for(data), params);
+                    const dataView = this.config.dataViewTransform(data);
+                    this.processData(DataViewFacade.for(dataView), params);
                 })
                 .catch((err) => {
                     // eslint-disable-next-line no-console


### PR DESCRIPTION
Currently only the [first page](https://github.com/gooddata/gooddata-ui-sdk/blob/fbdd52cd3cba2fcd668cb287526b513391f3fe14/libs/sdk-ui-pivot/src/impl/data/dataSource.ts#L157) is processed, this fix applies the processing to other virtual pages as well, fixing the missing (empty value) string on these pages.

JIRA: TNT-1


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)