### PR TITLE
RELATED: RAIL-3627 port Export drilled insight feature

### DIFF
--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -16,6 +16,7 @@ options = {
             "dashboard",
             "src/presentation/dashboard/", // the trailing / is necessary here, otherwise dashboardContexts is matched as well
             [
+                "src/_staging/*",
                 "src/model",
                 "src/presentation/dashboardContexts",
                 "src/presentation/filterBar",

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -91,7 +91,9 @@ import { ObjectType } from '@gooddata/sdk-model';
 import { ObjRef } from '@gooddata/sdk-model';
 import { ObjRefInScope } from '@gooddata/sdk-model';
 import { OnError } from '@gooddata/sdk-ui';
+import { OnExportReady } from '@gooddata/sdk-ui';
 import { OnFiredDrillEvent } from '@gooddata/sdk-ui';
+import { OnLoadingChanged } from '@gooddata/sdk-ui';
 import { OutputSelector } from '@reduxjs/toolkit';
 import { Patch } from 'immer';
 import { PlatformEdition } from '@gooddata/sdk-backend-spi';
@@ -1849,6 +1851,10 @@ export interface IDashboardInsightProps {
     onDrillToInsight?: OnDrillToInsight;
     // (undocumented)
     onError?: OnError;
+    // (undocumented)
+    onExportReady?: OnExportReady;
+    // (undocumented)
+    onLoadingChanged?: OnLoadingChanged;
     // (undocumented)
     widget: IInsightWidget;
     // (undocumented)

--- a/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/fileUtils/downloadFile.ts
@@ -1,0 +1,12 @@
+// (C) 2019-2021 GoodData Corporation
+export const DOWNLOADER_ID = "downloader";
+
+export function downloadFile(uri: string): void {
+    const anchor = document.createElement("a");
+    anchor.id = DOWNLOADER_ID;
+    anchor.href = uri;
+    anchor.download = uri;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -4,6 +4,7 @@ import {
     FilterContextItem,
     IDashboardAttributeFilter,
     IDashboardDateFilter,
+    isProtectedDataError,
 } from "@gooddata/sdk-backend-spi";
 import { ToastMessageContextProvider, ToastMessages, useToastMessage } from "@gooddata/sdk-ui-kit";
 import { ErrorComponent as DefaultError, LoadingComponent as DefaultLoading } from "@gooddata/sdk-ui";
@@ -136,7 +137,7 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
         workspace,
         onLoading: () => {
             lastExportMessageId.current = addProgress(
-                { id: "options.menu.export.PDF.start" },
+                { id: "messages.exportResultStart" },
                 // make sure the message stays there until removed by either success or error
                 { duration: 0 },
             );
@@ -145,13 +146,18 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
             if (lastExportMessageId.current) {
                 removeMessage(lastExportMessageId.current);
             }
-            addSuccess({ id: "options.menu.export.PDF.success" });
+            addSuccess({ id: "messages.exportResultSuccess" });
         },
-        onError: () => {
+        onError: (err) => {
             if (lastExportMessageId.current) {
                 removeMessage(lastExportMessageId.current);
             }
-            addError({ id: "options.menu.export.PDF.error" });
+
+            if (isProtectedDataError(err)) {
+                addError({ id: "messages.exportResultRestrictedError" });
+            } else {
+                addError({ id: "messages.exportResultError" });
+            }
         },
     });
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/hooks/useDashboardPdfExporter.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/hooks/useDashboardPdfExporter.ts
@@ -4,16 +4,7 @@ import { AnalyticalBackendError, FilterContextItem, IAnalyticalBackend } from "@
 import { UseCancelablePromiseCallbacks, UseCancelablePromiseStatus } from "@gooddata/sdk-ui";
 import { ObjRef } from "@gooddata/sdk-model";
 import { useExportDashboardToPdf as useExportDashboardToPdfCore } from "./useExportDashboardToPdf";
-
-function downloadFile(uri: string): void {
-    const anchor = document.createElement("a");
-    anchor.id = "downloader";
-    anchor.href = uri;
-    anchor.download = uri;
-    document.body.appendChild(anchor);
-    anchor.click();
-    document.body.removeChild(anchor);
-}
+import { downloadFile } from "../../../_staging/fileUtils/downloadFile";
 
 /**
  * @beta

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Alle anzeigen",
     "filterBar.showLess": "Weniger anzeigen",
     "options.menu.export.PDF": "Nach PFD exportieren",
-    "options.menu.export.PDF.error": "Daten konnten nicht exportiert werden. Versuchen Sie es später noch einmal.",
-    "options.menu.export.PDF.start": "Export wird durchgeführt",
-    "options.menu.export.PDF.success": "Export erfolgreich abgeschlossen.",
     "options.menu.schedule.email": "E-Mailing planen",
     "dialogs.schedule.email.submit.success": "Erfolgreich! Ihr Dashboard ist jetzt für E-Mails eingerichtet.",
     "dialogs.schedule.email.submit.error": "Fehler! E-Mails für das Dashboard konnten nicht eingerichtet werden. Bitte später erneut versuchen.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "KPI-Dashboard verlassen?",
     "kpiAlertDialog.unsaved.changes.message": "Unveröffentlichte Änderungen gehen verloren.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Trotzdem verlassen",
-    "kpiAlertDialog.unsaved.changes.stay": "Bleiben"
+    "kpiAlertDialog.unsaved.changes.stay": "Bleiben",
+    "messages.exportResultError": "Daten konnten nicht exportiert werden. Versuchen Sie es später noch einmal.",
+    "messages.exportResultRestrictedError": "Sie können die Betrachtungsansicht nicht exportieren, weil sie zugriffsbeschränkte Daten enthält.",
+    "messages.exportResultStart": "Export wird durchgeführt",
+    "messages.exportResultSuccess": "Export erfolgreich abgeschlossen."
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -14,21 +14,6 @@
         "comment": "Export whole KPI dashboard to PDF",
         "limit": 0
     },
-    "options.menu.export.PDF.error": {
-        "value": "Export to PDF failed. Please try again.",
-        "comment": "Export whole KPI dashboard to PDF failed",
-        "limit": 0
-    },
-    "options.menu.export.PDF.start": {
-        "value": "Export in progress",
-        "comment": "Dialog. Export of the visualization to the file is in progress.",
-        "limit": 0
-    },
-    "options.menu.export.PDF.success": {
-        "value": "Export successful.",
-        "comment": "Dialog. Export of the visualization to the file is done.",
-        "limit": 0
-    },
     "options.menu.schedule.email": {
         "value": "Schedule emailing",
         "comment": "Translate as imperative. Schedule emailing whole KPI dashboard",
@@ -427,6 +412,26 @@
     "kpiAlertDialog.unsaved.changes.stay": {
         "value": "Stay",
         "comment": "",
+        "limit": 0
+    },
+    "messages.exportResultError": {
+        "value": "Failed to export the data. Try again later.",
+        "comment": "Error dialog. Exporting insight to the file fails.",
+        "limit": 0
+    },
+    "messages.exportResultRestrictedError": {
+        "value": "You cannot export this insight because it contains restricted data.",
+        "comment": "Error dialog. Exporting insight to the file fails because contains restricted data.",
+        "limit": 0
+    },
+    "messages.exportResultStart": {
+        "value": "Export in progress",
+        "comment": "Dialog. Export of the visualization to the file is in progress.",
+        "limit": 0
+    },
+    "messages.exportResultSuccess": {
+        "value": "Export successful.",
+        "comment": "Dialog. Export of the visualization to the file is done.",
         "limit": 0
     }
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Mostrar todo",
     "filterBar.showLess": "Mostrar menos",
     "options.menu.export.PDF": "Exportar a PDF",
-    "options.menu.export.PDF.error": "Error al exportar los datos. Inténtelo de nuevo más tarde.",
-    "options.menu.export.PDF.start": "Exportación en curso",
-    "options.menu.export.PDF.success": "Exportación correcta.",
     "options.menu.schedule.email": "Programar el envío de correos",
     "dialogs.schedule.email.submit.success": "¡Hecho! Su panel se ha configurado para el envío de correos.",
     "dialogs.schedule.email.submit.error": "Error al programar el panel. Inténtelo de nuevo más tarde.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "¿Salir del panel de KPI?",
     "kpiAlertDialog.unsaved.changes.message": "Hay cambios sin publicar que se perderán.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Salir de todas formas",
-    "kpiAlertDialog.unsaved.changes.stay": "Quedarse"
+    "kpiAlertDialog.unsaved.changes.stay": "Quedarse",
+    "messages.exportResultError": "Error al exportar los datos. Inténtelo de nuevo más tarde.",
+    "messages.exportResultRestrictedError": "No puede exportar esta perspectiva porque contiene datos restringidos.",
+    "messages.exportResultStart": "Exportación en curso",
+    "messages.exportResultSuccess": "Exportación correcta."
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Afficher tout",
     "filterBar.showLess": "Montrer moins",
     "options.menu.export.PDF": "Exporter vers PDF",
-    "options.menu.export.PDF.error": "Échec de l'exportation des données. Réessayez plus tard.",
-    "options.menu.export.PDF.start": "Exportation en cours",
-    "options.menu.export.PDF.success": "Exportation effectuée",
     "options.menu.schedule.email": "Programmer l'envoi d'e-mails",
     "dialogs.schedule.email.submit.success": "Le tableau de bord est programmé pour envoyer des e-mails.",
     "dialogs.schedule.email.submit.error": "Échec de la programmation du tableau de bord. Réessayez plus tard.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "Quitter le tableau de bord de KPI ?",
     "kpiAlertDialog.unsaved.changes.message": "Certaines modifications ne sont pas publiées et seront perdues.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Quitter quand même",
-    "kpiAlertDialog.unsaved.changes.stay": "Rester"
+    "kpiAlertDialog.unsaved.changes.stay": "Rester",
+    "messages.exportResultError": "Échec de l'exportation des données. Réessayez plus tard.",
+    "messages.exportResultRestrictedError": "Vous ne pouvez pas exporter cette perception car elle contient des données à accès restreint.",
+    "messages.exportResultStart": "Exportation en cours",
+    "messages.exportResultSuccess": "Exportation effectuée"
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "すべて表示",
     "filterBar.showLess": "簡易表示",
     "options.menu.export.PDF": "PDF にエクスポート",
-    "options.menu.export.PDF.error": "データをエクスポートできませんでした。後でもう一度お試しください。",
-    "options.menu.export.PDF.start": "エクスポート実行中",
-    "options.menu.export.PDF.success": "正常にエクスポートしました。",
     "options.menu.schedule.email": "メール送信をスケジュール",
     "dialogs.schedule.email.submit.success": "成功！あなたのダッシュボードでメール送信がスケジュールされました。",
     "dialogs.schedule.email.submit.error": "ダッシュボードのスケジュールに失敗。後で再試行してください。",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "KPI ダッシュボードを終了しますか？",
     "kpiAlertDialog.unsaved.changes.message": "未公開の変更は破棄されます。",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "終了",
-    "kpiAlertDialog.unsaved.changes.stay": "終了しない"
+    "kpiAlertDialog.unsaved.changes.stay": "終了しない",
+    "messages.exportResultError": "データをエクスポートできませんでした。後でもう一度お試しください。",
+    "messages.exportResultRestrictedError": "制限されているデータを含んでいるため、このインサイトをエクスポートできません。",
+    "messages.exportResultStart": "エクスポート実行中",
+    "messages.exportResultSuccess": "正常にエクスポートしました。"
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Alle tonen",
     "filterBar.showLess": "Minder weergeven",
     "options.menu.export.PDF": "Exporteren naar PDF",
-    "options.menu.export.PDF.error": "Exporteren van gegevens is mislukt. Probeer het later opnieuw.",
-    "options.menu.export.PDF.start": "Bezig met exporteren",
-    "options.menu.export.PDF.success": "Exporteren geslaagd.",
     "options.menu.schedule.email": "E-mail plannen",
     "dialogs.schedule.email.submit.success": "Gelukt! Uw dashboard is ingesteld om te mailen.",
     "dialogs.schedule.email.submit.error": "Inplannen van dashboard mislukt. Probeer het later opnieuw.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "Het KPI-dashboard verlaten?",
     "kpiAlertDialog.unsaved.changes.message": "Er zijn ongepubliceerde wijzigingen die verloren gaan.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Toch verlaten",
-    "kpiAlertDialog.unsaved.changes.stay": "Blijven"
+    "kpiAlertDialog.unsaved.changes.stay": "Blijven",
+    "messages.exportResultError": "Exporteren van gegevens is mislukt. Probeer het later opnieuw.",
+    "messages.exportResultRestrictedError": "U kunt dit inzicht niet exporteren omdat het beperkte gegevens bevat.",
+    "messages.exportResultStart": "Bezig met exporteren",
+    "messages.exportResultSuccess": "Exporteren geslaagd."
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Exibir tudo",
     "filterBar.showLess": "Exibir menos",
     "options.menu.export.PDF": "Exportar para PDF",
-    "options.menu.export.PDF.error": "Falha ao exportar os dados. Tente novamente.",
-    "options.menu.export.PDF.start": "Exportação em curso",
-    "options.menu.export.PDF.success": "Exportação concluída com sucesso.",
     "options.menu.schedule.email": "Agendar envio por e-mail",
     "dialogs.schedule.email.submit.success": "Sucesso! Seu painel está agendado para envio por e-mail.",
     "dialogs.schedule.email.submit.error": "Erro ao agendar o painel. Tente novamente mais tarde.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "Deixar o dashboard de KPI?",
     "kpiAlertDialog.unsaved.changes.message": "Há alterações não publicadas que serão perdidas.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Deixar mesmo assim",
-    "kpiAlertDialog.unsaved.changes.stay": "Manter"
+    "kpiAlertDialog.unsaved.changes.stay": "Manter",
+    "messages.exportResultError": "Falha ao exportar os dados. Tente novamente.",
+    "messages.exportResultRestrictedError": "Você não pode exportar esse insight porque ele contém dados restritos.",
+    "messages.exportResultStart": "Exportação em curso",
+    "messages.exportResultSuccess": "Exportação concluída com sucesso."
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "Mostrar tudo",
     "filterBar.showLess": "Mostrar menos",
     "options.menu.export.PDF": "Exportar para PDF",
-    "options.menu.export.PDF.error": "Falha ao exportar os dados. Tente mais tarde.",
-    "options.menu.export.PDF.start": "Exportação em curso",
-    "options.menu.export.PDF.success": "Exportação bem sucedida.",
     "options.menu.schedule.email": "Agenda envio de e-mail",
     "dialogs.schedule.email.submit.success": "Êxito! O seu dashboard está agendado para envio de e-mail.",
     "dialogs.schedule.email.submit.error": "Não foi possível agendar o dashboard. Tente mais tarde.",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "Sair do dashboard de KPI?",
     "kpiAlertDialog.unsaved.changes.message": "Existem alterações não publicadas que serão perdidas.",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "Sim, pretendo sair",
-    "kpiAlertDialog.unsaved.changes.stay": "Permanecer"
+    "kpiAlertDialog.unsaved.changes.stay": "Permanecer",
+    "messages.exportResultError": "Falha ao exportar os dados. Tente mais tarde.",
+    "messages.exportResultRestrictedError": "Não é possível exportar este insight porque contém dados confidenciais.",
+    "messages.exportResultStart": "Exportação em curso",
+    "messages.exportResultSuccess": "Exportação bem sucedida."
 }

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
@@ -2,9 +2,6 @@
     "filterBar.showAll": "显示全部",
     "filterBar.showLess": "显示更少",
     "options.menu.export.PDF": "导出为 PDF",
-    "options.menu.export.PDF.error": "数据导出失败，请稍后重试。",
-    "options.menu.export.PDF.start": "正在导出",
-    "options.menu.export.PDF.success": "导出成功！",
     "options.menu.schedule.email": "安排电子邮件发送",
     "dialogs.schedule.email.submit.success": "成功！您的控制面板已计划发送电子邮件。",
     "dialogs.schedule.email.submit.error": "计划控制面板失败，请稍后重试。",
@@ -84,5 +81,9 @@
     "kpiAlertDialog.unsaved.changes.headline": "离开 KPI 控制面板？",
     "kpiAlertDialog.unsaved.changes.message": "有未发布的更改，它们将丢失。",
     "kpiAlertDialog.unsaved.changes.leave.anyway": "离开",
-    "kpiAlertDialog.unsaved.changes.stay": "留下"
+    "kpiAlertDialog.unsaved.changes.stay": "留下",
+    "messages.exportResultError": "数据导出失败，请稍后重试。",
+    "messages.exportResultRestrictedError": "您不能导出此洞察，因为它包含限制数据。",
+    "messages.exportResultStart": "正在导出",
+    "messages.exportResultSuccess": "导出成功！"
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightCore.tsx
@@ -57,6 +57,8 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
         LoadingComponent: CustomLoadingComponent,
         drillTargets,
         onAvailableDrillTargetsReceived,
+        onLoadingChanged,
+        onExportReady,
     } = props;
 
     const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext({
@@ -105,6 +107,7 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
             onResolveAsyncRender();
         }
         setIsVisualizationLoading(isLoading);
+        onLoadingChanged?.({ isLoading });
     }, []);
 
     const handleError = useCallback<OnError>(
@@ -185,6 +188,7 @@ export const DashboardInsightCore = (props: IDashboardInsightProps): JSX.Element
                             pushData={handlePushData}
                             ErrorComponent={ErrorComponent}
                             LoadingComponent={LoadingComponent}
+                            onExportReady={onExportReady}
                         />
                     )}
                 </IntlWrapper>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialog.tsx
@@ -2,7 +2,9 @@
 import React from "react";
 import { useIntl } from "react-intl";
 import { Button, Bubble, BubbleHoverTrigger, ShortenedText } from "@gooddata/sdk-ui-kit";
+import { selectPermissions, selectSettings, useDashboardSelector } from "../../../../../model";
 import { PoweredByGDLogo } from "./PoweredByGDLogo";
+import { DrillModalFooter } from "./DrillModalFooter";
 
 export interface DrillDialogProps {
     title: string;
@@ -11,6 +13,13 @@ export interface DrillDialogProps {
     onBackButtonClick: () => void;
     isBackButtonVisible?: boolean;
     children: React.ReactNode;
+
+    exportAvailable: boolean;
+    onExportXLSX: () => void;
+    onExportCSV: () => void;
+    exportXLSXEnabled: boolean;
+    exportCSVEnabled: boolean;
+    isLoading: boolean;
 }
 
 export const DrillDialog: React.FC<DrillDialogProps> = ({
@@ -20,8 +29,21 @@ export const DrillDialog: React.FC<DrillDialogProps> = ({
     onBackButtonClick,
     isBackButtonVisible,
     children,
+
+    exportAvailable,
+    exportXLSXEnabled,
+    exportCSVEnabled,
+    onExportCSV,
+    onExportXLSX,
+    isLoading,
 }) => {
     const intl = useIntl();
+
+    const settings = useDashboardSelector(selectSettings);
+    const permissions = useDashboardSelector(selectPermissions);
+    const shouldShowDrilledInsightExport =
+        settings?.enableDrilledInsightExport && permissions.canExportReport;
+
     const renderTitle = () => {
         const separator = "\u203A";
         const paddedSeparator = ` ${separator} `;
@@ -67,6 +89,18 @@ export const DrillDialog: React.FC<DrillDialogProps> = ({
             <div className="gd-drill-modal-dialog-content visualization">
                 <div className="gd-drill-modal-dialog-content-base">{children}</div>
             </div>
+            {shouldShowDrilledInsightExport && (
+                <div className="gd-drill-modal-dialog-footer gd-drill-modal-dialog-footer-with-border s-drill-modal-dialog-footer">
+                    <DrillModalFooter
+                        exportAvailable={exportAvailable}
+                        exportXLSXEnabled={exportXLSXEnabled}
+                        exportCSVEnabled={exportCSVEnabled}
+                        onExportXLSX={onExportXLSX}
+                        onExportCSV={onExportCSV}
+                        isLoading={isLoading}
+                    />
+                </div>
+            )}
             <PoweredByGDLogo isSmall />
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillModalExportOptions.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillModalExportOptions.tsx
@@ -1,0 +1,61 @@
+// (C) 2021 GoodData Corporation
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { Overlay, ItemsWrapper, Item } from "@gooddata/sdk-ui-kit";
+
+export interface IDrillModalExportOptionsProps {
+    showDropdown: boolean;
+    toggleShowDropdown(): void;
+    exportXLSXEnabled: boolean;
+    onExportXLSX: () => void;
+    exportCSVEnabled: boolean;
+    onExportCSV: () => void;
+}
+
+const DrillModalExportOptions: React.FC<IDrillModalExportOptionsProps> = ({
+    showDropdown,
+    toggleShowDropdown,
+    exportXLSXEnabled,
+    onExportXLSX,
+    exportCSVEnabled,
+    onExportCSV,
+}) =>
+    showDropdown ? (
+        <Overlay
+            key="DrillModalOptionsMenu"
+            alignTo=".export-drilled-insight"
+            alignPoints={[
+                {
+                    align: "tc bc",
+                    offset: {
+                        x: -10,
+                        y: -5,
+                    },
+                },
+            ]}
+            className="gd-header-menu-overlay s-drill-modal-export-options"
+            closeOnOutsideClick={true}
+            onClose={toggleShowDropdown}
+        >
+            <ItemsWrapper smallItemsSpacing={true}>
+                {exportXLSXEnabled && (
+                    <Item
+                        onClick={onExportXLSX}
+                        className="options-menu-export-xlsx s-export-drilled-insight-xlsx"
+                    >
+                        <FormattedMessage id="widget.options.menu.exportToXLSX" />
+                    </Item>
+                )}
+                {exportCSVEnabled && (
+                    <Item
+                        onClick={onExportCSV}
+                        className="options-menu-export-csv s-export-drilled-insight-csv"
+                    >
+                        <FormattedMessage id="widget.options.menu.exportToCSV" />
+                    </Item>
+                )}
+            </ItemsWrapper>
+        </Overlay>
+    ) : null;
+
+export default DrillModalExportOptions;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillModalFooter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillModalFooter.tsx
@@ -1,0 +1,87 @@
+// (C) 2021 GoodData Corporation
+import React, { useState, useCallback, useMemo } from "react";
+import { FormattedMessage } from "react-intl";
+import cx from "classnames";
+import { BubbleHoverTrigger, Bubble } from "@gooddata/sdk-ui-kit";
+
+import DrillModalExportOptions from "./DrillModalExportOptions";
+
+export interface IDrillModalFooterProps {
+    exportAvailable: boolean;
+    exportXLSXEnabled: boolean;
+    onExportXLSX: () => void;
+    exportCSVEnabled: boolean;
+    onExportCSV: () => void;
+    isLoading: boolean;
+}
+
+export const DrillModalFooter: React.FC<IDrillModalFooterProps> = ({
+    exportAvailable,
+    exportXLSXEnabled,
+    onExportXLSX,
+    exportCSVEnabled,
+    onExportCSV,
+    isLoading,
+}) => {
+    const [showDropdown, setShowDropdown] = useState(false);
+
+    const toggleShowDropdown = useCallback(() => setShowDropdown((oldValue) => !oldValue), []);
+
+    const handleOnExportXLSX = useCallback(() => {
+        onExportXLSX();
+        setShowDropdown(false);
+    }, [onExportXLSX]);
+
+    const handleOnExportCSV = useCallback(() => {
+        onExportCSV();
+        setShowDropdown(false);
+    }, [onExportCSV]);
+
+    const exportDisabled = !exportAvailable || (!exportXLSXEnabled && !exportCSVEnabled);
+
+    const toggleButton = useMemo(
+        () => (
+            <button
+                onClick={toggleShowDropdown}
+                className={cx("gd-button-link-dimmed gd-button gd-icon-download export-menu-toggle-button", {
+                    disabled: exportDisabled,
+                })}
+                type="button"
+            >
+                <span className="gd-button-text">
+                    <FormattedMessage id="dialogs.export.submit" />
+                </span>
+            </button>
+        ),
+        [exportDisabled, toggleShowDropdown],
+    );
+
+    return (
+        <div
+            className={cx("s-export-drilled-insight export-drilled-insight", {
+                "is-disabled": exportDisabled,
+            })}
+        >
+            {exportDisabled && !isLoading ? (
+                <BubbleHoverTrigger>
+                    {toggleButton}
+                    <Bubble className="bubble-primary" alignPoints={[{ align: "tc bc" }]}>
+                        <FormattedMessage id="export_unsupported.disabled" />
+                    </Bubble>
+                </BubbleHoverTrigger>
+            ) : (
+                <>
+                    {toggleButton}
+                    <DrillModalExportOptions
+                        showDropdown={showDropdown}
+                        toggleShowDropdown={toggleShowDropdown}
+                        exportXLSXEnabled={exportXLSXEnabled}
+                        exportCSVEnabled={exportCSVEnabled}
+                        onExportXLSX={handleOnExportXLSX}
+                        onExportCSV={handleOnExportCSV}
+                    />
+                </>
+            )}
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/useDrillExport.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/useDrillExport.ts
@@ -1,0 +1,112 @@
+// (C) 2021 GoodData Corporation
+import { useCallback, useMemo, useState } from "react";
+import invariant from "ts-invariant";
+import { IExportDialogData } from "@gooddata/sdk-ui-kit";
+import {
+    GoodDataSdkError,
+    IExportFunction,
+    IExtendedExportConfig,
+    isBadRequest,
+    isDataTooLargeToCompute,
+    isNoDataSdkError,
+    isProtectedReport,
+    isUnknownSdkError,
+} from "@gooddata/sdk-ui";
+import { isEmptyAfm } from "@gooddata/sdk-ui-ext/dist/internal";
+import { selectPermissions, selectSettings, useDashboardSelector } from "../../../../../model";
+
+const nonExportableErrorGuards: Array<(item: unknown) => boolean> = [
+    isUnknownSdkError,
+    isBadRequest,
+    isNoDataSdkError,
+    isProtectedReport,
+    isDataTooLargeToCompute,
+    isEmptyAfm,
+];
+
+const isExportable = (error: GoodDataSdkError | undefined) => {
+    if (!error) {
+        return true;
+    }
+
+    return !nonExportableErrorGuards.some((guard) => guard(error));
+};
+
+export const useDrillExport = (
+    title: string,
+    error: GoodDataSdkError | undefined,
+    isLoading: boolean,
+    onExport: (exportFunction: IExportFunction, exportConfig: IExtendedExportConfig) => void,
+) => {
+    const [exportFunction, setExportFunction] = useState<IExportFunction | undefined>();
+    const [isExportDialogVisible, setIsExportDialogVisible] = useState(false);
+
+    const settings = useDashboardSelector(selectSettings);
+    const permissions = useDashboardSelector(selectPermissions);
+
+    const isExportEnabled = settings.enableKPIDashboardExport && permissions.canExportReport;
+    const isRawExportEnabled = isExportEnabled && permissions.canExecuteRaw;
+
+    const onExportDialogSubmit = useCallback(
+        (data: IExportDialogData) => {
+            const { mergeHeaders, includeFilterContext } = data;
+
+            const exportConfig: IExtendedExportConfig = {
+                format: "xlsx",
+                includeFilterContext,
+                mergeHeaders,
+                title,
+            };
+
+            setIsExportDialogVisible(false);
+            // if this bombs there is an issue with the logic enabling the buttons
+            invariant(exportFunction);
+            onExport(exportFunction, exportConfig);
+        },
+        [exportFunction, title],
+    );
+
+    const onExportReady = useCallback((exportFunction: IExportFunction) => {
+        setExportFunction(() => exportFunction);
+    }, []);
+
+    const onExportCSV = useCallback(() => {
+        const exportConfig: IExtendedExportConfig = {
+            format: "csv",
+            title,
+        };
+        // if this bombs there is an issue with the logic enabling the buttons
+        invariant(exportFunction);
+        onExport(exportFunction, exportConfig);
+    }, [exportFunction, title]);
+
+    const onExportXLSX = useCallback(() => {
+        setIsExportDialogVisible(true);
+    }, []);
+
+    const onExportDialogCancel = useCallback(() => {
+        setIsExportDialogVisible(false);
+    }, []);
+
+    const exportCSVEnabled = useMemo(
+        () => Boolean(isExportable(error) && !isLoading && isRawExportEnabled),
+        [error, isLoading, isRawExportEnabled],
+    );
+
+    const exportXLSXEnabled = useMemo(
+        () => Boolean(isExportable(error) && !isLoading && isExportEnabled),
+        [error, isLoading, isExportEnabled],
+    );
+
+    return {
+        exportFunction,
+        onExportReady,
+        isExportDialogVisible,
+        onExportDialogSubmit,
+        onExportDialogCancel,
+        exportCSVEnabled,
+        exportXLSXEnabled,
+        onExportCSV,
+        onExportXLSX,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/useExportHandler.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/useExportHandler.ts
@@ -1,0 +1,44 @@
+// (C) 2020-2021 GoodData Corporation
+import { useCallback, useRef } from "react";
+import { IExportConfig, isProtectedDataError } from "@gooddata/sdk-backend-spi";
+import { IExportFunction } from "@gooddata/sdk-ui";
+import { useToastMessage } from "@gooddata/sdk-ui-kit";
+import { downloadFile } from "../../../../../_staging/fileUtils/downloadFile";
+
+type ExportHandler = (exportFunction: IExportFunction, exportConfig: IExportConfig) => Promise<void>;
+
+export const useExportHandler = (): ExportHandler => {
+    const { addProgress, addSuccess, addError, removeMessage } = useToastMessage();
+    const lastExportMessageId = useRef("");
+    return useCallback(
+        async (exportFunction: IExportFunction, exportConfig: IExportConfig): Promise<void> => {
+            try {
+                lastExportMessageId.current = addProgress(
+                    { id: "messages.exportResultStart" },
+                    // make sure the message stays there until removed by either success or error
+                    { duration: 0 },
+                );
+
+                const exportResult = await exportFunction(exportConfig);
+
+                if (lastExportMessageId.current) {
+                    removeMessage(lastExportMessageId.current);
+                }
+                addSuccess({ id: "messages.exportResultSuccess" });
+
+                downloadFile(exportResult.uri);
+            } catch (err) {
+                if (lastExportMessageId.current) {
+                    removeMessage(lastExportMessageId.current);
+                }
+
+                if (isProtectedDataError(err)) {
+                    addError({ id: "messages.exportResultRestrictedError" });
+                } else {
+                    addError({ id: "messages.exportResultError" });
+                }
+            }
+        },
+        [],
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
@@ -9,6 +9,8 @@ import {
     IHeaderPredicate,
     ILoadingProps,
     OnError,
+    OnExportReady,
+    OnLoadingChanged,
 } from "@gooddata/sdk-ui";
 import {
     OnDashboardDrill,
@@ -58,6 +60,9 @@ export interface IDashboardInsightProps {
     onDrillToCustomUrl?: OnDrillToCustomUrl;
 
     onError?: OnError;
+    onLoadingChanged?: OnLoadingChanged;
+    onExportReady?: OnExportReady;
+
     ErrorComponent?: ComponentType<IErrorProps>;
     LoadingComponent?: ComponentType<ILoadingProps>;
 }


### PR DESCRIPTION
Ports the Export drilled insight feature from gdc-dashboards (simplifying the code in some places).
As part of the change some localization strings were aligned with gdc-dasbhoards in order to be usable for PDF and non-PDF exports (as they are in gdc-dashboards).
Finally, a missing protected data error handling in exports was added.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
