### PR TITLE
Dashboard component: make the rendering worker more fault tolerant

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
@@ -155,7 +155,6 @@ function* waitForAsyncRenderResolution(id: string, config: RenderingWorkerConfig
     const maxRetries = 3;
     let retries = 0;
     const renderResolvedChannel = yield actionChannel(isAsyncRenderResolvedEvent(id));
-    const renderRequestedChannel = yield actionChannel(isAsyncRenderRequestedEvent(id));
 
     while (true) {
         yield take(renderResolvedChannel);
@@ -165,7 +164,7 @@ function* waitForAsyncRenderResolution(id: string, config: RenderingWorkerConfig
         // (e.g. by data received from PluggableVisualization pushData callback)
         const { timeout } = yield race({
             timeout: call(wait, config.asyncRenderResolvedTimeout),
-            anotherExecution: take(renderRequestedChannel),
+            anotherExecution: take(isAsyncRenderRequestedEvent(id)),
         });
 
         retries += 1;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
@@ -111,6 +111,39 @@ Array [
 ]
 `;
 
+exports[`renderingWorker async rendering resolution should emit render resolved after async rendering resolution, even if the component requested async rendering multiple times before the resolution 1`] = `
+Array [
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.RENDER.REQUESTED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.VALIDATION.FAILED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.LOADED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
+  },
+  Object {
+    "correlationId": undefined,
+    "type": "GDC.DASH/EVT.RENDER.RESOLVED",
+  },
+]
+`;
+
 exports[`renderingWorker async rendering resolution should emit render resolved, when async renderings are resolved during the asyncRenderRequestedTimeout 1`] = `
 Array [
   Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
@@ -77,6 +77,18 @@ describe("renderingWorker", () => {
             expect(Tester.emittedEventsDigest()).toMatchSnapshot();
         });
 
+        it("should emit render resolved after async rendering resolution, even if the component requested async rendering multiple times before the resolution", async () => {
+            const componentId = "component";
+            await Tester.waitFor("GDC.DASH/EVT.RENDER.REQUESTED");
+            await Tester.dispatchAndWaitFor(loadDashboard(), "GDC.DASH/EVT.LOADED");
+            Tester.dispatch(requestAsyncRender(componentId));
+            await Tester.wait(asyncRenderRequestedTimeout);
+            Tester.dispatch(requestAsyncRender(componentId));
+            Tester.dispatch(resolveAsyncRender(componentId));
+            await Tester.waitFor("GDC.DASH/EVT.RENDER.RESOLVED", asyncRenderResolvedTimeout);
+            expect(Tester.emittedEventsDigest()).toMatchSnapshot();
+        });
+
         it("should not emit render resolved, when async rendering is not resolved", async () => {
             const componentId = "component";
             await Tester.waitFor("GDC.DASH/EVT.RENDER.REQUESTED");


### PR DESCRIPTION
- Allow to fire multiple async rendering requests for the same component before the resolution
- This makes it more fault-tolerant (eg PivotTable for some reason fires onLoadingChanged with loading: true multiple times)
- Issue was when requests & resolved events count did not match

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
