### PR TITLE
RELATED: RAIL-3385 Add user interactions for kpi alert dialog

### DIFF
--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -367,7 +367,7 @@ export class XhrModule {
         // eslint-disable-next-line no-console
         console.warn(
             `The REST API version ${LATEST_REST_API_VERSION} is deprecated (${deprecatedVersionDetails}). ` +
-                "Please migrate your application to use GoodData.UI SDK or @gooddata/gd-bear-client package that " +
+                "Please migrate your application to use GoodData.UI SDK or @gooddata/api-client-bear package that " +
                 "supports newer version of the API.",
         );
     }

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -638,7 +638,7 @@ export const DashboardDateFilterPropsProvider: React_2.FC<IDashboardDateFilterPr
 export interface DashboardDateFilterSelectionChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
-        readonly filter: IDashboardDateFilter;
+        readonly filter: IDashboardDateFilter | undefined;
         readonly dateFilterOptionLocalId?: string;
     };
     // (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -190,6 +190,15 @@ export interface BackendCapabilitiesState {
     backendCapabilities?: IBackendCapabilities;
 }
 
+// @alpha (undocumented)
+export interface BareUserInteractionPayload {
+    // (undocumented)
+    interaction: "kpiAlertDialogClosed" | "poweredByGDLogoClicked";
+}
+
+// @alpha (undocumented)
+export type BareUserInteractionType = BareUserInteractionPayload["interaction"];
+
 // @internal (undocumented)
 export const ButtonBar: () => JSX.Element;
 
@@ -1268,9 +1277,7 @@ export const DashboardStoreProvider: React_2.FC<IDashboardStoreProviderProps>;
 // @alpha
 export interface DashboardUserInteractionTriggered extends IDashboardEvent {
     // (undocumented)
-    readonly payload: {
-        interaction: UserInteractionType;
-    };
+    readonly payload: UserInteractionPayload;
     // (undocumented)
     readonly type: "GDC.DASH/EVT.USER_INTERACTION.TRIGGERED";
 }
@@ -1919,6 +1926,11 @@ export interface ITopBarProps {
     // (undocumented)
     titleProps: ITitleProps;
 }
