### PR TITLE
RELATED: RAIL-3599 Fix InsightView telemetry

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -5,7 +5,7 @@ import isEqual from "lodash/isEqual";
 import noop from "lodash/noop";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IAnalyticalBackend, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
-import { IInsight, IColorPalette, idRef, insightTitle } from "@gooddata/sdk-model";
+import { IInsight, IColorPalette, idRef, insightTitle, insightVisualizationUrl } from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     ILocale,
@@ -240,6 +240,21 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
         }
     };
 
+    private getBackendWithTelemetry = (): IAnalyticalBackend => {
+        const telemetryProps: object = {
+            ...this.props,
+        };
+
+        // add a fake prop so that the type of the visualization rendered is present in the telemetry
+        if (this.state.insight) {
+            const visualizationUrl = insightVisualizationUrl(this.state.insight);
+            const key = `visualizationUrl_${visualizationUrl}`;
+            telemetryProps[key] = true;
+        }
+
+        return this.props.backend.withTelemetry("InsightView", telemetryProps);
+    };
+
     public render(): React.ReactNode {
         const { LoadingComponent, TitleComponent } = this.props;
         const { error, isDataLoading, isVisualizationLoading } = this.state;
@@ -262,7 +277,7 @@ class InsightViewCore extends React.Component<IInsightViewProps & WrappedCompone
                     <InsightRenderer
                         insight={this.state.insight}
                         workspace={this.props.workspace}
-                        backend={this.props.backend}
+                        backend={this.getBackendWithTelemetry()}
                         colorPalette={this.props.colorPalette ?? this.state.colorPalette}
                         config={this.props.config}
                         execConfig={this.props.execConfig}


### PR DESCRIPTION
Add a missing withTelemetry call and enrich it with a way to log the type of the visualization rendered.

Memoization is not needed as the value would change on almost any change to props and state. This means this will not introduce new re-renders (they happen anyway because the props or state change).

Sample of the headers now

```
X-GDC-JS-SDK-COMP: InsightView
X-GDC-JS-SDK-COMP-PROPS: insight,showTitle,backend,workspace,intl,ErrorComponent,filters,drillableItems,LoadingComponent,TitleComponent,pushData,visualizationUrl_local:table
```

JIRA: RAIL-3599

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
