### PR TITLE
RELATED: RAIL-3665, RAIL-3684 export drilled insight fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -61,6 +61,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         workspace,
         onError,
         onDrill: onDrillFn,
+        onExportReady,
         ErrorComponent: CustomErrorComponent,
         LoadingComponent: CustomLoadingComponent,
     } = props;
@@ -155,6 +156,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
                             settings={settings as IUserWorkspaceSettings}
                             colorPalette={colorPalette}
                             onError={handleError}
+                            onExportReady={onExportReady}
                             pushData={onPushData}
                             ErrorComponent={ErrorComponent}
                             LoadingComponent={LoadingComponent}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -11,7 +11,7 @@ import {
     useBackendStrict,
     useWorkspaceStrict,
 } from "@gooddata/sdk-ui";
-import { InsightError, InsightRenderer } from "@gooddata/sdk-ui-ext";
+import { InsightRenderer } from "@gooddata/sdk-ui-ext";
 import { useDashboardComponentsContext } from "../../../../dashboardContexts";
 import {
     useDashboardSelector,
@@ -27,6 +27,7 @@ import { IDashboardInsightProps } from "../../types";
 import { useWidgetFiltersQuery } from "../../../common";
 import { useResolveDashboardInsightProperties } from "../useResolveDashboardInsightProperties";
 import { useDrillDialogInsightDrills } from "./useDrillDialogInsightDrills";
+import { CustomError } from "../CustomError/CustomError";
 
 const insightStyle: CSSProperties = { width: "100%", height: "100%", position: "relative", flex: "1 1 auto" };
 
@@ -57,6 +58,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         insight,
         widget,
         clientHeight,
+        clientWidth,
         backend,
         workspace,
         onError,
@@ -136,11 +138,11 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
                 <IntlWrapper locale={locale}>
                     {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
                     {error && (
-                        <InsightError
+                        <CustomError
                             error={error}
-                            ErrorComponent={ErrorComponent}
-                            clientHeight={settings?.enableKDWidgetCustomHeight ? clientHeight : undefined}
-                            height={null} // make sure the error is aligned to the top (this is the behavior in gdc-dashboards)
+                            isCustomWidgetHeightEnabled={!!settings?.enableKDWidgetCustomHeight}
+                            height={clientHeight}
+                            width={clientWidth}
                         />
                     )}
                     {filtersStatus === "success" && (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/InsightDrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/InsightDrillDialog.tsx
@@ -102,6 +102,7 @@ export const InsightDrillDialog = (props: InsightDrillDialogProps): JSX.Element 
                                     onDrill={onDrill}
                                     onLoadingChanged={handleLoadingChanged}
                                     onExportReady={handleExportReady}
+                                    onError={setError}
                                 />
                             );
                         }}


### PR DESCRIPTION
* RAIL-3665 - fix error messages in drill to insight
* RAIL-3684 - fix onError callback propagation which made export drilled insight always disabled

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
