### PR TITLE
RELATED: RAIL-3680 Fix and simplify useWidgetBrokenAlertsQuery

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
@@ -1,32 +1,25 @@
 // (C) 2020-2021 GoodData Corporation
 import { useEffect } from "react";
-import { ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
+import { IKpiWidget, IWidgetAlert } from "@gooddata/sdk-backend-spi";
 
 import {
     queryWidgetBrokenAlerts,
     IBrokenAlertFilterBasicInfo,
     QueryProcessingStatus,
     useDashboardQueryProcessing,
-    selectAlertByWidgetRef,
     useDashboardSelector,
-    selectWidgetByRef,
     selectFilterContextFilters,
 } from "../../../model";
 
 export const useWidgetBrokenAlertsQuery = (
-    widgetRef: ObjRef,
+    widget: IKpiWidget,
+    alert: IWidgetAlert | undefined,
 ): {
     result?: IBrokenAlertFilterBasicInfo[];
     status?: QueryProcessingStatus;
     error?: GoodDataSdkError;
 } => {
-    const alertSelector = selectAlertByWidgetRef(widgetRef);
-    const alert = useDashboardSelector(alertSelector);
-
-    const widgetSelector = selectWidgetByRef(widgetRef);
-    const widget = useDashboardSelector(widgetSelector);
-
     const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
 
     const {
@@ -41,12 +34,12 @@ export const useWidgetBrokenAlertsQuery = (
     const effectiveFilters = result as IBrokenAlertFilterBasicInfo[];
 
     useEffect(() => {
-        if (widgetRef) {
-            runBrokenAlertsQuery(widgetRef);
+        if (widget.ref) {
+            runBrokenAlertsQuery(widget.ref);
         }
-        // queryWidgetBrokenAlerts as a parameter it needs just widgetRef but internally result depends on alert, widget, dashboardFilters
+        // queryWidgetBrokenAlerts as a parameter it needs just widget.ref but internally result depends on alert, widget, dashboardFilters
         // we have to call query every time when this dependency changed to get fresh results
-    }, [widgetRef, alert, widget, dashboardFilters]);
+    }, [alert, widget, dashboardFilters]);
 
     return {
         result: effectiveFilters,

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { injectIntl, IntlShape, WrappedComponentProps } from "react-intl";
 import compact from "lodash/compact";
+import isEqual from "lodash/isEqual";
 import isNil from "lodash/isNil";
 import isNumber from "lodash/isNumber";
 import flowRight from "lodash/flowRight";
@@ -133,7 +134,7 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     const drillableItems = useDashboardSelector(selectDrillableItems);
     const disableDefaultDrills = useDashboardSelector(selectDisableDefaultDrills);
 
-    const { result: brokenAlertsBasicInfo } = useWidgetBrokenAlertsQuery(kpiWidget.ref);
+    const { result: brokenAlertsBasicInfo } = useWidgetBrokenAlertsQuery(kpiWidget, alert);
 
     const isAlertBroken = !!brokenAlertsBasicInfo?.length;
 
@@ -375,6 +376,13 @@ export const KpiExecutor = flowRight(
         },
         exportTitle: "",
         loadOnMount: true,
+        shouldRefetch: (prevProps, nextProps) => {
+            return (
+                prevProps.alert !== nextProps.alert ||
+                !isEqual(prevProps.primaryMeasure, nextProps.primaryMeasure) ||
+                !isEqual(prevProps.effectiveFilters, nextProps.effectiveFilters)
+            );
+        },
     }),
     (WrappedComponent: React.ComponentType<Partial<IKpiProps>>) => {
         const withAlertProps = ({ result, error, isLoading, ...props }: IKpiResultsProps) => (
@@ -398,6 +406,13 @@ export const KpiExecutor = flowRight(
         },
         exportTitle: "",
         loadOnMount: true,
+        shouldRefetch: (prevProps, nextProps) => {
+            return (
+                !isEqual(prevProps.primaryMeasure, nextProps.primaryMeasure) ||
+                !isEqual(prevProps.secondaryMeasure, nextProps.secondaryMeasure) ||
+                !isEqual(prevProps.effectiveFilters, nextProps.effectiveFilters)
+            );
+        },
     }),
 )(KpiExecutorCore);
 


### PR DESCRIPTION
This makes sure the query is properly re-run when alert changes (for example when it is deleted).
Also adds missing shouldRefetch checks for KPI.

JIRA: RAIL-3680

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
