### PR TITLE
RELATED: RAIL-3385 Fix ambiguous idRef type

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/InsightConverter.ts
@@ -19,7 +19,7 @@ export const insightFromInsightDefinition = (
             ...insight.insight,
             identifier: id,
             uri,
-            ref: idRef(id, "visualizationObject"),
+            ref: idRef(id, "insight"),
             // TODO: TIGER-HACK: inherited objects must be locked; they are read-only for all
             isLocked: isInheritedObject(id),
             tags,

--- a/libs/sdk-backend-tiger/src/convertors/tests/ObjectConverter.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/tests/ObjectConverter.test.ts
@@ -11,7 +11,7 @@ const mapping: [TigerCompatibleObjectType, TigerObjectType][] = [
     ["dataSet", "dataset"],
     ["fact", "fact"],
     ["variable", "variable"],
-    ["visualizationObject", "visualizationObject"],
+    ["insight", "visualizationObject"],
     ["filterContext", "filterContext"],
 ];
 

--- a/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
+++ b/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
@@ -6,7 +6,7 @@ import isEmpty from "lodash/isEmpty";
 import values from "lodash/values";
 import { TigerObjectType } from "./index";
 
-export type TigerCompatibleObjectType = Exclude<ObjectType, "tag" | "insight">;
+export type TigerCompatibleObjectType = Exclude<ObjectType, "tag">;
 
 export const tigerIdTypeToObjectType: {
     [tigerType in TigerObjectType]: TigerCompatibleObjectType;
@@ -18,7 +18,7 @@ export const tigerIdTypeToObjectType: {
     fact: "fact",
     variable: "variable",
     analyticalDashboard: "analyticalDashboard",
-    visualizationObject: "visualizationObject",
+    visualizationObject: "insight",
     filterContext: "filterContext",
 };
 

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1219,7 +1219,11 @@ export function newTotal(type: TotalType, measureOrId: IMeasure | Identifier, at
 export function newTwoDimensional(dim1Input: DimensionItem[], dim2Input: DimensionItem[]): IDimension[];
 
 // @public
-export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "analyticalDashboard" | "visualizationObject" | "filterContext";
+export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dataSet" | "tag" | "insight" | "variable" | "analyticalDashboard"
+/**
+* @deprecated will be removed in the next major release, use "insight" instead
+*/
+| "visualizationObject" | "filterContext";
 
 // @public
 export type ObjRef = UriRef | IdentifierRef;
@@ -1240,7 +1244,7 @@ export class PoPMeasureBuilder extends MeasureBuilderBase<IPoPMeasureDefinition>
     protected generateLocalId(): string;
     masterMeasure: (measureOrLocalId: MeasureOrLocalId) => this;
     popAttribute: (popAttrIdOrRef: ObjRef | Identifier) => this;
-    }
+}
 
 // @public
 export type PoPMeasureBuilderInput = {
@@ -1258,7 +1262,7 @@ export class PreviousPeriodMeasureBuilder extends MeasureBuilderBase<IPreviousPe
     // (undocumented)
     protected generateLocalId(): string;
     masterMeasure: (measureOrLocalId: MeasureOrLocalId) => this;
-    }
+}
 
 // @public
 export type PreviousPeriodMeasureBuilderInput = {
@@ -1330,6 +1334,5 @@ export function visClassUrl(vc: IVisualizationClass): string;
 export type VisualizationProperties = {
     [key: string]: any;
 };
-
 
 ```

--- a/libs/sdk-model/src/objRef/index.ts
+++ b/libs/sdk-model/src/objRef/index.ts
@@ -45,6 +45,9 @@ export type ObjectType =
     | "insight"
     | "variable"
     | "analyticalDashboard"
+    /**
+     * @deprecated will be removed in the next major release, use "insight" instead
+     */
     | "visualizationObject"
     | "filterContext";
 


### PR DESCRIPTION
There is insight and visualizationObject ObjectType value.
This duplicity made the Dashboard component fail on Tiger.

A ticket for removing the "visualizationObject" value in the next major
was created to track the clean up.

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
