### PR TITLE
TRIVIAL: NAS-229 Repair of optional feature flag and .toString() call

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2341,7 +2341,7 @@ export interface IRowsIconProps extends IIconProps {
 export const isDateDatasetHeader: (obj: unknown) => obj is IDateDatasetHeader;
 
 // @internal (undocumented)
-export function isFreemiumEdition(platformEdition: string): boolean;
+export function isFreemiumEdition(platformEdition: string | undefined): boolean;
 
 // @internal (undocumented)
 export interface IShortenedTextProps {

--- a/libs/sdk-ui-kit/src/Header/generateHeaderMenuItemsGroups.ts
+++ b/libs/sdk-ui-kit/src/Header/generateHeaderMenuItemsGroups.ts
@@ -143,7 +143,7 @@ function createInsightsItemsGroup(
     backendSupportsDataItem: boolean,
     hasNoDataSet: boolean,
 ) {
-    const isFreemiumCustomer = isFreemiumEdition(featureFlags.platformEdition.toString());
+    const isFreemiumCustomer = isFreemiumEdition(featureFlags.platformEdition);
 
     const insightItemsGroup: IHeaderMenuItem[] = [];
 

--- a/libs/sdk-ui-kit/src/Header/tests/generateHeaderMenuItemsGroups.test.ts
+++ b/libs/sdk-ui-kit/src/Header/tests/generateHeaderMenuItemsGroups.test.ts
@@ -522,4 +522,47 @@ describe("generateHeaderMenuItemsGroups", () => {
             ],
         ]);
     });
+
+    it("should return dashboards if feature flags are empty", () => {
+        const items = generateHeaderMenuItemsGroups(
+            {},
+            getWorkspacePermissionsMock(true, true),
+            true,
+            "TestWorkspaceId",
+            "TestDashboardId",
+            "TestTabId",
+            false,
+            false,
+            false,
+            false,
+        );
+        expect(items).toEqual([
+            [
+                {
+                    className: "s-menu-dashboards",
+                    href: "/#s=/gdc/projects/TestWorkspaceId|projectDashboardPage|TestDashboardId|TestTabId",
+                    key: "gs.header.dashboards",
+                },
+                {
+                    className: "s-menu-reports",
+                    href: "/#s=/gdc/projects/TestWorkspaceId|domainPage|all-reports",
+                    key: "gs.header.reports",
+                },
+            ],
+            [
+                {
+                    className: "s-menu-kpis",
+                    href: "/dashboards/#/project/TestWorkspaceId",
+                    key: "gs.header.kpis",
+                },
+            ],
+            [
+                {
+                    className: "s-menu-manage",
+                    href: "/#s=/gdc/projects/TestWorkspaceId|dataPage|",
+                    key: "gs.header.manage",
+                },
+            ],
+        ]);
+    });
 });

--- a/libs/sdk-ui-kit/src/utils/featureFlags.ts
+++ b/libs/sdk-ui-kit/src/utils/featureFlags.ts
@@ -11,8 +11,7 @@ const GROWTH = "growth";
 export function shouldHidePPExperience(featureFlags: ISettings): boolean {
     const hidePPExperience = Boolean(featureFlags.hidePixelPerfectExperience);
     const enablePPExperience = featureFlags.enablePixelPerfectExperience;
-    const platformEdition = featureFlags.platformEdition;
-    const isFreemiumUser = isFreemiumEdition(platformEdition.toString());
+    const isFreemiumUser = isFreemiumEdition(featureFlags.platformEdition);
 
     return hidePPExperience || (isFreemiumUser && !enablePPExperience);
 }
@@ -21,7 +20,7 @@ export function shouldHidePPExperience(featureFlags: ISettings): boolean {
  * @internal
  */
 
-export function isFreemiumEdition(platformEdition: string): boolean {
+export function isFreemiumEdition(platformEdition: string | undefined): boolean {
     return platformEdition === FREE || platformEdition === GROWTH;
 }
 

--- a/libs/sdk-ui-kit/src/utils/tests/featureFlags.test.ts
+++ b/libs/sdk-ui-kit/src/utils/tests/featureFlags.test.ts
@@ -38,9 +38,19 @@ describe("featureFlags utils", () => {
             expect(isFreemiumCustomer).toBe(false);
         });
 
-        it("should return true if user is free/growth", () => {
+        it("should return true if user is growth", () => {
             const isFreemiumCustomer = isFreemiumEdition("growth");
             expect(isFreemiumCustomer).toBe(true);
+        });
+
+        it("should return true if user is free", () => {
+            const isFreemiumCustomer = isFreemiumEdition("free");
+            expect(isFreemiumCustomer).toBe(true);
+        });
+
+        it("should return false if user is not defined", () => {
+            const isFreemiumCustomer = isFreemiumEdition(undefined);
+            expect(isFreemiumCustomer).toBe(false);
         });
     });
 


### PR DESCRIPTION
Can not call .toString() on property that is defined as optional. Remove this call because is not necessary.
Method isFreemiumEdition can have also undefined as parameter due to specification of types in featureFlags.ts

JIRA: NAS-229
---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
