### PR TITLE
RELATED: RAIL-3620, RAIL-3681 attribute filter fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeFilterBody.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeFilterBody.tsx
@@ -20,7 +20,11 @@ import { IntlWrapper } from "../../../localization";
 import min from "lodash/min";
 import max from "lodash/max";
 import isEmpty from "lodash/isEmpty";
-import { IAttributeDropdownBodyExtendedProps } from "@gooddata/sdk-ui-filters";
+import {
+    AttributeListItem,
+    IAttributeDropdownBodyExtendedProps,
+    isEmptyListItem,
+} from "@gooddata/sdk-ui-filters";
 import { IAttributeElement } from "@gooddata/sdk-backend-spi";
 import AttributeDropdownListItem from "./AttributeDropdownListItem";
 
@@ -61,14 +65,21 @@ const AttributeFilterBodyCore: React.FC<IAttributeDropdownBodyExtendedProps> = (
         "gd-flex-row-container-mobile": isMobile,
     });
 
-    const getElementsList = (items: IAttributeElement[], emptyString: string) => {
+    const getElementsList = (items: AttributeListItem[], emptyString: string) => {
         return items.map((item) => {
-            return !isEmpty(item?.title)
-                ? item
-                : {
+            // for empty list items return an empty object -> this causes the underlying list to render an empty row (without checkboxes)
+            if (isEmptyListItem(item)) {
+                return {} as any;
+            }
+
+            // set "empty value" title only to items that have empty title but not URL
+            // this is to distinguish between elements that have not been loaded yet and those who have and have empty title
+            return isEmpty(item?.title) && !isEmpty(item?.uri)
+                ? {
                       ...item,
                       title: emptyString,
-                  };
+                  }
+                : item;
         });
     };
 
@@ -100,7 +111,7 @@ const AttributeFilterBodyCore: React.FC<IAttributeDropdownBodyExtendedProps> = (
             onRangeChange={props.onRangeChange}
             isInverted={props.isInverted}
             items={getElementsList(
-                props.items as IAttributeElement[],
+                props.items,
                 intl.formatMessage({ id: "attributeFilterDropdown.emptyValue" }),
             )}
             listItemClass={AttributeDropdownListItem}

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -98,7 +98,7 @@ export const defaultDateFilterOptions: IDateFilterOptionsByType;
 // @public (undocumented)
 export interface EmptyListItem {
     // (undocumented)
-    empty: boolean;
+    empty: true;
 }
 
 // @public
@@ -467,6 +467,12 @@ export interface IRankingFilterProps {
 
 // @public
 export const isAbsoluteDateFilterOption: (obj: unknown) => obj is AbsoluteDateFilterOption;
+
+// @public (undocumented)
+export const isEmptyListItem: (item: Partial<AttributeListItem>) => item is EmptyListItem;
+
+// @public (undocumented)
+export const isNonEmptyListItem: (item: Partial<AttributeListItem>) => item is IAttributeElement;
 
 // @public
 export const isRelativeDateFilterOption: (obj: unknown) => obj is RelativeDateFilterOption;

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/types.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/types.ts
@@ -7,13 +7,22 @@ export const emptyListItem: EmptyListItem = { empty: true };
  * @public
  */
 export interface EmptyListItem {
-    empty: boolean;
+    empty: true;
 }
 /**
  * @public
  */
 export type AttributeListItem = IAttributeElement | EmptyListItem;
 
+/**
+ * @public
+ */
+export const isEmptyListItem = (item: Partial<AttributeListItem>): item is EmptyListItem =>
+    item && (item as EmptyListItem).empty;
+
+/**
+ * @public
+ */
 export const isNonEmptyListItem = (item: Partial<AttributeListItem>): item is IAttributeElement =>
     item && !(item as EmptyListItem).empty;
 

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -307,7 +307,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                     items,
                 );
 
-                const validOptions = resolvedParentFilters ? newElements : mergedValidElements;
+                const validOptions = resolvedParentFilters?.length ? newElements : mergedValidElements;
 
                 setState({
                     ...state,

--- a/libs/sdk-ui-filters/src/index.ts
+++ b/libs/sdk-ui-filters/src/index.ts
@@ -21,7 +21,12 @@ export {
     IAttributeDropdownBodyExtendedProps,
     IAttributeDropdownListItemProps,
 } from "./AttributeFilter/AttributeDropdown/AttributeDropdownBody";
-export { AttributeListItem, EmptyListItem } from "./AttributeFilter/AttributeDropdown/types";
+export {
+    AttributeListItem,
+    EmptyListItem,
+    isEmptyListItem,
+    isNonEmptyListItem,
+} from "./AttributeFilter/AttributeDropdown/types";
 export {
     DateFilter,
     IDateFilterCallbackProps,

--- a/libs/sdk-ui-kit/src/List/LegacyInvertableList.tsx
+++ b/libs/sdk-ui-kit/src/List/LegacyInvertableList.tsx
@@ -247,7 +247,7 @@ export class LegacyInvertableList<T> extends Component<
 
     /**
      * If change in selection happens to select all or unselect all items it is converted
-     * to the respective empty selectionj.
+     * to the respective empty selection.
      */
     private notifyUpstreamOfSelectionChange(newSelection: Array<T>) {
         const { itemsCount } = this.props;


### PR DESCRIPTION
* RAIL-3620 - fix paging by handling empty but defined parent filters
* RAIL-3681 - fix handling of not yet loaded vs empty items

The change to the sdk-ui-filters api is safe, in SDK 8.5.0 the EmptyListItem interface was defined using the typeof and the emptyListItem object, so it was effectively the same as it is now.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
