### PR TITLE
RELATED: RAIL-3534 Prevent duplicate token requests in bear

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-3534-logout-token-cherry_2021-08-18-09-19.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-3534-logout-token-cherry_2021-08-18-09-19.json
@@ -1,0 +1,11 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Some redundant token requests prevented.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all",
+    "email": "dan.homola@gooddata.com"
+}

--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import isPlainObject from "lodash/isPlainObject";
 import isFunction from "lodash/isFunction";
 import set from "lodash/set";
@@ -188,9 +188,16 @@ export class XhrModule {
 
         if (response.status === 401) {
             // if 401 is in login-request, it means wrong user/password (we wont continue)
-            if (url.indexOf("/gdc/account/login") !== -1) {
+            const isLoginRequest = url.indexOf("/gdc/account/login") !== -1;
+            // if 401 is in token request already, it makes no sense to try handling unauthorized again by calling the same token endpoint again
+            const isTokenRequest = url.indexOf("/gdc/account/token") !== -1;
+
+            const shouldSkipUnauthorizedHandling = isLoginRequest || isTokenRequest;
+
+            if (shouldSkipUnauthorizedHandling) {
                 throw new ApiResponseError("Unauthorized", response, responseBody);
             }
+
             return this.handleUnauthorized(url, settings);
         }
 


### PR DESCRIPTION
Cherry pick of 83333d2da878ce438e7296e9709c51eedef6b2ce and prepration for the patch release.

See the original PR (#1643) for more details.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
