### PR TITLE
RELATED: RAIL-3650 Detect parent ThemeProvider in Dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -8,7 +8,7 @@ import {
 } from "@gooddata/sdk-backend-spi";
 import { ToastMessageContextProvider, ToastMessages, useToastMessage } from "@gooddata/sdk-ui-kit";
 import { ErrorComponent as DefaultError, LoadingComponent as DefaultLoading } from "@gooddata/sdk-ui";
-import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
+import { ThemeProvider, useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
 import { useIntl } from "react-intl";
 
 import {
@@ -285,7 +285,10 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
         [props.DashboardAttributeFilterComponentFactory],
     );
 
-    return (
+    const isThemeLoading = useThemeIsLoading();
+    const hasThemeProvider = isThemeLoading !== undefined;
+
+    let dashboardRender = (
         <DashboardStoreProvider
             dashboardRef={props.dashboardRef}
             backend={props.backend}
@@ -296,37 +299,45 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
         >
             <ToastMessageContextProvider>
                 <ExportDialogContextProvider>
-                    <ThemeProvider
-                        theme={props.theme}
-                        modifier={props.themeModifier ?? defaultDashboardThemeModifier}
+                    <DashboardComponentsProvider
+                        ErrorComponent={props.ErrorComponent ?? DefaultError}
+                        LoadingComponent={props.LoadingComponent ?? DefaultLoading}
+                        LayoutComponent={props.LayoutComponent ?? DefaultDashboardLayoutInner}
+                        InsightComponent={props.InsightComponent ?? DefaultDashboardInsightInner}
+                        KpiComponent={props.KpiComponent ?? DefaultDashboardKpiInner}
+                        WidgetComponent={props.WidgetComponent ?? DefaultDashboardWidgetInner}
+                        ButtonBarComponent={props.ButtonBarComponent ?? DefaultButtonBarInner}
+                        MenuButtonComponent={props.MenuButtonComponent ?? DefaultMenuButtonInner}
+                        TopBarComponent={props.TopBarComponent ?? DefaultTopBarInner}
+                        TitleComponent={props.TitleComponent ?? DefaultTitleInner}
+                        ScheduledEmailDialogComponent={
+                            props.ScheduledEmailDialogComponent ?? DefaultScheduledEmailDialogInner
+                        }
+                        DashboardAttributeFilterComponentFactory={attributeFilterFactory}
+                        DashboardDateFilterComponent={
+                            props.DashboardDateFilterComponent ?? DefaultDashboardDateFilterInner
+                        }
+                        FilterBarComponent={props.FilterBarComponent ?? DefaultFilterBarInner}
                     >
-                        <DashboardComponentsProvider
-                            ErrorComponent={props.ErrorComponent ?? DefaultError}
-                            LoadingComponent={props.LoadingComponent ?? DefaultLoading}
-                            LayoutComponent={props.LayoutComponent ?? DefaultDashboardLayoutInner}
-                            InsightComponent={props.InsightComponent ?? DefaultDashboardInsightInner}
-                            KpiComponent={props.KpiComponent ?? DefaultDashboardKpiInner}
-                            WidgetComponent={props.WidgetComponent ?? DefaultDashboardWidgetInner}
-                            ButtonBarComponent={props.ButtonBarComponent ?? DefaultButtonBarInner}
-                            MenuButtonComponent={props.MenuButtonComponent ?? DefaultMenuButtonInner}
-                            TopBarComponent={props.TopBarComponent ?? DefaultTopBarInner}
-                            TitleComponent={props.TitleComponent ?? DefaultTitleInner}
-                            ScheduledEmailDialogComponent={
-                                props.ScheduledEmailDialogComponent ?? DefaultScheduledEmailDialogInner
-                            }
-                            DashboardAttributeFilterComponentFactory={attributeFilterFactory}
-                            DashboardDateFilterComponent={
-                                props.DashboardDateFilterComponent ?? DefaultDashboardDateFilterInner
-                            }
-                            FilterBarComponent={props.FilterBarComponent ?? DefaultFilterBarInner}
-                        >
-                            <DashboardConfigProvider menuButtonConfig={props.menuButtonConfig}>
-                                <DashboardLoading {...props} />
-                            </DashboardConfigProvider>
-                        </DashboardComponentsProvider>
-                    </ThemeProvider>
+                        <DashboardConfigProvider menuButtonConfig={props.menuButtonConfig}>
+                            <DashboardLoading {...props} />
+                        </DashboardConfigProvider>
+                    </DashboardComponentsProvider>
                 </ExportDialogContextProvider>
             </ToastMessageContextProvider>
         </DashboardStoreProvider>
     );
+
+    if (props.theme || !hasThemeProvider) {
+        dashboardRender = (
+            <ThemeProvider
+                theme={props.theme}
+                modifier={props.themeModifier ?? defaultDashboardThemeModifier}
+            >
+                {dashboardRender}
+            </ThemeProvider>
+        );
+    }
+
+    return dashboardRender;
 };

--- a/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
+++ b/libs/sdk-ui-theme-provider/src/ThemeProvider/ThemeProvider.tsx
@@ -48,7 +48,7 @@ export interface IThemeProviderProps {
 
     /**
      * Flag determining whether the complementary palette is enabled or not. If set to false, complementary
-     * palette is discarted.
+     * palette is discarded.
      * Useful for applications not yet fully supporting dark-based themes achievable with the complementary palette.
      */
     enableComplementaryPalette?: boolean;


### PR DESCRIPTION
Similarly to DashboardView, if there is already a ThemeProvider higher up
the component tree and there is no theme prop passed, there is no need
to render additional ThemeProvider.

This makes the component tree smaller and also prevents unwanted theme
cleanup done on unmount (this would reset the global theme CSS variables
in applications that already use their own ThemeProvider).

Also fix typo in ThemeProvider.

JIRA: RAIL-3650

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
