### PR TITLE
Dashboard component - unify/improve drill eventing

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -642,7 +642,7 @@ export type DashboardDispatch = Dispatch<AnyAction>;
 // @alpha (undocumented)
 export interface DashboardDrillContext {
     insight?: IInsight;
-    widget?: IInsightWidget;
+    widget?: IWidget;
 }
 
 // @beta
@@ -1374,13 +1374,7 @@ export const DefaultDashboardDateFilterInner: () => JSX.Element;
 export const DefaultDashboardInsight: (props: IDashboardInsightProps) => JSX.Element;
 
 // @internal (undocumented)
-export const DefaultDashboardInsightWithDrillDialog: (props: IDashboardInsightProps) => JSX.Element;
-
-// @internal (undocumented)
-export const DefaultDashboardInsightWithDrillDialogInner: () => JSX.Element;
-
-// @internal (undocumented)
-export const DefaultDashboardInsightWithDrillSelect: (props: IDashboardInsightProps) => JSX.Element;
+export const DefaultDashboardInsightInner: () => JSX.Element;
 
 // @internal (undocumented)
 export const DefaultDashboardKpi: (props: DashboardKpiProps) => JSX.Element;
@@ -1686,7 +1680,7 @@ export interface IDashboardDateFilterProps {
 
 // @beta
 export interface IDashboardDrillEvent extends IDrillEvent {
-    drillDefinitions?: DashboardDrillDefinition[];
+    drillDefinitions: DashboardDrillDefinition[];
     widgetRef?: ObjRef;
 }
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -24,7 +24,7 @@ import {
     FilterBar,
 } from "../filterBar";
 import {
-    DefaultDashboardInsightWithDrillDialogInner,
+    DefaultDashboardInsightInner,
     DefaultDashboardKpiInner,
     DefaultDashboardWidgetInner,
 } from "../widget";
@@ -271,9 +271,7 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
                         ErrorComponent={props.ErrorComponent ?? DefaultError}
                         LoadingComponent={props.LoadingComponent ?? DefaultLoading}
                         LayoutComponent={props.LayoutComponent ?? DefaultDashboardLayoutInner}
-                        InsightComponent={
-                            props.InsightComponent ?? DefaultDashboardInsightWithDrillDialogInner
-                        }
+                        InsightComponent={props.InsightComponent ?? DefaultDashboardInsightInner}
                         KpiComponent={props.KpiComponent ?? DefaultDashboardKpiInner}
                         WidgetComponent={props.WidgetComponent ?? DefaultDashboardWidgetInner}
                         ButtonBarComponent={props.ButtonBarComponent ?? DefaultButtonBarInner}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -144,7 +144,7 @@ export interface IDashboardProps {
      *
      * @remarks
      * To access the necessary props in your component, use the {@link useDashboardInsightProps} hook.
-     * To fall back to the default implementation, use the {@link DefaultDashboardInsightWithDrillDialog} component.
+     * To fall back to the default implementation, use the {@link DefaultDashboardInsight} component.
      */
     InsightComponent?: CustomDashboardInsightComponent;
 

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/WithDrillSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/WithDrillSelect.tsx
@@ -124,19 +124,24 @@ export function WithDrillSelect({
     });
 
     const onSelect = useCallback(
-        (drillDefinition: DashboardDrillDefinition, drillEvent?: IDashboardDrillEvent) => {
+        (
+            drillDefinition: DashboardDrillDefinition,
+            drillEvent?: IDashboardDrillEvent,
+            correlationId?: string,
+        ) => {
             const effectiveDrillEvent = drillEvent ?? dropdownProps?.drillEvent;
+            const effectiveCorrelationId = correlationId ?? dropdownProps?.correlationId;
             if (effectiveDrillEvent) {
                 if (isDrillDownDefinition(drillDefinition)) {
-                    drillDown.run(insight, drillDefinition, effectiveDrillEvent);
+                    drillDown.run(insight, drillDefinition, effectiveDrillEvent, effectiveCorrelationId);
                 } else if (isDrillToInsight(drillDefinition)) {
-                    drillToInsight.run(drillDefinition, effectiveDrillEvent);
+                    drillToInsight.run(drillDefinition, effectiveDrillEvent, effectiveCorrelationId);
                 } else if (isDrillToDashboard(drillDefinition)) {
-                    drillToDashboard.run(drillDefinition, effectiveDrillEvent);
+                    drillToDashboard.run(drillDefinition, effectiveDrillEvent, effectiveCorrelationId);
                 } else if (isDrillToAttributeUrl(drillDefinition)) {
-                    drillToAttributeUrl.run(drillDefinition, effectiveDrillEvent);
+                    drillToAttributeUrl.run(drillDefinition, effectiveDrillEvent, effectiveCorrelationId);
                 } else if (isDrillToCustomUrl(drillDefinition)) {
-                    drillToCustomUrl.run(drillDefinition, effectiveDrillEvent);
+                    drillToCustomUrl.run(drillDefinition, effectiveDrillEvent, effectiveCorrelationId);
                 }
                 setDropdownProps(null);
                 setIsOpen(false);
@@ -154,12 +159,13 @@ export function WithDrillSelect({
             const filteredByPriority = filterDrillFromAttributeByPriority(drillDefinition);
 
             if (filteredByPriority.length === 1) {
-                onSelect(filteredByPriority[0], drillEvent);
+                onSelect(filteredByPriority[0], drillEvent, s.correlationId);
             } else if (filteredByPriority.length > 1) {
                 setDropdownProps({
                     drillDefinitions: filteredByPriority,
                     drillEvent: drillEvent,
                     drillContext: context,
+                    correlationId: s.correlationId,
                 });
                 setIsOpen(true);
             }

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/types.ts
@@ -23,4 +23,5 @@ export interface DrillSelectContext {
     drillDefinitions: DashboardDrillDefinition[];
     drillEvent: IDashboardDrillEvent;
     drillContext?: DashboardDrillContext;
+    correlationId?: string;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
@@ -1,0 +1,190 @@
+// (C) 2020 GoodData Corporation
+import React, { useCallback, useMemo, useState, CSSProperties } from "react";
+import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import {
+    IFilter,
+    insightFilters,
+    insightSetFilters,
+    insightVisualizationUrl,
+    objRefToString,
+} from "@gooddata/sdk-model";
+import {
+    GoodDataSdkError,
+    IntlWrapper,
+    IPushData,
+    OnError,
+    OnLoadingChanged,
+    useBackendStrict,
+    useWorkspaceStrict,
+} from "@gooddata/sdk-ui";
+import { InsightError, InsightRenderer } from "@gooddata/sdk-ui-ext";
+
+import { useDashboardComponentsContext } from "../../../dashboardContexts";
+import {
+    useDashboardSelector,
+    selectColorPalette,
+    selectLocale,
+    selectMapboxToken,
+    selectSeparators,
+    selectSettings,
+    selectIsExport,
+    useDashboardAsyncRender,
+} from "../../../../model";
+
+import { useResolveDashboardInsightProperties } from "./useResolveDashboardInsightProperties";
+import { useDashboardInsightDrills } from "./useDashboardInsightDrills";
+import { IDashboardInsightProps } from "../types";
+import { useWidgetFiltersQuery } from "../../common";
+
+const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative", flex: "1 1 auto" };
+
+/**
+ * @internal
+ */
+export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element => {
+    const {
+        insight,
+        widget,
+        clientHeight,
+        backend,
+        workspace,
+        disableWidgetImplicitDrills,
+        drillableItems,
+        onDrill,
+        onError,
+        ErrorComponent: CustomErrorComponent,
+        LoadingComponent: CustomLoadingComponent,
+        drillTargets,
+        onAvailableDrillTargetsReceived,
+    } = props;
+
+    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext({
+        ErrorComponent: CustomErrorComponent,
+        LoadingComponent: CustomLoadingComponent,
+    });
+
+    const effectiveBackend = useBackendStrict(backend);
+    const effectiveWorkspace = useWorkspaceStrict(workspace);
+
+    const separators = useDashboardSelector(selectSeparators);
+    const mapboxToken = useDashboardSelector(selectMapboxToken);
+    const locale = useDashboardSelector(selectLocale);
+    const settings = useDashboardSelector(selectSettings);
+    const colorPalette = useDashboardSelector(selectColorPalette);
+    const isExport = useDashboardSelector(selectIsExport);
+
+    const {
+        result: filtersForInsight,
+        status: filtersStatus,
+        error: filtersError,
+    } = useWidgetFiltersQuery(widget, insight && insightFilters(insight));
+
+    const [isVisualizationLoading, setIsVisualizationLoading] = useState(false);
+    const [visualizationError, setVisualizationError] = useState<GoodDataSdkError | undefined>();
+
+    const { onRequestAsyncRender, onResolveAsyncRender } = useDashboardAsyncRender(
+        objRefToString(widget.ref),
+    );
+
+    const handlePushData = useCallback(
+        (data: IPushData): void => {
+            if (onAvailableDrillTargetsReceived && data?.availableDrillTargets) {
+                onAvailableDrillTargetsReceived(data.availableDrillTargets);
+            }
+        },
+        [onAvailableDrillTargetsReceived],
+    );
+
+    const handleLoadingChanged = useCallback<OnLoadingChanged>(({ isLoading }) => {
+        if (isLoading) {
+            onRequestAsyncRender();
+        } else {
+            onResolveAsyncRender();
+        }
+        setIsVisualizationLoading(isLoading);
+    }, []);
+
+    const handleError = useCallback<OnError>(
+        (error) => {
+            setVisualizationError(error);
+            onError?.(error);
+        },
+        [onError],
+    );
+
+    const insightWithAddedFilters = insightSetFilters(insight, filtersForInsight as IFilter[]); // TODO how to type this better?
+
+    const insightWithAddedWidgetProperties = useResolveDashboardInsightProperties({
+        insight: insightWithAddedFilters ?? insight,
+        widget,
+    });
+
+    const { drillableItems: drillableItemsToUse, handleDrill } = useDashboardInsightDrills({
+        insight: insightWithAddedWidgetProperties,
+        widget,
+        disableWidgetImplicitDrills,
+        drillableItems,
+        drillTargets,
+        onDrill,
+    });
+
+    const chartConfig = useMemo(
+        () => ({
+            mapboxToken,
+            separators,
+            forceDisableDrillOnAxes: !drillableItems, // to keep in line with KD, enable axes drilling only if using explicit drills
+            isExportMode: isExport,
+        }),
+        [separators, mapboxToken, drillableItems, isExport],
+    );
+
+    const insightPositionStyle: CSSProperties = useMemo(() => {
+        return {
+            width: "100%",
+            height: "100%",
+            position:
+                // Headline violates the layout contract.
+                // It should fit parent height and adapt to it as other visualizations.
+                // Now, it works differently for the Headline - parent container adapts to Headline size.
+                insight && insightVisualizationUrl(insight).includes("headline") ? "relative" : "absolute",
+        };
+    }, [insight]);
+
+    const error = filtersError ?? visualizationError;
+
+    return (
+        <div style={insightStyle}>
+            <div style={insightPositionStyle}>
+                <IntlWrapper locale={locale}>
+                    {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
+                    {error && (
+                        <InsightError
+                            error={error}
+                            ErrorComponent={ErrorComponent}
+                            clientHeight={settings?.enableKDWidgetCustomHeight ? clientHeight : undefined}
+                            height={null} // make sure the error is aligned to the top (this is the behavior in gdc-dashboards)
+                        />
+                    )}
+                    {filtersStatus === "success" && (
+                        <InsightRenderer
+                            insight={insightWithAddedWidgetProperties}
+                            backend={effectiveBackend}
+                            workspace={effectiveWorkspace}
+                            drillableItems={drillableItemsToUse}
+                            onDrill={handleDrill}
+                            config={chartConfig}
+                            onLoadingChanged={handleLoadingChanged}
+                            locale={locale}
+                            settings={settings as IUserWorkspaceSettings}
+                            colorPalette={colorPalette}
+                            onError={handleError}
+                            pushData={handlePushData}
+                            ErrorComponent={ErrorComponent}
+                            LoadingComponent={LoadingComponent}
+                        />
+                    )}
+                </IntlWrapper>
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsight.tsx
@@ -1,190 +1,31 @@
 // (C) 2020 GoodData Corporation
-import React, { useCallback, useMemo, useState, CSSProperties } from "react";
-import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
-import {
-    IFilter,
-    insightFilters,
-    insightSetFilters,
-    insightVisualizationUrl,
-    objRefToString,
-} from "@gooddata/sdk-model";
-import {
-    GoodDataSdkError,
-    IntlWrapper,
-    IPushData,
-    OnError,
-    OnLoadingChanged,
-    useBackendStrict,
-    useWorkspaceStrict,
-} from "@gooddata/sdk-ui";
-import { InsightError, InsightRenderer } from "@gooddata/sdk-ui-ext";
+import React from "react";
 
-import { useDashboardComponentsContext } from "../../../dashboardContexts";
-import {
-    useDashboardSelector,
-    selectColorPalette,
-    selectLocale,
-    selectMapboxToken,
-    selectSeparators,
-    selectSettings,
-    selectIsExport,
-    useDashboardAsyncRender,
-} from "../../../../model";
-
-import { useResolveDashboardInsightProperties } from "./useResolveDashboardInsightProperties";
-import { useDashboardInsightDrills } from "./useDashboardInsightDrills";
 import { IDashboardInsightProps } from "../types";
-import { useWidgetFiltersQuery } from "../../common";
+import { DefaultDashboardInsightWithDrillableItems } from "./DefaultDashboardInsightWithDrillableItems";
+import { DefaultDashboardInsightWithDrillDialog } from "./DefaultDashboardInsightWithDrillDialog";
+import { DashboardInsightPropsProvider, useDashboardInsightProps } from "../DashboardInsightPropsContext";
 
-const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative", flex: "1 1 auto" };
+/**
+ * @internal
+ */
+export const DefaultDashboardInsightInner = (): JSX.Element => {
+    const props = useDashboardInsightProps();
+
+    return props.drillableItems?.length ? (
+        <DefaultDashboardInsightWithDrillableItems {...props} />
+    ) : (
+        <DefaultDashboardInsightWithDrillDialog {...props} />
+    );
+};
 
 /**
  * @internal
  */
 export const DefaultDashboardInsight = (props: IDashboardInsightProps): JSX.Element => {
-    const {
-        insight,
-        widget,
-        clientHeight,
-        backend,
-        workspace,
-        disableWidgetImplicitDrills,
-        drillableItems,
-        onDrill,
-        onError,
-        ErrorComponent: CustomErrorComponent,
-        LoadingComponent: CustomLoadingComponent,
-        drillTargets,
-        onAvailableDrillTargetsReceived,
-    } = props;
-
-    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext({
-        ErrorComponent: CustomErrorComponent,
-        LoadingComponent: CustomLoadingComponent,
-    });
-
-    const effectiveBackend = useBackendStrict(backend);
-    const effectiveWorkspace = useWorkspaceStrict(workspace);
-
-    const separators = useDashboardSelector(selectSeparators);
-    const mapboxToken = useDashboardSelector(selectMapboxToken);
-    const locale = useDashboardSelector(selectLocale);
-    const settings = useDashboardSelector(selectSettings);
-    const colorPalette = useDashboardSelector(selectColorPalette);
-    const isExport = useDashboardSelector(selectIsExport);
-
-    const {
-        result: filtersForInsight,
-        status: filtersStatus,
-        error: filtersError,
-    } = useWidgetFiltersQuery(widget, insight && insightFilters(insight));
-
-    const [isVisualizationLoading, setIsVisualizationLoading] = useState(false);
-    const [visualizationError, setVisualizationError] = useState<GoodDataSdkError | undefined>();
-
-    const { onRequestAsyncRender, onResolveAsyncRender } = useDashboardAsyncRender(
-        objRefToString(widget.ref),
-    );
-
-    const handlePushData = useCallback(
-        (data: IPushData): void => {
-            if (onAvailableDrillTargetsReceived && data?.availableDrillTargets) {
-                onAvailableDrillTargetsReceived(data.availableDrillTargets);
-            }
-        },
-        [onAvailableDrillTargetsReceived],
-    );
-
-    const handleLoadingChanged = useCallback<OnLoadingChanged>(({ isLoading }) => {
-        if (isLoading) {
-            onRequestAsyncRender();
-        } else {
-            onResolveAsyncRender();
-        }
-        setIsVisualizationLoading(isLoading);
-    }, []);
-
-    const handleError = useCallback<OnError>(
-        (error) => {
-            setVisualizationError(error);
-            onError?.(error);
-        },
-        [onError],
-    );
-
-    const insightWithAddedFilters = insightSetFilters(insight, filtersForInsight as IFilter[]); // TODO how to type this better?
-
-    const insightWithAddedWidgetProperties = useResolveDashboardInsightProperties({
-        insight: insightWithAddedFilters ?? insight,
-        widget,
-    });
-
-    const { drillableItems: drillableItemsToUse, handleDrill } = useDashboardInsightDrills({
-        insight: insightWithAddedWidgetProperties,
-        widget,
-        disableWidgetImplicitDrills,
-        drillableItems,
-        drillTargets,
-        onDrill,
-    });
-
-    const chartConfig = useMemo(
-        () => ({
-            mapboxToken,
-            separators,
-            forceDisableDrillOnAxes: !drillableItems, // to keep in line with KD, enable axes drilling only if using explicit drills
-            isExportMode: isExport,
-        }),
-        [separators, mapboxToken, drillableItems, isExport],
-    );
-
-    const insightPositionStyle: CSSProperties = useMemo(() => {
-        return {
-            width: "100%",
-            height: "100%",
-            position:
-                // Headline violates the layout contract.
-                // It should fit parent height and adapt to it as other visualizations.
-                // Now, it works differently for the Headline - parent container adapts to Headline size.
-                insight && insightVisualizationUrl(insight).includes("headline") ? "relative" : "absolute",
-        };
-    }, [insight]);
-
-    const error = filtersError ?? visualizationError;
-
     return (
-        <div style={insightStyle}>
-            <div style={insightPositionStyle}>
-                <IntlWrapper locale={locale}>
-                    {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
-                    {error && (
-                        <InsightError
-                            error={error}
-                            ErrorComponent={ErrorComponent}
-                            clientHeight={settings?.enableKDWidgetCustomHeight ? clientHeight : undefined}
-                            height={null} // make sure the error is aligned to the top (this is the behavior in gdc-dashboards)
-                        />
-                    )}
-                    {filtersStatus === "success" && (
-                        <InsightRenderer
-                            insight={insightWithAddedWidgetProperties}
-                            backend={effectiveBackend}
-                            workspace={effectiveWorkspace}
-                            drillableItems={drillableItemsToUse}
-                            onDrill={handleDrill}
-                            config={chartConfig}
-                            onLoadingChanged={handleLoadingChanged}
-                            locale={locale}
-                            settings={settings as IUserWorkspaceSettings}
-                            colorPalette={colorPalette}
-                            onError={handleError}
-                            pushData={handlePushData}
-                            ErrorComponent={ErrorComponent}
-                            LoadingComponent={LoadingComponent}
-                        />
-                    )}
-                </IntlWrapper>
-            </div>
-        </div>
+        <DashboardInsightPropsProvider {...props}>
+            <DefaultDashboardInsightInner />
+        </DashboardInsightPropsProvider>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillDialog.tsx
@@ -7,18 +7,16 @@ import { selectLocale, selectWidgetByRef, useDashboardSelector } from "../../../
 import { DrillStep, OnDashboardDrill, getDrillDownAttributeTitle } from "../../../drill";
 import { IDrillDownDefinition, isDrillDownDefinition } from "../../../../types";
 
-import { DashboardInsightPropsProvider, useDashboardInsightProps } from "../DashboardInsightPropsContext";
-import { IDashboardInsightProps } from "../types";
 import { DefaultDashboardInsightWithDrillSelect } from "./DefaultDashboardInsightWithDrillSelect";
 import { InsightDrillDialog } from "./InsightDrillDialog";
 import { useDashboardDrillTargets } from "./useDashboardDrillTargets";
 import { getDrillOriginLocalIdentifier } from "../../../../_staging/drills/InsightDrillDefinitionUtils";
+import { IDashboardInsightProps } from "../types";
 
 /**
  * @internal
  */
-export const DefaultDashboardInsightWithDrillDialogInner = (): JSX.Element => {
-    const props = useDashboardInsightProps();
+export const DefaultDashboardInsightWithDrillDialog = (props: IDashboardInsightProps): JSX.Element => {
     const [drillSteps, setDrillSteps] = useState<DrillStep[]>([]);
 
     const { drillTargets, onAvailableDrillTargetsReceived } = useDashboardDrillTargets({
@@ -77,16 +75,5 @@ export const DefaultDashboardInsightWithDrillDialogInner = (): JSX.Element => {
                 />
             )}
         </>
-    );
-};
-
-/**
- * @internal
- */
-export const DefaultDashboardInsightWithDrillDialog = (props: IDashboardInsightProps): JSX.Element => {
-    return (
-        <DashboardInsightPropsProvider {...props}>
-            <DefaultDashboardInsightWithDrillDialogInner />
-        </DashboardInsightPropsProvider>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillSelect.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { WithDrillSelect } from "../../../drill";
 import { IDashboardInsightProps } from "../types";
 
-import { DefaultDashboardInsight } from "./DefaultDashboardInsight";
+import { DashboardInsightCore } from "./DashboardInsightCore";
 
 /**
  * @internal
@@ -12,6 +12,7 @@ import { DefaultDashboardInsight } from "./DefaultDashboardInsight";
 export const DefaultDashboardInsightWithDrillSelect = (props: IDashboardInsightProps): JSX.Element => {
     const { onDrillDown, onDrillToInsight, onDrillToAttributeUrl, onDrillToCustomUrl, onDrillToDashboard } =
         props;
+
     return (
         <WithDrillSelect
             insight={props.insight}
@@ -22,7 +23,7 @@ export const DefaultDashboardInsightWithDrillSelect = (props: IDashboardInsightP
             onDrillToDashboard={onDrillToDashboard}
         >
             {({ onDrill }) => {
-                return <DefaultDashboardInsight {...props} onDrill={onDrill} />;
+                return <DashboardInsightCore {...props} onDrill={onDrill} />;
             }}
         </WithDrillSelect>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillableItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsightWithDrillableItems.tsx
@@ -1,0 +1,16 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+
+import { useDrill } from "../../../drill";
+import { IDashboardInsightProps } from "../types";
+
+import { DashboardInsightCore } from "./DashboardInsightCore";
+
+/**
+ * @internal
+ */
+export const DefaultDashboardInsightWithDrillableItems = (props: IDashboardInsightProps): JSX.Element => {
+    const { run: onDrill } = useDrill();
+
+    return <DashboardInsightCore {...props} onDrill={onDrill} />;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/index.ts
@@ -1,7 +1,2 @@
 // (C) 2021 GoodData Corporation
-export { DefaultDashboardInsight } from "./DefaultDashboardInsight";
-export {
-    DefaultDashboardInsightWithDrillDialog,
-    DefaultDashboardInsightWithDrillDialogInner,
-} from "./DefaultDashboardInsightWithDrillDialog";
-export { DefaultDashboardInsightWithDrillSelect } from "./DefaultDashboardInsightWithDrillSelect";
+export { DefaultDashboardInsightInner, DefaultDashboardInsight } from "./DefaultDashboardInsight";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DashboardKpi.tsx
@@ -1,30 +1,12 @@
 // (C) 2020 GoodData Corporation
-import React, { useCallback } from "react";
-import { IDrillToLegacyDashboard } from "@gooddata/sdk-backend-spi";
-
+import React from "react";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
-import { useDrillToLegacyDashboard } from "../../drill";
-
-import { DashboardKpiPropsProvider, useDashboardKpiProps } from "./DashboardKpiPropsContext";
-import { OnFiredDashboardViewDrillEvent } from "@gooddata/sdk-ui-ext";
 
 /**
  * @internal
  */
 export const DashboardKpi = (): JSX.Element => {
-    const { KpiComponent } = useDashboardComponentsContext({});
-    const { run: handleDrillToLegacyDashboard } = useDrillToLegacyDashboard({});
-    const props = useDashboardKpiProps();
-    const onDrill = useCallback<OnFiredDashboardViewDrillEvent>(
-        (event) => {
-            handleDrillToLegacyDashboard(event.drillDefinitions![0] as IDrillToLegacyDashboard, event);
-        },
-        [handleDrillToLegacyDashboard],
-    );
+    const { KpiComponent } = useDashboardComponentsContext();
 
-    return (
-        <DashboardKpiPropsProvider {...props} onDrill={onDrill}>
-            <KpiComponent />
-        </DashboardKpiPropsProvider>
-    );
+    return <KpiComponent />;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
@@ -16,12 +16,11 @@ import { DashboardKpiProps } from "../types";
 
 import { KpiExecutor } from "./KpiExecutor";
 import { useKpiData } from "./useKpiData";
-import { DashboardKpiPropsProvider, useDashboardKpiProps } from "../DashboardKpiPropsContext";
 
 /**
  * @internal
  */
-export const DefaultDashboardKpiInner = (): JSX.Element => {
+export const DashboardKpiCore = (props: DashboardKpiProps): JSX.Element => {
     const {
         kpiWidget,
         alert,
@@ -34,7 +33,8 @@ export const DefaultDashboardKpiInner = (): JSX.Element => {
         workspace: customWorkspace,
         ErrorComponent: CustomErrorComponent,
         LoadingComponent: CustomLoadingComponent,
-    } = useDashboardKpiProps();
+    } = props;
+
     invariant(kpiWidget.kpi, "The provided widget is not a KPI widget.");
 
     const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext({
@@ -88,16 +88,5 @@ export const DefaultDashboardKpiInner = (): JSX.Element => {
             LoadingComponent={LoadingComponent}
             isReadOnly={isReadOnly}
         />
-    );
-};
-
-/**
- * @internal
- */
-export const DefaultDashboardKpi = (props: DashboardKpiProps): JSX.Element => {
-    return (
-        <DashboardKpiPropsProvider {...props}>
-            <DefaultDashboardKpiInner />
-        </DashboardKpiPropsProvider>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpi.tsx
@@ -1,0 +1,31 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+
+import { DashboardKpiPropsProvider, useDashboardKpiProps } from "../DashboardKpiPropsContext";
+import { DashboardKpiProps } from "../types";
+import { DefaultDashboardKpiWithDrillableItems } from "./DefaultDashboardKpiWithDrillableItems";
+import { DefaultDashboardKpiWithDrills } from "./DefaultDashboardKpiWithDrills";
+
+/**
+ * @internal
+ */
+export const DefaultDashboardKpiInner = (): JSX.Element => {
+    const props = useDashboardKpiProps();
+
+    return props.drillableItems?.length ? (
+        <DefaultDashboardKpiWithDrillableItems {...props} />
+    ) : (
+        <DefaultDashboardKpiWithDrills {...props} />
+    );
+};
+
+/**
+ * @internal
+ */
+export const DefaultDashboardKpi = (props: DashboardKpiProps): JSX.Element => {
+    return (
+        <DashboardKpiPropsProvider {...props}>
+            <DefaultDashboardKpiInner />
+        </DashboardKpiPropsProvider>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpiWithDrillableItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpiWithDrillableItems.tsx
@@ -1,0 +1,26 @@
+// (C) 2020 GoodData Corporation
+import React, { useCallback } from "react";
+import { DashboardKpiProps } from "../types";
+import { DashboardKpiCore } from "./DashboardKpiCore";
+import { OnFiredDashboardViewDrillEvent } from "../../../../types";
+import { useDrill } from "../../../drill";
+
+/**
+ * @internal
+ */
+export const DefaultDashboardKpiWithDrillableItems = (props: DashboardKpiProps): JSX.Element => {
+    const { kpiWidget } = props;
+
+    const { run: handleDrill } = useDrill();
+
+    const onDrill = useCallback<OnFiredDashboardViewDrillEvent>(
+        (event) => {
+            handleDrill(event, {
+                widget: kpiWidget,
+            });
+        },
+        [handleDrill, kpiWidget],
+    );
+
+    return <DashboardKpiCore {...props} onDrill={onDrill} />;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpiWithDrills.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpiWithDrills.tsx
@@ -1,0 +1,36 @@
+// (C) 2020 GoodData Corporation
+import React, { useCallback } from "react";
+import { IDrillToLegacyDashboard } from "@gooddata/sdk-backend-spi";
+import { DashboardKpiProps } from "../types";
+import { DashboardKpiCore } from "./DashboardKpiCore";
+import { OnFiredDashboardViewDrillEvent } from "../../../../types";
+import { useDrill, useDrillToLegacyDashboard } from "../../../drill";
+
+/**
+ * @internal
+ */
+export const DefaultDashboardKpiWithDrills = (props: DashboardKpiProps): JSX.Element => {
+    const { kpiWidget } = props;
+
+    const { run: handleDrillToLegacyDashboard } = useDrillToLegacyDashboard();
+    const { run: handleDrill } = useDrill({
+        onSuccess: (event) => {
+            handleDrillToLegacyDashboard(
+                event.payload.drillEvent.drillDefinitions[0] as IDrillToLegacyDashboard,
+                event.payload.drillEvent,
+                event.correlationId,
+            );
+        },
+    });
+
+    const onDrill = useCallback<OnFiredDashboardViewDrillEvent>(
+        (event) => {
+            handleDrill(event, {
+                widget: kpiWidget,
+            });
+        },
+        [handleDrill, kpiWidget],
+    );
+
+    return <DashboardKpiCore {...props} onDrill={onDrill} />;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -164,19 +164,14 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                 return false;
             }
 
-            // only return the definitions if there are no custom-specified drillableItems
-            // if there are, we assume it was the custom drill
-            const drillDefinitions =
-                !drillableItems?.length && kpiWidget.drills.length > 0 ? kpiWidget.drills : undefined;
-
             return onDrill({
                 dataView: result.dataView,
                 drillContext,
-                drillDefinitions,
+                drillDefinitions: kpiWidget.drills,
                 widgetRef: kpiWidget.ref,
             });
         },
-        [onDrill, result],
+        [onDrill, result, kpiWidget],
     );
 
     const [isAlertDialogOpen, setIsAlertDialogOpen] = useState(false);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/index.ts
@@ -1,0 +1,2 @@
+// (C) 2021 GoodData Corporation
+export { DefaultDashboardKpi, DefaultDashboardKpiInner } from "./DefaultDashboardKpi";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/index.tsx
@@ -1,5 +1,5 @@
 // (C) 2020 GoodData Corporation
+export * from "./DefaultDashboardKpi";
 export { DashboardKpi } from "./DashboardKpi";
-export { DefaultDashboardKpi, DefaultDashboardKpiInner } from "./DefaultDashboardKpi";
 export { DashboardKpiPropsProvider, useDashboardKpiProps } from "./DashboardKpiPropsContext";
 export { DashboardKpiProps, CustomDashboardKpiComponent } from "./types";

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-import { DrillDefinition, IInsightWidget } from "@gooddata/sdk-backend-spi";
+import { DrillDefinition, IWidget } from "@gooddata/sdk-backend-spi";
 import {
     IAbsoluteDateFilter,
     IInsight,
@@ -37,7 +37,7 @@ export interface IDashboardDrillEvent extends IDrillEvent {
     /**
      * All the drilling interactions set in KPI dashboards that are relevant to the given drill event (including drill downs).
      */
-    drillDefinitions?: DashboardDrillDefinition[];
+    drillDefinitions: DashboardDrillDefinition[];
 
     /**
      * Reference to the widget that triggered the drill event.
@@ -99,7 +99,7 @@ export interface DashboardDrillContext {
     /**
      * Particular widget that triggered the drill event.
      */
-    widget?: IInsightWidget;
+    widget?: IWidget;
 }
 
 /**


### PR DESCRIPTION
- Enable granular drill events only in case the drillableItems are not provided
- Unify Kpi/Insight drill events (send drill definitions to the generic drill event without relation to the input drillableItems)
- Fire generic drill event also for Kpi as the first event (to unify it with insight widget drills)
- Preserve correlationId across whole drill eventing chain
- Separate components / make them more consistent for kpi/insight widgets

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
