### PR TITLE
Add filter context to drillToUrl on dashboard component

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -53,6 +53,7 @@ export const DefaultUiSettings: ISettings = {
     enableKPIDashboardImplicitDrillDown: false,
     enableKPIDashboardDrillFromAttribute: false,
     enableDrilledInsightExport: false,
+    enableFilterValuesResolution: false,
 
     enableNewNavigationForResponsiveUi: true,
     enableDataSection: true,

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -636,6 +636,7 @@ export type DashboardConfig = {
     isEmbedded?: boolean;
     isExport?: boolean;
     disableDefaultDrills?: boolean;
+    enableFilterValuesResolutionInDrillEvents?: boolean;
 };
 
 // @alpha
@@ -763,6 +764,7 @@ export interface DashboardDrillToAttributeUrlResolved extends IDashboardEvent {
         readonly drillEvent: IDashboardDrillEvent;
         readonly drillDefinition: IDrillToAttributeUrl;
         readonly url: string;
+        readonly filtersInfo: FiltersInfo;
     };
     // (undocumented)
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_ATTRIBUTE_URL.RESOLVED";
@@ -786,6 +788,7 @@ export interface DashboardDrillToCustomUrlResolved extends IDashboardEvent {
         readonly drillEvent: IDashboardDrillEvent;
         readonly drillDefinition: IDrillToCustomUrl;
         readonly url: string;
+        readonly filtersInfo: FiltersInfo;
     };
     // (undocumented)
     readonly type: "GDC.DASH/EVT.DRILL.DRILL_TO_CUSTOM_URL.RESOLVED";
@@ -1591,7 +1594,7 @@ export function drillToAttributeUrl(drillDefinition: IDrillToAttributeUrl, drill
 export function drillToAttributeUrlRequested(ctx: DashboardContext, drillDefinition: IDrillToAttributeUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToAttributeUrlRequested;
 
 // @alpha (undocumented)
-export function drillToAttributeUrlResolved(ctx: DashboardContext, url: string, drillDefinition: IDrillToAttributeUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToAttributeUrlResolved;
+export function drillToAttributeUrlResolved(ctx: DashboardContext, url: string, drillDefinition: IDrillToAttributeUrl, drillEvent: IDashboardDrillEvent, filtersInfo: FiltersInfo, correlationId?: string): DashboardDrillToAttributeUrlResolved;
 
 // @alpha (undocumented)
 export interface DrillToCustomUrl extends IDashboardCommand {
@@ -1611,7 +1614,7 @@ export function drillToCustomUrl(drillDefinition: IDrillToCustomUrl, drillEvent:
 export function drillToCustomUrlRequested(ctx: DashboardContext, drillDefinition: IDrillToCustomUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToCustomUrlRequested;
 
 // @alpha (undocumented)
-export function drillToCustomUrlResolved(ctx: DashboardContext, url: string, drillDefinition: IDrillToCustomUrl, drillEvent: IDashboardDrillEvent, correlationId?: string): DashboardDrillToCustomUrlResolved;
+export function drillToCustomUrlResolved(ctx: DashboardContext, url: string, drillDefinition: IDrillToCustomUrl, drillEvent: IDashboardDrillEvent, filtersInfo: FiltersInfo, correlationId?: string): DashboardDrillToCustomUrlResolved;
 
 // @alpha (undocumented)
 export interface DrillToDashboard extends IDashboardCommand {
@@ -1759,6 +1762,12 @@ export interface FilterOpUnignoreAttributeFilter extends FilterOp {
     // (undocumented)
     type: "unignoreAttributeFilter";
 }
+
+// @alpha
+export type FiltersInfo = {
+    filters: IDashboardFilter[];
+    resolvedFilterValues?: IResolvedFilterValues;
+};
 
 // @internal (undocumented)
 export function getDrillDownAttributeTitle(localIdentifier: string, drillEvent: IDrillEvent): string;
@@ -2229,6 +2238,9 @@ export function isDashboardEvent(obj: unknown): obj is IDashboardEvent;
 
 // @alpha
 export function isDashboardEventOrCustomDashboardEvent(obj: unknown): obj is IDashboardEvent | ICustomDashboardEvent;
+
+// @alpha
+export function isDashboardFilter(obj: unknown): obj is IDashboardFilter;
 
 // @alpha
 export const isDashboardFilterContextChanged: (obj: unknown) => obj is DashboardFilterContextChanged;
@@ -3012,6 +3024,9 @@ export const selectEffectiveDateFilterTitle: OutputSelector<DashboardState, stri
 
 // @alpha
 export const selectEnableCompanyLogoInEmbeddedUI: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
+// @alpha
+export const selectEnableFilterValuesResolutionInDrillEvents: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha
 export const selectEnableKPIDashboardSchedule: OutputSelector<DashboardState, boolean | undefined, (res: ResolvedDashboardConfig) => boolean | undefined>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -164,6 +164,7 @@ export function* resolveDashboardConfig(
         isEmbedded: config.isEmbedded ?? false,
         isExport: config.isExport ?? false,
         disableDefaultDrills: config.disableDefaultDrills ?? false,
+        enableFilterValuesResolutionInDrillEvents: config.enableFilterValuesResolutionInDrillEvents ?? false,
     };
 
     return resolvedConfig;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -186,6 +186,7 @@ Object {
     "selectedOption": "THIS_MONTH",
   },
   "disableDefaultDrills": false,
+  "enableFilterValuesResolutionInDrillEvents": false,
   "isEmbedded": false,
   "isExport": false,
   "isReadOnly": false,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
@@ -1,0 +1,38 @@
+// (C) 2021 GoodData Corporation
+
+import { call, select, SagaReturnType } from "redux-saga/effects";
+import { SagaIterator } from "redux-saga";
+import { ObjRef } from "@gooddata/sdk-model";
+import { selectEnableFilterValuesResolutionInDrillEvents } from "../../state/config/configSelectors";
+import { DashboardContext, FiltersInfo } from "../../types/commonTypes";
+import { resolveFilterValues } from "./common/filterValuesResolver";
+import { queryWidgetFilters } from "../../queries";
+import { QueryWidgetFiltersService } from "../../queryServices/queryWidgetFilters";
+import { isDashboardFilter } from "../../../types";
+
+export function* getDrillToUrlFiltersWithResolvedValues(
+    ctx: DashboardContext,
+    widgetRef: ObjRef,
+): SagaIterator<FiltersInfo> {
+    const query = queryWidgetFilters(widgetRef);
+    const effectiveFilters: SagaReturnType<typeof QueryWidgetFiltersService.generator> = yield call(
+        QueryWidgetFiltersService.generator,
+        ctx,
+        query,
+    );
+    const filters = effectiveFilters.filter(isDashboardFilter);
+
+    const enableFilterValuesResolutionInDrillEvents: SagaReturnType<
+        typeof selectEnableFilterValuesResolutionInDrillEvents
+    > = yield select(selectEnableFilterValuesResolutionInDrillEvents);
+    if (enableFilterValuesResolutionInDrillEvents) {
+        const resolvedFilterValues: SagaReturnType<typeof resolveFilterValues> = yield call(
+            resolveFilterValues,
+            filters,
+        );
+
+        return { filters, resolvedFilterValues };
+    }
+
+    return { filters };
+}

--- a/libs/sdk-ui-dashboard/src/model/events/drill.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/drill.ts
@@ -9,7 +9,7 @@ import {
     IDrillToLegacyDashboard,
 } from "@gooddata/sdk-backend-spi";
 
-import { DashboardContext } from "../types/commonTypes";
+import { DashboardContext, FiltersInfo } from "../types/commonTypes";
 import { IDashboardEvent } from "./base";
 import {
     IDashboardDrillEvent,
@@ -551,6 +551,10 @@ export interface DashboardDrillToCustomUrlResolved extends IDashboardEvent {
          * Resolved custom url.
          */
         readonly url: string;
+        /**
+         * Information about filters used on the dashboard.
+         */
+        readonly filtersInfo: FiltersInfo;
     };
 }
 
@@ -562,6 +566,7 @@ export function drillToCustomUrlResolved(
     url: string,
     drillDefinition: IDrillToCustomUrl,
     drillEvent: IDashboardDrillEvent,
+    filtersInfo: FiltersInfo,
     correlationId?: string,
 ): DashboardDrillToCustomUrlResolved {
     return {
@@ -572,6 +577,7 @@ export function drillToCustomUrlResolved(
             url,
             drillEvent,
             drillDefinition,
+            filtersInfo,
         },
     };
 }
@@ -660,6 +666,10 @@ export interface DashboardDrillToAttributeUrlResolved extends IDashboardEvent {
          * Resolved attribute url.
          */
         readonly url: string;
+        /**
+         * Information about filters used on the dashboard.
+         */
+        readonly filtersInfo: FiltersInfo;
     };
 }
 
@@ -671,6 +681,7 @@ export function drillToAttributeUrlResolved(
     url: string,
     drillDefinition: IDrillToAttributeUrl,
     drillEvent: IDashboardDrillEvent,
+    filtersInfo: FiltersInfo,
     correlationId?: string,
 ): DashboardDrillToAttributeUrlResolved {
     return {
@@ -681,6 +692,7 @@ export function drillToAttributeUrlResolved(
             drillEvent,
             drillDefinition,
             url,
+            filtersInfo,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -38,6 +38,7 @@ export {
     selectIsExport,
     selectPlatformEdition,
     selectDisableDefaultDrills,
+    selectEnableFilterValuesResolutionInDrillEvents,
 } from "./state/config/configSelectors";
 export { PermissionsState } from "./state/permissions/permissionsState";
 export {
@@ -143,6 +144,7 @@ export {
     DashboardContext,
     ObjectAvailabilityConfig,
     DashboardConfig,
+    FiltersInfo,
     ResolvedDashboardConfig,
     ResolvableFilter,
     ResolvedDateFilterValues,

--- a/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/config/configSelectors.ts
@@ -128,6 +128,15 @@ export const selectDisableDefaultDrills = createSelector(selectConfig, (state) =
     return state.disableDefaultDrills ?? false;
 });
 
+/**
+ * Returns whether filter values in drill events should be resolved.
+ *
+ * @alpha
+ */
+export const selectEnableFilterValuesResolutionInDrillEvents = createSelector(selectConfig, (state) => {
+    return state.enableFilterValuesResolutionInDrillEvents ?? false;
+});
+
 //
 // FEATURE FLAGS
 //

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -106,6 +106,13 @@ export type DashboardConfig = {
      * Defaults to false.
      */
     disableDefaultDrills?: boolean;
+
+    /**
+     * If set to true, filter values will resolve in drill events.
+     *
+     * Defaults to false.
+     */
+    enableFilterValuesResolutionInDrillEvents?: boolean;
 };
 
 /**
@@ -217,3 +224,13 @@ export interface IResolvedFilterValues {
  * @alpha
  */
 export type ResolvableFilter = IDashboardFilter;
+
+/**
+ * Contains information about dashboard filters.
+ *
+ * @alpha
+ */
+export type FiltersInfo = {
+    filters: IDashboardFilter[];
+    resolvedFilterValues?: IResolvedFilterValues;
+};

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -7,6 +7,8 @@ import {
     INegativeAttributeFilter,
     IPositiveAttributeFilter,
     IRelativeDateFilter,
+    isAttributeFilter,
+    isDateFilter,
     LocalIdRef,
     ObjRef,
 } from "@gooddata/sdk-model";
@@ -21,6 +23,15 @@ export type IDashboardFilter =
     | IRelativeDateFilter
     | IPositiveAttributeFilter
     | INegativeAttributeFilter;
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IDashboardFilter}.
+ *
+ * @alpha
+ */
+export function isDashboardFilter(obj: unknown): obj is IDashboardFilter {
+    return isAttributeFilter(obj) || isDateFilter(obj);
+}
 
 /**
  * Supported dashboard drill definitions.


### PR DESCRIPTION
DrillToUrl events should be expanded by filtersInfo which consists of used filters and resolvedFilterValues when filter values resolution is enabled.

JIRA: TNT-151

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
