### PR TITLE
RELATED: RAIL-3385 add action timestamping

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1744,6 +1744,9 @@ export interface IButtonBarProps {
 // @alpha
 export interface ICustomDashboardEvent<TPayload = any> {
     readonly ctx: DashboardContext;
+    readonly meta?: {
+        acceptedTimestamp: number;
+    };
     readonly payload?: TPayload;
     readonly type: string;
 }
@@ -1786,6 +1789,9 @@ export interface IDashboardDrillEvent extends IDrillEvent {
 export interface IDashboardEvent<TPayload = any> {
     readonly correlationId?: string;
     readonly ctx: DashboardContext;
+    readonly meta?: {
+        acceptedTimestamp: number;
+    };
     readonly payload?: TPayload;
     readonly type: DashboardEventType;
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/loadDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/loadDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -200,7 +200,7 @@ Object {
 exports[`load dashboard handler should emit events in correct order and carry-over correlationId 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "renderCorrelation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/loadDashboardHandler/tests/handler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/loadDashboardHandler/tests/handler.test.ts
@@ -21,7 +21,14 @@ describe("load dashboard handler", () => {
     });
 
     it("should emit events in correct order and carry-over correlationId", async () => {
-        const tester = DashboardTester.forRecording(EmptyDashboardIdentifier);
+        const tester = DashboardTester.forRecording(EmptyDashboardIdentifier, {
+            renderingWorkerConfig: {
+                asyncRenderRequestedTimeout: 2000,
+                asyncRenderResolvedTimeout: 2000,
+                maxTimeout: 60000,
+                correlationIdGenerator: () => "renderCorrelation",
+            },
+        });
 
         tester.dispatch(loadDashboard());
         await tester.waitFor("GDC.DASH/EVT.LOADED");

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/renderingWorker.ts
@@ -47,6 +47,13 @@ export interface RenderingWorkerConfiguration {
      * Default: 2000 (2s).
      */
     asyncRenderResolvedTimeout: number;
+
+    /**
+     * Generator of correlation ids
+     *
+     * Default: uuid4
+     */
+    correlationIdGenerator: () => string;
 }
 
 export function newRenderingWorker(
@@ -54,12 +61,13 @@ export function newRenderingWorker(
         asyncRenderRequestedTimeout: 2000,
         asyncRenderResolvedTimeout: 2000,
         maxTimeout: 60000,
+        correlationIdGenerator: uuidv4,
     },
 ) {
     return function* renderingWorker(ctx: DashboardContext): SagaIterator<void> {
         try {
             // Provide a correlation id so that event handlers can correlate the start and end of the rendering
-            const correlationId = uuidv4();
+            const correlationId = config.correlationIdGenerator();
 
             // First, notify that the rendering of the whole dashboard started.
             yield put(renderRequested(ctx, correlationId));

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`renderingWorker async rendering resolution should accept new async rendering request, when it's fired within time limit after resolution 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -31,7 +31,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -40,7 +40,7 @@ Array [
 exports[`renderingWorker async rendering resolution should accept new async rendering requests, when running requests are not yet resolved 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -76,7 +76,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -85,7 +85,7 @@ Array [
 exports[`renderingWorker async rendering resolution should emit render resolved after async rendering resolution 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -105,7 +105,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -114,7 +114,7 @@ Array [
 exports[`renderingWorker async rendering resolution should emit render resolved after async rendering resolution, even if the component requested async rendering multiple times before the resolution 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -138,7 +138,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -147,7 +147,7 @@ Array [
 exports[`renderingWorker async rendering resolution should emit render resolved, when async renderings are resolved during the asyncRenderRequestedTimeout 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -167,7 +167,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -176,7 +176,7 @@ Array [
 exports[`renderingWorker async rendering resolution should emit render resolved, when no async rendering is requested during the asyncRenderRequestedTimeout 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -188,7 +188,7 @@ Array [
     "type": "GDC.DASH/EVT.LOADED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]
@@ -199,7 +199,7 @@ exports[`renderingWorker async rendering resolution should not emit render resol
 exports[`renderingWorker async rendering resolution should not emit render resolved, when async rendering is not resolved 2`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -220,7 +220,7 @@ Array [
 exports[`renderingWorker maximum timeout should emit render resolved, when async rendering is still running, but the maximum timeout reached 1`] = `
 Array [
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
@@ -236,7 +236,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
-    "correlationId": undefined,
+    "correlationId": "correlation",
     "type": "GDC.DASH/EVT.RENDER.RESOLVED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/renderingWorker.test.ts
@@ -19,6 +19,7 @@ describe("renderingWorker", () => {
                         asyncRenderRequestedTimeout,
                         asyncRenderResolvedTimeout,
                         maxTimeout,
+                        correlationIdGenerator: () => "correlation",
                     },
                 })),
         );
@@ -45,6 +46,7 @@ describe("renderingWorker", () => {
                         asyncRenderRequestedTimeout,
                         asyncRenderResolvedTimeout,
                         maxTimeout,
+                        correlationIdGenerator: () => "correlation",
                     },
                 })),
         );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
@@ -107,7 +107,7 @@ function* unhandledCommand(ctx: DashboardContext, cmd: IDashboardCommand) {
 
 /**
  * Root command handler is the central point through which all command processing is done. The handler registers
- * for all actions starting with `GDC.CMD` === all dashboard commands.
+ * for all actions starting with `GDC.DASH/CMD` === all dashboard commands.
  *
  * The commands are intended for serial processing, without any forking. A buffering action channel is in place to
  * prevent loss of commands.

--- a/libs/sdk-ui-dashboard/src/model/events/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/base.ts
@@ -99,6 +99,16 @@ export interface IDashboardEvent<TPayload = any> {
      * Optionally specify any additional data the custom event needs.
      */
     readonly payload?: TPayload;
+
+    /**
+     * Metadata about the event useful for logging and handling of the event.
+     */
+    readonly meta?: {
+        /**
+         * When the event was accepted by the Dashboard store and emitted.
+         */
+        acceptedTimestamp: number;
+    };
 }
 
 /**
@@ -132,6 +142,16 @@ export interface ICustomDashboardEvent<TPayload = any> {
      * Optionally specify any additional data the custom event needs.
      */
     readonly payload?: TPayload;
+
+    /**
+     * Metadata about the event useful for logging and handling of the event.
+     */
+    readonly meta?: {
+        /**
+         * When the event was accepted by the Dashboard store and emitted.
+         */
+        acceptedTimestamp: number;
+    };
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
@@ -248,6 +248,7 @@ Object {
     },
     "workspace": "reference-workspace",
   },
+  "meta": Any<Object>,
   "payload": Object {
     "message": "Widget with ref non existent widget does not exist on the dashboard",
     "reason": "USER_ERROR",

--- a/libs/sdk-ui-dashboard/src/model/queryServices/tests/queryWidgetFilters.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/tests/queryWidgetFilters.test.ts
@@ -18,7 +18,9 @@ describe("query widget filters", () => {
         it("should fail in case the widget does not exist", async () => {
             await expect(
                 Tester.query(queryWidgetFilters(idRef("non existent widget"))),
-            ).rejects.toMatchSnapshot();
+            ).rejects.toMatchSnapshot({
+                meta: expect.any(Object),
+            } as any);
         });
 
         it.each<[string, IWidget]>([

--- a/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
@@ -9,13 +9,13 @@ const selectSelf = createSelector(
 );
 
 /**
- * Returns dashboard's filter context. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * Returns dashboard's config. It is expected that the selector is called only after the config state
+ * is correctly initialized. Invocations before initialization lead to invariant errors.
  *
  * @alpha
  */
 export const selectConfig = createSelector(selectSelf, (configState) => {
-    invariant(configState.config, "attempting to access uninitialized filter context state");
+    invariant(configState.config, "attempting to access uninitialized config state");
 
     return configState.config!;
 });

--- a/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dateFilterConfig/dateFilterConfigSelectors.ts
@@ -40,7 +40,7 @@ export const selectDateFilterConfigOverrides = createSelector(selectSelf, (dateF
 export const selectEffectiveDateFilterConfig = createSelector(selectSelf, (dateFilterConfigState) => {
     invariant(
         dateFilterConfigState.effectiveDateFilterConfig,
-        "attempting to access uninitialized filter context state",
+        "attempting to access uninitialized date filter config state",
     );
 
     return dateFilterConfigState.effectiveDateFilterConfig!;
@@ -80,7 +80,7 @@ export const selectEffectiveDateFilterAvailableGranularities = createSelector(
 const effectiveDateFilterConfigIsUsingOverrides = createSelector(selectSelf, (dateFilterConfigState) => {
     invariant(
         dateFilterConfigState.isUsingDashboardOverrides !== undefined,
-        "attempting to access uninitialized filter context state",
+        "attempting to access uninitialized date filter config state",
     );
 
     return dateFilterConfigState.isUsingDashboardOverrides!;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
@@ -2,7 +2,6 @@
 import React, { useCallback, useMemo, useState, CSSProperties } from "react";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import {
-    IFilter,
     insightFilters,
     insightSetFilters,
     insightVisualizationUrl,
@@ -117,7 +116,7 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
         [onError, dispatchEvent],
     );
 
-    const insightWithAddedFilters = insightSetFilters(insight, filtersForInsight as IFilter[]); // TODO how to type this better?
+    const insightWithAddedFilters = insightSetFilters(insight, filtersForInsight);
 
     const insightWithAddedWidgetProperties = useResolveDashboardInsightProperties({
         insight: insightWithAddedFilters ?? insight,


### PR DESCRIPTION
Also
* fix misleading invariant messages
* add correlation id to renderRequested and renderResolved events so that we can correlate those together

---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
