### PR TITLE
Remove granularity from date filter resolved values

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2228,8 +2228,6 @@ export interface IResolvedDateFilterValue {
     // (undocumented)
     from: string;
     // (undocumented)
-    granularity: string;
-    // (undocumented)
     to: string;
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/filterValuesResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/filterValuesResolver.ts
@@ -48,7 +48,6 @@ export async function resolveFilterValues(
                     resolve({
                         from: filter.absoluteDateFilter.from,
                         to: filter.absoluteDateFilter.to,
-                        granularity: "GDC.time.date",
                     }),
                 );
             }
@@ -122,7 +121,6 @@ async function resolveRelativeDateFilterValues(
     return {
         from: elements.items[0].title,
         to: getLastTitle(result.items),
-        granularity: filter.relativeDateFilter.granularity,
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/__snapshots__/filterValuesResolver.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/common/test/__snapshots__/filterValuesResolver.test.ts.snap
@@ -6,7 +6,6 @@ Object {
   "dateFilters": Array [
     Object {
       "from": "2021-08-01",
-      "granularity": "GDC.time.date",
       "to": "2021-08-04",
     },
   ],
@@ -42,7 +41,6 @@ Object {
   "dateFilters": Array [
     Object {
       "from": "2020-01-01",
-      "granularity": "GDC.time.date",
       "to": "2020-02-01",
     },
   ],

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -196,7 +196,6 @@ export interface IResolvedAttributeFilterValues {
  * @alpha
  */
 export interface IResolvedDateFilterValue {
-    granularity: string;
     from: string;
     to: string;
 }


### PR DESCRIPTION
JIRA: TNT-200
Granularity is now not used as a key in map and because its value is completely the same as in original filter it can be removed

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
