### PR TITLE
RELATED: RAIL-3622 Make the parent filters work in Dashboard component

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/addAttributeFilterHandler.ts
@@ -9,7 +9,7 @@ import { invalidArgumentsProvided } from "../../../events/general";
 import { attributeFilterAdded } from "../../../events/filters";
 import { filterContextActions } from "../../../state/filterContext";
 import {
-    makeSelectFilterContextAttributeFilterByDisplayForm,
+    selectFilterContextAttributeFilterByDisplayForm,
     selectFilterContextAttributeFilters,
 } from "../../../state/filterContext/filterContextSelectors";
 
@@ -54,11 +54,8 @@ export function* addAttributeFilterHandler(
         }),
     );
 
-    const selectAddedFilter = makeSelectFilterContextAttributeFilterByDisplayForm();
-    const addedFilter: ReturnType<typeof selectAddedFilter> = yield select(
-        selectAddedFilter,
-        cmd.payload.displayForm,
-    );
+    const addedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByDisplayForm>> =
+        yield select(selectFilterContextAttributeFilterByDisplayForm(cmd.payload.displayForm));
 
     invariant(addedFilter, "Inconsistent state in attributeFilterAddCommandHandler");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/changeAttributeFilterSelectionHandler.ts
@@ -9,7 +9,7 @@ import { ChangeAttributeFilterSelection } from "../../../commands/filters";
 import { filterContextActions } from "../../../state/filterContext";
 import { DashboardContext } from "../../../types/commonTypes";
 import { dispatchFilterContextChanged } from "../common";
