### PR TITLE
DashboardView handles empty dashboard layout

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
@@ -13,8 +13,8 @@ const EmptyDashboardErrorCore: React.FC<IEmptyDashboardErrorProps & WrappedCompo
 }) => {
     return (
         <ErrorComponent
-            message={intl.formatMessage({ id: "dashboard.embedded.error.empty.heading" })}
-            description={intl.formatMessage({ id: "dashboard.embedded.error.empty.text" })}
+            message={intl.formatMessage({ id: "dashboard.error.empty.heading" })}
+            description={intl.formatMessage({ id: "dashboard.error.empty.text" })}
         />
     );
 };

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardView.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardView.tsx
@@ -2,7 +2,7 @@
 import React, { useEffect, useMemo } from "react";
 import { ErrorComponent as DefaultError, LoadingComponent as DefaultLoading } from "@gooddata/sdk-ui";
 import { ThemeProvider, useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
-import { isDashboardLayoutEmpty } from "@gooddata/sdk-backend-spi";
+import { isDashboardLayoutEmpty, IDashboardLayout } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
 
 import { filterArrayToFilterContextItems } from "../internal";
@@ -19,6 +19,11 @@ import { DashboardRenderer } from "./DashboardRenderer";
 import { EmptyDashboardError } from "./EmptyDashboardError";
 import { IDashboardViewConfig, IDashboardViewProps } from "./types";
 import { DashboardViewProvider } from "./DashboardViewProvider";
+
+const defaultEmptyLayout: IDashboardLayout = {
+    type: "IDashboardLayout",
+    sections: [],
+};
 
 export const DashboardView: React.FC<IDashboardViewProps> = ({
     dashboard,
@@ -102,7 +107,9 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
         result: dashboardLayoutResult,
         status: dashboardLayoutStatus,
     } = useDashboardLayoutData({
-        dashboardLayout: dashboardData?.layout,
+        // With new delete insight functionality, dashboards layout can now be empty.
+        // Use an empty layout to avoid the permanent 'pending' status.
+        dashboardLayout: dashboardData?.layout ?? defaultEmptyLayout,
         backend,
         workspace,
     });
@@ -208,7 +215,7 @@ export const DashboardView: React.FC<IDashboardViewProps> = ({
                     isVisible={isScheduledMailDialogVisible}
                 />
             )}
-            {isDashboardLayoutEmpty(dashboardData.layout) ? (
+            {!dashboardData.layout || isDashboardLayoutEmpty(dashboardData.layout) ? (
                 <EmptyDashboardError ErrorComponent={ErrorComponent} />
             ) : (
                 <DashboardRenderer

--- a/libs/sdk-ui-ext/src/dashboardView/EmptyDashboardError.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/EmptyDashboardError.tsx
@@ -13,8 +13,8 @@ const EmptyDashboardErrorCore: React.FC<IEmptyDashboardErrorProps & WrappedCompo
 }) => {
     return (
         <ErrorComponent
-            message={intl.formatMessage({ id: "dashboard.embedded.error.empty.heading" })}
-            description={intl.formatMessage({ id: "dashboard.embedded.error.empty.text" })}
+            message={intl.formatMessage({ id: "dashboard.error.empty.heading" })}
+            description={intl.formatMessage({ id: "dashboardView.error.empty.text" })}
         />
     );
 };

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -379,6 +379,21 @@
         "comment": "The user should be instructed to review that they have added one measure and one date attribute to the insight",
         "limit": 0
     },
+    "dashboard.error.empty.heading": {
+        "value": "This dashboard is empty",
+        "comment": "The user has a dashboard that contains no widgets.",
+        "limit": 0
+    },
+    "dashboard.error.empty.text": {
+        "value": "All insights were removed.",
+        "comment": "The user has a dashboard that contains no widgets.",
+        "limit": 0
+    },
+    "dashboardView.error.empty.text": {
+        "value": "All insights were removed or the dashboard was saved empty.",
+        "comment": "The user has a dashboard that contains no widgets.",
+        "limit": 0
+    },
     "dashboard.embedded.error.empty.heading": {
         "value": "No widgets in the dashboard",
         "comment": "The user embedded a dashboard that contains no widgets.",


### PR DESCRIPTION
 - With new delete insight from AD, dashboard can now exist but without any layout.
 - Adapt it so it behaves correctly when layout is empty.

JIRA: TNT-26

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
