### PR TITLE
NAS-150 measure usage

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
@@ -1,9 +1,10 @@
-// (C) 2019-2020 GoodData Corporation
-import { GdcMetadata, GdcMetadataObject } from "@gooddata/api-model-bear";
+// (C) 2019-2021 GoodData Corporation
+import { GdcMetadata, GdcMetadataObject, GdcVisualizationObject } from "@gooddata/api-model-bear";
 import {
     IMeasureExpressionToken,
     IMeasureMetadataObject,
     IMeasureMetadataObjectDefinition,
+    IMeasureReferencing,
     IWorkspaceMeasuresService,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
@@ -13,14 +14,16 @@ import replace from "lodash/fp/replace";
 import uniq from "lodash/fp/uniq";
 import {
     convertMetadataObject,
+    convertMetadataObjectXrefEntry,
     SupportedMetadataObject,
     SupportedWrappedMetadataObject,
 } from "../../../convertors/fromBackend/MetaConverter";
 import { convertMetricFromBackend } from "../../../convertors/fromBackend/MetricConverter";
 import { convertMetricToBackend } from "../../../convertors/toBackend/MetricConverter";
 import { BearAuthenticatedCallGuard } from "../../../types/auth";
-import { objRefToUri } from "../../../utils/api";
+import { getObjectIdFromUri, objRefToUri } from "../../../utils/api";
 import { getTokenValuesOfType, tokenizeExpression } from "./measureExpressionTokens";
+import { convertVisualization } from "../../../convertors/fromBackend/VisualizationConverter";
 
 export class BearWorkspaceMeasures implements IWorkspaceMeasuresService {
     constructor(private readonly authCall: BearAuthenticatedCallGuard, public readonly workspace: string) {}
@@ -153,5 +156,40 @@ export class BearWorkspaceMeasures implements IWorkspaceMeasuresService {
         });
 
         return measure;
+    }
+
+    async getMeasureReferencingObjects(ref: ObjRef): Promise<IMeasureReferencing> {
+        const uri = await objRefToUri(ref, this.workspace, this.authCall);
+        const objectId = getObjectIdFromUri(uri);
+
+        const measures = await this.authCall(async (sdk) => {
+            const usedBy = await sdk.xhr.getParsed<{ entries: GdcMetadata.IObjectXrefEntry[] }>(
+                `/gdc/md/${this.workspace}/usedby2/${objectId}?types=metric`,
+            );
+
+            return usedBy.entries.map((entry: GdcMetadata.IObjectXrefEntry) =>
+                convertMetadataObjectXrefEntry("measure", entry),
+            );
+        });
+
+        const visualizations = await this.authCall(async (sdk) => {
+            const usedBy = await sdk.xhr.getParsed<{ entries: GdcVisualizationObject.IVisualization[] }>(
+                `/gdc/md/${this.workspace}/usedby2/${objectId}?types=visualizationObject`,
+            );
+
+            return usedBy.entries;
+        });
+
+        const insights = visualizations.map((visualization) =>
+            convertVisualization(
+                visualization,
+                visualization.visualizationObject.content.visualizationClass.uri,
+            ),
+        );
+
+        return Promise.resolve({
+            measures: measures,
+            insights: insights,
+        });
     }
 }

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/MetricConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/MetricConverter.ts
@@ -25,3 +25,15 @@ export function convertMetricFromBackend(metric: IMetric): IMeasureMetadataObjec
             .unlisted(Boolean(meta.unlisted)),
     );
 }
+
+export function convertListedMetric(metricLink: GdcMetadata.IObjectLink): IMeasureMetadataObject {
+    const ref = uriRef(metricLink.link);
+
+    return newMeasureMetadataObject(ref, (m) =>
+        m
+            .id(metricLink.identifier!)
+            .uri(metricLink.link as string)
+            .title(metricLink.title || "")
+            .description(metricLink.summary || ""),
+    );
+}

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -18,7 +18,7 @@ import compact from "lodash/compact";
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
 import omit from "lodash/omit";