+
+// @alpha (undocumented)
+export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kpiAlertDialogOpened", {
+    alreadyHasAlert: boolean;
+}>;
 
 // @alpha (undocumented)
 export type KpiPlaceholderWidget = {
@@ -3025,13 +3037,12 @@ export const useDashboardQueryProcessing: <TQuery extends DashboardQueries, TQue
 // @alpha (undocumented)
 export const useDashboardSelector: TypedUseSelectorHook<DashboardState>;
 
-// @internal (undocumented)
-export type UseDashboardUserInteraction = {
-    [interaction in UserInteractionType]: () => void;
-};
-
 // @internal
-export const useDashboardUserInteraction: () => UseDashboardUserInteraction;
+export const useDashboardUserInteraction: () => {
+    poweredByGDLogoClicked: () => void;
+    kpiAlertDialogClosed: () => void;
+    kpiAlertDialogOpened: (alreadyHasAlert: boolean) => void;
+};
 
 // @internal (undocumented)
 export const useDashboardWidgetProps: () => DashboardWidgetProps;
@@ -3157,21 +3168,33 @@ export const useMenuButtonProps: (config?: IMenuButtonConfiguration | undefined)
 // @alpha
 export interface UserInteraction extends IDashboardCommand {
     // (undocumented)
-    readonly payload: {
-        interaction: UserInteractionType;
-    };
+    readonly payload: UserInteractionPayload;
     // (undocumented)
     readonly type: "GDC.DASH/CMD.USER_INTERACTION";
 }
 
-// @alpha (undocumented)
-export function userInteraction(interaction: UserInteractionType, correlationId?: string): UserInteraction;
+// @alpha
+export function userInteraction(interactionPayloadOrType: UserInteractionPayload | BareUserInteractionType, correlationId?: string): UserInteraction;
 
 // @alpha (undocumented)
-export function userInteractionTriggered(ctx: DashboardContext, interaction: UserInteractionType, correlationId?: string): DashboardUserInteractionTriggered;
+export type UserInteractionPayload = UserInteractionPayloadWithData | BareUserInteractionPayload;
 
 // @alpha (undocumented)
-export type UserInteractionType = "poweredByGDLogoClicked";
+export type UserInteractionPayloadWithData = KpiAlertDialogOpenedPayload;
+
+// @alpha (undocumented)
+export interface UserInteractionPayloadWithDataBase<TType extends string, TData extends object> {
+    // (undocumented)
+    data: TData;
+    // (undocumented)
+    interaction: TType;
+}
+
+// @alpha (undocumented)
+export function userInteractionTriggered(ctx: DashboardContext, interactionPayload: UserInteractionPayload, correlationId?: string): DashboardUserInteractionTriggered;
+
+// @alpha (undocumented)
+export type UserInteractionType = UserInteractionPayload["interaction"];
 
 // @alpha (undocumented)
 export interface UserState {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/changeDateFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/changeDateFilterSelectionHandler.ts
@@ -37,13 +37,7 @@ export function* changeDateFilterSelectionHandler(
     );
 
     yield dispatchDashboardEvent(
-        dateFilterChanged(
-            ctx,
-            // TODO we need to decide how to externally represent All Time date filter and unify this
-            affectedFilter ?? { dateFilter: { granularity: "GDC.time.date", type: "relative" } },
-            cmd.payload.dateFilterOptionLocalId,
-            cmd.correlationId,
-        ),
+        dateFilterChanged(ctx, affectedFilter, cmd.payload.dateFilterOptionLocalId, cmd.correlationId),
     );
 
     yield call(dispatchFilterContextChanged, ctx, cmd);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/userInteraction/userInteractionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/userInteraction/userInteractionHandler.ts
@@ -7,5 +7,5 @@ export function userInteractionHandler(
     ctx: DashboardContext,
     cmd: UserInteraction,
 ): DashboardUserInteractionTriggered {
-    return userInteractionTriggered(ctx, cmd.payload.interaction, cmd.correlationId);
+    return userInteractionTriggered(ctx, cmd.payload, cmd.correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -161,7 +161,7 @@ export {
     refreshInsightWidget,
 } from "./insight";
 
-export { UserInteraction, UserInteractionType, userInteraction } from "./userInteraction";
+export * from "./userInteraction";
 
 export { RequestAsyncRender, ResolveAsyncRender } from "./render";
 

--- a/libs/sdk-ui-dashboard/src/model/commands/userInteraction.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/userInteraction.ts
@@ -1,10 +1,51 @@
 // (C) 2021 GoodData Corporation
+import isString from "lodash/isString";
 import { IDashboardCommand } from "./base";
 
 /**
  * @alpha
  */
-export type UserInteractionType = "poweredByGDLogoClicked";
+export interface UserInteractionPayloadWithDataBase<TType extends string, TData extends object> {
+    interaction: TType;
+    data: TData;
+}
+
+/**
+ * @alpha
+ */
+export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<
+    "kpiAlertDialogOpened",
+    {
+        alreadyHasAlert: boolean;
+    }
+>;
+
+/**
+ * @alpha
+ */
+export interface BareUserInteractionPayload {
+    interaction: "kpiAlertDialogClosed" | "poweredByGDLogoClicked";
+}
+
+/**
+ * @alpha
+ */
+export type UserInteractionPayloadWithData = KpiAlertDialogOpenedPayload;
+
+/**
+ * @alpha
+ */
+export type UserInteractionPayload = UserInteractionPayloadWithData | BareUserInteractionPayload;
+
+/**
+ * @alpha
+ */
+export type UserInteractionType = UserInteractionPayload["interaction"];
+
+/**
+ * @alpha
+ */
+export type BareUserInteractionType = BareUserInteractionPayload["interaction"];
 
 /**
  * Triggers user interaction.
@@ -14,20 +55,32 @@ export type UserInteractionType = "poweredByGDLogoClicked";
  */
 export interface UserInteraction extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.USER_INTERACTION";
-    readonly payload: {
-        interaction: UserInteractionType;
-    };
+    readonly payload: UserInteractionPayload;
 }
 
 /**
+ * Creates the {@link UserInteraction} command.
+ *
+ * @param interactionPayloadOrType - interaction payload or a type of a user interaction without extra data (for convenience)
+ * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
+ *  events that will be emitted during the command processing
  * @alpha
  */
-export function userInteraction(interaction: UserInteractionType, correlationId?: string): UserInteraction {
+export function userInteraction(
+    interactionPayloadOrType: UserInteractionPayload | BareUserInteractionType,
+    correlationId?: string,
+): UserInteraction {
+    if (isString(interactionPayloadOrType)) {
+        return {
+            type: "GDC.DASH/CMD.USER_INTERACTION",
+            correlationId,
+            payload: { interaction: interactionPayloadOrType },
+        };
+    }
+
     return {
         type: "GDC.DASH/CMD.USER_INTERACTION",
         correlationId,
-        payload: {
-            interaction,
-        },
+        payload: interactionPayloadOrType,
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/events/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/filters.ts
@@ -15,14 +15,14 @@ import { DashboardContext } from "../types/commonTypes";
 export interface DashboardDateFilterSelectionChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.SELECTION_CHANGED";
     readonly payload: {
-        readonly filter: IDashboardDateFilter;
+        readonly filter: IDashboardDateFilter | undefined;
         readonly dateFilterOptionLocalId?: string;
     };
 }
 
 export function dateFilterChanged(
     ctx: DashboardContext,
-    filter: IDashboardDateFilter,
+    filter: IDashboardDateFilter | undefined,
     dateFilterOptionLocalId?: string,
     correlationId?: string,
 ): DashboardDateFilterSelectionChanged {

--- a/libs/sdk-ui-dashboard/src/model/events/userInteraction.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/userInteraction.ts
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import { UserInteractionType } from "../commands/userInteraction";
+import { UserInteractionPayload } from "../commands/userInteraction";
 import { DashboardContext } from "../types/commonTypes";
 import { IDashboardEvent } from "./base";
 
@@ -11,9 +11,7 @@ import { IDashboardEvent } from "./base";
  */
 export interface DashboardUserInteractionTriggered extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.USER_INTERACTION.TRIGGERED";
-    readonly payload: {
-        interaction: UserInteractionType;
-    };
+    readonly payload: UserInteractionPayload;
 }
 
 /**
@@ -21,15 +19,13 @@ export interface DashboardUserInteractionTriggered extends IDashboardEvent {
  */
 export function userInteractionTriggered(
     ctx: DashboardContext,
-    interaction: UserInteractionType,
+    interactionPayload: UserInteractionPayload,
     correlationId?: string,
 ): DashboardUserInteractionTriggered {
     return {
         type: "GDC.DASH/EVT.USER_INTERACTION.TRIGGERED",
         ctx,
         correlationId,
-        payload: {
-            interaction,
-        },
+        payload: interactionPayload,
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/react/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/index.ts
@@ -5,6 +5,6 @@ export { useDashboardCommand } from "./useDashboardCommand";
 export { useDashboardCommandProcessing, CommandProcessingStatus } from "./useDashboardCommandProcessing";
 export { useDashboardQuery } from "./useDashboardQuery";
 export { useDashboardQueryProcessing, QueryProcessingStatus } from "./useDashboardQueryProcessing";
-export { UseDashboardUserInteraction, useDashboardUserInteraction } from "./useDashboardUserInteraction";
+export { useDashboardUserInteraction } from "./useDashboardUserInteraction";
 export { useDashboardAsyncRender, UseDashboardAsyncRender } from "./useDashboardAsyncRender";
 export { IDashboardStoreProviderProps } from "./types";

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardUserInteraction.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardUserInteraction.ts
@@ -1,15 +1,8 @@
 // (C) 2020-2021 GoodData Corporation
 import { useCallback } from "react";
 
-import { userInteraction, UserInteractionType } from "../commands/userInteraction";
+import { userInteraction } from "../commands/userInteraction";
 import { useDashboardDispatch } from "./DashboardStoreProvider";
-
-/**
- * @internal
- */
-export type UseDashboardUserInteraction = {
-    [interaction in UserInteractionType]: () => void;
-};
 
 /**
  * Hook for dispatching relevant user interaction commands.
@@ -17,17 +10,25 @@ export type UseDashboardUserInteraction = {
  *
  * @internal
  */
-export const useDashboardUserInteraction = (): UseDashboardUserInteraction => {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const useDashboardUserInteraction = () => {
     const dispatch = useDashboardDispatch();
 
-    const dispatchLogUserInteraction = (interaction: UserInteractionType) =>
-        dispatch(userInteraction(interaction));
-
     const poweredByGDLogoClicked = useCallback(() => {
-        dispatchLogUserInteraction("poweredByGDLogoClicked");
+        dispatch(userInteraction("poweredByGDLogoClicked"));
+    }, []);
+
+    const kpiAlertDialogClosed = useCallback(() => {
+        dispatch(userInteraction("kpiAlertDialogClosed"));
+    }, []);
+
+    const kpiAlertDialogOpened = useCallback((alreadyHasAlert: boolean) => {
+        dispatch(userInteraction({ interaction: "kpiAlertDialogOpened", data: { alreadyHasAlert } }));
     }, []);
 
     return {
         poweredByGDLogoClicked,
+        kpiAlertDialogClosed,
+        kpiAlertDialogOpened,
     };
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -48,6 +48,7 @@ import {
     selectUser,
     useDashboardSelector,
     useDashboardAsyncRender,
+    useDashboardUserInteraction,
 } from "../../../../model";
 import { DashboardItemHeadline } from "../../../presentationComponents";
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../../../types";
@@ -196,6 +197,8 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
         }
     }, [status, onRequestAsyncRender, onResolveAsyncRender]);
 
+    const { kpiAlertDialogClosed, kpiAlertDialogOpened } = useDashboardUserInteraction();
+
     if (status === "loading" || status === "pending") {
         return <LoadingComponent />;
     }
@@ -252,13 +255,19 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
             isAlertExecutionLoading={alertStatus === "loading"}
             isAlertBroken={isAlertBroken}
             isAlertDialogOpen={isAlertDialogOpen}
-            onAlertDialogOpenClick={() => setIsAlertDialogOpen(true)}
+            onAlertDialogOpenClick={() => {
+                kpiAlertDialogOpened(!!alert);
+                setIsAlertDialogOpen(true);
+            }}
             renderAlertDialog={() => (
                 <KpiAlertDialogWrapper
                     alert={alert}
                     dateFormat={settings.responsiveUiDateFormat!}
                     userEmail={currentUser.email!}
-                    onAlertDialogCloseClick={() => setIsAlertDialogOpen(false)}
+                    onAlertDialogCloseClick={() => {
+                        kpiAlertDialogClosed();
+                        setIsAlertDialogOpen(false);
+                    }}
                     onAlertDialogDeleteClick={() => {
                         kpiAlertOperations.onRemoveAlert(alert!);
                     }}


### PR DESCRIPTION
The command and event was reworked to allow passing extra data fro them.

Also an issue with dateFilterSelectionChanged event with All time filter fixed – now the all time filter is represented as undefined (this is in line with other places in the package).

Finally, a minor warning text content was fixed.

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
