### PR TITLE
RELATED: RAIL-3385 Add selector evaluator to event handlers

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -47,6 +47,7 @@ import { IDashboardWidget } from '@gooddata/sdk-backend-spi';
 import { IDateFilterConfig } from '@gooddata/sdk-backend-spi';
 import { IDateFilterOptionsByType } from '@gooddata/sdk-ui-filters';
 import { Identifier } from '@gooddata/sdk-model';
+import { IdentifierRef } from '@gooddata/sdk-model';
 import { IDrillableItem } from '@gooddata/sdk-ui';
 import { IDrillEvent } from '@gooddata/sdk-ui';
 import { IDrillToAttributeUrl } from '@gooddata/sdk-backend-spi';
@@ -811,7 +812,7 @@ export interface DashboardDrillToLegacyDashboardResolved extends IDashboardEvent
 // @alpha
 export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
     eval: (event: DashboardEvents) => boolean;
-    handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void) => void;
+    handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void, evalSelector: DashboardSelectorEvaluator) => void;
 };
 
 // @alpha (undocumented)
@@ -1233,6 +1234,12 @@ export interface DashboardScheduledEmailCreated extends IDashboardEvent {
     // (undocumented)
     readonly type: "GDC.DASH/EVT.SCHEDULED_EMAIL.CREATED";
 }
+
+// @alpha
+export type DashboardSelector<TResult> = (state: DashboardState) => TResult;
+
+// @alpha
+export type DashboardSelectorEvaluator = <TResult>(selector: DashboardSelector<TResult>) => TResult;
 
 // @alpha
 export type DashboardState = {
@@ -2405,6 +2412,9 @@ export const selectColorPalette: OutputSelector<DashboardState, IColorPalette, (
 
 // @alpha
 export const selectConfig: OutputSelector<DashboardState, ResolvedDashboardConfig, (res: ConfigState) => ResolvedDashboardConfig>;
+
+// @alpha
+export const selectDashboardIdRef: OutputSelector<DashboardState, IdentifierRef, (res: string) => IdentifierRef>;
 
 // @internal (undocumented)
 export const selectDashboardLoading: OutputSelector<DashboardState, LoadingState, (res: DashboardState) => LoadingState>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -812,7 +812,7 @@ export interface DashboardDrillToLegacyDashboardResolved extends IDashboardEvent
 // @alpha
 export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
     eval: (event: DashboardEvents) => boolean;
-    handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void, evalSelector: DashboardSelectorEvaluator) => void;
+    handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void, stateSelect: DashboardSelectorEvaluator) => void;
 };
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
@@ -24,12 +24,12 @@ export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
      *
      * @param event - event to handle
      * @param dispatchCommand - callback to dispatch any dashboard command
-     * @param evalSelector - callback to execute arbitrary selectors against the dashboard state
+     * @param stateSelect - callback to execute arbitrary selectors against the dashboard state
      */
     handler: (
         event: TEvents,
         dispatchCommand: (command: DashboardCommands) => void,
-        evalSelector: DashboardSelectorEvaluator,
+        stateSelect: DashboardSelectorEvaluator,
     ) => void;
 };
 

--- a/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/eventHandler.ts
@@ -1,5 +1,6 @@
 // (C) 2021 GoodData Corporation
 import { DashboardCommands } from "../commands";
+import { DashboardState } from "../state/types";
 import { DashboardEvents } from "./index";
 
 /**
@@ -23,6 +24,25 @@ export type DashboardEventHandler<TEvents extends DashboardEvents = any> = {
      *
      * @param event - event to handle
      * @param dispatchCommand - callback to dispatch any dashboard command
+     * @param evalSelector - callback to execute arbitrary selectors against the dashboard state
      */
-    handler: (event: TEvents, dispatchCommand: (command: DashboardCommands) => void) => void;
+    handler: (
+        event: TEvents,
+        dispatchCommand: (command: DashboardCommands) => void,
+        evalSelector: DashboardSelectorEvaluator,
+    ) => void;
 };
+
+/**
+ * Function that selects part of the Dashboard state.
+ *
+ * @alpha
+ */
+export type DashboardSelector<TResult> = (state: DashboardState) => TResult;
+
+/**
+ * Type of a callback that evaluates a selector function against the Dashboard state
+ *
+ * @alpha
+ */
+export type DashboardSelectorEvaluator = <TResult>(selector: DashboardSelector<TResult>) => TResult;

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -92,7 +92,12 @@ export { selectAlerts } from "./state/alerts/alertsSelectors";
 export { UserState } from "./state/user/userState";
 export { selectUser } from "./state/user/userSelectors";
 export { DashboardMeta, DashboardMetaState } from "./state/meta/metaState";