-import { makeSelectFilterContextAttributeFilterByLocalId } from "../../../state/filterContext/filterContextSelectors";
+import { selectFilterContextAttributeFilterByLocalId } from "../../../state/filterContext/filterContextSelectors";
 import { dispatchDashboardEvent } from "../../../state/_infra/eventDispatcher";
 
 export function* changeAttributeFilterSelectionHandler(
@@ -18,13 +18,9 @@ export function* changeAttributeFilterSelectionHandler(
 ): SagaIterator<void> {
     const { elements, filterLocalId, selectionType } = cmd.payload;
 
-    const selectFilterByLocalId = makeSelectFilterContextAttributeFilterByLocalId();
-
     // validate filterLocalId
-    const affectedFilter: ReturnType<typeof selectFilterByLocalId> = yield select(
-        selectFilterByLocalId,
-        cmd.payload.filterLocalId,
-    );
+    const affectedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
+        yield select(selectFilterContextAttributeFilterByLocalId(cmd.payload.filterLocalId));
 
     if (!affectedFilter) {
         throw invalidArgumentsProvided(ctx, cmd, `Filter with filterLocalId ${filterLocalId} not found.`);
@@ -38,10 +34,8 @@ export function* changeAttributeFilterSelectionHandler(
         }),
     );
 
-    const changedFilter: ReturnType<typeof selectFilterByLocalId> = yield select(
-        selectFilterByLocalId,
-        cmd.payload.filterLocalId,
-    );
+    const changedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
+        yield select(selectFilterContextAttributeFilterByLocalId(cmd.payload.filterLocalId));
 
     invariant(changedFilter, "Inconsistent state in attributeFilterChangeSelectionCommandHandler");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/moveAttributeFilterHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/moveAttributeFilterHandler.ts
@@ -6,8 +6,8 @@ import { invalidArgumentsProvided } from "../../../events/general";
 import { attributeFilterMoved } from "../../../events/filters";
 import { filterContextActions } from "../../../state/filterContext";
 import {
-    makeSelectFilterContextAttributeFilterByLocalId,
-    makeSelectFilterContextAttributeFilterIndexByLocalId,
+    selectFilterContextAttributeFilterByLocalId,
+    selectFilterContextAttributeFilterIndexByLocalId,
     selectFilterContextFilters,
 } from "../../../state/filterContext/filterContextSelectors";
 import { DashboardContext } from "../../../types/commonTypes";
@@ -21,12 +21,8 @@ export function* moveAttributeFilterHandler(
     const { filterLocalId, index } = cmd.payload;
 
     // validate filterLocalId
-    const selectFilterByLocalId = makeSelectFilterContextAttributeFilterByLocalId();
-
-    const affectedFilter: ReturnType<typeof selectFilterByLocalId> = yield select(
-        selectFilterByLocalId,
-        filterLocalId,
-    );
+    const affectedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
+        yield select(selectFilterContextAttributeFilterByLocalId(filterLocalId));
 
     if (!affectedFilter) {
         throw invalidArgumentsProvided(ctx, cmd, `Filter with filterLocalId ${filterLocalId} not found.`);
@@ -47,12 +43,8 @@ export function* moveAttributeFilterHandler(
         );
     }
 
-    const selectFilterIndexByLocalId = makeSelectFilterContextAttributeFilterIndexByLocalId();
-
-    const originalIndex: ReturnType<typeof selectFilterIndexByLocalId> = yield select(
-        selectFilterIndexByLocalId,
-        filterLocalId,
-    );
+    const originalIndex: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterIndexByLocalId>> =
+        yield select(selectFilterContextAttributeFilterIndexByLocalId(filterLocalId));
 
     yield put(
         filterContextActions.moveAttributeFilter({
@@ -61,10 +53,8 @@ export function* moveAttributeFilterHandler(
         }),
     );
 
-    const finalIndex: ReturnType<typeof selectFilterIndexByLocalId> = yield select(
-        selectFilterIndexByLocalId,
-        filterLocalId,
-    );
+    const finalIndex: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterIndexByLocalId>> =
+        yield select(selectFilterContextAttributeFilterIndexByLocalId(filterLocalId));
 
     yield dispatchDashboardEvent(
         attributeFilterMoved(ctx, affectedFilter, originalIndex, finalIndex, cmd.correlationId),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/setAttributeFilterParentHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/setAttributeFilterParentHandler.ts
@@ -8,7 +8,7 @@ import { invalidArgumentsProvided } from "../../../events/general";
 import { attributeFilterParentChanged } from "../../../events/filters";
 import { filterContextActions } from "../../../state/filterContext";
 import {
-    makeSelectFilterContextAttributeFilterByLocalId,
+    selectFilterContextAttributeFilterByLocalId,
     selectFilterContextAttributeFilters,
 } from "../../../state/filterContext/filterContextSelectors";
 import { DashboardContext } from "../../../types/commonTypes";
@@ -26,12 +26,8 @@ export function* setAttributeFilterParentHandler(
         selectFilterContextAttributeFilters,
     );
 
-    const selectFilterByLocalId = makeSelectFilterContextAttributeFilterByLocalId();
-
-    const affectedFilter: ReturnType<typeof selectFilterByLocalId> = yield select(
-        selectFilterByLocalId,
-        filterLocalId,
-    );
+    const affectedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
+        yield select(selectFilterContextAttributeFilterByLocalId(filterLocalId));
 
     if (!affectedFilter) {
         throw invalidArgumentsProvided(ctx, cmd, `Filter with localId ${filterLocalId} was not found.`);
@@ -62,10 +58,8 @@ export function* setAttributeFilterParentHandler(
         }),
     );
 
-    const changedFilter: ReturnType<typeof selectFilterByLocalId> = yield select(
-        selectFilterByLocalId,
-        filterLocalId,
-    );
+    const changedFilter: ReturnType<ReturnType<typeof selectFilterContextAttributeFilterByLocalId>> =
+        yield select(selectFilterContextAttributeFilterByLocalId(filterLocalId));
 
     invariant(changedFilter, "Inconsistent state in attributeFilterSetParentCommandHandler");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
@@ -4,7 +4,7 @@ import { SagaIterator } from "redux-saga";
 import { DashboardContext } from "../../types/commonTypes";
 import { ChangeFilterContextSelection } from "../../commands";
 import { filterContextActions } from "../../state/filterContext";
-import { makeSelectFilterContextAttributeFilterByDisplayForm } from "../../state/filterContext/filterContextSelectors";
+import { selectFilterContextAttributeFilterByDisplayForm } from "../../state/filterContext/filterContextSelectors";
 import { batchActions } from "redux-batched-actions";
 import { AnyAction } from "@reduxjs/toolkit";
 import { dispatchFilterContextChanged } from "./common";
@@ -31,15 +31,12 @@ export function* changeFilterContextSelectionHandler(
 
     const [attributeFilters, [dateFilter]] = partition(uniqueFilters, isAttributeFilter);
 
-    const selectFilterByDisplayForm = makeSelectFilterContextAttributeFilterByDisplayForm();
-
     const updateActions: AnyAction[] = [];
     for (const attributeFilter of attributeFilters) {
         const filterRef = filterObjRef(attributeFilter);
-        const dashboardFilter: ReturnType<typeof selectFilterByDisplayForm> = yield select(
-            selectFilterByDisplayForm,
-            filterRef,
-        );
+        const dashboardFilter: ReturnType<
+            ReturnType<typeof selectFilterContextAttributeFilterByDisplayForm>
+        > = yield select(selectFilterContextAttributeFilterByDisplayForm(filterRef));
 
         if (dashboardFilter) {
             updateActions.push(

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
@@ -2,6 +2,7 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { DashboardState } from "../types";
 import invariant from "ts-invariant";
+import memoize from "lodash/memoize";
 import {
     FilterContextItem,
     IDashboardAttributeFilter,
@@ -9,7 +10,7 @@ import {
     isDashboardAttributeFilter,
     isDashboardDateFilter,
 } from "@gooddata/sdk-backend-spi";
-import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
+import { areObjRefsEqual, ObjRef, serializeObjRef } from "@gooddata/sdk-model";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -64,46 +65,37 @@ export const selectFilterContextDateFilter = createSelector(
 /**
  * Creates a selector for selecting attribute filter by its displayForm {@link @gooddata/sdk-model#ObjRef}.
  *
- * TODO: switch to select.. with memoize
- *
  * @alpha
  */
-export const makeSelectFilterContextAttributeFilterByDisplayForm = () =>
-    createSelector(
-        selectFilterContextAttributeFilters,
-        (_: any, displayForm: ObjRef) => displayForm,
-        (attributeFilters, displayForm) =>
+export const selectFilterContextAttributeFilterByDisplayForm = memoize(
+    (displayForm: ObjRef) =>
+        createSelector(selectFilterContextAttributeFilters, (attributeFilters) =>
             attributeFilters.find((filter) =>
                 areObjRefsEqual(filter.attributeFilter.displayForm, displayForm),
             ),
-    );
+        ),
+    (ref) => ref && serializeObjRef(ref),
+);
 
 /**
  * Creates a selector for selecting attribute filter by its localId.
  *
- * TODO: switch to select.. with memoize
- *
  * @alpha
  */
-export const makeSelectFilterContextAttributeFilterByLocalId = () =>
-    createSelector(
-        selectFilterContextAttributeFilters,
-        (_: any, localId: string) => localId,
-        (attributeFilters, localId) =>
-            attributeFilters.find((filter) => filter.attributeFilter.localIdentifier === localId),
-    );
+export const selectFilterContextAttributeFilterByLocalId = memoize((localId: string) =>
+    createSelector(selectFilterContextAttributeFilters, (attributeFilters) =>
+        attributeFilters.find((filter) => filter.attributeFilter.localIdentifier === localId),
+    ),
+);
 
 /**
  * Creates a selector for selecting attribute filter index by its localId.
  *
- * TODO: switch to select.. with memoize
  *
  * @alpha
  */
-export const makeSelectFilterContextAttributeFilterIndexByLocalId = () =>
-    createSelector(
-        selectFilterContextAttributeFilters,
-        (_: any, localId: string) => localId,
-        (attributeFilters, localId) =>
-            attributeFilters.findIndex((filter) => filter.attributeFilter.localIdentifier === localId),
-    );
+export const selectFilterContextAttributeFilterIndexByLocalId = memoize((localId: string) =>
+    createSelector(selectFilterContextAttributeFilters, (attributeFilters) =>
+        attributeFilters.findIndex((filter) => filter.attributeFilter.localIdentifier === localId),
+    ),
+);

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -13,12 +13,15 @@ import {
 } from "./DashboardAttributeFilterPropsContext";
 import { IDashboardAttributeFilterProps } from "./types";
 import { AttributeFilterBody } from "./dashboardDropdownBody/AttributeFilterBody";
+import { useParentFilters } from "./useParentFilters";
 
 /**
  * @internal
  */
 export const DefaultDashboardAttributeFilterInner = (): JSX.Element => {
     const { filter, onFilterChanged } = useDashboardAttributeFilterProps();
+    const { parentFilters, parentFilterOverAttribute } = useParentFilters(filter);
+
     return (
         <AttributeFilterButton
             // TODO: https://jira.intgdc.com/browse/RAIL-2174
@@ -36,6 +39,8 @@ export const DefaultDashboardAttributeFilterInner = (): JSX.Element => {
             renderBody={(filterBodyProps: IAttributeDropdownBodyExtendedProps) => {
                 return <AttributeFilterBody {...filterBodyProps} />;
             }}
+            parentFilters={parentFilters}
+            parentFilterOverAttribute={parentFilterOverAttribute}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
@@ -1,0 +1,86 @@
+// (C) 2021 GoodData Corporation
+import { useMemo } from "react";
+import invariant from "ts-invariant";
+import { areObjRefsEqual, filterObjRef, IAttributeFilter, ObjRef } from "@gooddata/sdk-model";
+import { IDashboardAttributeFilter } from "@gooddata/sdk-backend-spi";
+
+import { dashboardAttributeFilterToAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter";
+import { selectFilterContextAttributeFilters, useDashboardSelector } from "../../../model";
+import { IAttributeFilterButtonProps } from "@gooddata/sdk-ui-filters";
+
+type UseParentFiltersResult = Pick<
+    IAttributeFilterButtonProps,
+    "parentFilters" | "parentFilterOverAttribute"
+>;
+
+/**
+ * Returns parent filter-related data to use as AttributeFilterButton props.
+ * @param filter - filter to get the parent filter-related data
+ */
+export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFiltersResult => {
+    const allAttributeFilters = useDashboardSelector(selectFilterContextAttributeFilters);
+
+    // for all parent filters: a map localId -> the filter object
+    // this is then used to derive parentFilterOver attributes
+    const parentFiltersMap = useMemo(() => {
+        if (!filter.attributeFilter.filterElementsBy) {
+            return {};
+        }
+        return filter.attributeFilter.filterElementsBy.reduce(
+            (acc: Record<string, IDashboardAttributeFilter>, curr) => {
+                const matchingFilter = allAttributeFilters.find(
+                    (filter) => filter.attributeFilter.localIdentifier === curr.filterLocalIdentifier,
+                );
+
+                invariant(matchingFilter); // if this blows up, the state is inconsistent
+
+                acc[curr.filterLocalIdentifier] = matchingFilter;
+                return acc;
+            },
+            {},
+        );
+    }, [allAttributeFilters, filter.attributeFilter.filterElementsBy]);
+
+    const parentFilters = useMemo(() => {
+        const values = Object.values(parentFiltersMap);
+        return values.length > 0 ? values.map(dashboardAttributeFilterToAttributeFilter) : undefined;
+    }, [parentFiltersMap]);
+
+    const parentOverLookup = useMemo(() => {
+        // no parents -> no need for the lookup function
+        if (!filter.attributeFilter.filterElementsBy) {
+            return undefined;
+        }
+        // function looking up the over attribute based on a parent filter object
+        // this is so convoluted, because the Dashboard data use localIds to identify parent filters
+        // while the AttributeFilterButton uses the IAttributeFilter which do not have localIds
+        // so we have to do some "back linking" here
+        return (parentFilter: IAttributeFilter): ObjRef => {
+            // translate the parent filter back to its original localId...
+            const originalLocalId = Object.keys(parentFiltersMap).find((localId) => {
+                // we know the refs are of the same type here: both sides of the expression were created using the same source data
+                return areObjRefsEqual(
+                    parentFiltersMap[localId].attributeFilter.displayForm,
+                    filterObjRef(parentFilter),
+                );
+            });
+
+            invariant(originalLocalId); // if this blows up, the state is inconsistent
+
+            // ...then find the original filterElementsBy item...
+            const match = filter.attributeFilter.filterElementsBy!.find(
+                (item) => item.filterLocalIdentifier === originalLocalId,
+            );
+
+            invariant(match); // if this blows up, the state is inconsistent
+
+            // ...and return its first "over attribute"
+            return match.over.attributes[0];
+        };
+    }, [parentFiltersMap, filter.attributeFilter.filterElementsBy]);
+
+    return {
+        parentFilters,
+        parentFilterOverAttribute: parentOverLookup,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/useParentFilters.ts
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 import { useMemo } from "react";
 import invariant from "ts-invariant";
-import { areObjRefsEqual, filterObjRef, IAttributeFilter, ObjRef } from "@gooddata/sdk-model";
+import { IAttributeFilter, ObjRef } from "@gooddata/sdk-model";
 import { IDashboardAttributeFilter } from "@gooddata/sdk-backend-spi";
 
 import { dashboardAttributeFilterToAttributeFilter } from "../../../_staging/dashboard/dashboardFilterConverter";
@@ -20,64 +20,30 @@ type UseParentFiltersResult = Pick<
 export const useParentFilters = (filter: IDashboardAttributeFilter): UseParentFiltersResult => {
     const allAttributeFilters = useDashboardSelector(selectFilterContextAttributeFilters);
 
-    // for all parent filters: a map localId -> the filter object
-    // this is then used to derive parentFilterOver attributes
-    const parentFiltersMap = useMemo(() => {
-        if (!filter.attributeFilter.filterElementsBy) {
-            return {};
-        }
-        return filter.attributeFilter.filterElementsBy.reduce(
-            (acc: Record<string, IDashboardAttributeFilter>, curr) => {
-                const matchingFilter = allAttributeFilters.find(
-                    (filter) => filter.attributeFilter.localIdentifier === curr.filterLocalIdentifier,
-                );
+    const parentFiltersData = useMemo(() => {
+        return filter.attributeFilter.filterElementsBy?.map((parent) => {
+            const matchingFilter = allAttributeFilters.find(
+                (filter) => filter.attributeFilter.localIdentifier === parent.filterLocalIdentifier,
+            );
 
-                invariant(matchingFilter); // if this blows up, the state is inconsistent
+            invariant(matchingFilter); // if this blows up, the state is inconsistent
 
-                acc[curr.filterLocalIdentifier] = matchingFilter;
-                return acc;
-            },
-            {},
-        );
+            return { filter: matchingFilter, over: parent.over.attributes[0] };
+        });
     }, [allAttributeFilters, filter.attributeFilter.filterElementsBy]);
 
     const parentFilters = useMemo(() => {
-        const values = Object.values(parentFiltersMap);
-        return values.length > 0 ? values.map(dashboardAttributeFilterToAttributeFilter) : undefined;
-    }, [parentFiltersMap]);
+        return parentFiltersData?.map((item) => dashboardAttributeFilterToAttributeFilter(item.filter));
+    }, [parentFiltersData]);
 
     const parentOverLookup = useMemo(() => {
         // no parents -> no need for the lookup function
-        if (!filter.attributeFilter.filterElementsBy) {
+        if (!parentFiltersData) {
             return undefined;
         }
-        // function looking up the over attribute based on a parent filter object
-        // this is so convoluted, because the Dashboard data use localIds to identify parent filters
-        // while the AttributeFilterButton uses the IAttributeFilter which do not have localIds
-        // so we have to do some "back linking" here
-        return (parentFilter: IAttributeFilter): ObjRef => {
-            // translate the parent filter back to its original localId...
-            const originalLocalId = Object.keys(parentFiltersMap).find((localId) => {
-                // we know the refs are of the same type here: both sides of the expression were created using the same source data
-                return areObjRefsEqual(
-                    parentFiltersMap[localId].attributeFilter.displayForm,
-                    filterObjRef(parentFilter),
-                );
-            });
 
-            invariant(originalLocalId); // if this blows up, the state is inconsistent
-
-            // ...then find the original filterElementsBy item...
-            const match = filter.attributeFilter.filterElementsBy!.find(
-                (item) => item.filterLocalIdentifier === originalLocalId,
-            );
-
-            invariant(match); // if this blows up, the state is inconsistent
-
-            // ...and return its first "over attribute"
-            return match.over.attributes[0];
-        };
-    }, [parentFiltersMap, filter.attributeFilter.filterElementsBy]);
+        return (_parentFilter: IAttributeFilter, index: number): ObjRef => parentFiltersData[index].over;
+    }, [parentFiltersData]);
 
     return {
         parentFilters,

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -232,7 +232,7 @@ export interface IAttributeFilterButtonOwnProps {
     locale?: string;
     onApply?: (filter: IAttributeFilter, isInverted: boolean) => void;
     onError?: (error: any) => void;
-    parentFilterOverAttribute?: ObjRef;
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
     parentFilters?: AttributeFiltersOrPlaceholders;
     renderBody?: (props: IAttributeDropdownBodyExtendedProps) => React_2.ReactNode;
     title?: string;
@@ -257,7 +257,7 @@ export interface IAttributeFilterProps {
     locale?: string;
     onApply?: (filter: IAttributeFilter) => void;
     onError?: OnError;
-    parentFilterOverAttribute?: ObjRef;
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
     parentFilters?: AttributeFiltersOrPlaceholders;
     title?: string;
     titleWithSelection?: boolean;

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -232,7 +232,7 @@ export interface IAttributeFilterButtonOwnProps {
     locale?: string;
     onApply?: (filter: IAttributeFilter, isInverted: boolean) => void;
     onError?: (error: any) => void;
-    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter, index: number) => ObjRef);
     parentFilters?: AttributeFiltersOrPlaceholders;
     renderBody?: (props: IAttributeDropdownBodyExtendedProps) => React_2.ReactNode;
     title?: string;
@@ -257,7 +257,7 @@ export interface IAttributeFilterProps {
     locale?: string;
     onApply?: (filter: IAttributeFilter) => void;
     onError?: OnError;
-    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter, index: number) => ObjRef);
     parentFilters?: AttributeFiltersOrPlaceholders;
     title?: string;
     titleWithSelection?: boolean;

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
@@ -87,9 +87,12 @@ export interface IAttributeFilterProps {
     connectToPlaceholder?: IPlaceholder<IAttributeFilter>;
 
     /**
-     * Specify and parent filter attribute ref over which should be available options reduced.
+     * Specify the over attribute - an attribute the filter and its parent filter are connected through.
+     *
+     * You can either provide an {@link @gooddata/sdk-model#ObjRef} which will be used for all the parent filters,
+     * or you can provide a function that will be called for each parent filter to determine the respective over attribute.
      */
-    parentFilterOverAttribute?: ObjRef;
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
 
     /**
      * Specify function which will be called when user clicks 'Apply' button. The function will receive the current

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilter.tsx
@@ -92,7 +92,7 @@ export interface IAttributeFilterProps {
      * You can either provide an {@link @gooddata/sdk-model#ObjRef} which will be used for all the parent filters,
      * or you can provide a function that will be called for each parent filter to determine the respective over attribute.
      */
-    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter, index: number) => ObjRef);
 
     /**
      * Specify function which will be called when user clicks 'Apply' button. The function will receive the current

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -318,7 +318,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 });
             },
         },
-        [state.validOptions, state.offset, state.limit],
+        [state.validOptions, state.offset, state.limit, resolvedParentFilters],
     );
 
     const {
@@ -461,7 +461,8 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     };
 
     const isElementsLoading = () => {
-        return elementsStatus === "pending" || elementsStatus === "loading";
+        // pending means idle in this context
+        return elementsStatus === "loading";
     };
 
     const isTotalCountLoading = () => {

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -105,9 +105,12 @@ export interface IAttributeFilterButtonOwnProps {
     connectToPlaceholder?: IPlaceholder<IAttributeFilter>;
 
     /**
-     * Specify and parent filter attribute ref over which should be available options reduced.
+     * Specify the over attribute - an attribute the filter and its parent filter are connected through.
+     *
+     * You can either provide an {@link @gooddata/sdk-model#ObjRef} which will be used for all the parent filters,
+     * or you can provide a function that will be called for each parent filter to determine the respective over attribute.
      */
-    parentFilterOverAttribute?: ObjRef;
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
 
     /**
      * Specify identifier of attribute, for which you want to construct the filter.

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -110,7 +110,7 @@ export interface IAttributeFilterButtonOwnProps {
      * You can either provide an {@link @gooddata/sdk-model#ObjRef} which will be used for all the parent filters,
      * or you can provide a function that will be called for each parent filter to determine the respective over attribute.
      */
-    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef);
+    parentFilterOverAttribute?: ObjRef | ((parentFilter: IAttributeFilter, index: number) => ObjRef);
 
     /**
      * Specify identifier of attribute, for which you want to construct the filter.

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -163,7 +163,7 @@ export const getObjRef = (filter: IAttributeFilter, identifier: string): ObjRef 
 
 export const getValidElementsFilters = (
     parentFilters: IAttributeFilter[],
-    overAttribute: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef),
+    overAttribute: ObjRef | ((parentFilter: IAttributeFilter, index: number) => ObjRef),
 ): IElementsQueryAttributeFilter[] => {
     if (!parentFilters || !overAttribute) {
         return [];
@@ -178,10 +178,10 @@ export const getValidElementsFilters = (
                 isAttributeElementsByRef(filterAttributeElements(parentFilter))
             );
         })
-        .map((attributeFilter) => {
+        .map((attributeFilter, index) => {
             return {
                 attributeFilter,
-                overAttribute: overAttributeGetter(attributeFilter),
+                overAttribute: overAttributeGetter(attributeFilter, index),
             };
         });
 };

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -6,6 +6,7 @@ import {
     IElementsQueryAttributeFilter,
 } from "@gooddata/sdk-backend-spi";
 import { IntlShape } from "react-intl";
+import isFunction from "lodash/isFunction";
 import {
     AttributeListItem,
     EmptyListItem,
@@ -162,11 +163,13 @@ export const getObjRef = (filter: IAttributeFilter, identifier: string): ObjRef 
 
 export const getValidElementsFilters = (
     parentFilters: IAttributeFilter[],
-    overAttribute: ObjRef,
+    overAttribute: ObjRef | ((parentFilter: IAttributeFilter) => ObjRef),
 ): IElementsQueryAttributeFilter[] => {
     if (!parentFilters || !overAttribute) {
         return [];
     }
+
+    const overAttributeGetter = isFunction(overAttribute) ? overAttribute : () => overAttribute;
 
     return parentFilters
         .filter((parentFilter) => {
@@ -178,7 +181,7 @@ export const getValidElementsFilters = (
         .map((attributeFilter) => {
             return {
                 attributeFilter,
-                overAttribute: overAttribute,
+                overAttribute: overAttributeGetter(attributeFilter),
             };
         });
 };


### PR DESCRIPTION
* The options to specify the parent filters in the SDK filter components was extended to allow us to specify over attribute for every parent separately while not breaking the API
* This extended API was used to make the parent filters work in Dashboard component
* A bug related to the invalidation of the loaded items in AttributeFilterButton was fixed
* Filter-related selectors were rewritten to use the "newer" memoize approach (even thou they were not needed for this bug in the end anyway)

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
