### PR TITLE
RELATED: RAIL-3385 Add s- classes to the menu button items

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -147,13 +147,13 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
         () => [
             {
                 type: "button",
-                itemId: "export-to-pdf",
+                itemId: "pdf-export-item", // careful, this is also used as a selector in tests, do not change
                 itemName: intl.formatMessage({ id: "options.menu.export.PDF" }),
                 onClick: defaultOnExportToPdf,
             },
             {
                 type: "button",
-                itemId: "schedule-emailing",
+                itemId: "schedule-email-item", // careful, this is also used as a selector in tests, do not change
                 itemName: intl.formatMessage({ id: "options.menu.schedule.email" }),
                 onClick: defaultOnScheduleEmailing,
             },

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/DefaultMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/DefaultMenuButton.tsx
@@ -63,7 +63,7 @@ export const DefaultMenuButtonInner = (): JSX.Element | null => {
                         const selectorClassName = `gd-menu-item-${menuItem.itemId}`;
                         const body = (
                             <SingleSelectListItem
-                                className={cx("gd-menu-item", {
+                                className={cx("gd-menu-item", `s-${menuItem.itemId}`, {
                                     [selectorClassName]: menuItem.tooltip,
                                     "is-disabled": menuItem.disabled,
                                 })}


### PR DESCRIPTION
Also makes the default items' ids in line with KD to maintain
the existing test selectors.

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
