### PR TITLE
RELATED: RAIL-3492 - Save & SaveAs command handlers

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21183,7 +21183,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-JgSBoXZwIAmKOtiCuYjEnVNjhStmBeYzFi6+hdr81ZWTUebCxgZ4/Solvk8XH6t7y8Zm61pkwcOj+EgwBmi0Tg==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-TtES41oX0EKCUKHbHfPQ0UfiGZzLndLL/cTXxBWOy1qpHu3HjsljRz091nWcycTM0u6Lc6wgdnRfsvnur5TuAw==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -21243,7 +21243,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-0WLFuXGlT2kHeA5ODbmZjR9hcribKA6rUjJ2sXHsVyqGrV5QBYimiH4qbrdGf/PmjCJHmi1X61R037DIe7OOEw==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-YuxAtaXMwJLaZFFxe+rEGJOOsckm27aptXf37+QfOhg7sAj1sNQOhpvDeDZ97G76ds9TP49KZH6DoJvw+2HOZw==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21373,7 +21373,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-qwpr/jZGdSaAcjVxEkKQpMNxHc5PZWSHIF5EA9vBU7A9kjL8/KD7hpaxPNFyCXflnrYlOcD83FTWPJnY1u/LcQ==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-3oKUTZyU88mkTfQ8wQfHtbQFJ88Zq6WF29SUqDS8WPdV+YHyOv9oyQhzzFt7XtQEp2LAmS/lNaboV+KCXdz+SA==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21420,7 +21420,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-uUrNk0JaqZHodhHprVqQi7affAIuGtgRNs6BbljkLzTnLw3JVZVtfoJ1s5wHxz+6+0iM0i9D4mEGrkmwkRcJKQ==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-bQ9cSDSOZQBLkkXBkkTMobjGGTe5+89ZFwK2VkkebFt49I/ZVffqq6wHPSOaDg3OhJQ8tkt09GZkPP4dxDqdMQ==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21487,7 +21487,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-NmxGLvVTITQbqg+QPGFGqduklT/tRpQ3DPFLFYfH6WzTUs44E79m5uMQDt/Ft1LFB0Y72ExuJB8smcsHdige1Q==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-ji/OGBlYc6jQz97ISPYvQ37RdUTcphK2zgRRl62PkdmxE78XxAg8wC06cUp9I01TTPr/b42D1O6b2XNhgCSCxw==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21524,7 +21524,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-f1w9T2OS94P7Yol6p8dx2q13ovQyQ46eAWHWcvVduKUx10OH1mvS6ftJyuEZVJKiVNPbl3ZSPdDt0V1gv4bEuA==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-0fpC4FxjlqJTU7pGZGszgSlA67R3cUXhm7sI4+aNUZwoy18FmH+qlIxw48bNPCI8iekGdkAr1xu1yTqJg4TSuw==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21560,7 +21560,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-umA+Inj6TT7ZzGKtv+sb4OqcCcHt/HlhgEmC1deh2R3cOJinS8G8pmTqIIAkVPzS9J51JmQrW+cnbenTnUhv/A==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-fFgDltqLh5Aflj3EjLIoGwy+wOYwiAOS+TN+zAYWbctUFqGUtf/JMoyAdTsbuAADh2FDs7ZICqSD3iH4R3oNKw==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21607,7 +21607,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-QPG7x5mprOJwn2K4l1O7LC9DsSC+9Ve9rSiKXtH+blNcZBVQPXFfaNW7l26EqOhFMoM21qIQ6zOCk/UBNjta7Q==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-NscoDRHjhqbP5a2m9iKbU4zgebSquhWJl0TRacA3OBACQtxyJHP+bTKEhe3aNgmEoI5jy8sreJ7dPaMEtUM79A==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21721,7 +21721,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-sqN1SPbbOAs0zI4MZY1t1FDE2W4zUMPsjiri1L8flag46pNHj3+2dgA/yu0ckbFuJyPOVYyOfIvkVdjgpjYA6w==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-PGqDurzkE+uzv/k1MimG4Ob0jDvpzJeUU4XwYQNoyK2fnftPaqgTrz9v7aU/e5bQkw1TUNR7sn8qN0mJ91KfIg==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -21756,7 +21756,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-FQpMIuyG6zj/V11HreWnBEeQSfX8m2Sx7QYR96idrGWWeLT+LLOpZ5EZ+EC07IpMNQnxUOqkFjLZhGIhIg/WWA==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-udFNu+re13jyrbi8MpnZfBxYaFebT8fZN2ZcjfxtnrvDrdj3tL4rDOwFVpOruC/r58efanUg/8ULhImVTKMRVQ==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -21792,7 +21792,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-IO34Dif8nZshcJIYXUTS3ok8R3zRZisadhvH5mUFyz907YkF0HP+lymBi0KfvPszRcPvIytbWfuNOOh7ZucVoA==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-x9PJwTkflVo0Tc9EZpuFjXS+P08WNnhJIJE1mVOPsGtdAAu9IjqH5GZV9+CnWxj2QBoE9I/lM7e1McZ+VuLbEQ==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -21837,7 +21837,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-xFUGoNDeP+1SdWq/Zp0w2seXtC8zVFApC9cz+mBO9/HkQV16gm+7cJTrhGody/9Ve4wT9Oufv4KiFgXI3meODw==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-BTHfYU9ggFetVRFTtc0Bl65htGyWSUExfXj5oIMVkiQZVNtWbmOv3acfGP/VkqB1AJERbq1eIxfFujCc/Y/oBQ==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -21885,7 +21885,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-VEFYM2qe9OlxddC/c7HoHQ0GMxm1c1p7AegEGeYCQGjOvMzc/izgLO7pPcbcR3QwqcCNtvgKs9ym8/Kyv5q6sg==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-izVh0zSxsP52ImhIYZEw5MoLNncO0xSaqIZP920PjfyZSk0h1mxuKMJWQ2GAtZmEhKdMAHjmRA1ajI0qHpHQjA==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -21895,6 +21895,7 @@ packages:
       '@microsoft/api-extractor': 7.18.4
       '@types/jest': 26.0.23
       '@types/lodash': 4.14.170
+      '@types/uuid': 8.3.0
       '@typescript-eslint/eslint-plugin': 4.26.1_7bd7a7858841324c95046422bb20bae5
       '@typescript-eslint/parser': 4.26.1_eslint@7.28.0+typescript@4.0.2
       concurrently: 6.2.0
@@ -21914,6 +21915,7 @@ packages:
       ts-jest: 26.5.6_jest@26.6.3+typescript@4.0.2
       tslib: 2.2.0
       typescript: 4.0.2
+      uuid: 8.3.2
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -21924,7 +21926,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-9g0blFfoU8WjY6jf6b9uNicLaRErwuwa0jJzCztpyW8vZRpTIwvIO3LDrk+X2jJHKAbXRZTptGJyKgG+eqZMVQ==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-WlxJ8TdZf2xxnN7Z3PaoY2QeHEGf8EdbIiC4IgxznI4T5IUBYEaAAYaeY2v56sOblv/RgQCppL7Gs2YbEJVSuA==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -21965,7 +21967,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-Uh0mdro7USjL05hnyrsjAAMlt3iJDo+SVGRBZS4IupI75K3diffrfxcsl7+WtBn7IYOfal/Odm2PDQh4/DROXw==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-QgGAwt9mu5US+66kBW4tSK4F3CbRDcK8VF30yYxqze3Sqc6Z0wwQJGWqJ+ubKqWJkG2QgOLI5qlidWQWhHCYSw==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -22013,7 +22015,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-JJODuBqeJZLwjtB4YCswSC9HarMelCvh1wdBB4qei2SrH+9MuxXi2zS2x4xGxbuZEY+g8IU6lqMaPcGbQSyorA==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-NmVLbCUb2GkQ3UmxKb9+LxwaPBEbI1xpdofrgoR5wdOzxiC3YB1slolJwWNU7N/hIBR7rz/X5mMaWiVGUIk+oQ==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -22052,7 +22054,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-Y+voWPjLMkEwl/XCNYWYd7qgv1dv0TuN9uAVX3ia3uAItCX4BROB9SzastWbFYnku1ZcZ6q236zKyHMU+lRYJg==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-S9iVbrNVst/SLYAdxI1eGG4ciksE5u4TIYnAWH4QsnODjgTxQOHl9davuBD9pd49URSedMU2osW14f344gqlVg==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22297,7 +22299,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-Edko+ycTPY0+/rmIKJ0B+gmNcbSljpIv13S9qHOPkyDoRznX5cNz7zgKy36Ufw56QMLNs9L7ZMRu3J9x7zR7Dw==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-t7ToUZsjULHBSAAQROwVuSvPFdLSD9ISNptXXk1I2tUyB6m09SgHH2jSQ0NzXVAy4ALKH/bRzG4dWhpOUojBOw==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22333,7 +22335,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-51ffA1Z7R9Dl9ALCFIFb8y2nxkMnMoGFUe+B5u8rh2spuBCymnle/RPZVdWTLDOUone3gAVvKnn3M4nH5zyPjA==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-Sq+cBxsLPI5nt+gE/QpNj3PUPLrCNhM1rWZITOMafE+qWxK9g7KR21t8rFldInnQKr/vQr0roBR+hf/Sn0GhMg==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22407,7 +22409,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-P1AmiXqAe/h7lX5NBaThRxNrjoCQVB3H1KOrV+2rbDFrZCxgi9fQrEEvfKSUtOpTB4N9KxWa05auWgMUDiHL5w==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-dQ0rHf6mMV7gCWQKIWsMB68Zya3u96bCMlO7pKXT1nOoxSfxEBlnyE0CXRXGNdxka6gxKNn/vmfb+Iba9vvdlQ==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22490,7 +22492,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-7aq3RJtUWXnVCHViTuUc+wg27spAlGKGR2DE8ATxoJBTzQ7FwwYGC6tsky+9v2OIo4znT2Twqguiv7VlvPYDBQ==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-mzLY7Ws17U+H7m0Ms9x4EX9sRuI/D5iBNSGu0zkAJeMK3uURcC+H250ZseuP19O3i6MWM86I+CLZpo+EpwhPEg==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22573,7 +22575,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-D6Pwjw7jvherj73VgGKSK3KDfjmz/fk47VUncQVB3A2Xwfq9FBggZ7N1Uo1c4R7QW8MIprE46GnQZkewxJx2PA==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-uWLiV+5+6E/u/vZ3B8DPhm7MINGeCsKnNLfLCpBSY05ymNrCbWwtpfjMBBhxiONu6HflTAkMmpvipYMA0eoS2Q==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -22650,7 +22652,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-CSteVKdxwLYKvsi0VuY5TzfjYHqy7Mh+MWwy8ZvVnFj3QBXgvZs61SEbe9odn0Rv+MC3kRDXe4FxU3HwlzDcgQ==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-nF0R4Z0ysfBFpdx5Gz+ARb7VmGjsZpHFDRLFV4Ma6k2lKCRa32XG+RdjCyGLUxvcoyt+HZIORl5WEeIHjQK6fA==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -22718,7 +22720,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-IRw82RJctGyBseD38VnFZGPAwv3b01tlSkH/xTRkbZSS4BZv+lcmLKv3CvbPUoEfbvDNbdVKRD89nXptUAXo1A==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-aCOuJCyIMRdWnKi3PeulI/yzKuv5yDhjPMM59I36TkFAlhn+3HaktPGo0CIFPoC74U5vG8VdYFmN4V4b5sUZuw==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -22807,7 +22809,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-B7Z0/to4PWhcaG/dyh3tUvob0yL2uOqXrVm79Pj2geAfDfn4A55fFtCdgzFfY0RDuKyH7yqTLfGFcYvXXZWE5g==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-S3NFahIffzUoN/NWTXl8AoUChiJzu6ET6E7KGj4E/ghN+a0oKMIQ/WGxOus9AtqsGqYYMqaXqKsvjujjvVgwJA==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -22880,7 +22882,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-gycLCdL2Mj2e5wjcOInXDUV+QFTn7XE/k4gQ6+kyZyiBZ5Dlwzmvc5wI+SUjKXN8yumL4ibLR9kOrmrE08Y1VQ==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-QhUnJjA2Y5utNQfd8KXBOvdZ8zC2buba7DJQlWSsk3EQdDx1QY1QojkcLX0nCqr3wA3+i86ymeEJM4lFGtSC+Q==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -22977,7 +22979,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-6c4x4riydCPuydyaiY0Q3nYBdsCGG8ULVypAMyWBLOGx215lRuE7plGRGPITvvpWE02CLrh7Ftz3Awc4UTDYsw==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-8Jf5e5wmktwwu28LnY7J5yHL2TL6MvWUIEryuM141usxwiI+uufDBIwy8aaVxtVwwq1WYcXMh8CRHqH/h/UF8Q==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -23071,7 +23073,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-sNcExtWHoeXPFtHuX8d9VM5trS9g3IkTiU0nVC7t5ZrVg1JWi5v5mk8Unxo0uwoZyAbRbO1iaEyHrIUp4WGkjg==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-uxA0IObov/SzBrMDgix5Ux6DRyHajRzTOBT6jo1GD3O38by2DbOAf39zstMhn2d5pxqBIXxNxMZc3XbqvWLn9w==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23129,7 +23131,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-yNyhgldj/zXz2LobadkKDvht9p3aUdpWg0GknLS2dW2IaThFY0SzEgVWnd3s30AbvrQNXcCcHn887i5w239kEQ==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-/r/sOIzxDo6wwT7v/pVi81c7a4T+7zFGuADA/e9WrIHGoGGp6psaHkZHBfzCfkJ2IUHtxUPMNMXr0IhlS/AKDA==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23191,7 +23193,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-LWOiZMPNhFnwE/Hj20+Wi1c+wqBdxnZdD5qAVkCbq1Jys1/GVA8kJiYiTblsSDW+jmmonDDzG6As+/jZ2+d1WQ==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-mLvR28/h/VdRLXuYy1HKXUWHFxLewBKKtnBELSL8rNUdGgt4ZCeYOxWWP+rhfhiBBpHVzLmnSiV74tcUv1uVwg==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0

