### PR TITLE
Dashboard component: fix Kpi widget with drillable items

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -209,8 +209,9 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
         kpiResult &&
         result &&
         status !== "error" &&
-        (kpiWidget.drills.length > 0 ||
-            isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result));
+        (drillableItems
+            ? isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result)
+            : kpiWidget.drills.length > 0);
 
     const enableCompactSize = settings.enableKDWidgetCustomHeight;
 


### PR DESCRIPTION
- Omit default drill when drillableItems are provided and use them instead

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