-import { GdcVisualizationObject } from "@gooddata/api-model-bear";
+import { GdcMetadata, GdcVisualizationObject } from "@gooddata/api-model-bear";
 import { convertReferencesToUris } from "./ReferenceConverter";
 import { deserializeProperties, serializeProperties } from "./PropertiesConverter";
 import { fromBearRef, fromScopedBearRef } from "./ObjRefConverter";
@@ -231,6 +231,25 @@ export const convertVisualization = (
             updated: meta.updated,
             isLocked: meta.locked,
             tags: meta.tags?.split(" ").filter(Boolean) ?? [],
+        },
+    };
+};
+
+export const convertListedVisualization = (visualizationLink: GdcMetadata.IObjectLink): IInsight => {
+    const ref = uriRef(visualizationLink.link);
+
+    return {
+        insight: {
+            identifier: visualizationLink.identifier || "",
+            title: visualizationLink.title || "",
+            uri: visualizationLink.link,
+            ref: ref,
+            properties: [],
+            sorts: [],
+            visualizationUrl: "",
+            buckets: [],
+            filters: [],
+            tags: [],
         },
     };
 };

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/measures.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/measures.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 import {
     IWorkspaceMeasuresService,
@@ -6,6 +6,7 @@ import {
     IMeasureExpressionToken,
     IMeasureMetadataObject,
     IMeasureMetadataObjectDefinition,
+    IMeasureReferencing,
 } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 
@@ -26,6 +27,10 @@ export class RecordedMeasures implements IWorkspaceMeasuresService {
     }
 
     updateMeasure(_: IMeasureMetadataObject): Promise<IMeasureMetadataObject> {
+        throw new NotSupported("not supported");
+    }
+
+    getMeasureReferencingObjects(_: ObjRef): Promise<IMeasureReferencing> {
         throw new NotSupported("not supported");
     }
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -954,6 +954,14 @@ export interface IMeasureMetadataObjectBase {
 // @public
 export type IMeasureMetadataObjectDefinition = IMetadataObjectDefinition & IMeasureMetadataObjectBase;
 
+// @public
+export interface IMeasureReferencing {
+    // (undocumented)
+    insights?: IInsight[];
+    // (undocumented)
+    measures?: IMetadataObject[];
+}
+
 // @public (undocumented)
 export interface IMetadataObject extends IMetadataObjectBase, IMetadataObjectIdentity {
 }
@@ -1814,6 +1822,7 @@ export interface IWorkspaceMeasuresService {
     createMeasure(measure: IMeasureMetadataObjectDefinition): Promise<IMeasureMetadataObject>;
     deleteMeasure(measureRef: ObjRef): Promise<void>;
     getMeasureExpressionTokens(ref: ObjRef): Promise<IMeasureExpressionToken[]>;
+    getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
     updateMeasure(measure: IMeasureMetadataObject): Promise<IMeasureMetadataObject>;
 }
 

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -377,6 +377,7 @@ export {
     metadataObjectId,
     IDashboardMetadataObject,
     isDashboardMetadataObject,
+    IMeasureReferencing,
 } from "./workspace/fromModel/ldm/metadata";
 
 export {

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/index.ts
@@ -14,6 +14,7 @@ import {
     IMeasureMetadataObjectDefinition,
     isMeasureMetadataObject,
     isMeasureMetadataObjectDefinition,
+    IMeasureReferencing,
 } from "./measure";
 import { IMetadataObject, IMetadataObjectBase, IMetadataObjectIdentity, isMetadataObject } from "./types";
 import { isVariableMetadataObject, IVariableMetadataObject } from "./variable";
@@ -41,6 +42,7 @@ export {
     isVariableMetadataObject,
     IDashboardMetadataObject,
     isDashboardMetadataObject,
+    IMeasureReferencing,
 };
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/metadata/measure/index.ts
@@ -1,5 +1,6 @@
 // (C) 2019-2021 GoodData Corporation
 import { IMetadataObject, IMetadataObjectBase, isMetadataObject } from "../types";
+import { IInsight } from "@gooddata/sdk-model";
 
 /**
  * @internal
@@ -44,6 +45,16 @@ export type IMeasureMetadataObject = IMetadataObject & IMeasureMetadataObjectBas
  * @public
  */
 export type IMeasureMetadataObjectDefinition = IMetadataObjectDefinition & IMeasureMetadataObjectBase;
+
+/**
+ * Contains information about objects that may be referencing an measure. {@link IWorkspaceMeasuresService.getMeasureReferencingObjects} function.
+ *
+ * @public
+ */
+export interface IMeasureReferencing {
+    measures?: IMetadataObject[];
+    insights?: IInsight[];
+}
 
 /**
  * Tests whether the provided object is of type {@link IMeasureMetadataObject}.

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -46,7 +46,7 @@ export interface IWorkspaceMeasuresService {
     deleteMeasure(measureRef: ObjRef): Promise<void>;
 
     /**
-     * Get all metadata objects which uses specified object(ie. object is used by these objects) by a given reference.
+     * Get all metadata objects which uses specified object (ie. object is used by these objects) by a given reference.
      *
      * @param measureRef - ref of the measure to check
      * @returns promise of references

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -1,7 +1,11 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
 import { IMeasureExpressionToken } from "../fromModel/ldm/measure";
-import { IMeasureMetadataObject, IMeasureMetadataObjectDefinition } from "../fromModel/ldm/metadata";
+import {
+    IMeasureMetadataObject,
+    IMeasureMetadataObjectDefinition,
+    IMeasureReferencing,
+} from "../fromModel/ldm/metadata";
 
 /**
  * Service for create, update or delete measures and querying additional measures data.
@@ -40,4 +44,12 @@ export interface IWorkspaceMeasuresService {
      * @returns promise of undefined
      */
     deleteMeasure(measureRef: ObjRef): Promise<void>;
+
+    /**
+     * Get all metadata objects which uses specified object(ie. object is used by these objects) by a given reference.
+     *
+     * @param measureRef - ref of the measure to check
+     * @returns promise of references
+     */
+    getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
 }

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -15,6 +15,7 @@ import {
     jsonApiHeaders,
     JsonApiMetricInTypeEnum,
     MetadataUtilities,
+    JsonApiMetricOutWithLinks,
 } from "@gooddata/api-client-tiger";
 import { ObjRef, idRef, isIdentifierRef } from "@gooddata/sdk-model";
 import { convertMetricFromBackend } from "../../../convertors/fromBackend/MetricConverter";
@@ -179,13 +180,14 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
                 client.workspaceObjects.getAllEntitiesMetrics,
                 {
                     workspaceId: this.workspace,
+                    include: ["metrics"],
                 },
                 { query: filterReferencingObjX as any }, // return only measures that have a link to the given id in their visualizationObjects
             ).then(MetadataUtilities.mergeEntitiesResults),
         );
 
         return Promise.resolve({
-            measures: measures.data.map(convertMetricFromBackend),
+            measures: (measures.included as JsonApiMetricOutWithLinks[]).map(convertMetricFromBackend),
             insights: insights.data.map(visualizationObjectsItemToInsight),
         });
     };

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -4,6 +4,7 @@ import {
     IMeasureExpressionToken,
     IMeasureMetadataObject,
     IMeasureMetadataObjectDefinition,
+    IMeasureReferencing,
 } from "@gooddata/sdk-backend-spi";
 import {
     JsonApiAttributeOut,
@@ -13,6 +14,7 @@ import {
     JsonApiMetricOutDocument,
     jsonApiHeaders,
     JsonApiMetricInTypeEnum,
+    MetadataUtilities,
 } from "@gooddata/api-client-tiger";
 import { ObjRef, idRef, isIdentifierRef } from "@gooddata/sdk-model";
 import { convertMetricFromBackend } from "../../../convertors/fromBackend/MetricConverter";
@@ -21,6 +23,7 @@ import { TigerAuthenticatedCallGuard } from "../../../types";
 import { objRefToIdentifier } from "../../../utils/api";
 import { tokenizeExpression, IExpressionToken } from "./measureExpressionTokens";
 import { v4 as uuidv4 } from "uuid";
+import { visualizationObjectsItemToInsight } from "../../../convertors/fromBackend/InsightConverter";
 
 export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
     constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}
