### PR TITLE
RELATED: RAIL-3635 fix detection of empty dashboards

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -1,13 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { useMemo } from "react";
-import {
-    isWidget,
-    widgetId,
-    widgetUri,
-    isInsightWidget,
-    isDashboardLayoutEmpty,
-    IDashboardLayout,
-} from "@gooddata/sdk-backend-spi";
+import { isWidget, widgetId, widgetUri, isInsightWidget, IDashboardLayout } from "@gooddata/sdk-backend-spi";
 import {
     ObjRef,
     IInsight,
@@ -23,6 +16,7 @@ import {
     selectBasicLayout,
     useDashboardSelector,
     selectIsExport,
+    selectIsLayoutEmpty,
 } from "../../model";
 import { useDashboardComponentsContext } from "../dashboardContexts";
 
@@ -89,6 +83,7 @@ export const DefaultDashboardLayoutInner = (): JSX.Element => {
     } = useDashboardLayoutProps();
 
     const layout = useDashboardSelector(selectBasicLayout);
+    const isLayoutEmpty = useDashboardSelector(selectIsLayoutEmpty);
     const settings = useDashboardSelector(selectSettings);
     const insights = useDashboardSelector(selectInsights);
     const { ErrorComponent } = useDashboardComponentsContext({ ErrorComponent: CustomError });
@@ -112,7 +107,7 @@ export const DefaultDashboardLayoutInner = (): JSX.Element => {
         return isExport ? getDashboardLayoutForExport(layout) : layoutWithRefs;
     }, [layout, isExport]);
 
-    return isDashboardLayoutEmpty(layout) ? (
+    return isLayoutEmpty ? (
         <EmptyDashboardError ErrorComponent={ErrorComponent} />
     ) : (
         <DashboardLayout


### PR DESCRIPTION
This now covers more cases (e.g. non empty layout without content in columns).

JIRA: RAIL-3635

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