--- a/libs/sdk-backend-mockingbird/package.json
+++ b/libs/sdk-backend-mockingbird/package.json
@@ -52,7 +52,8 @@
         "@gooddata/sdk-model": "^8.6.0-alpha.65",
         "lodash": "^4.17.19",
         "ts-invariant": "^0.7.3",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
     },
     "devDependencies": {
         "@gooddata/api-model-bear": "^8.6.0-alpha.65",
@@ -62,6 +63,7 @@
         "@microsoft/api-extractor": "^7.18.4",
         "@types/jest": "^26.0.12",
         "@types/lodash": "^4.14.158",
+        "@types/uuid": "^8.3.0",
         "@typescript-eslint/eslint-plugin": "^4.14.2",
         "@typescript-eslint/parser": "^4.14.2",
         "concurrently": "^6.0.2",

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/dashboards.ts
@@ -45,7 +45,7 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
         private readonly recordings: RecordingIndex,
     ) {}
 
-    private findDashboardRecording(ref: ObjRef): DashboardRecording | IDashboard | undefined {
+    private findRecordingOrLocalDashboard(ref: ObjRef): DashboardRecording | IDashboard | undefined {
         const recordedDashboard = values(this.recordings.metadata?.dashboards ?? {}).find((recording) => {
             const {
                 obj: { dashboard },
@@ -101,7 +101,7 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
             throw new NotSupported("recorded backend does not support filter context override");
         }
 
-        const recording = this.findDashboardRecording(ref);
+        const recording = this.findRecordingOrLocalDashboard(ref);
 
         if (!recording) {
             return Promise.reject(new UnexpectedResponseError("Not Found", 404, {}));
@@ -115,7 +115,7 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
     };
 
     public getDashboardWidgetAlertsForCurrentUser = (ref: ObjRef): Promise<IWidgetAlert[]> => {
-        const recording = this.findDashboardRecording(ref);
+        const recording = this.findRecordingOrLocalDashboard(ref);
 
         if (!recording) {
             return Promise.reject(new UnexpectedResponseError("Not Found", 404, {}));
@@ -136,7 +136,7 @@ export class RecordedDashboards implements IWorkspaceDashboardsService {
             throw new NotSupported("recorded backend does not support filter context override");
         }
 
-        const recording = this.findDashboardRecording(ref);
+        const recording = this.findRecordingOrLocalDashboard(ref);
 
         if (!recording) {
             return Promise.reject(new UnexpectedResponseError("Not Found", 404, {}));

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -132,6 +132,8 @@ function recordedWorkspace(
     recordings: RecordingIndex = {},
     implConfig: RecordedBackendConfig,
 ): IAnalyticalWorkspace {
+    const insightsService = new RecordedInsights(recordings, implConfig.useRefType ?? "uri");
+
     return {
         workspace,
         async getDescriptor(): Promise<IWorkspaceDescriptor> {
@@ -153,10 +155,10 @@ function recordedWorkspace(
             return new RecordedFacts();
         },
         insights(): IWorkspaceInsightsService {
-            return new RecordedInsights(recordings, implConfig.useRefType ?? "uri");
+            return insightsService;
         },
         dashboards(): IWorkspaceDashboardsService {
-            return new RecordedDashboards(this.workspace, recordings);
+            return new RecordedDashboards(this.workspace, insightsService, recordings);
         },
         settings(): IWorkspaceSettingsService {
             return {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2883,13 +2883,14 @@ export interface SaveDashboardAs extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
         readonly title?: string;
+        readonly switchToCopy?: boolean;
     };
     // (undocumented)
     readonly type: "GDC.DASH/CMD.SAVEAS";
 }
 
 // @alpha
-export function saveDashboardAs(title?: string, correlationId?: string): SaveDashboardAs;
+export function saveDashboardAs(title?: string, switchToCopy?: boolean, correlationId?: string): SaveDashboardAs;
 
 // @internal (undocumented)
 export const ScheduledEmailDialog: () => JSX.Element;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -44,7 +44,6 @@ import { IDashboardLayoutItem } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutSection } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutSectionHeader } from '@gooddata/sdk-backend-spi';
 import { IDashboardObjectIdentity } from '@gooddata/sdk-backend-spi';
-import { IDashboardWidget } from '@gooddata/sdk-backend-spi';
 import { IDateFilterConfig } from '@gooddata/sdk-backend-spi';
 import { IDateFilterOptionsByType } from '@gooddata/sdk-ui-filters';
 import { Identifier } from '@gooddata/sdk-model';
@@ -999,7 +998,7 @@ export interface DashboardInsightWidgetVisPropertiesChanged extends IDashboardEv
 }
 
 // @alpha
-export type DashboardItemDefinition = ExtendedDashboardItem | StashedDashboardItemsId;
+export type DashboardItemDefinition = ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition> | StashedDashboardItemsId;
 
 // @internal (undocumented)
 export const DashboardKpi: () => JSX.Element;
@@ -1692,13 +1691,13 @@ export function enableInsightWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef, 
 export function enableKpiWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef, correlationId?: string): ChangeKpiWidgetFilterSettings;
 
 // @alpha
-export type ExtendedDashboardItem = IDashboardLayoutItem<ExtendedDashboardWidget>;
+export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayoutItem<T>;
 
 // @alpha
 export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDashboardWidget>;
 
 // @alpha
-export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
+export type ExtendedDashboardWidget = IWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
 
 // @internal (undocumented)
 export const FilterBar: () => JSX.Element;
@@ -2929,7 +2928,7 @@ export const selectAttributesWithDrillDown: OutputSelector<DashboardState, (ICat
 export const selectBackendCapabilities: OutputSelector<DashboardState, IBackendCapabilities, (res: BackendCapabilitiesState) => IBackendCapabilities>;
 
 // @internal
-export const selectBasicLayout: OutputSelector<DashboardState, IDashboardLayout<IDashboardWidget>, (res: IDashboardLayout<ExtendedDashboardWidget>) => IDashboardLayout<IDashboardWidget>>;
+export const selectBasicLayout: OutputSelector<DashboardState, IDashboardLayout<IWidget>, (res: IDashboardLayout<ExtendedDashboardWidget>) => IDashboardLayout<IWidget>>;
 
 // @alpha
 export const selectCanListUsersInWorkspace: OutputSelector<DashboardState, boolean, (res: IWorkspacePermissions) => boolean>;
@@ -3151,7 +3150,7 @@ export const selectSeparators: OutputSelector<DashboardState, ISeparators, (res:
 export const selectSettings: OutputSelector<DashboardState, ISettings, (res: ResolvedDashboardConfig) => ISettings>;
 
 // @internal
-export const selectStash: OutputSelector<DashboardState, Record<string, ExtendedDashboardItem[]>, (res: LayoutState) => Record<string, ExtendedDashboardItem[]>>;
+export const selectStash: OutputSelector<DashboardState, Record<string, ExtendedDashboardItem<ExtendedDashboardWidget>[]>, (res: LayoutState) => Record<string, ExtendedDashboardItem<ExtendedDashboardWidget>[]>>;
 
 // @alpha
 export const selectUser: OutputSelector<DashboardState, IUser, (res: UserState) => IUser>;

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
@@ -46,11 +46,11 @@ function extractContentFromWidget(
  * @param insightsById - list of insights available; insight widgets will be resolved using this
  * @param settings - settings that may impact the sizing
  */
-function dashboardLayoutItemSanitize(
-    item: IDashboardLayoutItem,
+function dashboardLayoutItemSanitize<T = IDashboardWidget>(
+    item: IDashboardLayoutItem<T>,
     insightsById: Record<string, IInsight>,
     settings: ISettings,
-): IDashboardLayoutItem | undefined {
+): IDashboardLayoutItem<T> | undefined {
     const {
         widget,
         size: { xl },
@@ -99,11 +99,11 @@ function dashboardLayoutItemSanitize(
  * @param insights - existing insights that are referenced by the layout's widgets
  * @param settings - current settings; these may influence sizing of the widgets
  */
-export function dashboardLayoutSanitize(
-    layout: IDashboardLayout,
+export function dashboardLayoutSanitize<T = IDashboardWidget>(
+    layout: IDashboardLayout<T>,
     insights: IInsight[],
     settings: ISettings,
-): IDashboardLayout {
+): IDashboardLayout<T> {
     const insightsById: Record<string, IInsight> = keyBy(insights, (insight) =>
         serializeObjRef(insightRef(insight)),
     );

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
@@ -249,7 +249,7 @@ export function dashboardLayoutRemoveIdentity<T extends IDashboardWidget>(
             } else {
                 const identity = getWidgetIdentity(item.widget);
 
-                if (!identity || identityPredicate(identity)) {
+                if (!identity || !identityPredicate(identity)) {
                     return item;
                 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -1,0 +1,133 @@
+// (C) 2021 GoodData Corporation
+
+import { IDashboard, IDashboardDefinition } from '@gooddata/sdk-backend-spi';
+import { BatchAction, batchActions } from 'redux-batched-actions';
+import { SagaIterator } from 'redux-saga';
+import { call, put, SagaReturnType, select } from 'redux-saga/effects';
+import {
+    DashboardContext,
+    DashboardCopySaved,
+    SaveDashboardAs,
+    selectBasicLayout,
+    selectDateFilterConfigOverrides,
+    selectFilterContextDefinition
+} from '../..';
+import { dashboardFilterContextIdentity } from '../../../_staging/dashboard/dashboardFilterContext';
+import {
+    dashboardLayoutRemoveIdentity,
+    dashboardLayoutWidgetIdentityMap
+} from '../../../_staging/dashboard/dashboardLayout';
+import { dashboardCopySaved } from '../../events/dashboard';
+import { filterContextActions } from '../../state/filterContext';
+import { layoutActions } from '../../state/layout';
+import { metaActions } from '../../state/meta';
+import { selectDashboardDescriptor } from '../../state/meta/metaSelectors';
+import { PromiseFnReturnType } from '../../types/sagas';
+
+type DashboardSaveAsContext = {
+    cmd: SaveDashboardAs;
+
+    /**
+     * This contains definition of dashboard that reflects the current state.
+     */
+    dashboardFromState: IDashboardDefinition;
+
+    /**
+     * This contains definition that should be used during save as. This is based on the `dashboardFromState` but
+     * has few distinctions:
+     *
+     * -  all widgets will have their identity cleared up; this is to ensure that new widgets will be created
+     *    during `createDashboard` call
+     * -  the title passed from command will be used here
+     */
+    dashboardToSave: IDashboardDefinition;
+};
+
+type DashboardSaveAsResult = {
+    batch: BatchAction;
+    dashboard: IDashboard;
+};
+
+function createDashboard(ctx: DashboardContext, saveAsCtx: DashboardSaveAsContext): Promise<IDashboard> {
+    return ctx.backend.workspace(ctx.workspace).dashboards().createDashboard(saveAsCtx.dashboardToSave);
+}
+
+function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<DashboardSaveAsContext> {
+    const {title} = cmd.payload;
+    const titleProp = title ? { title } : {};
+    const dashboardDescriptor: ReturnType<typeof selectDashboardDescriptor> = yield select(
+        selectDashboardDescriptor,
+    );
+    const filterContextDefinition: ReturnType<typeof selectFilterContextDefinition> = yield select(
+        selectFilterContextDefinition,
+    );
+    const layout: ReturnType<typeof selectBasicLayout> = yield select(selectBasicLayout);
+    const dateFilterConfig: ReturnType<typeof selectDateFilterConfigOverrides> = yield select(
+        selectDateFilterConfigOverrides,
+    );
+
+    const dashboardFromState: IDashboardDefinition = {
+        ...dashboardDescriptor,
+        filterContext: {
+            ...filterContextDefinition,
+        },
+        layout,
+        dateFilterConfig,
+    };
+
+    const dashboardToSave: IDashboardDefinition = {
+        ...dashboardFromState,
+        ...titleProp,
+        layout: dashboardLayoutRemoveIdentity(layout, () => true),
+    };
+
+    return {
+        cmd,
+        dashboardFromState,
+        dashboardToSave,
+    };
+}
+
+function* saveAs(
+    ctx: DashboardContext,
+    saveAsCtx: DashboardSaveAsContext,
+): SagaIterator<DashboardSaveAsResult> {
+    const dashboard: PromiseFnReturnType<typeof createDashboard> = yield call(createDashboard, ctx, saveAsCtx);
+    const identityMapping = dashboardLayoutWidgetIdentityMap(
+        saveAsCtx.dashboardFromState.layout!,
+        dashboard.layout!,
+    );
+
+    const batch = batchActions(
+        [
+            metaActions.setMeta({ dashboard }),
+            filterContextActions.updateFilterContextIdentity({
+                filterContextIdentity: dashboardFilterContextIdentity(dashboard),
+            }),
+            layoutActions.updateWidgetIdentities(identityMapping),
+            layoutActions.clearLayoutHistory(),
+        ],
+        "@@GDC.DASH.SAVE_AS",
+    );
+
+    return {
+        batch,
+        dashboard,
+    };
+}
+
+export function* saveAsDashboardHandler(
+    ctx: DashboardContext,
+    cmd: SaveDashboardAs,
+): SagaIterator<DashboardCopySaved> {
+    const saveAsCtx: SagaReturnType<typeof createDashboardSaveAsContext> = yield call(
+        createDashboardSaveAsContext,
+        cmd,
+    );
+    const result: SagaReturnType<typeof saveAs> = yield call(saveAs, ctx, saveAsCtx);
+    const { dashboard, batch } = result;
+
+    yield put(batch);
+
+    return dashboardCopySaved(ctx, dashboard, cmd.correlationId);
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -1,0 +1,200 @@
+// (C) 2021 GoodData Corporation
+import { DashboardContext } from "../../types/commonTypes";
+import { SaveDashboard } from "../../commands";
+import { SagaIterator } from "redux-saga";
+import { DashboardSaved } from "../../events";
+import { selectBasicLayout } from "../../state/layout/layoutSelectors";
+import { call, put, SagaReturnType, select, setContext } from "redux-saga/effects";
+import {
+    selectFilterContextDefinition,
+    selectFilterContextIdentity,
+} from "../../state/filterContext/filterContextSelectors";
+import { selectDashboardDescriptor, selectPersistedDashboard } from "../../state/meta/metaSelectors";
+import { selectDateFilterConfigOverrides } from "../../state/dateFilterConfig/dateFilterConfigSelectors";
+import { IDashboard, IDashboardDefinition, IDashboardObjectIdentity } from "@gooddata/sdk-backend-spi";
+import { BatchAction, batchActions } from "redux-batched-actions";
+import { PromiseFnReturnType } from "../../types/sagas";
+import { dashboardSaved } from "../../events/dashboard";
+import { metaActions } from "../../state/meta";
+import { filterContextActions } from "../../state/filterContext";
+import { dashboardFilterContextIdentity } from "../../../_staging/dashboard/dashboardFilterContext";
+import { invariant } from "ts-invariant";
+import {
+    dashboardLayoutRemoveIdentity,
+    dashboardLayoutWidgetIdentityMap,
+} from "../../../_staging/dashboard/dashboardLayout";
+import { isTemporaryIdentity } from "../../utils/dashboardItemUtils";
+import { layoutActions } from "../../state/layout";
+
+type DashboardSaveContext = {
+    cmd: SaveDashboard;
+    /**
+     * This contains definition of dashboard that reflects the current state.
+     */
+    dashboardFromState: IDashboardDefinition;
+
+    /**
+     * This contains definition that should be used during save. This is based on the `dashboardFromState` but
+     * has one distinction: there will be no widgets that have the temporary identity assigned. All such
+     * widgets will have the identity cleared up; this is essential for the backend SPI create/updateDashboard
+     * methods to know which widgets are new.
+     */
+    dashboardToSave: IDashboardDefinition;
+
+    /**
+     * Dashboard as it is saved on the backend.
+     *
+     * This will be undefined if a dashboard is not yet saved.
+     */
+    persistedDashboard?: IDashboard;
+};
+
+type DashboardSaveResult = {
+    batch: BatchAction;
+    dashboard: IDashboard;
+};
+
+type DashboardSaveFn = (ctx: DashboardContext, saveCtx: DashboardSaveContext) => Promise<IDashboard>;
+
+function createDashboard(ctx: DashboardContext, saveCtx: DashboardSaveContext): Promise<IDashboard> {
+    return ctx.backend.workspace(ctx.workspace).dashboards().createDashboard(saveCtx.dashboardToSave);
+}
+
+function updateDashboard(ctx: DashboardContext, saveCtx: DashboardSaveContext): Promise<IDashboard> {
+    const { persistedDashboard, dashboardToSave } = saveCtx;
+    invariant(persistedDashboard);
+
+    return ctx.backend
+        .workspace(ctx.workspace)
+        .dashboards()
+        .updateDashboard(persistedDashboard, dashboardToSave);
+}
+
+function* createDashboardSaveContext(cmd: SaveDashboard): SagaIterator<DashboardSaveContext> {
+    const persistedDashboard: ReturnType<typeof selectPersistedDashboard> = yield select(
+        selectPersistedDashboard,
+    );
+    const dashboardDescriptor: ReturnType<typeof selectDashboardDescriptor> = yield select(
+        selectDashboardDescriptor,
+    );
+    const filterContextDefinition: ReturnType<typeof selectFilterContextDefinition> = yield select(
+        selectFilterContextDefinition,
+    );
+    const filterContextIdentity: ReturnType<typeof selectFilterContextIdentity> = yield select(
+        selectFilterContextIdentity,
+    );
+    const layout: ReturnType<typeof selectBasicLayout> = yield select(selectBasicLayout);
+    const dateFilterConfig: ReturnType<typeof selectDateFilterConfigOverrides> = yield select(
+        selectDateFilterConfigOverrides,
+    );
+
+    /*
+     * When updating an existing dashboard, the services expect that the dashboard definition to use for
+     * updating contains the identity of the existing dashboard.
+     *
+     * It's ok to have no identity when creating a new dashboard - it will be assigned during the save.
+     */
+    const dashboardIdentity: Partial<IDashboardObjectIdentity> = {
+        ref: persistedDashboard?.ref,
+        uri: persistedDashboard?.uri,
+        identifier: persistedDashboard?.identifier,
+    };
+
+    const dashboardFromState: IDashboardDefinition = {
+        ...dashboardDescriptor,
+        ...dashboardIdentity,
+        filterContext: {
+            ...filterContextIdentity,
+            ...filterContextDefinition,
+        },
+        layout,
+        dateFilterConfig,
+    };
+
+    const dashboardToSave: IDashboardDefinition = {
+        ...dashboardFromState,
+        layout: dashboardLayoutRemoveIdentity(layout, isTemporaryIdentity),
+    };
+
+    return {
+        cmd,
+        persistedDashboard,
+        dashboardFromState,
+        dashboardToSave,
+    };
+}
+
+function* save(
+    ctx: DashboardContext,
+    saveCtx: DashboardSaveContext,
+    saveFn: DashboardSaveFn,
+    saveActionName: string,
+): SagaIterator<DashboardSaveResult> {
+    const dashboard: PromiseFnReturnType<typeof saveFn> = yield call(saveFn, ctx, saveCtx);
+
+    /*
+     * The crucial thing to do after the save is to update the identities of different objects that are stored
+     * in the dashboard state and either:
+     *
+     * 1.  have no identity (such as dashboard itself or filter context in case of new dashboards)
+     * 2.  or have temporary identity (such as KPI and Insight widgets in case of any dashboard that gets
+     *     modified with new content).
+     *
+     * The first task is easy. The second requires additional processing to identify mapping between
+     * temporary identity and persistent identity and then update the layout state accordingly.
+     */
+    const identityMapping = dashboardLayoutWidgetIdentityMap(
+        saveCtx.dashboardFromState.layout!,
+        dashboard.layout!,
+    );
+
+    const batch = batchActions(
+        [
+            metaActions.setMeta({ dashboard }),
+            filterContextActions.updateFilterContextIdentity({
+                filterContextIdentity: dashboardFilterContextIdentity(dashboard),
+            }),
+            layoutActions.updateWidgetIdentities(identityMapping),
+            layoutActions.clearLayoutHistory(),
+        ],
+        saveActionName,
+    );
+
+    return {
+        batch,
+        dashboard,
+    };
+}
+
+export function* saveDashboardHandler(
+    ctx: DashboardContext,
+    cmd: SaveDashboard,
+): SagaIterator<DashboardSaved> {
+    const saveCtx: SagaReturnType<typeof createDashboardSaveContext> = yield call(
+        createDashboardSaveContext,
+        cmd,
+    );
+    const isNewDashboard = saveCtx.persistedDashboard === undefined;
+    let result: DashboardSaveResult;
+
+    if (!isNewDashboard) {
+        result = yield call(save, ctx, saveCtx, createDashboard, "@@GDC.DASH.SAVE_NEW");
+    } else {
+        result = yield call(save, ctx, saveCtx, updateDashboard, "@@GDC.DASH.SAVE_EXISTING");
+    }
+
+    const { dashboard, batch } = result;
+
+    yield put(batch);
+
+    if (isNewDashboard) {
+        yield setContext({
+            dashboardContext: {
+                ...ctx,
+                dashboardRef: dashboard.ref,
+            },
+        });
+    }
+
+    return dashboardSaved(ctx, dashboard, isNewDashboard, cmd.correlationId);
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -177,7 +177,7 @@ export function* saveDashboardHandler(
     const isNewDashboard = saveCtx.persistedDashboard === undefined;
     let result: DashboardSaveResult;
 
-    if (!isNewDashboard) {
+    if (isNewDashboard) {
         result = yield call(save, ctx, saveCtx, createDashboard, "@@GDC.DASH.SAVE_NEW");
     } else {
         result = yield call(save, ctx, saveCtx, updateDashboard, "@@GDC.DASH.SAVE_EXISTING");

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveAsDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveAsDashboardHandler.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`save as dashboard handler for a new dashboard should emit correct events 1`] = `
+Array [
+  Object {
+    "correlationId": "testCorrelationId",
+    "type": "GDC.DASH/EVT.COPY_SAVED",
+  },
+]
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveDashboardHandler.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`save dashboard handler for a new dashboard should emit correct events 1`] = `
+Array [
+  Object {
+    "correlationId": "testCorrelationId",
+    "type": "GDC.DASH/EVT.SAVED",
+  },
+]
+`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveAsDashboardHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveAsDashboardHandler.test.ts
@@ -1,0 +1,115 @@
+// (C) 2021 GoodData Corporation
+import { DashboardTester, preloadedTesterFactory } from "../../../tests/DashboardTester";
+import { addLayoutSection, saveDashboard, saveDashboardAs } from "../../../commands";
+import { TestInsightItem } from "../../../tests/fixtures/Layout.fixtures";
+import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
+import { DashboardCopySaved, DashboardSaved } from "../../../events";
+import { selectBasicLayout } from "../../../state/layout/layoutSelectors";
+import { isTemporaryIdentity } from "../../../utils/dashboardItemUtils";
+import { selectFilterContextIdentity } from "../../../state/filterContext/filterContextSelectors";
+import { selectDashboardTitle, selectPersistedDashboard } from "../../../state/meta/metaSelectors";
+
+describe("save as dashboard handler", () => {
+    describe("for a new dashboard", () => {
+        let Tester: DashboardTester;
+        // each test starts with a new dashboard
+        beforeEach(
+            preloadedTesterFactory(
+                (tester) => {
+                    Tester = tester;
+                },
+                undefined,
+                {
+                    backendConfig: {
+                        useRefType: "id",
+                    },
+                },
+            ),
+        );
+
+        const TestDashboardTitle = "My Dashboard Copy";
+
+        it("should save an existing dashboard as a copy and switch to copy", async () => {
+            await Tester.dispatchAndWaitFor(
+                addLayoutSection(0, {}, [TestInsightItem], false, TestCorrelation),
+                "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+            );
+
+            const initialSaveEvent: DashboardSaved = await Tester.dispatchAndWaitFor(
+                saveDashboard(),
+                "GDC.DASH/EVT.SAVED",
+            );
+
+            expect(initialSaveEvent.payload.newDashboard).toEqual(true);
+            const originalState = Tester.state();
+
+            const event: DashboardCopySaved = await Tester.dispatchAndWaitFor(
+                saveDashboardAs(TestDashboardTitle, true),
+                "GDC.DASH/EVT.COPY_SAVED",
+            );
+
+            expect(event.payload.dashboard.ref).not.toEqual(initialSaveEvent.payload.dashboard.ref);
+            expect(event.payload.dashboard.title).toEqual(TestDashboardTitle);
+            const newState = Tester.state();
+
+            const originalLayout = selectBasicLayout(originalState);
+            const newLayout = selectBasicLayout(newState);
+
+            expect(newLayout.sections[0].items[0].widget).not.toEqual(
+                originalLayout.sections[0].items[0].widget,
+            );
+            expect(isTemporaryIdentity(newLayout.sections[0].items[0].widget!)).toEqual(false);
+
+            expect(selectDashboardTitle(newState)).not.toEqual(selectDashboardTitle(originalState));
+            expect(selectFilterContextIdentity(newState)).not.toEqual(
+                selectFilterContextIdentity(originalState),
+            );
+            expect(selectPersistedDashboard(newState)?.ref).not.toEqual(
+                selectPersistedDashboard(originalState)?.ref,
+            );
+        });
+
+        it("should save an existing dashboard as a copy and leave current dashboard open", async () => {
+            await Tester.dispatchAndWaitFor(
+                addLayoutSection(0, {}, [TestInsightItem], false, TestCorrelation),
+                "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+            );
+
+            const initialSaveEvent: DashboardSaved = await Tester.dispatchAndWaitFor(
+                saveDashboard(),
+                "GDC.DASH/EVT.SAVED",
+            );
+
+            expect(initialSaveEvent.payload.newDashboard).toEqual(true);
+            const originalState = Tester.state();
+
+            const event: DashboardCopySaved = await Tester.dispatchAndWaitFor(
+                saveDashboardAs(TestDashboardTitle, false),
+                "GDC.DASH/EVT.COPY_SAVED",
+            );
+
+            expect(event.payload.dashboard.ref).not.toEqual(initialSaveEvent.payload.dashboard.ref);
+            expect(event.payload.dashboard.title).toEqual(TestDashboardTitle);
+            const newState = Tester.state();
+
+            const originalLayout = selectBasicLayout(originalState);
+            const newLayout = selectBasicLayout(newState);
+
+            expect(newLayout.sections[0].items[0].widget).toEqual(originalLayout.sections[0].items[0].widget);
+            expect(selectDashboardTitle(newState)).toEqual(selectDashboardTitle(originalState));
+            expect(selectFilterContextIdentity(newState)).toEqual(selectFilterContextIdentity(originalState));
+            expect(selectPersistedDashboard(newState)?.ref).toEqual(
+                selectPersistedDashboard(originalState)?.ref,
+            );
+        });
+
+        it("should emit correct events", async () => {
+            await Tester.dispatchAndWaitFor(
+                saveDashboardAs("My Dashboard Copy", false, TestCorrelation),
+                "GDC.DASH/EVT.COPY_SAVED",
+            );
+
+            expect(Tester.emittedEventsDigest()).toMatchSnapshot();
+        });
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveDashboardHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/saveDashboardHandler.test.ts
@@ -1,0 +1,102 @@
+// (C) 2021 GoodData Corporation
+import { DashboardTester, preloadedTesterFactory } from "../../../tests/DashboardTester";
+import { addLayoutSection, saveDashboard } from "../../../commands";
+import { TestInsightItem } from "../../../tests/fixtures/Layout.fixtures";
+import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
+import { DashboardSaved } from "../../../events";
+import { selectBasicLayout } from "../../../state/layout/layoutSelectors";
+import { isTemporaryIdentity } from "../../../utils/dashboardItemUtils";
+import { selectFilterContextIdentity } from "../../../state/filterContext/filterContextSelectors";
+import { selectPersistedDashboard } from "../../../state/meta/metaSelectors";
+
+describe("save dashboard handler", () => {
+    describe("for a new dashboard", () => {
+        let Tester: DashboardTester;
+        // each test starts with a new dashboard
+        beforeEach(
+            preloadedTesterFactory(
+                (tester) => {
+                    Tester = tester;
+                },
+                undefined,
+                {
+                    backendConfig: {
+                        useRefType: "id",
+                    },
+                },
+            ),
+        );
+
+        it("should save a new dashboard", async () => {
+            // add something onto the layout
+            await Tester.dispatchAndWaitFor(
+                addLayoutSection(0, {}, [TestInsightItem], false, TestCorrelation),
+                "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+            );
+            // .. and perform save
+            const event: DashboardSaved = await Tester.dispatchAndWaitFor(
+                saveDashboard(),
+                "GDC.DASH/EVT.SAVED",
+            );
+
+            expect(event.payload.dashboard.ref).toBeDefined();
+            expect(event.payload.newDashboard).toEqual(true);
+
+            const state = Tester.state();
+
+            // verify that assigned identities of the entities that make up the dashboard are stored in the state
+            expect(selectPersistedDashboard(state)?.ref).toEqual(event.payload.dashboard.ref);
+
+            const filterContextIdentity = selectFilterContextIdentity(state);
+            expect(filterContextIdentity).toBeDefined();
+            expect(isTemporaryIdentity(filterContextIdentity!)).toBe(false);
+
+            const layout = selectBasicLayout(state);
+            expect(isTemporaryIdentity(layout.sections[0].items[0].widget!)).toEqual(false);
+        });
+
+        it("should save an existing dashboard", async () => {
+            await Tester.dispatchAndWaitFor(
+                addLayoutSection(0, {}, [TestInsightItem], false, TestCorrelation),
+                "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+            );
+
+            const initialSaveEvent: DashboardSaved = await Tester.dispatchAndWaitFor(
+                saveDashboard(),
+                "GDC.DASH/EVT.SAVED",
+            );
+
+            expect(initialSaveEvent.payload.newDashboard).toEqual(true);
+            const originalState = Tester.state();
+
+            await Tester.dispatchAndWaitFor(
+                addLayoutSection(-1, {}, [TestInsightItem], false, TestCorrelation),
+                "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+            );
+            const event: DashboardSaved = await Tester.dispatchAndWaitFor(
+                saveDashboard(),
+                "GDC.DASH/EVT.SAVED",
+            );
+
+            expect(event.payload.newDashboard).toEqual(false);
+            const newState = Tester.state();
+
+            const originalLayout = selectBasicLayout(originalState);
+            const newLayout = selectBasicLayout(newState);
+
+            expect(newLayout.sections[0].items[0].widget).toEqual(originalLayout.sections[0].items[0].widget);
+            expect(isTemporaryIdentity(newLayout.sections[1].items[0].widget!)).toEqual(false);
+
+            expect(selectFilterContextIdentity(newState)).toEqual(selectFilterContextIdentity(originalState));
+            expect(selectPersistedDashboard(newState)?.ref).toEqual(
+                selectPersistedDashboard(originalState)?.ref,
+            );
+        });
+
+        it("should emit correct events", async () => {
+            await Tester.dispatchAndWaitFor(saveDashboard(TestCorrelation), "GDC.DASH/EVT.SAVED");
+
+            expect(Tester.emittedEventsDigest()).toMatchSnapshot();
+        });
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
@@ -6,7 +6,7 @@ import { AddLayoutSection } from "../../commands";
 import { invalidArgumentsProvided } from "../../events/general";
 import { selectLayout, selectStash } from "../../state/layout/layoutSelectors";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
-import { ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
+import { DashboardItemDefinition, ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
 import isEmpty from "lodash/isEmpty";
 import { layoutActions } from "../../state/layout";
 import { DashboardLayoutSectionAdded, layoutSectionAdded } from "../../events/layout";
@@ -20,10 +20,12 @@ import {
     validateAndNormalizeWidgetItems,
     validateAndResolveItemFilterSettings,
 } from "./validation/itemValidation";
+import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 
 type AddLayoutSectionContext = {
     readonly ctx: DashboardContext;
     readonly cmd: AddLayoutSection;
+    readonly initialItems: DashboardItemDefinition[];
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
     readonly availableInsights: ReturnType<typeof selectInsightsMap>;
@@ -34,8 +36,9 @@ function validateAndResolveItems(commandCtx: AddLayoutSectionContext): ItemResol
         ctx,
         layout,
         stash,
+        initialItems,
         cmd: {
-            payload: { index, initialItems = [] },
+            payload: { index },
         },
     } = commandCtx;
 
@@ -66,9 +69,13 @@ export function* addLayoutSectionHandler(
     ctx: DashboardContext,
     cmd: AddLayoutSection,
 ): SagaIterator<DashboardLayoutSectionAdded> {
+    const {
+        payload: { initialItems = [] },
+    } = cmd;
     const commandCtx: AddLayoutSectionContext = {
         ctx,
         cmd,
+        initialItems: addTemporaryIdentityToWidgets(initialItems),
         layout: yield select(selectLayout),
         stash: yield select(selectStash),
         availableInsights: yield select(selectInsightsMap),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
@@ -6,7 +6,7 @@ import { AddLayoutSection } from "../../commands";
 import { invalidArgumentsProvided } from "../../events/general";
 import { selectLayout, selectStash } from "../../state/layout/layoutSelectors";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
-import { DashboardItemDefinition, ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
+import { ExtendedDashboardLayoutSection, InternalDashboardItemDefinition } from "../../types/layoutTypes";
 import isEmpty from "lodash/isEmpty";
 import { layoutActions } from "../../state/layout";
 import { DashboardLayoutSectionAdded, layoutSectionAdded } from "../../events/layout";
@@ -25,7 +25,7 @@ import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 type AddLayoutSectionContext = {
     readonly ctx: DashboardContext;
     readonly cmd: AddLayoutSection;
-    readonly initialItems: DashboardItemDefinition[];
+    readonly initialItems: InternalDashboardItemDefinition[];
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
     readonly availableInsights: ReturnType<typeof selectInsightsMap>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
@@ -6,7 +6,7 @@ import { invalidArgumentsProvided } from "../../events/general";
 import { selectLayout, selectStash } from "../../state/layout/layoutSelectors";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import { validateItemPlacement, validateSectionExists } from "./validation/layoutValidation";
-import { DashboardItemDefinition, ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
+import { ExtendedDashboardLayoutSection, InternalDashboardItemDefinition } from "../../types/layoutTypes";
 import { validateAndResolveStashedItems } from "./validation/stashValidation";
 import isEmpty from "lodash/isEmpty";
 import { layoutActions } from "../../state/layout";
@@ -24,7 +24,7 @@ import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 type AddSectionItemsContext = {
     readonly ctx: DashboardContext;
     readonly cmd: AddSectionItems;
-    readonly items: DashboardItemDefinition[];
+    readonly items: InternalDashboardItemDefinition[];
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
     readonly availableInsights: ReturnType<typeof selectInsightsMap>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addSectionItemsHandler.ts
@@ -6,7 +6,7 @@ import { invalidArgumentsProvided } from "../../events/general";
 import { selectLayout, selectStash } from "../../state/layout/layoutSelectors";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import { validateItemPlacement, validateSectionExists } from "./validation/layoutValidation";
-import { ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
+import { DashboardItemDefinition, ExtendedDashboardLayoutSection } from "../../types/layoutTypes";
 import { validateAndResolveStashedItems } from "./validation/stashValidation";
 import isEmpty from "lodash/isEmpty";
 import { layoutActions } from "../../state/layout";
@@ -19,10 +19,12 @@ import {
     validateAndNormalizeWidgetItems,
     validateAndResolveItemFilterSettings,
 } from "./validation/itemValidation";
+import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 
 type AddSectionItemsContext = {
     readonly ctx: DashboardContext;
     readonly cmd: AddSectionItems;
+    readonly items: DashboardItemDefinition[];
     readonly layout: ReturnType<typeof selectLayout>;
     readonly stash: ReturnType<typeof selectStash>;
     readonly availableInsights: ReturnType<typeof selectInsightsMap>;
@@ -33,8 +35,9 @@ function validateAndResolveItems(commandCtx: AddSectionItemsContext) {
         ctx,
         layout,
         stash,
+        items,
         cmd: {
-            payload: { sectionIndex, itemIndex, items },
+            payload: { sectionIndex, itemIndex },
         },
     } = commandCtx;
     if (!validateSectionExists(layout, sectionIndex)) {
@@ -77,9 +80,13 @@ export function* addSectionItemsHandler(
     ctx: DashboardContext,
     cmd: AddSectionItems,
 ): SagaIterator<DashboardLayoutSectionItemsAdded> {
+    const {
+        payload: { items },
+    } = cmd;
     const commandCtx: AddSectionItemsContext = {
         ctx,
         cmd,
+        items: addTemporaryIdentityToWidgets(items),
         layout: yield select(selectLayout),
         stash: yield select(selectStash),
         availableInsights: yield select(selectInsightsMap),

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
@@ -16,13 +16,13 @@ import {
 } from "./validation/itemValidation";
 import { batchActions } from "redux-batched-actions";
 import { insightsActions } from "../../state/insights";
-import { DashboardItemDefinition } from "../../types/layoutTypes";
+import { InternalDashboardItemDefinition } from "../../types/layoutTypes";
 import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 
 type ReplaceSectionItemContext = {
     ctx: DashboardContext;
     cmd: ReplaceSectionItem;
-    items: DashboardItemDefinition[];
+    items: InternalDashboardItemDefinition[];
     layout: ReturnType<typeof selectLayout>;
     stash: ReturnType<typeof selectStash>;
 };

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/replaceSectionItemHandler.ts
@@ -16,10 +16,13 @@ import {
 } from "./validation/itemValidation";
 import { batchActions } from "redux-batched-actions";
 import { insightsActions } from "../../state/insights";
+import { DashboardItemDefinition } from "../../types/layoutTypes";
+import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
 
 type ReplaceSectionItemContext = {
     ctx: DashboardContext;
     cmd: ReplaceSectionItem;
+    items: DashboardItemDefinition[];
     layout: ReturnType<typeof selectLayout>;
     stash: ReturnType<typeof selectStash>;
 };
@@ -28,8 +31,9 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
     const {
         ctx,
         cmd: {
-            payload: { sectionIndex, itemIndex, item },
+            payload: { sectionIndex, itemIndex },
         },
+        items,
         layout,
         stash,
     } = commandCtx;
@@ -52,7 +56,7 @@ function validateAndResolve(commandCtx: ReplaceSectionItemContext) {
         );
     }
 
-    const stashValidationResult = validateAndResolveStashedItems(stash, [item]);
+    const stashValidationResult = validateAndResolveStashedItems(stash, items);
 
     if (!isEmpty(stashValidationResult.missing)) {
         throw invalidArgumentsProvided(
@@ -74,9 +78,13 @@ export function* replaceSectionItemHandler(
     ctx: DashboardContext,
     cmd: ReplaceSectionItem,
 ): SagaIterator<DashboardLayoutSectionItemReplaced> {
+    const {
+        payload: { item },
+    } = cmd;
     const commandCtx: ReplaceSectionItemContext = {
         ctx,
         cmd,
+        items: addTemporaryIdentityToWidgets([item]),
         layout: yield select(selectLayout),
         stash: yield select(selectStash),
     };

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
@@ -21,6 +21,7 @@ import {
     TestKpiPlaceholderItem,
 } from "../../../tests/fixtures/Layout.fixtures";
 import { ActivityDateDatasetRef } from "../../../tests/fixtures/CatalogAvailability.fixtures";
+import { IWidgetBase } from "@gooddata/sdk-backend-spi";
 
 describe("add layout section handler", () => {
     describe("for an empty dashboard", () => {
@@ -86,12 +87,11 @@ describe("add layout section handler", () => {
         });
 
         it("should load and add insight when adding new section insight widget", async () => {
-            const event: DashboardLayoutSectionAdded = await Tester.dispatchAndWaitFor(
+            await Tester.dispatchAndWaitFor(
                 addLayoutSection(0, {}, [TestInsightItem], false, TestCorrelation),
                 "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
             );
 
-            expect(event.payload.section.items).toEqual([TestInsightItem]);
             const insight = selectInsightByRef(TestInsightItem.widget!.insight)(Tester.state());
             expect(insight).toBeDefined();
         });
@@ -102,9 +102,9 @@ describe("add layout section handler", () => {
                 "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
             );
 
-            expect(event.payload.section.items).toEqual([
-                testItemWithDateDataset(TestInsightItem, ActivityDateDatasetRef),
-            ]);
+            expect((event.payload.section.items[0].widget as IWidgetBase).dateDataSet).toEqual(
+                ActivityDateDatasetRef,
+            );
         });
 
         it("should be undoable and revert to empty layout", async () => {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addSectionItemsHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addSectionItemsHandler.test.ts
@@ -34,12 +34,11 @@ describe("add section items handler", () => {
         );
 
         it("should load and add insight when adding insight widget", async () => {
-            const event: DashboardLayoutSectionItemsAdded = await Tester.dispatchAndWaitFor(
+            await Tester.dispatchAndWaitFor(
                 addSectionItem(0, 0, TestInsightItem, false, TestCorrelation),
                 "GDC.DASH/EVT.FLUID_LAYOUT.ITEMS_ADDED",
             );
 
-            expect(event.payload.itemsAdded).toEqual([TestInsightItem]);
             const insight = selectInsightByRef(TestInsightItem.widget!.insight)(Tester.state());
             expect(insight).toBeDefined();
         });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/replaceSectionItemHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/replaceSectionItemHandler.test.ts
@@ -155,12 +155,11 @@ describe("replace section item handler", () => {
         });
 
         it("should resolve insight used in the replacing item and store that insight in state", async () => {
-            const event: DashboardLayoutSectionItemReplaced = await Tester.dispatchAndWaitFor(
+            await Tester.dispatchAndWaitFor(
                 replaceSectionItem(1, 0, TestInsightItem, undefined, false, TestCorrelation),
                 "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED",
             );
 
-            expect(event.payload.items).toEqual([TestInsightItem]);
             const insight = selectInsightByRef(TestInsightItem.widget!.insight)(Tester.state());
             expect(insight).toBeDefined();
         });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/stashValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/stashValidation.ts
@@ -1,8 +1,8 @@
 // (C) 2021 GoodData Corporation
 
 import {
-    DashboardItemDefinition,
     ExtendedDashboardItem,
+    InternalDashboardItemDefinition,
     isStashedDashboardItemsId,
     StashedDashboardItemsId,
 } from "../../../types/layoutTypes";
@@ -52,7 +52,7 @@ export type ItemResolutionResult = {
  */
 export function validateAndResolveStashedItems(
     stash: LayoutStash,
-    itemDefinitions: ReadonlyArray<DashboardItemDefinition>,
+    itemDefinitions: ReadonlyArray<InternalDashboardItemDefinition>,
 ): ItemResolutionResult {
     const result: ItemResolutionResult = {
         missing: [],

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
@@ -8,6 +8,7 @@ import { DashboardContext } from "../types/commonTypes";
 import { DashboardCommands, IDashboardCommand } from "../commands";
 import { dispatchDashboardEvent } from "../state/_infra/eventDispatcher";
 import { commandRejected, internalErrorOccurred, isDashboardCommandFailed } from "../events/general";
+import { saveDashboardHandler } from './dashboard/saveDashboardHandler';
 import { changeDateFilterSelectionHandler } from "./filterContext/dateFilter/changeDateFilterSelectionHandler";
 import { addAttributeFilterHandler } from "./filterContext/attributeFilter/addAttributeFilterHandler";
 import { removeAttributeFiltersHandler } from "./filterContext/attributeFilter/removeAttributeFiltersHandler";
@@ -55,7 +56,7 @@ const DefaultCommandHandlers: {
     [cmd in DashboardCommands["type"]]?: (...args: any[]) => SagaIterator<any> | any;
 } = {
     "GDC.DASH/CMD.INITIALIZE": initializeDashboardHandler,
-    "GDC.DASH/CMD.SAVE": unhandledCommand,
+    "GDC.DASH/CMD.SAVE": saveDashboardHandler,
     "GDC.DASH/CMD.SAVEAS": unhandledCommand,
     "GDC.DASH/CMD.RESET": unhandledCommand,
     "GDC.DASH/CMD.RENAME": unhandledCommand,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/rootCommandHandler.ts
@@ -8,7 +8,8 @@ import { DashboardContext } from "../types/commonTypes";
 import { DashboardCommands, IDashboardCommand } from "../commands";
 import { dispatchDashboardEvent } from "../state/_infra/eventDispatcher";
 import { commandRejected, internalErrorOccurred, isDashboardCommandFailed } from "../events/general";
-import { saveDashboardHandler } from './dashboard/saveDashboardHandler';
+import { saveAsDashboardHandler } from "./dashboard/saveAsDashboardHandler";
+import { saveDashboardHandler } from "./dashboard/saveDashboardHandler";
 import { changeDateFilterSelectionHandler } from "./filterContext/dateFilter/changeDateFilterSelectionHandler";
 import { addAttributeFilterHandler } from "./filterContext/attributeFilter/addAttributeFilterHandler";
 import { removeAttributeFiltersHandler } from "./filterContext/attributeFilter/removeAttributeFiltersHandler";
@@ -57,7 +58,7 @@ const DefaultCommandHandlers: {
 } = {
     "GDC.DASH/CMD.INITIALIZE": initializeDashboardHandler,
     "GDC.DASH/CMD.SAVE": saveDashboardHandler,
-    "GDC.DASH/CMD.SAVEAS": unhandledCommand,
+    "GDC.DASH/CMD.SAVEAS": saveAsDashboardHandler,
     "GDC.DASH/CMD.RESET": unhandledCommand,
     "GDC.DASH/CMD.RENAME": unhandledCommand,
     "GDC.DASH/CMD.EVENT.TRIGGER": triggerEventHandler,

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -128,7 +128,7 @@ export interface SaveDashboardAs extends IDashboardCommand {
  *
  * @param title - new title for the dashboard; if not specified, the title of original dashboard will be used
  * @param switchToCopy - optionally indicate whether the dashboard component should switch to the dashboard that will
- *  be created during save-as.
+ *  be created during save-as; the default is false
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -105,7 +105,16 @@ export function saveDashboard(correlationId?: string): SaveDashboard {
 export interface SaveDashboardAs extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SAVEAS";
     readonly payload: {
+        /**
+         * Specify new title for the dashboard that will be created during the Save As operation.
+         */
         readonly title?: string;
+
+        /**
+         * Indicate whether the dashboard component should switch to the copy of the dashboard or whether
+         * it should stay on the current dashboard.
+         */
+        readonly switchToCopy?: boolean;
     };
 }
 
@@ -118,16 +127,23 @@ export interface SaveDashboardAs extends IDashboardCommand {
  * that processed the command is unchanged - it still works with the original dashboard.
  *
  * @param title - new title for the dashboard; if not specified, the title of original dashboard will be used
+ * @param switchToCopy - optionally indicate whether the dashboard component should switch to the dashboard that will
+ *  be created during save-as.
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha
  */
-export function saveDashboardAs(title?: string, correlationId?: string): SaveDashboardAs {
+export function saveDashboardAs(
+    title?: string,
+    switchToCopy?: boolean,
+    correlationId?: string,
+): SaveDashboardAs {
     return {
         type: "GDC.DASH/CMD.SAVEAS",
         correlationId,
         payload: {
             title,
+            switchToCopy,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/undoEnhancer.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/undoEnhancer.ts
@@ -186,6 +186,15 @@ export const undoReducer = <TState extends UndoEnhancedState>(
     });
 };
 
+/**
+ * A reducer to reset the undo state. This will clear the undo stack (the 'history').
+ *
+ * @param state - undo enhanced state whose undo to reset
+ */
+export const resetUndoReducer = <TState extends UndoEnhancedState>(state: Draft<TState>): void => {
+    state._undo = InitialUndoState._undo;
+};
+
 export type UndoableCommand<TCmd extends IDashboardCommand = IDashboardCommand> = {
     /**
      * Command that can be un-done.

--- a/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/dashboardStore.ts
@@ -44,6 +44,9 @@ const nonSerializableEventsAndCommands: (DashboardEventType | DashboardCommandTy
     "GDC.DASH/EVT.QUERY.FAILED",
     "@@QUERY.ENVELOPE" as any,
     "@@COMMAND.ENVELOPE" as any,
+    "@@GDC.DASH.SAVE_NEW",
+    "@@GDC.DASH.SAVE_EXISTING",
+    "@@GDC.DASH.SAVE_AS",
     // Execution failed events have the actual error in them
     "GDC.DASH/EVT.INSIGHT_WIDGET.EXECUTION_FAILED",
     "GDC.DASH/EVT.KPI_WIDGET.EXECUTION_FAILED",
@@ -74,6 +77,7 @@ const nonSerializableEventsAndCommands: (DashboardEventType | DashboardCommandTy
     "GDC.DASH/CMD.DRILL.DRILLABLE_ITEMS.CHANGE",
     "GDC.DASH/EVT.DRILL.DRILLABLE_ITEMS.CHANGED",
     "meta/setDrillableItems",
+    "layout/updateWidgetIdentities",
 ];
 
 /*

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
@@ -49,6 +49,16 @@ const setFilterContext: FilterContextReducer<PayloadAction<SetFilterContextPaylo
     state.filterContextIdentity = filterContextIdentity;
 };
 
+type SetFilterContextIdentityPayload = {
+    filterContextIdentity?: IDashboardObjectIdentity;
+};
+const updateFilterContextIdentity: FilterContextReducer<PayloadAction<SetFilterContextIdentityPayload>> = (
+    state,
+    action,
+) => {
+    state.filterContextIdentity = action.payload.filterContextIdentity;
+};
+
 export interface IUpsertDateFilterAllTimePayload {
     readonly type: "allTime";
 }
@@ -237,6 +247,7 @@ const setAttributeFilterParents: FilterContextReducer<PayloadAction<ISetAttribut
 
 export const filterContextReducers = {
     setFilterContext,
+    updateFilterContextIdentity,
     addAttributeFilter,
     removeAttributeFilter,
     moveAttributeFilter,

--- a/libs/sdk-ui-dashboard/src/model/state/layout/layoutReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/layoutReducers.ts
@@ -16,6 +16,7 @@ import { undoReducer, withUndo } from "../_infra/undoEnhancer";
 import {
     ExtendedDashboardItem,
     ExtendedDashboardLayoutSection,
+    ExtendedDashboardWidget,
     RelativeIndex,
     StashedDashboardItemsId,
 } from "../../types/layoutTypes";
@@ -31,7 +32,7 @@ type LayoutReducer<A> = CaseReducer<LayoutState, PayloadAction<A>>;
 //
 //
 
-const setLayout: LayoutReducer<IDashboardLayout> = (state, action) => {
+const setLayout: LayoutReducer<IDashboardLayout<ExtendedDashboardWidget>> = (state, action) => {
     state.layout = action.payload;
 };
 

--- a/libs/sdk-ui-dashboard/src/model/state/layout/layoutReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/layoutReducers.ts
@@ -12,7 +12,7 @@ import {
     isKpiWidget,
 } from "@gooddata/sdk-backend-spi";
 import { invariant } from "ts-invariant";
-import { undoReducer, withUndo } from "../_infra/undoEnhancer";
+import { resetUndoReducer, undoReducer, withUndo } from "../_infra/undoEnhancer";
 import {
     ExtendedDashboardItem,
     ExtendedDashboardLayoutSection,
@@ -25,6 +25,8 @@ import { areObjRefsEqual, ObjRef, VisualizationProperties } from "@gooddata/sdk-
 import { WidgetHeader } from "../../types/widgetTypes";
 import flatMap from "lodash/flatMap";
 import { Draft } from "immer";
+import { ObjRefMap } from "../../../_staging/metadata/objRefMap";
+import { IdentityMapping } from "../../../_staging/dashboard/dashboardLayout";
 
 type LayoutReducer<A> = CaseReducer<LayoutState, PayloadAction<A>>;
 
@@ -34,6 +36,41 @@ type LayoutReducer<A> = CaseReducer<LayoutState, PayloadAction<A>>;
 
 const setLayout: LayoutReducer<IDashboardLayout<ExtendedDashboardWidget>> = (state, action) => {
     state.layout = action.payload;
+};
+
+//
+//
+//
+
+function recurseLayoutAndUpdateWidgetIds(
+    layout: Draft<IDashboardLayout<ExtendedDashboardWidget>>,
+    mapping: ObjRefMap<IdentityMapping>,
+) {
+    layout.sections.forEach((section) => {
+        section.items.forEach((item) => {
+            const widget = item.widget;
+
+            if (!isInsightWidget(widget) && !isKpiWidget(widget)) {
+                return;
+            }
+
+            const { updated: newIdentity } = mapping.get(widget.ref) ?? {};
+
+            if (!newIdentity) {
+                return;
+            }
+
+            widget.ref = newIdentity.ref;
+            widget.uri = newIdentity.uri;
+            widget.identifier = newIdentity.identifier;
+        });
+    });
+}
+
+const updateWidgetIdentities: LayoutReducer<ObjRefMap<IdentityMapping>> = (state, action) => {
+    invariant(state.layout);
+
+    recurseLayoutAndUpdateWidgetIds(state.layout, action.payload);
 };
 
 //
@@ -399,6 +436,7 @@ const replaceKpiWidgetComparison: LayoutReducer<ReplaceKpiWidgetComparison> = (s
 
 export const layoutReducers = {
     setLayout,
+    updateWidgetIdentities,
     addSection: withUndo(addSection),
     removeSection: withUndo(removeSection),
     moveSection: withUndo(moveSection),
@@ -415,4 +453,5 @@ export const layoutReducers = {
     replaceKpiWidgetMeasure: withUndo(replaceKpiWidgetMeasure),
     replaceKpiWidgetComparison: withUndo(replaceKpiWidgetComparison),
     undoLayout: undoReducer,
+    clearLayoutHistory: resetUndoReducer,
 };

--- a/libs/sdk-ui-dashboard/src/model/state/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/layoutSelectors.ts
@@ -11,7 +11,7 @@ import {
     isKpiWidget,
     IWidget,
 } from "@gooddata/sdk-backend-spi";
-import { isInsightPlaceholderWidget, isKpiPlaceholderWidget } from "../../types/layoutTypes";
+import { ExtendedDashboardWidget } from "../../types/layoutTypes";
 import { createUndoableCommandsMapping } from "../_infra/undoEnhancer";
 import { newMapForObjectWithIdentity } from "../../../_staging/metadata/objRefMap";
 import { selectFilterContextFilters } from "../filterContext/filterContextSelectors";
@@ -55,9 +55,12 @@ export const selectLayout = createSelector(selectSelf, (layoutState: LayoutState
     return layoutState.layout;
 });
 
-function isItemWithBaseWidget(obj: IDashboardLayoutItem<unknown>): obj is IDashboardLayoutItem {
+function isItemWithBaseWidget(
+    obj: IDashboardLayoutItem<ExtendedDashboardWidget>,
+): obj is IDashboardLayoutItem<IWidget> {
     const widget = obj.widget;
-    return !!widget && !isKpiPlaceholderWidget(widget) && !isInsightPlaceholderWidget(widget);
+
+    return isInsightWidget(widget) || isKpiWidget(widget);
 }
 
 /**
@@ -70,7 +73,7 @@ function isItemWithBaseWidget(obj: IDashboardLayoutItem<unknown>): obj is IDashb
  * @internal
  */
 export const selectBasicLayout = createSelector(selectLayout, (layout) => {
-    const dashboardLayout: IDashboardLayout = {
+    const dashboardLayout: IDashboardLayout<IWidget> = {
         ...layout,
         sections: layout.sections.map((section) => {
             return {

--- a/libs/sdk-ui-dashboard/src/model/state/layout/tests/layoutReducers.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/layout/tests/layoutReducers.test.ts
@@ -12,13 +12,14 @@ import {
     SimpleDashboardLayout,
     SimpleSortedTableWidgetRef,
 } from "../../../tests/fixtures/SimpleDashboard.fixtures";
+import { ExtendedDashboardWidget } from "../../../types/layoutTypes";
 
 describe("layout slice reducer", () => {
     function createLayoutSliceInitialState(layout?: IDashboardLayout): LayoutState {
         const copyOfLayout = cloneDeep(layout);
 
         return {
-            layout: copyOfLayout,
+            layout: copyOfLayout as IDashboardLayout<ExtendedDashboardWidget>,
             stash: {},
             ...InitialUndoState,
         };

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -9,7 +9,12 @@ import { ReferenceRecordings } from "@gooddata/reference-workspace";
 import { DashboardEvents, DashboardEventType } from "../events";
 import { Middleware, PayloadAction } from "@reduxjs/toolkit";
 import noop from "lodash/noop";
-import { DashboardCommandType, InitializeDashboard, initializeDashboard } from "../commands";
+import {
+    DashboardCommands,
+    DashboardCommandType,
+    InitializeDashboard,
+    initializeDashboard,
+} from "../commands";
 import { IDashboardQuery } from "../queries";
 import { queryEnvelopeWithPromise } from "../state/_infra/queryProcessing";
 import { IDashboardQueryService } from "../state/_infra/queryService";
@@ -168,7 +173,7 @@ export class DashboardTester {
         return new DashboardTester(ctx, testerConfig);
     }
 
-    public dispatch(action: PayloadAction<any>): void {
+    public dispatch(action: DashboardCommands | PayloadAction<any>): void {
         /*
          * Clearing monitored actions is essential to allow sane usage in tests that need fire a command and wait
          * for the same type of event multiple times. Monitored actions is what is used to wait in the `waitFor`
@@ -187,7 +192,7 @@ export class DashboardTester {
      * @param timeout - timeout after which the wait fails, default is 1000
      */
     public dispatchAndWaitFor(
-        action: PayloadAction<any>,
+        action: DashboardCommands | PayloadAction<any>,
         actionType: DashboardEventType | DashboardCommandType | string,
         timeout: number = 1000,
     ): Promise<any> {

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
@@ -4,7 +4,9 @@ import {
     IDashboardLayoutItem,
     IDashboardLayoutSectionHeader,
     IInsightWidget,
+    IInsightWidgetDefinition,
     IKpiWidget,
+    IKpiWidgetDefinition,
 } from "@gooddata/sdk-backend-spi";
 import { idRef, IInsight, insightId, isObjRef, ObjRef } from "@gooddata/sdk-model";
 import { PivotTableWithRowAndColumnAttributes } from "./Insights.fixtures";
@@ -37,13 +39,13 @@ export const TestInsightPlaceholderItem: IDashboardLayoutItem<InsightPlaceholder
         },
     },
 };
-export const TestInsightItem: IDashboardLayoutItem<IInsightWidget> = createTestInsightItem(
+export const TestInsightItem: IDashboardLayoutItem<IInsightWidgetDefinition> = createTestInsightItem(
     PivotTableWithRowAndColumnAttributes,
 );
 
 export function createTestInsightItem(
     insightOrInsightRef: IInsight | ObjRef,
-): IDashboardLayoutItem<IInsightWidget> {
+): IDashboardLayoutItem<IInsightWidgetDefinition> {
     const insightRef = isObjRef(insightOrInsightRef)
         ? insightOrInsightRef
         : idRef(insightId(insightOrInsightRef), "insight");
@@ -53,9 +55,6 @@ export function createTestInsightItem(
         widget: {
             type: "insight",
             insight: insightRef,
-            ref: idRef("newWidget"),
-            uri: "newWidgetUri",
-            identifier: "newWidgetIdentifier",
             ignoreDashboardFilters: [],
             drills: [],
             title: "Test Insight Item",
@@ -69,10 +68,9 @@ export function createTestInsightItem(
     };
 }
 
-export function testItemWithDateDataset<T extends IInsightWidget | IKpiWidget>(
-    item: IDashboardLayoutItem<T>,
-    dataset: ObjRef,
-): IDashboardLayoutItem<T> {
+export function testItemWithDateDataset<
+    T extends IInsightWidget | IKpiWidget | IInsightWidgetDefinition | IKpiWidgetDefinition,
+>(item: IDashboardLayoutItem<T>, dataset: ObjRef): IDashboardLayoutItem<T> {
     return {
         ...item,
         widget: {
@@ -82,10 +80,9 @@ export function testItemWithDateDataset<T extends IInsightWidget | IKpiWidget>(
     } as IDashboardLayoutItem<T>;
 }
 
-export function testItemWithFilterIgnoreList<T extends IInsightWidget | IKpiWidget>(
-    item: IDashboardLayoutItem<T>,
-    displayForms: ObjRef[],
-): IDashboardLayoutItem<T> {
+export function testItemWithFilterIgnoreList<
+    T extends IInsightWidget | IKpiWidget | IInsightWidgetDefinition | IKpiWidgetDefinition,
+>(item: IDashboardLayoutItem<T>, displayForms: ObjRef[]): IDashboardLayoutItem<T> {
     return {
         ...item,
         widget: {

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -1,6 +1,11 @@
 // (C) 2021 GoodData Corporation
 
-import { IDashboardLayoutItem, IDashboardLayoutSection, IDashboardWidget } from "@gooddata/sdk-backend-spi";
+import {
+    IDashboardLayoutItem,
+    IDashboardLayoutSection,
+    IWidget,
+    IWidgetDefinition,
+} from "@gooddata/sdk-backend-spi";
 import isEmpty from "lodash/isEmpty";
 
 /**
@@ -38,12 +43,12 @@ export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlacehol
 }
 
 /**
- * Extension of the default {@link @gooddata/sdk-backend-spi#DashboardWidget} type to also include view-only
+ * Extension of the default {@link @gooddata/sdk-backend-spi#IWidget} type to also include view-only
  * widget types for KPI placeholder and Insight placeholder.
  *
  * @alpha
  */
-export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
+export type ExtendedDashboardWidget = IWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
 
 /**
  * Specialization of the IDashboardLayoutItem which also includes the extended dashboard widgets - KPI and
@@ -51,7 +56,7 @@ export type ExtendedDashboardWidget = IDashboardWidget | KpiPlaceholderWidget | 
  *
  * @alpha
  */
-export type ExtendedDashboardItem = IDashboardLayoutItem<ExtendedDashboardWidget>;
+export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayoutItem<T>;
 
 /**
  * Identifier of a stashed dashboard items. When removing one or more item, the caller may decide to 'stash' these items
@@ -85,7 +90,21 @@ export type RelativeIndex = number;
  *
  * @alpha
  */
-export type DashboardItemDefinition = ExtendedDashboardItem | StashedDashboardItemsId;
+export type DashboardItemDefinition =
+    | ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition>
+    | StashedDashboardItemsId;
+
+/**
+ * This type should be used in handlers that add new items onto dashboard.
+ *
+ * First thing those handlers need to do is to assign a temporary identity to all new KPI and Insight widget
+ * definitions -> thus ensure that anything that gets added onto a dashboard has identifier and can be referenced.
+ *
+ * This type narrows down the DashboardItemDefinition to contain just KPI and Insight widgets that have identity.
+ *
+ * @internal
+ */
+export type InternalDashboardItemDefinition = ExtendedDashboardItem | StashedDashboardItemsId;
 
 /**
  * Dashboard layout section that can contain extended set of items - including KPI and Insight placeholders.

--- a/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
@@ -1,5 +1,9 @@
 // (C) 2021 GoodData Corporation
-import { DashboardItemDefinition, ExtendedDashboardItem } from "../types/layoutTypes";
+import {
+    DashboardItemDefinition,
+    ExtendedDashboardItem,
+    InternalDashboardItemDefinition,
+} from "../types/layoutTypes";
 import { idRef, ObjRef } from "@gooddata/sdk-model";
 import {
     IDashboardObjectIdentity,
@@ -65,7 +69,7 @@ export function isTemporaryIdentity(obj: IDashboardObjectIdentity): boolean {
  */
 export function addTemporaryIdentityToWidgets(
     items: ReadonlyArray<DashboardItemDefinition>,
-): DashboardItemDefinition[] {
+): InternalDashboardItemDefinition[] {
     return items.map((item) => {
         if (!isDashboardLayoutItem(item)) {
             return item;
@@ -80,7 +84,7 @@ export function addTemporaryIdentityToWidgets(
                     ...item.widget,
                     ...temporaryIdentity,
                 },
-            };
+            } as any;
         }
 
         return item;

--- a/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
@@ -1,7 +1,14 @@
 // (C) 2021 GoodData Corporation
-import { ExtendedDashboardItem } from "../types/layoutTypes";
-import { ObjRef } from "@gooddata/sdk-model";
-import { isInsightWidget } from "@gooddata/sdk-backend-spi";
+import { DashboardItemDefinition, ExtendedDashboardItem } from "../types/layoutTypes";
+import { idRef, ObjRef } from "@gooddata/sdk-model";
+import {
+    IDashboardObjectIdentity,
+    isDashboardLayoutItem,
+    isInsightWidget,
+    isInsightWidgetDefinition,
+    isKpiWidgetDefinition,
+} from "@gooddata/sdk-backend-spi";
+import { v4 as uuidv4 } from "uuid";
 
 export function extractInsightRefsFromItems(items: ReadonlyArray<ExtendedDashboardItem>): ObjRef[] {
     const result: ObjRef[] = [];
@@ -13,4 +20,69 @@ export function extractInsightRefsFromItems(items: ReadonlyArray<ExtendedDashboa
     });
 
     return result;
+}
+
+const TemporaryIdentityPrefix = "@@GDC.DASH.TEMP";
+function generateTemporaryIdentityForWidget(): IDashboardObjectIdentity {
+    const id = `${TemporaryIdentityPrefix}-${uuidv4()}`;
+
+    return {
+        ref: idRef(id),
+        identifier: id,
+        uri: id,
+    };
+}
+
+/**
+ * Tests whether the provided object is/has a temporary identity. A temporary identity is used for those
+ * objects which are not yet persisted however need to be reference-able from the dashboard itself.
+ *
+ * @param obj - object to test
+ * @internal
+ */
+export function isTemporaryIdentity(obj: IDashboardObjectIdentity): boolean {
+    return obj.identifier.startsWith(TemporaryIdentityPrefix);
+}
+
+/**
+ * Adds temporary identity to all insight and KPI widget definitions found within the provided dashboard item
+ * definitions.
+ *
+ * Having an identity for each widget is important for the dashboard; many places both internal and through
+ * public API for different use-cases rely on identification of widget by reference.
+ *
+ * This function will map the input items so that the result never contains bare insight widget definitions
+ * or kpi widget definitions (which do not have the identity).
+ *
+ * The identity assigned to those widgets is temporary one. It is a specially formatted identifier combined
+ * with UUID. You can use {@link isTemporaryIdentity} function to test whether object has temporary
+ * identity. When the dashboard gets saved, this temporary identity will change to permanent one that
+ * will be assigned by the backend.
+ *
+ * @param items - items to map, will not be modified
+ * @returns new array with the necessary items mapped to widgets with temporary identity.
+ * @internal
+ */
+export function addTemporaryIdentityToWidgets(
+    items: ReadonlyArray<DashboardItemDefinition>,
+): DashboardItemDefinition[] {
+    return items.map((item) => {
+        if (!isDashboardLayoutItem(item)) {
+            return item;
+        }
+
+        if (isInsightWidgetDefinition(item.widget) || isKpiWidgetDefinition(item.widget)) {
+            const temporaryIdentity = generateTemporaryIdentityForWidget();
+
+            return {
+                ...item,
+                widget: {
+                    ...item.widget,
+                    ...temporaryIdentity,
+                },
+            };
+        }
+
+        return item;
+    });
 }


### PR DESCRIPTION
-  sanitization of widgets and their identities (all widgets need some kind of identity so that they are reference-able from the outside)
-  sanitization of current layout typing
-  impl save & save as handlers
- enhance mockingbird to allow 'saving' (== ensure widgets get some identities assigned)
- add tests

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
