### PR TITLE
RELATED: RAIL-3534 Prevent duplicate token requests in bear

### DIFF
--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import set from "lodash/set";
@@ -188,9 +188,16 @@ export class XhrModule {
 
         if (response.status === 401) {
             // if 401 is in login-request, it means wrong user/password (we wont continue)
-            if (url.indexOf("/gdc/account/login") !== -1) {
+            const isLoginRequest = url.indexOf("/gdc/account/login") !== -1;
+            // if 401 is in token request already, it makes no sense to try handling unauthorized again by calling the same token endpoint again
+            const isTokenRequest = url.indexOf("/gdc/account/token") !== -1;
+
+            const shouldSkipUnauthorizedHandling = isLoginRequest || isTokenRequest;
+
+            if (shouldSkipUnauthorizedHandling) {
                 throw new ApiResponseError("Unauthorized", response, responseBody);
             }
+
             return this.handleUnauthorized(url, settings);
         }
 


### PR DESCRIPTION
Previously, when an unauthorized user called the logout function,
it would result in two failed /gdc/account/token requests:

1. call caused by the isLoggedIn call in the logout function
2. call caused by the first one failing and the logic that tries to refresh the token kicking in

The second one is unnecessary because if the first fails, the second
will fail as well every time. This makes network log unnecessarily fuzzy
which complicates debugging/support.

So, similarly to /gdc/account/login, we now no longer try to recover
the requests /gdc/account/token either.

JIRA: RAIL-3534

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