@@ -149,4 +152,41 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
             });
         });
     }
+
+    public getMeasureReferencingObjects = async (ref: ObjRef): Promise<IMeasureReferencing> => {
+        const id = await objRefToIdentifier(ref, this.authCall);
+        const filterReferencingObj = {
+            filter: `metrics.id==${id}`, // RSQL format of querying data
+        };
+
+        const insights = await this.authCall((client) =>
+            MetadataUtilities.getAllPagesOf(
+                client,
+                client.workspaceObjects.getAllEntitiesVisualizationObjects,
+                {
+                    workspaceId: this.workspace,
+                },
+                { query: filterReferencingObj as any }, // return only measures that have a link to the given id in their visualizationObjects
+            ).then(MetadataUtilities.mergeEntitiesResults),
+        );
+
+        const filterReferencingObjX = {
+            filter: `metric.id==${id}`, // RSQL format of querying data
+        };
+        const measures = await this.authCall((client) =>
+            MetadataUtilities.getAllPagesOf(
+                client,
+                client.workspaceObjects.getAllEntitiesMetrics,
+                {
+                    workspaceId: this.workspace,
+                },
+                { query: filterReferencingObjX as any }, // return only measures that have a link to the given id in their visualizationObjects
+            ).then(MetadataUtilities.mergeEntitiesResults),
+        );
+
+        return Promise.resolve({
+            measures: measures.data.map(convertMetricFromBackend),
+            insights: insights.data.map(visualizationObjectsItemToInsight),
+        });
+    };
 }

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/MetricConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/MetricConverter.ts
@@ -10,12 +10,19 @@ import { IMeasureMetadataObject } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
 import { isInheritedObject } from "./utils";
 
