### PR TITLE
RELATED: RAIL-3671 Prevent multiple concurrent exports of one insight

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -93,6 +93,11 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         title: widgetTitle(widget) || intl.formatMessage({ id: "export.defaultTitle" }),
     });
 
+    const onExportCSVWrapped = useCallback(() => {
+        setIsMenuOpen(false);
+        onExportCSV();
+    }, [onExportCSV]);
+
     const onExportXLSXWrapped = useCallback(() => {
         setIsMenuOpen(false);
         onExportXLSX();
@@ -131,7 +136,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
                             exportFunction={exportFunction}
                             bubbleMessageKey={bubbleMessageKey}
                             exportCSVDisabled={!exportCSVEnabled}
-                            onExportCSV={onExportCSV}
+                            onExportCSV={onExportCSVWrapped}
                             exportXLSXDisabled={!exportXLSXEnabled}
                             onExportXLSX={onExportXLSXWrapped}
                         />

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/OptionsMenu/OptionsMenu.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/OptionsMenu/OptionsMenu.tsx
@@ -8,6 +8,7 @@ import { stringUtils } from "@gooddata/util";
 import { IWidget, widgetRef } from "@gooddata/sdk-backend-spi";
 
 import { OptionsMenuItem } from "./OptionsMenuItem";
+import { DOWNLOADER_ID } from "../../../../_staging/fileUtils/downloadFile";
 
 export interface IOptionsMenuProps extends WrappedComponentProps {
     exportFunction: IExportFunction | undefined;
@@ -21,6 +22,8 @@ export interface IOptionsMenuProps extends WrappedComponentProps {
 }
 
 const alignPoints: IAlignPoint[] = [{ align: "bc tr", offset: { x: 2, y: 0 } }];
+
+const ignoredOutsideClickClasses = [`#${DOWNLOADER_ID}`];
 
 const OptionsMenuCore: React.FC<IOptionsMenuProps> = ({
     bubbleMessageKey = "",
@@ -43,6 +46,9 @@ const OptionsMenuCore: React.FC<IOptionsMenuProps> = ({
             alignPoints={alignPoints}
             className="bubble-light options-menu-bubble s-options-menu-bubble"
             closeOnOutsideClick
+            // we need to ignore the "clicks" on the hidden downloader link to prevent the menu from closing
+            // when the download starts (if the user opened it again before the download was ready)
+            ignoreClicksOnByClass={ignoredOutsideClickClasses}
             onClose={hideOptionsMenu}
         >
             <ItemsWrapper smallItemsSpacing>

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -627,6 +627,9 @@ export interface IBubbleProps {
     className?: string;
     // (undocumented)
     closeOnOutsideClick?: boolean;
+    ignoreClicksOn?: any[];
+    // (undocumented)
+    ignoreClicksOnByClass?: string[];
     // (undocumented)
     onClose?: () => void;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
@@ -61,6 +61,13 @@ export interface IBubbleProps {
     arrowStyle?: React.CSSProperties;
     className?: string;
     closeOnOutsideClick?: boolean;
+
+    /**
+     * Array of refs where user clicks should be ignored
+     * and bubble should not be closed by clicking on them
+     */
+    ignoreClicksOn?: any[];
+    ignoreClicksOnByClass?: string[];
     onClose?: () => void;
     onMouseEnter?: () => void;
     onMouseLeave?: () => void;
@@ -179,6 +186,8 @@ export class Bubble extends React.Component<IBubbleProps, IBubbleState> {
                 closeOnParentScroll
                 closeOnMouseDrag
                 closeOnOutsideClick={this.props.closeOnOutsideClick}
+                ignoreClicksOn={this.props.ignoreClicksOn}
+                ignoreClicksOnByClass={this.props.ignoreClicksOnByClass}
                 onClose={this.props.onClose}
             >
                 <div


### PR DESCRIPTION
This mimics the behavior of gdc-dashboards and improves the UX
by actually disabling the buttons while an export is in progress:
gdc-dashboards leave them enabled and clicking them is a noop
while an export is in progress.

To prevent strange closes of the menu when download of the result
file starts (which involves clicking on a hidden link), the Bubble API
was extended to allow us to configure the ignoreClicks* props of
the underlying Overlay and thus ignore this hidden "click".

JIRA: RAIL-3671

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
