### PR TITLE
RELATED: RAIL-3620 fix paging of AttributeFilterButton

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
@@ -257,7 +257,7 @@ export class AttributeDropdownCore extends React.PureComponent<
                 isLoading: false,
                 validElements: state.searchString ? newElements : mergedValidElements,
                 items,
-                totalCount: state.firstLoad ? items.length : state.totalCount,
+                totalCount: state.firstLoad ? newElements.totalCount : state.totalCount,
                 firstLoad: false,
             };
         });

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
@@ -54,7 +54,7 @@ export const AttributeDropdownList: React.FC<IAttributeDropdownListProps> = ({
         <LegacyInvertableList
             items={items}
             itemsCount={totalCount}
-            filteredItemsCount={items.length}
+            filteredItemsCount={totalCount}
             selection={selectedItems}
             isLoading={isLoading}
             isLoadingClass={ListLoading}

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -672,7 +672,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                     ) : (
                         <AttributeDropdownBody
                             items={state.validOptions?.items ?? []}
-                            totalCount={totalCount || LIMIT}
+                            totalCount={totalCount ?? LIMIT}
                             selectedItems={state.selectedFilterOptions}
                             isInverted={state.isInverted}
                             isLoading={

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -106,13 +106,11 @@ export interface ILoadElementsResult {
     totalCount: number;
 }
 
-export const getElements = async (
+export function needsLoading(
     validElements: IElementQueryResultWithEmptyItems,
     offset: number,
     limit: number,
-    loadElements: (offset: number, limit: number) => Promise<ILoadElementsResult>,
-    force = false,
-): Promise<ILoadElementsResult> => {
+): boolean {
     const currentElements = validElements ? validElements.items : [];
     const isQueryOutOfBound = offset + limit > currentElements.length;
     const isMissingDataInWindow = currentElements
@@ -124,11 +122,20 @@ export const getElements = async (
         currentElements.length === validElements.totalCount &&
         !currentElements.some((e: IAttributeElement | EmptyListItem) => (e as EmptyListItem).empty);
 
-    const needsLoading = !hasAllData && (isQueryOutOfBound || isMissingDataInWindow);
+    return !hasAllData && (isQueryOutOfBound || isMissingDataInWindow);
+}
 
-    if (needsLoading || force) {
+export const getElements = async (
+    validElements: IElementQueryResultWithEmptyItems,
+    offset: number,
+    limit: number,
+    loadElements: (offset: number, limit: number) => Promise<ILoadElementsResult>,
+    force = false,
+): Promise<ILoadElementsResult> => {
+    if (needsLoading(validElements, offset, limit) || force) {
         return loadElements(offset, limit);
     }
+
     return {
         validOptions: validElements,
         totalCount: validElements.totalCount,


### PR DESCRIPTION
Fixes issues with the AttributeFilterButton:

* paging now works properly
* search now works properly (incl. when nothing matches search)

Also fixes paging inssue in AttributeFilter

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
