### PR TITLE
RELATED: RAIL-3678 - Ensure initiateSamlSso does not fail on failed token request

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
-local NVM_PATH="$HOME/.nvm/nvm.sh"
+local FALLBACK_NVM_DIR="$HOME/.nvm"
+local NVM_PATH="${NVM_DIR:-$FALLBACK_NVM_DIR}/nvm.sh"
+
 . "${NVM_PATH}"
 nvm use

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -292,10 +292,18 @@ export class UserModule {
     }
 
     /**
-     * Initiates SPI SAML SSO
+     * Initiates SPI SAML SSO.
+     *
      * @param relayState URL of the page where the user is redirected after a successful login
      */
     public initiateSamlSso(relayState: string): Promise<void> {
+        /*
+         * make sure code does not try to get new token before initiating the SAML; the token request would
+         * fail and prevent the samlrequest call; there is no point in getting token anyway because it is just
+         * now that the client is initializing the session security context.
+         */
+        this.xhr.ensureNoLeadingTokenRequest();
+
         return this.xhr
             .get(`/gdc/account/samlrequest?${qs.stringify({ relayState })}`)
             .then((data) => data.getData())

--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -149,6 +149,18 @@ export class XhrModule {
     }
 
     /**
+     * Clears the indicator that is making the XHR module to perform token requests before making
+     * the actual call. The module may get into this state typically during the application initialization
+     * when the session is not yet authenticated.
+     *
+     * Calling this method will clear that indicator, ensuring that the next call will be called without
+     * the leading call to token (which will typically fail).
+     */
+    public ensureNoLeadingTokenRequest(): void {
+        this.tokenRequest = null;
+    }
+
+    /**
      * Back compatible method for setting common XHR settings
      *
      * Usually in our apps we used beforeSend ajax callback to set the X-GDC-REQUEST header with unique ID.


### PR DESCRIPTION
XHR module would get into a state where GET samlrequest would be preceded by POST on the token resource - which would fail and prevent the samlrequest processing from starting.

Unsure how the XHR module can get into the state (it seems intentional but i did not study further). Nevertheless, it makes no sense to try and get the token before calling the samlrequest. 

The code modification is 'surgical' and ensures initiateSamlSso tells XHR module to clear the tokenRequest.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