-export { selectDashboardRef, selectDashboardUriRef, selectDashboardTitle } from "./state/meta/metaSelectors";
+export {
+    selectDashboardRef,
+    selectDashboardUriRef,
+    selectDashboardTitle,
+    selectDashboardIdRef,
+} from "./state/meta/metaSelectors";
 export { selectListedDashboards } from "./state/listedDashboards/listedDashboardsSelectors";
 export {
     selectDrillTargetsByWidgetRef,
@@ -125,5 +130,5 @@ export * from "./commands";
 export * from "./events";
 export * from "./queries";
 export * from "./react";
-export { DashboardEventHandler } from "./events/eventHandler";
+export { DashboardEventHandler, DashboardSelector, DashboardSelectorEvaluator } from "./events/eventHandler";
 export { newDrillToSameDashboardHandler } from "./eventHandlers/drillToSameDashboardHandlerFactory";

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/rootEventEmitter.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/rootEventEmitter.ts
@@ -4,6 +4,7 @@ import { actionChannel, take } from "redux-saga/effects";
 import { DashboardEventHandler } from "../../events/eventHandler";
 import { DashboardEvents } from "../../events";
 import { DashboardCommands } from "../../commands";
+import { DashboardState } from "../types";
 
 export type EventEmitter = {
     registerHandler: (handler: DashboardEventHandler) => void;
@@ -24,6 +25,7 @@ export type EventEmitter = {
 export function createRootEventEmitter(
     initialHandlers: DashboardEventHandler[] = [],
     dispatch: (command: DashboardCommands) => void,
+    evalSelector: <TResult>(selector: (state: DashboardState) => TResult) => TResult,
 ): EventEmitter {
     let eventHandlers = initialHandlers;
 
@@ -43,7 +45,7 @@ export function createRootEventEmitter(
                 try {
                     eventHandlers.forEach((handler) => {
                         if (handler.eval(event)) {
-                            handler.handler(event, dispatch);
+                            handler.handler(event, dispatch, evalSelector);
                         }
                     });
                 } catch (e) {

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/rootEventEmitter.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/rootEventEmitter.ts
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 import { SagaIterator } from "redux-saga";
-import { actionChannel, take } from "redux-saga/effects";
-import { DashboardEventHandler } from "../../events/eventHandler";
+import { actionChannel, select, take } from "redux-saga/effects";
+import { DashboardEventHandler, DashboardSelectorEvaluator } from "../../events/eventHandler";
 import { DashboardEvents } from "../../events";
 import { DashboardCommands } from "../../commands";
 import { DashboardState } from "../types";
@@ -25,7 +25,6 @@ export type EventEmitter = {
 export function createRootEventEmitter(
     initialHandlers: DashboardEventHandler[] = [],
     dispatch: (command: DashboardCommands) => void,
-    evalSelector: <TResult>(selector: (state: DashboardState) => TResult) => TResult,
 ): EventEmitter {
     let eventHandlers = initialHandlers;
 
@@ -42,10 +41,14 @@ export function createRootEventEmitter(
             while (true) {
                 const event: DashboardEvents = yield take(eventChannel);
 
+                // snapshot current state to ensure event handlers operate on state relevant to when they were fired
+                const stateSnapshot: DashboardState = yield select();
+                const selectorEvaluator: DashboardSelectorEvaluator = (selector) => selector(stateSnapshot);
+
                 try {
                     eventHandlers.forEach((handler) => {
                         if (handler.eval(event)) {
-                            handler.handler(event, dispatch, evalSelector);
+                            handler.handler(event, dispatch, selectorEvaluator);
                         }
                     });
                 } catch (e) {

--- a/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
@@ -231,9 +231,7 @@ export function createDashboardStore(config: DashboardStoreConfig): ReduxedDashb
         middleware,
     });
 
-    const rootEventEmitter = createRootEventEmitter(config.initialEventHandlers, store.dispatch, (selector) =>
-        selector(store.getState()),
-    );
+    const rootEventEmitter = createRootEventEmitter(config.initialEventHandlers, store.dispatch);
 
     const rootSagaTask = sagaMiddleware.run(
         rootSaga,

--- a/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
@@ -231,7 +231,9 @@ export function createDashboardStore(config: DashboardStoreConfig): ReduxedDashb
         middleware,
     });
 
-    const rootEventEmitter = createRootEventEmitter(config.initialEventHandlers, store.dispatch);
+    const rootEventEmitter = createRootEventEmitter(config.initialEventHandlers, store.dispatch, (selector) =>
+        selector(store.getState()),
+    );
 
     const rootSagaTask = sagaMiddleware.run(
         rootSaga,

--- a/libs/sdk-ui-dashboard/src/model/state/meta/metaSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/meta/metaSelectors.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
-import { uriRef } from "@gooddata/sdk-model";
+import { idRef, uriRef } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
 import { DashboardState } from "../types";
 
@@ -46,6 +46,15 @@ export const selectDashboardId = createSelector(selectDashboardMetadata, (state)
  */
 const selectDashboardUri = createSelector(selectDashboardMetadata, (state) => {
     return state.uri;
+});
+
+/**
+ * Returns current dashboard id ref.
+ *
+ * @alpha
+ */
+export const selectDashboardIdRef = createSelector(selectDashboardId, (id) => {
+    return idRef(id, "analyticalDashboard");
 });
 
 /**


### PR DESCRIPTION
This allows the callers to read data from the dashboard state
from the event handlers.

Also add selectDashboardIdRef analog for selectDashboardUriRef.

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
