### PR TITLE
Handle ALL filter without unused API calls

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
@@ -186,13 +186,17 @@ class BearWorkspaceFilterElementsQuery implements IFilterElementsQuery {
     }
 
     private async resultForElementsByRef(selectedElements: IAttributeElementsByRef) {
-        return this.elementsQuery
-            .withOptions({
-                uris: selectedElements.uris,
-            })
-            .withOffset(this.offset)
-            .withLimit(this.limit)
-            .query();
+        if (selectedElements.uris.length) {
+            return this.elementsQuery
+                .withOptions({
+                    uris: selectedElements.uris,
+                })
+                .withOffset(this.offset)
+                .withLimit(this.limit)
+                .query();
+        }
+        // Filter with empty selection resolves to empty values
+        return Promise.resolve(new InMemoryPaging<IAttributeElement>([], this.limit, this.offset));
     }
 
     private async resultForElementsByValue(

--- a/libs/sdk-backend-bear/tests/integrated/__snapshots__/elements.test.ts.snap
+++ b/libs/sdk-backend-bear/tests/integrated/__snapshots__/elements.test.ts.snap
@@ -303,6 +303,16 @@ Object {
 }
 `;
 
+exports[`bear elements forFilter should load no attribute filter elements for provided ALL attribute filter 1`] = `
+InMemoryPaging {
+  "all": Array [],
+  "items": Array [],
+  "limit": 50,
+  "offset": 0,
+  "totalCount": 0,
+}
+`;
+
 exports[`bear elements forFilter should return attribute filter elements for provided attribute filter with elements by value 1`] = `
 InMemoryPaging {
   "all": Array [

--- a/libs/sdk-backend-bear/tests/integrated/elements.test.ts
+++ b/libs/sdk-backend-bear/tests/integrated/elements.test.ts
@@ -106,6 +106,21 @@ describe("bear elements", () => {
             expect(result).toMatchSnapshot();
         });
 
+        it("should load no attribute filter elements for provided ALL attribute filter", async () => {
+            const testAttributeRef = attributeDisplayFormRef(ReferenceLdm.Product.Name);
+            const allAttributeFilter = newNegativeAttributeFilter(testAttributeRef, {
+                uris: [],
+            });
+            const result = await backend
+                .workspace(testWorkspace())
+                .attributes()
+                .elements()
+                .forFilter(allAttributeFilter)
+                .query();
+
+            expect(result).toMatchSnapshot();
+        });
+
         it("should return attribute filter elements for provided attribute filter with elements by value", async () => {
             const testAttributeRef = attributeDisplayFormRef(ReferenceLdm.Product.Name);
             const attributeFilter = newNegativeAttributeFilter(testAttributeRef, {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/__snapshots__/filterValuesResolver.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/__snapshots__/filterValuesResolver.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`resolveFilterValues should resolved ALL attribute filter to empty values 1`] = `
+Object {
+  "attributeFilters": Object {
+    "label.product.id.name": Object {},
+  },
+  "dateFilters": Array [],
+}
+`;
+
 exports[`resolveFilterValues should resolved multiple attribute filters 1`] = `
 Object {
   "attributeFilters": Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/filterValuesResolver.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/filterValuesResolver.test.ts
@@ -3,8 +3,10 @@ import { ReferenceLdm, ReferenceRecordings } from "@gooddata/reference-workspace
 import {
     attributeDisplayFormRef,
     IAbsoluteDateFilter,
+    INegativeAttributeFilter,
     IPositiveAttributeFilter,
     newAbsoluteDateFilter,
+    newNegativeAttributeFilter,
     newPositiveAttributeFilter,
     uriRef,
 } from "@gooddata/sdk-model";
@@ -58,6 +60,18 @@ describe("resolveFilterValues", () => {
         });
 
         const result = await resolveFilterValues([attributeFilter1, attributeFilter2], backend, workspace);
+        expect(result).toMatchSnapshot();
+    });
+
+    it("should resolved ALL attribute filter to empty values", async () => {
+        const backend = recordedBackend(ReferenceRecordings.Recordings);
+        const workspace = "referenceworkspace";
+        const testAttributeRef = attributeDisplayFormRef(ReferenceLdm.Product.Name);
+        const allAttributeFilter: INegativeAttributeFilter = newNegativeAttributeFilter(testAttributeRef, {
+            values: [],
+        });
+
+        const result = await resolveFilterValues([allAttributeFilter], backend, workspace);
         expect(result).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
JIRA: TNT-191
Query for ALL attribute filter was getting all attribute elements just to not use them then. Fixed by returning empty array immediately.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
