### PR TITLE
REALTED: RAIL-3385 Add failed command to DashboardCommandFailed event

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -574,6 +574,7 @@ export interface DashboardCommandFailed extends IDashboardEvent {
         readonly reason: ActionFailedErrorReason;
         readonly message: string;
         readonly error?: Error;
+        readonly command: IDashboardCommand;
     };
     // (undocumented)
     readonly type: "GDC.DASH/EVT.COMMAND.FAILED";

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
@@ -39,8 +39,8 @@ export function* addAttributeFilterHandler(
     if (!canBeAdded) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Filter for the displayForm ${objRefToString(displayForm)} already exists in the filter context.`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
@@ -27,11 +27,7 @@ export function* changeAttributeFilterSelectionHandler(
     );
 
     if (!affectedFilter) {
-        throw invalidArgumentsProvided(
-            ctx,
-            `Filter with filterLocalId ${filterLocalId} not found.`,
-            cmd.correlationId,
-        );
+        throw invalidArgumentsProvided(ctx, cmd, `Filter with filterLocalId ${filterLocalId} not found.`);
     }
 
     yield put(

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/moveAttributeFilterHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/moveAttributeFilterHandler.ts
@@ -29,11 +29,7 @@ export function* moveAttributeFilterHandler(
     );
 
     if (!affectedFilter) {
-        throw invalidArgumentsProvided(
-            ctx,
-            `Filter with filterLocalId ${filterLocalId} not found.`,
-            cmd.correlationId,
-        );
+        throw invalidArgumentsProvided(ctx, cmd, `Filter with filterLocalId ${filterLocalId} not found.`);
     }
 
     // validate target index
@@ -46,8 +42,8 @@ export function* moveAttributeFilterHandler(
     if (index > maximalTargetIndex || index < -1) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Invalid index (${index}) provided, it must be between -1 and ${maximalTargetIndex}`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
@@ -36,8 +36,8 @@ export function* removeAttributeFiltersHandler(
     if (invalidLocalIds.length) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Invalid filterLocalIds provided. These ids were not found: ${invalidLocalIds.join(", ")}.`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/setAttributeFilterParentHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/setAttributeFilterParentHandler.ts
@@ -34,11 +34,7 @@ export function* setAttributeFilterParentHandler(
     );
 
     if (!affectedFilter) {
-        throw invalidArgumentsProvided(
-            ctx,
-            `Filter with localId ${filterLocalId} was not found.`,
-            cmd.correlationId,
-        );
+        throw invalidArgumentsProvided(ctx, cmd, `Filter with localId ${filterLocalId} was not found.`);
     }
 
     const validationResult: SagaReturnType<typeof validateAttributeFilterParents> = yield call(
@@ -56,7 +52,7 @@ export function* setAttributeFilterParentHandler(
                   "Only existing filters can be used as parent filters."
                 : "Some of the parents provided cannot be used because the 'over' parameter is invalid for the target filter.";
 
-        throw invalidArgumentsProvided(ctx, message, cmd.correlationId);
+        throw invalidArgumentsProvided(ctx, cmd, message);
     }
 
     yield put(

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
@@ -34,15 +34,14 @@ function validateAndResolve(commandCtx: AddLayoutSectionContext): StashValidatio
         stash,
         cmd: {
             payload: { index, initialItems = [] },
-            correlationId,
         },
     } = commandCtx;
 
     if (!validateSectionPlacement(layout, index)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to insert new section at wrong index ${index}. There are currently ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -51,10 +50,10 @@ function validateAndResolve(commandCtx: AddLayoutSectionContext): StashValidatio
     if (!isEmpty(stashValidationResult.missing)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to use non-existing stashes. Identifiers of missing stashes: ${stashValidationResult.missing.join(
                 ", ",
             )}`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
@@ -33,14 +33,13 @@ function validateAndResolve(commandCtx: AddSectionItemsContext) {
         stash,
         cmd: {
             payload: { sectionIndex, itemIndex, items },
-            correlationId,
         },
     } = commandCtx;
     if (!validateSectionExists(layout, sectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to add items to non-existing layout section at index ${sectionIndex}.`,
-            correlationId,
         );
     }
 
@@ -49,8 +48,8 @@ function validateAndResolve(commandCtx: AddSectionItemsContext) {
     if (!validateItemPlacement(section, itemIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to insert new item at wrong index ${itemIndex}. There are currently ${section.items.length} items.`,
-            correlationId,
         );
     }
 
@@ -59,10 +58,10 @@ function validateAndResolve(commandCtx: AddSectionItemsContext) {
     if (!isEmpty(stashValidationResult.missing)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to use non-existing stashes. Identifiers of missing stashes: ${stashValidationResult.missing.join(
                 ", ",
             )}`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/changeLayoutSectionHeaderHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/changeLayoutSectionHeaderHandler.ts
@@ -21,8 +21,8 @@ export function* changeLayoutSectionHeaderHandler(
     if (!validateSectionExists(layout, index)) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Attempting to modify header of non-existent section at ${index}. There are currently ${layout.sections.length} sections.`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/moveLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/moveLayoutSectionHandler.ts
@@ -21,7 +21,6 @@ function validateAndResolve(commandCtx: MoveLayoutSectionContext) {
         ctx,
         cmd: {
             payload: { sectionIndex, toIndex },
-            correlationId,
         },
         layout,
     } = commandCtx;
@@ -29,16 +28,16 @@ function validateAndResolve(commandCtx: MoveLayoutSectionContext) {
     if (!validateSectionExists(layout, sectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move non-existent section from index ${sectionIndex}. There are only ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
     if (!validateSectionPlacement(layout, toIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move section to a wrong index ${toIndex}. There are currently ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -47,8 +46,8 @@ function validateAndResolve(commandCtx: MoveLayoutSectionContext) {
     if (sectionIndex === absoluteIndex) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move section to a same index where it already resides ${sectionIndex}.`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/moveSectionItemHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/moveSectionItemHandler.ts
@@ -27,15 +27,14 @@ function validateAndResolve(commandCtx: MoveSectionItemContext) {
         layout,
         cmd: {
             payload: { sectionIndex, toSectionIndex, itemIndex, toItemIndex },
-            correlationId,
         },
     } = commandCtx;
 
     if (!validateSectionExists(layout, sectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move item from non-existent section at ${sectionIndex}. There are only ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -44,8 +43,8 @@ function validateAndResolve(commandCtx: MoveSectionItemContext) {
     if (!validateItemExists(fromSection, itemIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move non-existent item from index ${itemIndex}. There are only ${fromSection.items.length} items.`,
-            correlationId,
         );
     }
 
@@ -54,8 +53,8 @@ function validateAndResolve(commandCtx: MoveSectionItemContext) {
     if (!validateSectionPlacement(layout, toSectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move item to a wrong section at index ${toSectionIndex}. There are currently ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -65,8 +64,8 @@ function validateAndResolve(commandCtx: MoveSectionItemContext) {
     if (!validateItemPlacement(targetSection, toItemIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to move item to a wrong location at index ${toItemIndex}. Target section has ${targetSection.items.length} items.`,
-            correlationId,
         );
     }
 
@@ -78,8 +77,8 @@ function validateAndResolve(commandCtx: MoveSectionItemContext) {
         if (itemIndex === targetItemIndex) {
             throw invalidArgumentsProvided(
                 ctx,
+                commandCtx.cmd,
                 `Attempting to move item to a same place where it already resides ${toItemIndex}.`,
-                correlationId,
             );
         }
     } else {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/removeLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/removeLayoutSectionHandler.ts
@@ -19,18 +19,14 @@ export function* removeLayoutSectionHandler(
     const { index, stashIdentifier } = cmd.payload;
 
     if (isEmpty(layout.sections)) {
-        throw invalidArgumentsProvided(
-            ctx,
-            `Attempting to remove a section from an empty layout.`,
-            cmd.correlationId,
-        );
+        throw invalidArgumentsProvided(ctx, cmd, `Attempting to remove a section from an empty layout.`);
     }
 
     if (!validateSectionExists(layout, index)) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Attempting to remove non-existing layout section at index ${index}.`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/removeSectionItemHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/removeSectionItemHandler.ts
@@ -22,7 +22,6 @@ function validateAndResolve(commandCtx: RemoveSectionItemContext) {
         ctx,
         cmd: {
             payload: { sectionIndex, itemIndex },
-            correlationId,
         },
         layout,
     } = commandCtx;
@@ -30,8 +29,8 @@ function validateAndResolve(commandCtx: RemoveSectionItemContext) {
     if (!validateSectionExists(layout, sectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to remove item from non-existent section at ${sectionIndex}. There are only ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -40,8 +39,8 @@ function validateAndResolve(commandCtx: RemoveSectionItemContext) {
     if (!validateItemExists(fromSection, itemIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to remove non-existent item from index ${itemIndex} in section ${sectionIndex}. There are only ${fromSection.items.length} items in this section.`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
@@ -23,7 +23,6 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
         ctx,
         cmd: {
             payload: { sectionIndex, itemIndex, item },
-            correlationId,
         },
         layout,
         stash,
@@ -32,8 +31,8 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
     if (!validateSectionExists(layout, sectionIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to replace item from non-existent section at ${sectionIndex}. There are only ${layout.sections.length} sections.`,
-            correlationId,
         );
     }
 
@@ -42,8 +41,8 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
     if (!validateItemExists(fromSection, itemIndex)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to replace non-existent item from index ${itemIndex} in section ${sectionIndex}. There are only ${fromSection.items.length} items in this section.`,
-            correlationId,
         );
     }
 
@@ -52,10 +51,10 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
     if (!isEmpty(stashValidationResult.missing)) {
         throw invalidArgumentsProvided(
             ctx,
+            commandCtx.cmd,
             `Attempting to use non-existing stashes. Identifiers of missing stashes: ${stashValidationResult.missing.join(
                 ", ",
             )}`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/undoLayoutChangesHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/undoLayoutChangesHandler.ts
@@ -30,8 +30,8 @@ export function* undoLayoutChangesHandler(
     if (undoUpToIncludingCmd < 0 || undoUpToIncludingCmd >= undoableCommands.length) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Undo point selector returned result out of bounds. Undoable commands: ${undoableCommands.length}. Got index: ${undoUpToIncludingCmd}`,
-            cmd.correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
@@ -132,9 +132,9 @@ export function* rootCommandHandler(): SagaIterator<void> {
                 yield dispatchDashboardEvent(
                     internalErrorOccurred(
                         dashboardContext,
+                        command,
                         `Internal error has occurred while handling ${command.type}`,
                         e,
-                        command.correlationId,
                     ),
                 );
             }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/modifyDrillsForInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/modifyDrillsForInsightWidgetHandler.ts
@@ -35,7 +35,7 @@ export function* modifyDrillsForInsightWidgetHandler(
     const { drills: currentInsightDrills = [] } = insightWidget;
 
     const validatedDrillDefinition = drillsToModify.map((drillItem) =>
-        validateInsightDrillDefinition(drillItem, drillTargets, ctx, correlationId),
+        validateInsightDrillDefinition(drillItem, drillTargets, ctx, cmd),
     );
 
     const addedDrillDefinition = validatedDrillDefinition.filter(

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/removeDrillsForInsightWidgetHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/removeDrillsForInsightWidgetHandler.ts
@@ -24,7 +24,7 @@ export function* removeDrillsForInsightWidgetHandler(
     const insightWidget = validateExistingInsightWidget(widgets, cmd, ctx);
     const { ref: widgetRef, drills: currentInsightDrills } = insightWidget;
 
-    const drillToRemove = validateRemoveDrillsByOrigins(origins, currentInsightDrills, ctx, correlationId);
+    const drillToRemove = validateRemoveDrillsByOrigins(origins, currentInsightDrills, ctx, cmd);
 
     const notModifiedDrillDefinition = currentInsightDrills.filter(
         (drillItem) => !existsDrillDefinitionInArray(drillItem, drillToRemove),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
@@ -11,6 +11,33 @@ Array [
 
 exports[`modifyDrillsForInsightWidgetHandler validate should fail if trying to modify/add drills and drill has invalid attribute origin 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "drills": Array [
+        Object {
+          "origin": Object {
+            "attribute": Object {
+              "localIdentifier": "some origin",
+            },
+            "type": "drillFromAttribute",
+          },
+          "target": Object {
+            "identifier": "aeis6NlXcL7X",
+          },
+          "transition": "in-place",
+          "type": "drillToDashboard",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1310",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
+  },
   "message": "Invalid drill origin for InsightDrillDefinition: {\\"origin\\":{\\"attribute\\":{\\"localIdentifier\\":\\"some origin\\"},\\"type\\":\\"drillFromAttribute\\"},\\"target\\":{\\"identifier\\":\\"aeis6NlXcL7X\\"},\\"transition\\":\\"in-place\\",\\"type\\":\\"drillToDashboard\\"}. Error: InsightDrillDefinition origin is not valid attribute drillTarget",
   "reason": "USER_ERROR",
 }
@@ -18,6 +45,33 @@ Object {
 
 exports[`modifyDrillsForInsightWidgetHandler validate should fail if trying to modify/add drills and drill has invalid measure origin 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "drills": Array [
+        Object {
+          "origin": Object {
+            "measure": Object {
+              "localIdentifier": "some origin",
+            },
+            "type": "drillFromMeasure",
+          },
+          "target": Object {
+            "identifier": "aeis6NlXcL7X",
+          },
+          "transition": "in-place",
+          "type": "drillToDashboard",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1310",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
+  },
   "message": "Invalid drill origin for InsightDrillDefinition: {\\"origin\\":{\\"measure\\":{\\"localIdentifier\\":\\"some origin\\"},\\"type\\":\\"drillFromMeasure\\"},\\"target\\":{\\"identifier\\":\\"aeis6NlXcL7X\\"},\\"transition\\":\\"in-place\\",\\"type\\":\\"drillToDashboard\\"}. Error: InsightDrillDefinition origin is not valid measure drillTarget",
   "reason": "USER_ERROR",
 }
@@ -25,6 +79,33 @@ Object {
 
 exports[`modifyDrillsForInsightWidgetHandler validate should fail if trying to modify/add drills and drill targets are not set 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "drills": Array [
+        Object {
+          "origin": Object {
+            "attribute": Object {
+              "localIdentifier": "3b196b9f8de04b61ba37762fa28fcf4f",
+            },
+            "type": "drillFromAttribute",
+          },
+          "target": Object {
+            "identifier": "aeis6NlXcL7X",
+          },
+          "transition": "in-place",
+          "type": "drillToDashboard",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1310",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
+  },
   "message": "Drill targets not set",
   "reason": "USER_ERROR",
 }
@@ -32,6 +113,33 @@ Object {
 
 exports[`modifyDrillsForInsightWidgetHandler validate should fail if trying to modify/add drills of kpi widget 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "drills": Array [
+        Object {
+          "origin": Object {
+            "attribute": Object {
+              "localIdentifier": "3b196b9f8de04b61ba37762fa28fcf4f",
+            },
+            "type": "drillFromAttribute",
+          },
+          "target": Object {
+            "identifier": "aeis6NlXcL7X",
+          },
+          "transition": "in-place",
+          "type": "drillToDashboard",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1386",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
+  },
   "message": "Widget with ref: {\\"uri\\":\\"/gdc/md/referenceworkspace/obj/1386\\"} exists but is not an insight widget.",
   "reason": "USER_ERROR",
 }
@@ -39,6 +147,33 @@ Object {
 
 exports[`modifyDrillsForInsightWidgetHandler validate should fail if trying to modify/add drills of non-existent widget 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "drills": Array [
+        Object {
+          "origin": Object {
+            "attribute": Object {
+              "localIdentifier": "3b196b9f8de04b61ba37762fa28fcf4f",
+            },
+            "type": "drillFromAttribute",
+          },
+          "target": Object {
+            "identifier": "aeis6NlXcL7X",
+          },
+          "transition": "in-place",
+          "type": "drillToDashboard",
+        },
+      ],
+      "ref": Object {
+        "uri": "missing",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
+  },
   "message": "Cannot find insight widget with ref: {\\"uri\\":\\"missing\\"}.",
   "reason": "USER_ERROR",
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
@@ -11,6 +11,23 @@ Array [
 
 exports[`removeDrillsForInsightWidgetHandler validate should fail if trying to remove drills of kpi widget 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "origins": Array [
+        Object {
+          "localIdentifier": "31c22194386b408aa80ab90b966e85a7",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1386",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS",
+  },
   "message": "Widget with ref: {\\"uri\\":\\"/gdc/md/referenceworkspace/obj/1386\\"} exists but is not an insight widget.",
   "reason": "USER_ERROR",
 }
@@ -18,6 +35,23 @@ Object {
 
 exports[`removeDrillsForInsightWidgetHandler validate should fail if trying to remove drills of non-existent widget 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "origins": Array [
+        Object {
+          "localIdentifier": "31c22194386b408aa80ab90b966e85a7",
+        },
+      ],
+      "ref": Object {
+        "uri": "missing",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS",
+  },
   "message": "Cannot find insight widget with ref: {\\"uri\\":\\"missing\\"}.",
   "reason": "USER_ERROR",
 }
@@ -25,6 +59,23 @@ Object {
 
 exports[`removeDrillsForInsightWidgetHandler validate should fail if trying to remove drills where origin is not specified by localIdRef 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "origins": Array [
+        Object {
+          "uri": "not-valid-ref",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1310",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS",
+  },
   "message": "Invalid measure or attribute origin: not-valid-ref. Error: Invalid ObjRef invariant expecting LocalIdRef",
   "reason": "USER_ERROR",
 }
@@ -32,6 +83,23 @@ Object {
 
 exports[`removeDrillsForInsightWidgetHandler validate should fail if trying to remove drills where origin missing in widget drills 1`] = `
 Object {
+  "command": Object {
+    "correlationId": "testCorrelationId",
+    "meta": Object {
+      "uuid": Any<String>,
+    },
+    "payload": Object {
+      "origins": Array [
+        Object {
+          "localIdentifier": "missing",
+        },
+      ],
+      "ref": Object {
+        "uri": "/gdc/md/referenceworkspace/obj/1310",
+      },
+    },
+    "type": "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS",
+  },
   "message": "Invalid measure or attribute origin: missing. Error: Cannot find drill definition specified by local identifier",
   "reason": "USER_ERROR",
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
@@ -100,7 +100,13 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
@@ -112,7 +118,13 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
@@ -129,7 +141,13 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
@@ -150,7 +168,13 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
@@ -171,7 +195,13 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/removeDrillsForInsightWidgetHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/removeDrillsForInsightWidgetHandler.test.ts
@@ -19,6 +19,7 @@ import {
 import { localIdRef, uriRef } from "@gooddata/sdk-model";
 import { selectWidgetByRef } from "../../../state/layout/layoutSelectors";
 import { DashboardInsightWidgetDrillsRemoved } from "../../../events/insight";
+import { DashboardCommandFailed } from "../../../events";
 
 describe("removeDrillsForInsightWidgetHandler", () => {
     const fromMeasureLocalIdRef = localIdRef(SimpleDashboardSimpleSortedTableWonMeasureLocalIdentifier);
@@ -93,27 +94,39 @@ describe("removeDrillsForInsightWidgetHandler", () => {
 
     describe("validate", () => {
         it("should fail if trying to remove drills of non-existent widget", async () => {
-            const event: DashboardInsightWidgetDrillsRemoved = await Tester.dispatchAndWaitFor(
+            const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
                 removeDrillsForInsightWidget(uriRef("missing"), [fromMeasureLocalIdRef], TestCorrelation),
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
         it("should fail if trying to remove drills of kpi widget", async () => {
-            const event: DashboardInsightWidgetDrillsRemoved = await Tester.dispatchAndWaitFor(
+            const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
                 removeDrillsForInsightWidget(KpiWidgetRef, [fromMeasureLocalIdRef], TestCorrelation),
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
         it("should fail if trying to remove drills where origin is not specified by localIdRef", async () => {
-            const event: DashboardInsightWidgetDrillsRemoved = await Tester.dispatchAndWaitFor(
+            const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
                 removeDrillsForInsightWidget(
                     SimpleSortedTableWidgetRef,
                     [uriRef("not-valid-ref")],
@@ -122,12 +135,18 @@ describe("removeDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
 
         it("should fail if trying to remove drills where origin missing in widget drills", async () => {
-            const event: DashboardInsightWidgetDrillsRemoved = await Tester.dispatchAndWaitFor(
+            const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
                 removeDrillsForInsightWidget(
                     SimpleSortedTableWidgetRef,
                     [localIdRef("missing")],
@@ -136,7 +155,13 @@ describe("removeDrillsForInsightWidgetHandler", () => {
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 
-            expect(event.payload).toMatchSnapshot();
+            expect(event.payload).toMatchSnapshot({
+                command: {
+                    meta: {
+                        uuid: expect.any(String),
+                    },
+                },
+            });
             expect(event.correlationId).toEqual(TestCorrelation);
         });
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
@@ -11,6 +11,7 @@ import { resolveDisplayFormMetadata } from "../../../utils/displayFormResolver";
 import isEmpty from "lodash/isEmpty";
 import { selectFilterContextAttributeFilters } from "../../../state/filterContext/filterContextSelectors";
 import { ICatalogDateDataset, IDashboardAttributeFilter, IInsightWidget } from "@gooddata/sdk-backend-spi";
+import { IDashboardCommand } from "../../../commands";
 
 /**
  * This generator validates that a date dataset with the provided ref can be used for date filtering of insight in
@@ -25,15 +26,15 @@ import { ICatalogDateDataset, IDashboardAttributeFilter, IInsightWidget } from "
  * the subsequent calls will be instant.
  *
  * @param ctx - dashboard context in which the validation is done
+ * @param cmd - dashboard command it the context of which the validation is done
  * @param widget - insight that whose date filter is about to change
  * @param dateDataSet - ref of a date dataset to validate
- * @param correlationId - correlation id to use in any events that may be raised during the validation
  */
 export function* validateDatasetForInsightWidgetDateFilter(
     ctx: DashboardContext,
+    cmd: IDashboardCommand,
     widget: IInsightWidget,
     dateDataSet: ObjRef,
-    correlationId: string | undefined,
 ): SagaIterator<ICatalogDateDataset> {
     const insightDateDatasets: InsightDateDatasets = yield call(
         query,
@@ -46,10 +47,10 @@ export function* validateDatasetForInsightWidgetDateFilter(
     if (!catalogDataSet) {
         throw invalidArgumentsProvided(
             ctx,
-            `Attempting to use date dataset ${objRefToString(dateDataSet)} 
-            to filter insight widget ${objRefToString(widget.ref)} but the data set either does not exist or 
+            cmd,
+            `Attempting to use date dataset ${objRefToString(dateDataSet)}
+            to filter insight widget ${objRefToString(widget.ref)} but the data set either does not exist or
             is not valid to use for filtering the insight.`,
-            correlationId,
         );
     }
 
@@ -74,13 +75,13 @@ export function* validateDatasetForInsightWidgetDateFilter(
  *    and will eventually bomb
  *
  * @param ctx - dashboard context in which the validation is done
+ * @param cmd - dashboard command in the context of which the validation is done
  * @param toIgnore - refs of display forms used in attribute filters that should be ignored
- * @param correlationId - correlation id to use in any events that may be raised during the validation
  */
 export function* validateAttributeFiltersToIgnore(
     ctx: DashboardContext,
+    cmd: IDashboardCommand,
     toIgnore: ObjRef[],
-    correlationId: string | undefined,
 ): SagaIterator<IDashboardAttributeFilter[]> {
     const resolvedDisplayForms: SagaReturnType<typeof resolveDisplayFormMetadata> = yield call(
         resolveDisplayFormMetadata,
@@ -92,10 +93,10 @@ export function* validateAttributeFiltersToIgnore(
     if (!isEmpty(missing)) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Attempting to disable attribute filters but some of the display form refs to disable filters by do not exist: ${missing
                 .map(objRefToString)
                 .join(", ")}`,
-            correlationId,
         );
     }
 
@@ -120,10 +121,10 @@ export function* validateAttributeFiltersToIgnore(
     if (!isEmpty(badIgnores)) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Attempting to disable attribute filters but some of the display form refs to disable filters by are not used for filtering at all: ${badIgnores
                 .map(objRefToString)
                 .join(", ")}`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/insightDrillDefinitionValidation.ts
@@ -5,16 +5,17 @@ import { invalidArgumentsProvided } from "../../../events/general";
 import { DashboardContext } from "../../../types/commonTypes";
 import stringify from "json-stable-stringify";
 import { validateDrillDefinitionOrigin } from "../../../../_staging/drills/InsightDrillDefinitionUtils";
-import { IDrillTargets } from "../../../../model/state/drillTargets/drillTargetsTypes";
+import { IDrillTargets } from "../../../state/drillTargets/drillTargetsTypes";
+import { IDashboardCommand } from "../../../commands";
 
 export function validateInsightDrillDefinition(
     drillDefinition: InsightDrillDefinition,
     drillTargets: IDrillTargets | undefined,
     ctx: DashboardContext,
-    correlationId: string | undefined,
+    cmd: IDashboardCommand,
 ): InsightDrillDefinition {
     if (!drillTargets?.availableDrillTargets) {
-        throw invalidArgumentsProvided(ctx, `Drill targets not set`, correlationId);
+        throw invalidArgumentsProvided(ctx, cmd, `Drill targets not set`);
     }
 
     try {
@@ -24,10 +25,10 @@ export function validateInsightDrillDefinition(
 
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Invalid drill origin for InsightDrillDefinition: ${stringify(drillDefinition, {
                 space: 0,
             })}. Error: ${messageDetail}`,
-            correlationId,
         );
     }
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/removeDrillsSelectorValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/removeDrillsSelectorValidation.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 
-import { RemoveDrillsSelector } from "../../../commands/";
+import { IDashboardCommand, RemoveDrillsSelector } from "../../../commands/";
 import { InsightDrillDefinition } from "@gooddata/sdk-backend-spi";
 import { DashboardContext } from "../../../types/commonTypes";
 import { invalidArgumentsProvided } from "../../../events/general";
@@ -14,7 +14,7 @@ export function validateRemoveDrillsByOrigins(
     drillSelector: RemoveDrillsSelector,
     drills: InsightDrillDefinition[],
     ctx: DashboardContext,
-    correlationId: string | undefined,
+    cmd: IDashboardCommand,
 ): InsightDrillDefinition[] {
     if (isAllDrillSelector(drillSelector)) {
         return drills;
@@ -28,8 +28,8 @@ export function validateRemoveDrillsByOrigins(
 
             throw invalidArgumentsProvided(
                 ctx,
+                cmd,
                 `Invalid measure or attribute origin: ${objRefToString(drillRef)}. Error: ${messageDetail}`,
-                correlationId,
             );
         }
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/widgetValidations.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/widgetValidations.ts
@@ -31,7 +31,6 @@ export function validateExistingInsightWidget(
     ctx: DashboardContext,
 ): IInsightWidget {
     const {
-        correlationId,
         payload: { ref },
     } = cmd;
     const widget = widgets.get(ref);
@@ -39,16 +38,16 @@ export function validateExistingInsightWidget(
     if (!widget) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Cannot find insight widget with ref: ${serializeObjRef(ref)}.`,
-            correlationId,
         );
     }
 
     if (!isInsightWidget(widget)) {
         throw invalidArgumentsProvided(
             ctx,
+            cmd,
             `Widget with ref: ${serializeObjRef(ref)} exists but is not an insight widget.`,
-            correlationId,
         );
     }
 

--- a/libs/sdk-ui-dashboard/src/model/events/general.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/general.ts
@@ -4,6 +4,7 @@ import { IDashboardEvent } from "./base";
 import { DashboardContext } from "../types/commonTypes";
 import isEmpty from "lodash/isEmpty";
 import { IDashboardQuery } from "../queries";
+import { IDashboardCommand } from "../commands";
 
 /**
  * @alpha
@@ -37,21 +38,27 @@ export interface DashboardCommandFailed extends IDashboardEvent {
          * Error that has occurred and caused the command to fail.
          */
         readonly error?: Error;
+
+        /**
+         * The command that failed.
+         */
+        readonly command: IDashboardCommand;
     };
 }
 
 export function internalErrorOccurred(
     ctx: DashboardContext,
+    command: IDashboardCommand,
     message: string,
     error?: Error,
-    correlationId?: string,
 ): DashboardCommandFailed {
     return {
         type: "GDC.DASH/EVT.COMMAND.FAILED",
         ctx,
-        correlationId,
+        correlationId: command.correlationId,
         payload: {
             reason: "INTERNAL_ERROR",
+            command,
             message,
             error,
         },
@@ -60,15 +67,16 @@ export function internalErrorOccurred(
 
 export function invalidArgumentsProvided(
     ctx: DashboardContext,
+    command: IDashboardCommand,
     message: string,
-    correlationId?: string,
 ): DashboardCommandFailed {
     return {
         type: "GDC.DASH/EVT.COMMAND.FAILED",
         ctx,
-        correlationId,
+        correlationId: command.correlationId,
         payload: {
             reason: "USER_ERROR",
+            command,
             message,
         },
     };


### PR DESCRIPTION
This will help the event handlers to see what type of command failed.
That in turn makes use cases like logging errors and similar easier.

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
