### PR TITLE
RELATED: NAS-229 Implementing of not supported method getDescriptor

### DIFF
--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -204,6 +204,7 @@ export function dummyDataView(
         },
     };
 }
+
 //
 // Internals
 //
@@ -211,8 +212,8 @@ export function dummyDataView(
 function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyticalWorkspace {
     return {
         workspace,
-        getDescriptor(): Promise<IWorkspaceDescriptor> {
-            throw new NotSupported("not supported");
+        async getDescriptor(): Promise<IWorkspaceDescriptor> {
+            return dummyDescriptor(this.workspace);
         },
         getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
             throw new NotSupported("not supported");
@@ -256,6 +257,15 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
         dateFilterConfigs(): IDateFilterConfigsQuery {
             throw new NotSupported("not supported");
         },
+    };
+}
+
+function dummyDescriptor(workspaceId: string): IWorkspaceDescriptor {
+    return {
+        id: workspaceId,
+        title: "Title",
+        description: "Description",
+        isDemo: false,
     };
 }
 

--- a/libs/sdk-backend-base/src/dummyBackend/tests/index.test.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/tests/index.test.ts
@@ -1,0 +1,24 @@
+// (C) 2021 GoodData Corporation
+
+import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
+
+import { dummyBackend } from "../index";
+
+describe("dummyBackend", () => {
+    describe("workspace", () => {
+        const WORKSPACE_ID = "workspaceId";
+
+        describe("descriptor", () => {
+            it("should return default filled workspace descriptor", async () => {
+                const descriptor = await dummyBackend().workspace(WORKSPACE_ID).getDescriptor();
+
+                expect(descriptor).toEqual({
+                    id: WORKSPACE_ID,
+                    title: "Title",
+                    description: "Description",
+                    isDemo: false,
+                } as IWorkspaceDescriptor);
+            });
+        });
+    });
+});

--- a/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
+++ b/libs/sdk-backend-mockingbird/api/sdk-backend-mockingbird.api.md
@@ -29,6 +29,7 @@ import { ITheme } from '@gooddata/sdk-backend-spi';
 import { IUser } from '@gooddata/sdk-backend-spi';
 import { IVisualizationClass } from '@gooddata/sdk-model';
 import { IWidgetAlert } from '@gooddata/sdk-backend-spi';
+import { IWorkspaceDescriptor } from '@gooddata/sdk-backend-spi';
 import { ObjRef } from '@gooddata/sdk-model';
 import { ValidationContext } from '@gooddata/sdk-backend-spi';
 
@@ -137,6 +138,7 @@ export type RecordedBackendConfig = IAnalyticalBackendConfig & {
     globalSettings?: ISettings;
     globalPalette?: IColorPalette;
     dateFilterConfig?: IDateFilterConfig;
+    workspaceDescriptor?: Partial<Pick<IWorkspaceDescriptor, "title" | "description" | "isDemo">>;
     theme?: ITheme;
     useRefType?: RecordedRefType;
     securitySettingsUrlValidator?: SecuritySettingsUrlValidator;
@@ -193,6 +195,5 @@ export type SecuritySettingsUrlValidator = (url: string, context: ValidationCont
 export type VisClassesRecording = {
     items: IVisualizationClass[];
 };
-
 
 ```

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -133,8 +133,8 @@ function recordedWorkspace(
 ): IAnalyticalWorkspace {
     return {
         workspace,
-        getDescriptor(): Promise<IWorkspaceDescriptor> {
-            throw new NotSupported("not supported");
+        async getDescriptor(): Promise<IWorkspaceDescriptor> {
+            return recordedDescriptor(this.workspace, implConfig);
         },
         getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined> {
             throw new NotSupported("not supported");
@@ -289,6 +289,17 @@ function recordedPermissionsFactory(): IWorkspacePermissionsService {
             canInviteUserToProject: true,
             canRefreshData: true,
         }),
+    };
+}
+
+function recordedDescriptor(workspaceId: string, implConfig: RecordedBackendConfig): IWorkspaceDescriptor {
+    const { title, description, isDemo } = implConfig.workspaceDescriptor || {};
+
+    return {
+        id: workspaceId,
+        title: title ?? "",
+        description: description ?? "",
+        isDemo: isDemo ?? false,
     };
 }
 

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/tests/index.test.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/tests/index.test.ts
@@ -1,6 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 import { ReferenceRecordings } from "@gooddata/reference-workspace";
+import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
 
 import { recordedBackend } from "../index";
 
@@ -53,6 +54,61 @@ describe("recordedBackend", () => {
 
                     expect(scope).toBe("#myOrganizationId#");
                 });
+            });
+        });
+    });
+
+    describe("workspace", () => {
+        const WORKSPACE_ID = "workspaceId";
+
+        describe("descriptor", () => {
+            it("should return default empty workspace descriptor", async () => {
+                const descriptor = await recordedBackend(ReferenceRecordings.Recordings)
+                    .workspace(WORKSPACE_ID)
+                    .getDescriptor();
+
+                expect(descriptor).toEqual({
+                    id: WORKSPACE_ID,
+                    title: "",
+                    description: "",
+                    isDemo: false,
+                } as IWorkspaceDescriptor);
+            });
+
+            it("should return from partial filled workspace descriptor", async () => {
+                const config = {
+                    workspaceDescriptor: {
+                        title: "Title",
+                    },
+                };
+                const descriptor = await recordedBackend(ReferenceRecordings.Recordings, config)
+                    .workspace(WORKSPACE_ID)
+                    .getDescriptor();
+
+                expect(descriptor).toEqual({
+                    id: WORKSPACE_ID,
+                    isDemo: false,
+                    description: "",
+                    ...config.workspaceDescriptor,
+                } as IWorkspaceDescriptor);
+            });
+
+            it("should return from filled workspace descriptor", async () => {
+                const config = {
+                    workspaceDescriptor: {
+                        title: "Title",
+                        description: "Description",
+                        isDemo: true,
+                    },
+                };
+                const descriptor = await recordedBackend(ReferenceRecordings.Recordings, config)
+                    .workspace(WORKSPACE_ID)
+                    .getDescriptor();
+
+                expect(descriptor).toEqual({
+                    id: WORKSPACE_ID,
+                    ...config.workspaceDescriptor,
+                } as IWorkspaceDescriptor);
             });
         });
     });

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/types.ts
@@ -16,6 +16,7 @@ import {
     IUser,
     IWidgetAlert,
     ValidationContext,
+    IWorkspaceDescriptor,
 } from "@gooddata/sdk-backend-spi";
 import {
     IColorPalette,
@@ -51,6 +52,11 @@ export type RecordedBackendConfig = IAnalyticalBackendConfig & {
      * resolves empty result.
      */
     dateFilterConfig?: IDateFilterConfig;
+
+    /**
+     * Optionally specify descriptor for workspace
+     */
+    workspaceDescriptor?: Partial<Pick<IWorkspaceDescriptor, "title" | "description" | "isDemo">>;
 
     /**
      * Specify theme to return


### PR DESCRIPTION
Implementing of not supported method getDescriptor on dummyBackend and recordedBackend

Added method for generating dummy descriptor for dummy and recorded backend that returns descriptor with given workspace id and setting of workspace based on provided config.

JIRA: NAS-229
---

Supported PR commands:

| Command                | Description            |
| ---------------------- | ---------------------- |
| `ok to test`           | Re-run standard checks |
| `extended test`        | BackstopJS tests       |
| `extended check sonar` | SonarQube tests        |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
