### PR TITLE
ResolveDrillToCustomUrl error handling

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToCustomUrlHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToCustomUrlHandler.ts
@@ -29,6 +29,7 @@ export function* drillToCustomUrlHandler(
         cmd.payload.drillEvent.widgetRef!,
         cmd.payload.drillEvent,
         ctx,
+        cmd,
     );
 
     return drillToCustomUrlResolved(


### PR DESCRIPTION
- thwrow error when some attributes to resolve URL are missing

JIRA: RAIL-3597

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
