### PR TITLE
RELATED: RAIL-3694, RAIL-3695 fix pivot table sizing bugs

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
@@ -123,7 +123,11 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         error: filtersError,
     } = useWidgetFiltersQuery(widget, insight && insightFilters(insight));
 
-    const insightWithAddedFilters = insightSetFilters(insight, filtersForInsight);
+    const insightWithAddedFilters = useMemo(
+        () => insightSetFilters(insight, filtersForInsight),
+        [insight, filtersForInsight],
+    );
+
     const insightWithAddedWidgetProperties = useResolveDashboardInsightProperties({
         insight: insightWithAddedFilters ?? insight,
         widget,
@@ -152,7 +156,7 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
                 // Now, it works differently for the Headline - parent container adapts to Headline size.
                 isPositionRelative ? "relative" : "absolute",
         };
-    }, [insight]);
+    }, [isPositionRelative]);
 
     // Error handling
     const handleError = useCallback<OnError>(


### PR DESCRIPTION
* RAIL-3694 - prevent render loops in DashboardInsight by proper memoization
* RAIL-3695 - fix merging logic of insight properties and widget properties

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
