### PR TITLE
RELATED:  RAIL-3665 Fix exportable error detection

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/errorUtils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/errorUtils.ts
@@ -12,9 +12,15 @@ import { isEmptyAfm } from "@gooddata/sdk-ui-ext/dist/internal";
 import { typesUtils } from "@gooddata/util";
 
 /**
+ * Returns true if the provided error should prevent exports.
+ *
+ * @remarks Some errors are still ok with respect to exports (e.g. negative values in a pie chart) and these
+ * should not prevent exports. However, errors detected by this function really make potential exports
+ * nonsensical and should lead to exports being disabled.
+ *
  * @internal
  */
-export const isExportableError = typesUtils.combineGuards(
+export const isNonExportableError = typesUtils.combineGuards(
     isUnknownSdkError,
     isBadRequest,
     isNoDataSdkError,

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightExport.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightExport.ts
@@ -5,7 +5,7 @@ import { GoodDataSdkError, IExportFunction, IExtendedExportConfig } from "@goodd
 import { selectPermissions, selectSettings, useDashboardSelector } from "../../../model";
 import { useExportHandler } from "./useExportHandler";
 import { useExportDialogContext } from "../../dashboardContexts";
-import { isExportableError } from "./errorUtils";
+import { isNonExportableError } from "./errorUtils";
 
 export const useInsightExport = (config: {
     title: string;
@@ -53,10 +53,8 @@ export const useInsightExport = (config: {
         });
     }, [settings, title, exportFunction, closeDialog]);
 
-    const exportCSVEnabled = Boolean(
-        (!error || isExportableError(error)) && !isLoading && isRawExportEnabled,
-    );
-    const exportXLSXEnabled = Boolean((!error || isExportableError(error)) && !isLoading && isExportEnabled);
+    const exportCSVEnabled = Boolean(!isNonExportableError(error) && !isLoading && isRawExportEnabled);
+    const exportXLSXEnabled = Boolean(!isNonExportableError(error) && !isLoading && isExportEnabled);
 
     return {
         exportCSVEnabled,


### PR DESCRIPTION
Turns out the detection was inverted due to out of date naming.

JIRA: RAIL-3665

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
