### PR TITLE
RELATED: RAIL-3625, RAIL-3626 improve error handling

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1822,6 +1822,8 @@ export interface IDashboardInsightProps {
     // (undocumented)
     clientHeight?: number;
     // (undocumented)
+    clientWidth?: number;
+    // (undocumented)
     disableWidgetImplicitDrills?: boolean;
     // (undocumented)
     drillableItems?: Array<IDrillableItem | IHeaderPredicate>;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/CompactContentError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/CompactContentError.tsx
@@ -1,0 +1,23 @@
+// (C) 2021 GoodData Corporation
+import React from "react";
+import { FormattedHTMLMessage } from "react-intl";
+import { BubbleHoverTrigger, Bubble } from "@gooddata/sdk-ui-kit";
+
+interface ICompactContentErrorProps {
+    className: string;
+    headline: string;
+    text: string;
+}
+
+export const CompactContentError: React.FC<ICompactContentErrorProps> = ({ className, headline, text }) => {
+    return (
+        <BubbleHoverTrigger>
+            <div className={`info-label-icon ${className}`} />
+            <Bubble alignPoints={[{ align: "bc tc", offset: { x: 0, y: 0 } }]}>
+                <FormattedHTMLMessage id={headline} />
+                <br />
+                <FormattedHTMLMessage id={text} />
+            </Bubble>
+        </BubbleHoverTrigger>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/CustomError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/CustomError.tsx
@@ -1,0 +1,41 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+import {
+    GoodDataSdkError,
+    isDataTooLargeToDisplay,
+    isNoDataSdkError,
+    isProtectedReport,
+} from "@gooddata/sdk-ui";
+
+import { ExecuteProtectedError } from "./ExecuteProtectedError";
+import { DataTooLargeError } from "./DataTooLargeError";
+import { NoDataError } from "./NoDataError";
+import { OtherError } from "./OtherError";
+import { shouldRenderFullContent } from "./sizingUtils";
+
+interface ICustomErrorProps {
+    error: GoodDataSdkError;
+    height?: number;
+    width?: number;
+    isCustomWidgetHeightEnabled?: boolean;
+}
+
+export const CustomError: React.FC<ICustomErrorProps> = ({
+    error,
+    height,
+    width,
+    isCustomWidgetHeightEnabled,
+}) => {
+    const fullContent = isCustomWidgetHeightEnabled ? shouldRenderFullContent(height, width) : true;
+    if (isProtectedReport(error)) {
+        return <ExecuteProtectedError fullContent={fullContent} />;
+    } else if (isDataTooLargeToDisplay(error)) {
+        return <DataTooLargeError fullContent={fullContent} />;
+    } else if (isNoDataSdkError(error)) {
+        return <NoDataError fullContent={fullContent} />;
+    } else if (error) {
+        return <OtherError fullContent={fullContent} />;
+    }
+
+    return null;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/DataTooLargeError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/DataTooLargeError.tsx
@@ -1,0 +1,34 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+import { FormattedHTMLMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+import { CompactContentError } from "./CompactContentError";
+import { ErrorContainer } from "./ErrorContainer";
+
+interface IDataTooLargeErrorProps {
+    fullContent: boolean;
+}
+
+export const DataTooLargeError: React.FC<IDataTooLargeErrorProps> = ({ fullContent }) => {
+    return (
+        <ErrorContainer>
+            {fullContent ? (
+                <div className="info-label-icon icon-rain">
+                    <Typography tagName="h2">
+                        <FormattedHTMLMessage id="visualization.dataTooLarge.headline" />
+                    </Typography>
+                    <Typography tagName="p">
+                        <FormattedHTMLMessage id="visualization.dataTooLarge.text" />
+                    </Typography>
+                </div>
+            ) : (
+                <CompactContentError
+                    className="icon-rain"
+                    headline="visualization.dataTooLarge.headline"
+                    text="visualization.dataTooLarge.text"
+                />
+            )}
+        </ErrorContainer>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ErrorContainer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ErrorContainer.tsx
@@ -1,0 +1,17 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+
+const fullHeightWidthStyle: React.CSSProperties = {
+    height: "100%",
+    width: "100%",
+};
+
+export const ErrorContainer: React.FC = ({ children }) => {
+    return (
+        <div className="gd-visualization-content" style={fullHeightWidthStyle}>
+            <div className="info-label">
+                <div style={fullHeightWidthStyle}>{children}</div>
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ExecuteProtectedError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ExecuteProtectedError.tsx
@@ -1,0 +1,34 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+import { FormattedHTMLMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+import { CompactContentError } from "./CompactContentError";
+import { ErrorContainer } from "./ErrorContainer";
+
+interface IExecuteProtectedErrorProps {
+    fullContent: boolean;
+}
+
+export const ExecuteProtectedError: React.FC<IExecuteProtectedErrorProps> = ({ fullContent }) => {
+    return (
+        <ErrorContainer>
+            {fullContent ? (
+                <div className="info-label-icon gd-icon-warning">
+                    <Typography tagName="h2">
+                        <FormattedHTMLMessage id="visualization.execute_protected_report.headline" />
+                    </Typography>
+                    <Typography tagName="h2">
+                        <FormattedHTMLMessage id="visualization.execute_protected_report.text" />
+                    </Typography>
+                </div>
+            ) : (
+                <CompactContentError
+                    className="gd-icon-warning"
+                    headline="visualization.execute_protected_report.headline"
+                    text="visualization.execute_protected_report.text"
+                />
+            )}
+        </ErrorContainer>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/NoDataError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/NoDataError.tsx
@@ -1,0 +1,32 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+import { FormattedHTMLMessage } from "react-intl";
+import { Typography, BubbleHoverTrigger, Bubble } from "@gooddata/sdk-ui-kit";
+
+interface INoDataErrorProps {
+    fullContent: boolean;
+}
+
+export const NoDataError: React.FC<INoDataErrorProps> = ({ fullContent }) => {
+    return (
+        <div className="gd-visualization-content visualization-empty">
+            <div className="info-label info-label-empty">
+                {fullContent ? (
+                    <>
+                        <div className="info-label-icon-empty" />
+                        <Typography tagName="p">
+                            <FormattedHTMLMessage id="visualization.empty.headline" />
+                        </Typography>
+                    </>
+                ) : (
+                    <BubbleHoverTrigger>
+                        <div className="info-label-icon-empty" />
+                        <Bubble alignPoints={[{ align: "bc tc", offset: { x: 0, y: 0 } }]}>
+                            <FormattedHTMLMessage id="visualization.empty.headline" />
+                        </Bubble>
+                    </BubbleHoverTrigger>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/OtherError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/OtherError.tsx
@@ -1,0 +1,34 @@
+// (C) 2007-2021 GoodData Corporation
+import React from "react";
+import { FormattedHTMLMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+
+import { CompactContentError } from "./CompactContentError";
+import { ErrorContainer } from "./ErrorContainer";
+
+interface IErrorProps {
+    fullContent: boolean;
+}
+
+export const OtherError: React.FC<IErrorProps> = ({ fullContent }) => {
+    return (
+        <ErrorContainer>
+            {fullContent ? (
+                <div className="info-label-icon gd-icon-warning">
+                    <Typography tagName="h2">
+                        <FormattedHTMLMessage id="visualization.error.headline" />
+                    </Typography>
+                    <Typography tagName="p">
+                        <FormattedHTMLMessage id="visualization.error.text" />
+                    </Typography>
+                </div>
+            ) : (
+                <CompactContentError
+                    className="gd-icon-warning"
+                    headline="visualization.error.headline"
+                    text="visualization.error.text"
+                />
+            )}
+        </ErrorContainer>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/sizingUtils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/sizingUtils.ts
@@ -1,0 +1,14 @@
+// (C) 2007-2021 GoodData Corporation
+const MINIMUM_LONGER_SIDE = 380;
+const MINIMUM_SHORTER_SIDE = 200;
+
+export const shouldRenderFullContent = (height: number | undefined, width: number | undefined): boolean => {
+    if (!height || !width) {
+        return false;
+    }
+
+    const shorter = Math.min(width, height);
+    const longer = Math.max(width, height);
+
+    return shorter >= MINIMUM_SHORTER_SIDE && longer >= MINIMUM_LONGER_SIDE;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/tests/sizingUtils.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/tests/sizingUtils.test.ts
@@ -1,0 +1,15 @@
+// (C) 2021 GoodData Corporation
+import { shouldRenderFullContent } from "../sizingUtils";
+
+describe("Report Visualization - resize utils", () => {
+    describe("shouldRenderFullContent", () => {
+        it.each`
+            expected | name              | height | width
+            ${true}  | ${"large enough"} | ${260} | ${420}
+            ${false} | ${"too narrow"}   | ${420} | ${150}
+            ${false} | ${"too short"}    | ${150} | ${420}
+        `("should return $expected when $name", ({ expected, height, width }) => {
+            expect(shouldRenderFullContent(height, width)).toBe(expected);
+        });
+    });
+});

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
@@ -101,6 +101,8 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
     const handleLoadingChanged = useCallback<OnLoadingChanged>(({ isLoading }) => {
         if (isLoading) {
             onRequestAsyncRender();
+            // if we started loading, any previous vis error is obsolete at this point, get rid of it
+            setVisualizationError(undefined);
         } else {
             onResolveAsyncRender();
         }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
@@ -16,7 +16,7 @@ import {
     useBackendStrict,
     useWorkspaceStrict,
 } from "@gooddata/sdk-ui";
-import { InsightError, InsightRenderer } from "@gooddata/sdk-ui-ext";
+import { InsightRenderer } from "@gooddata/sdk-ui-ext";
 
 import { useDashboardComponentsContext } from "../../../dashboardContexts";
 import {
@@ -36,6 +36,7 @@ import { useResolveDashboardInsightProperties } from "./useResolveDashboardInsig
 import { useDashboardInsightDrills } from "./useDashboardInsightDrills";
 import { IDashboardInsightProps } from "../types";
 import { useWidgetFiltersQuery } from "../../common";
+import { CustomError } from "./CustomError/CustomError";
 
 const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative", flex: "1 1 auto" };
 
@@ -47,6 +48,7 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
         insight,
         widget,
         clientHeight,
+        clientWidth,
         backend,
         workspace,
         disableWidgetImplicitDrills,
@@ -164,11 +166,11 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
                 <IntlWrapper locale={locale}>
                     {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
                     {error && (
-                        <InsightError
+                        <CustomError
                             error={error}
-                            ErrorComponent={ErrorComponent}
-                            clientHeight={settings?.enableKDWidgetCustomHeight ? clientHeight : undefined}
-                            height={null} // make sure the error is aligned to the top (this is the behavior in gdc-dashboards)
+                            isCustomWidgetHeightEnabled={!!settings?.enableKDWidgetCustomHeight}
+                            height={clientHeight}
+                            width={clientWidth}
                         />
                     )}
                     {filtersStatus === "success" && (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
@@ -40,6 +40,7 @@ export interface IDashboardInsightProps {
     insight: IInsight;
 
     clientHeight?: number;
+    clientWidth?: number;
 
     backend?: IAnalyticalBackend;
     workspace?: string;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -351,7 +351,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                 if (status === "error" && !isNoDataSdkError(error)) {
                     return <ErrorComponent message={(error! as Error).message} />;
                 }
-                return kpiResult ? (
+                return (
                     <KpiRenderer
                         kpi={kpiWidget}
                         kpiResult={kpiResult}
@@ -362,7 +362,7 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                         separators={separators}
                         enableCompactSize={enableCompactSize}
                     />
-                ) : null;
+                );
             }}
         </DashboardItemWithKpiAlert>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
@@ -11,7 +11,7 @@ import { IKpiResult } from "./types";
 
 interface IKpiRendererProps {
     kpi: IKpiWidget | IKpiWidgetDefinition;
-    kpiResult: IKpiResult;
+    kpiResult: IKpiResult | undefined;
     filters: IFilter[];
     separators: ISeparators;
     disableDrillUnderline?: boolean;
@@ -34,7 +34,7 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
     enableCompactSize,
 }) => {
     const onPrimaryValueClick = useCallback(() => {
-        if (!isDrillable || !onDrill) {
+        if (!isDrillable || !onDrill || !kpiResult) {
             return;
         }
         return onDrill({

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -85,9 +85,10 @@ export const DefaultDashboardWidgetInner = (): JSX.Element => {
                             <DashboardItemHeadline title={widget.title} clientHeight={clientHeight} />
                         )}
                     >
-                        {({ clientHeight }) => (
+                        {({ clientHeight, clientWidth }) => (
                             <DashboardInsightPropsProvider
                                 clientHeight={clientHeight}
+                                clientWidth={clientWidth}
                                 insight={insight!}
                                 widget={widget}
                             >


### PR DESCRIPTION
* RAIL-3625 - prevent stale No data errors in insighs and empty No data states in KPIs
* RAIL-3626 - migrate custom insight error components from gdc-dashboards

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
