### PR TITLE
RELATED: RAIL-3645 Align KPI error behavior with gdc-dashboards

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/de-DE.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "z. B.",
     "kpi.alertBox.unverifiedEmail": "Leider können Sie keinen Alarm sehen. Überprüfen Sie Ihre E-Mail. Wenn das nichts nützt, bitten Sie Ihren Administrator, Ihre Berechtigungen zu aktualisieren.",
     "kpi.alertBox.disabledInReadOnly": "Warnmeldungen im schreibgeschützten Modus deaktiviert",
+    "kpi.error.view": "KPI kann nicht angezeigt werden. Setzen Sie sich mit Ihrem Administrator in Verbindung, um die KPI-Definition festzulegen.",
     "kpiAlertDialog.delete": "Löschen",
     "kpiAlertDialog.deleting": "Wird gelöscht…",
     "kpiAlertDialog.emailMe": "Schicken Sie mir eine E-Mail",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -274,6 +274,11 @@
         "comment": "",
         "limit": 0
     },
+    "kpi.error.view": {
+        "value": "KPI cannot be displayed. Contact your administrator to fix the KPI definition.",
+        "comment": "",
+        "limit": 0
+    },
     "kpiAlertDialog.delete": {
         "value": "Delete",
         "comment": "",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/es-ES.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "p. ej.",
     "kpi.alertBox.unverifiedEmail": "Lo sentimos, no puede establecer una alerta. Asegúrese de que su correo electrónico está verificado. Si prosigue el problema, pídale a su administrador que actualice sus permisos.",
     "kpi.alertBox.disabledInReadOnly": "Las alertas están desactivadas en el modo de solo lectura",
+    "kpi.error.view": "No se puede mostrar el KPI. Póngase en contacto con su administrador para solucionar la definición del KPI.",
     "kpiAlertDialog.delete": "Eliminar",
     "kpiAlertDialog.deleting": "Eliminando…",
     "kpiAlertDialog.emailMe": "Enviarme un correo electrónico",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/fr-FR.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "Par ex.",
     "kpi.alertBox.unverifiedEmail": "Désolé, vous ne pouvez pas définir une alerte. Assurez-vous que votre e-mail est vérifié. Si cela n'aide pas, demandez à votre administrateur de mettre à jour vos autorisations.",
     "kpi.alertBox.disabledInReadOnly": "Les alertes sont désactivées en mode lecture seule",
+    "kpi.error.view": "Impossible d'afficher le KPI. Contactez votre administrateur pour corriger la définition du KPI.",
     "kpiAlertDialog.delete": "Supprimer",
     "kpiAlertDialog.deleting": "Suppression en cours…",
     "kpiAlertDialog.emailMe": "Envoyez-moi un e-mail",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/ja-JP.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "例:",
     "kpi.alertBox.unverifiedEmail": "申し訳ございませんが、通知を設定できません。電子メールが有効なことを確認してください。それでも問題が解決しない場合は、管理者にあなたの許可を更新するように要請してください。",
     "kpi.alertBox.disabledInReadOnly": "読み取り専用モードではアラートは無効になっています",
+    "kpi.error.view": "KPIを表示できません。管理者にKPI定義を修正するように要請してください。",
     "kpiAlertDialog.delete": "削除",
     "kpiAlertDialog.deleting": "消去しています…",
     "kpiAlertDialog.emailMe": "電子メールの受信を希望",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/nl-NL.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "bijv.",
     "kpi.alertBox.unverifiedEmail": "Sorry, u kunt geen alarm instellen. Zorg ervoor dat uw e-mailadres is geverifieerd. Als dit niet helpt, vraag uw beheerder dan om uw machtigingen bij te werken.",
     "kpi.alertBox.disabledInReadOnly": "Alarmen zijn uitgeschakeld in alleen-lezen",
+    "kpi.error.view": "KPI kan niet worden weergegeven. Neem contact op met uw beheerder om de KPI-definitie te corrigeren.",
     "kpiAlertDialog.delete": "Verwijderen",
     "kpiAlertDialog.deleting": "Verwijderen…",
     "kpiAlertDialog.emailMe": "E-mail mij",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-BR.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "p. ex.,",
     "kpi.alertBox.unverifiedEmail": "Infelizmente, você não pode definir um alerta. Garanta que seu e-mail seja verificado. Se isso não ajudar, peça para o administrador atualizar suas permissões.",
     "kpi.alertBox.disabledInReadOnly": "Os alertas estão desabilitados no modo somente leitura",
+    "kpi.error.view": "Não é possível exibir o KPI. Entre em contato com seu administrador para corrigir a definição do KPI.",
     "kpiAlertDialog.delete": "Excluir",
     "kpiAlertDialog.deleting": "Excluindo…",
     "kpiAlertDialog.emailMe": "Enviar-me e-mail",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/pt-PT.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "por ex.",
     "kpi.alertBox.unverifiedEmail": "Lamentamos, não pode definir um alerta. Certifique-se de que o seu e-mail foi verificado. Se isso não ajudar, solicite a atualização das suas permissões ao administrador.",
     "kpi.alertBox.disabledInReadOnly": "Os alertas encontram-se desativados no modo só de leitura",
+    "kpi.error.view": "Não é possível apresentar o KPI. Contacte o administrador para corrigir a definição do KPI.",
     "kpiAlertDialog.delete": "Eliminar",
     "kpiAlertDialog.deleting": "A eliminar…",
     "kpiAlertDialog.emailMe": "Enviar-me um e-mail",

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/zh-Hans.json
@@ -54,6 +54,7 @@
     "kpi.alertBox.example": "例如",
     "kpi.alertBox.unverifiedEmail": "抱歉，您无法设置警报。请确保您的电子邮件地址已经过验证。如果还未解决问题，请让管理员更新您的权限。",
     "kpi.alertBox.disabledInReadOnly": "在只读模式下禁用警报",
+    "kpi.error.view": "无法显示 KPI。请与您的管理员联系以修复 KPI 定义。",
     "kpiAlertDialog.delete": "删除",
     "kpiAlertDialog.deleting": "正在删除…",
     "kpiAlertDialog.emailMe": "给我发邮件",

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
@@ -96,7 +96,6 @@ export const DashboardKpiCore = (props: DashboardKpiProps): JSX.Element => {
             disableDrillUnderline={settings.disableKpiDashboardHeadlineUnderline}
             backend={backend}
             workspace={workspace}
-            ErrorComponent={ErrorComponent}
             LoadingComponent={LoadingComponent}
             isReadOnly={isReadOnly}
         />

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -27,10 +27,8 @@ import {
     IDataSeries,
     IDrillableItem,
     IDrillEventContext,
-    IErrorProps,
     IHeaderPredicate,
     ILoadingProps,
-    isNoDataSdkError,
     isSomeHeaderPredicateMatched,
     NoDataSdkError,
     OnError,
@@ -88,7 +86,6 @@ interface IKpiExecutorProps {
     separators: ISeparators;
     disableDrillUnderline?: boolean;
     isReadOnly?: boolean;
-    ErrorComponent?: React.ComponentType<IErrorProps>;
     LoadingComponent?: React.ComponentType<ILoadingProps>;
 }
 
@@ -110,14 +107,12 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
     disableDrillUnderline,
     intl,
     isReadOnly,
-    ErrorComponent: CustomErrorComponent,
     LoadingComponent: CustomLoadingComponent,
 }) => {
     const currentUser = useDashboardSelector(selectUser);
     const permissions = useDashboardSelector(selectPermissions);
     const settings = useDashboardSelector(selectSettings);
-    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext({
-        ErrorComponent: CustomErrorComponent,
+    const { LoadingComponent } = useDashboardComponentsContext({
         LoadingComponent: CustomLoadingComponent,
     });
 
@@ -348,9 +343,6 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
             alertSavingStatus={alertSavingStatus}
         >
             {() => {
-                if (status === "error" && !isNoDataSdkError(error)) {
-                    return <ErrorComponent message={(error! as Error).message} />;
-                }
                 return (
                     <KpiRenderer
                         kpi={kpiWidget}
@@ -361,6 +353,8 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps & WrappedComponentProps> = ({
                         onDrill={onDrill && handleOnDrill}
                         separators={separators}
                         enableCompactSize={enableCompactSize}
+                        error={error}
+                        errorHelp={intl.formatMessage({ id: "kpi.error.view" })}
                     />
                 );
             }}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
@@ -1,6 +1,6 @@
 // (C) 2020 GoodData Corporation
 import React, { useCallback } from "react";
-import { IDrillEventContext } from "@gooddata/sdk-ui";
+import { GoodDataSdkError, IDrillEventContext } from "@gooddata/sdk-ui";
 import { ISeparators, IKpiWidget, IKpiWidgetDefinition } from "@gooddata/sdk-backend-spi";
 import { IFilter } from "@gooddata/sdk-model";
 
@@ -18,6 +18,8 @@ interface IKpiRendererProps {
     isDrillable?: boolean;
     onDrill?: (drillContext: IDrillEventContext) => ReturnType<OnFiredDashboardViewDrillEvent>;
     enableCompactSize?: boolean;
+    error?: GoodDataSdkError;
+    errorHelp?: string;
 }
 
 /**
@@ -32,6 +34,8 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
     filters,
     separators,
     enableCompactSize,
+    error,
+    errorHelp,
 }) => {
     const onPrimaryValueClick = useCallback(() => {
         if (!isDrillable || !onDrill || !kpiResult) {
@@ -59,6 +63,8 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
             filters={filters}
             separators={separators}
             enableCompactSize={enableCompactSize}
+            error={error}
+            errorHelp={errorHelp}
         />
     );
 };


### PR DESCRIPTION
KPIs should not use the custom ErrorComponent for their execution
errors, they render them instead of the value (not with ErrorComponent).

We need to revisit this to enable customization if needed in the future.

JIRA: RAIL-3645

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