+/**
+ * Type guard checking whether object is an instance of JsonApiMetricOutDocument.
+ */
+function isJsonApiMetricOutDocument(obj: unknown): obj is JsonApiMetricOutDocument {
+    return (obj as JsonApiMetricOutDocument).data !== undefined;
+}
+
 export function convertMetricFromBackend(
     data: JsonApiMetricOutDocument | JsonApiMetricOutWithLinks,
 ): IMeasureMetadataObject {
     let id: string;
     let attributes: JsonApiMetricInAttributes;
-    if ("data" in data) {
+    if (isJsonApiMetricOutDocument(data)) {
         id = data.data.id;
         attributes = data.data.attributes;
     } else {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/MetricConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/MetricConverter.ts
@@ -1,13 +1,27 @@
 // (C) 2021 GoodData Corporation
 
-import { JsonApiMetricOutDocument } from "@gooddata/api-client-tiger";
+import {
+    JsonApiMetricInAttributes,
+    JsonApiMetricOutDocument,
+    JsonApiMetricOutWithLinks,
+} from "@gooddata/api-client-tiger";
 import { newMeasureMetadataObject } from "@gooddata/sdk-backend-base";
 import { IMeasureMetadataObject } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
 import { isInheritedObject } from "./utils";
 
-export function convertMetricFromBackend(data: JsonApiMetricOutDocument): IMeasureMetadataObject {
-    const { id, attributes } = data.data;
+export function convertMetricFromBackend(
+    data: JsonApiMetricOutDocument | JsonApiMetricOutWithLinks,
+): IMeasureMetadataObject {
+    let id: string;
+    let attributes: JsonApiMetricInAttributes;
+    if ("data" in data) {
+        id = data.data.id;
+        attributes = data.data.attributes;
+    } else {
+        id = data.id;
+        attributes = data.attributes;
+    }
     const ref = idRef(id, "measure");
 
     return newMeasureMetadataObject(ref, (m) =>


### PR DESCRIPTION
New sdk-backend-spi method getMeasureReferencingObjects added and used to get the data for measure editor

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
