### PR TITLE
RELATED: RAIL-3682 Prevent widget reloads on ignored filters changes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
@@ -1,8 +1,14 @@
 // (C) 2020-2021 GoodData Corporation
-import { useEffect } from "react";
-import { IWidget } from "@gooddata/sdk-backend-spi";
-import { IFilter } from "@gooddata/sdk-model";
+import { useEffect, useMemo, useState } from "react";
+import { FilterContextItem, isDashboardAttributeFilter, IWidget } from "@gooddata/sdk-backend-spi";
+import { areObjRefsEqual, filterObjRef, IFilter, ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
+import stringify from "json-stable-stringify";
+import compact from "lodash/compact";
+import first from "lodash/first";
+import flow from "lodash/flow";
+import isEqual from "lodash/isEqual";
+import sortBy from "lodash/fp/sortBy";
 
 import {
     QueryProcessingStatus,
@@ -28,28 +34,144 @@ export const useWidgetFiltersQuery = (
     status?: QueryProcessingStatus;
     error?: GoodDataSdkError;
 } => {
-    const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
+    const {
+        status: nonIgnoredStatus,
+        error: nonIgnoredError,
+        result: nonIgnoredFilters,
+    } = useNonIgnoredFilters(widget);
+
     const {
         run: runFiltersQuery,
-        result,
         status,
         error,
     } = useDashboardQueryProcessing({
         queryCreator: queryWidgetFilters,
+        onSuccess: (result) => {
+            setEffectiveFilters(result as IFilter[]);
+        },
     });
 
-    const effectiveFilters = result as IFilter[];
+    const [effectiveFilters, setEffectiveFilters] = useState<IFilter[]>([]);
 
+    // only run the "full" filters query if any of the non-ignored filters has changed
     useEffect(() => {
         if (widget) {
-            // TODO how to prevent reloads in case ignored filter changes?
             runFiltersQuery(widget, filters);
         }
-    }, [widget, dashboardFilters, filters]);
+    }, [widget, stringify(nonIgnoredFilters), filters]);
 
     return {
         result: effectiveFilters,
-        status,
-        error,
+        status: combineQueryProcessingStatuses(nonIgnoredStatus, status),
+        error: nonIgnoredError ?? error,
     };
 };
+
+/**
+ * Hook that retrieves the non-ignored dashboard level filters for a widget.
+ *
+ * @param widget - widget to get the non-ignored filters for
+ */
+function useNonIgnoredFilters(widget: IWidget | undefined) {
+    const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
+    const widgetIgnoresDateFilter = !widget?.dateDataSet;
+
+    const [nonIgnoredFilterRefs, setNonIgnoredFilterRefs] = useState<ObjRef[]>([]);
+
+    /**
+     * This handles cases where:
+     * - the set of filters themselves has changed (new filters added/filters removed)
+     * - widget itself has changed (potentially changing the ignore settings)
+     *
+     * Those are the only ways how the set of non-ignored filters can change.
+     */
+    const { run, status, error } = useDashboardQueryProcessing({
+        queryCreator: queryWidgetFilters,
+        onSuccess: (result) => {
+            setNonIgnoredFilterRefs((prevValue) => {
+                // only set state if the values really changed
+                // this prevents the full query from running unnecessarily
+                if (!isEqual(prevValue, result)) {
+                    return (result as IFilter[]).map(filterObjRef) as ObjRef[];
+                }
+                return prevValue;
+            });
+        },
+    });
+
+    useEffect(() => {
+        if (widget) {
+            // set [] as filter overrides to ignore filters on insights -> this way we get only the dashboard level filters
+            run(widget, []);
+        }
+    }, [widget, filtersDigest(dashboardFilters, widgetIgnoresDateFilter)]);
+
+    const nonIgnoredFilters = useMemo(
+        () =>
+            dashboardFilters.filter((filter) => {
+                if (isDashboardAttributeFilter(filter)) {
+                    return nonIgnoredFilterRefs.some((validRef) =>
+                        areObjRefsEqual(validRef, filter.attributeFilter.displayForm),
+                    );
+                } else {
+                    return !widgetIgnoresDateFilter;
+                }
+            }),
+        [dashboardFilters, nonIgnoredFilterRefs, widgetIgnoresDateFilter],
+    );
+
+    return {
+        error,
+        status,
+        result: nonIgnoredFilters,
+    };
+}
+
+// the lower the number, the more priority the status has
+const statusPriorities: { [S in QueryProcessingStatus]: number } = {
+    error: 0,
+    rejected: 1,
+    running: 2,
+    success: 3,
+};
+
+function combineQueryProcessingStatuses(
+    ...statuses: (QueryProcessingStatus | undefined)[]
+): QueryProcessingStatus | undefined {
+    return flow(
+        compact,
+        sortBy<QueryProcessingStatus>((status) => statusPriorities[status]),
+        first,
+    )(statuses);
+}
+
+/**
+ * Gets a serialized digest of the filters provided. This is useful for detecting if the set of filters has changed.
+ *
+ * @remarks
+ * This digest is only concerned with the display forms/datasets, not the selected values of the filters.
+ *
+ * @param filters - filters to get digest for
+ * @param ignoreDateFilter - whether to ignore date filters
+ * @returns
+ */
+function filtersDigest(filters: FilterContextItem[], ignoreDateFilter: boolean): string {
+    const data = filters
+        // if the widget ignores date filters, remove it from the digest to avoid false positives
+        // when date filter changes to or from All time (this effectively adds/removes the date filter in the filters set,
+        // but we do not care either way, so remove it altogether)
+        .filter((filter) => !ignoreDateFilter || isDashboardAttributeFilter(filter))
+        .map((filter) => {
+            if (isDashboardAttributeFilter(filter)) {
+                return {
+                    displayForm: filter.attributeFilter.displayForm,
+                };
+            } else {
+                return {
+                    dataSet: filter.dateFilter.dataSet,
+                };
+            }
+        });
+
+    return stringify(data);
+}


### PR DESCRIPTION
If a filter that is ignored changes, the widget does not need to run
the filters query again, its results will be the same. To prevent these
wasteful reloads (which also make the UX worse by showing unnecessary
loading animations), the set of non-ignored filters is "cached" for each
widget and this value is then used synchronously (so no loading) to
decide if a new run of the full filters query is necessary.

To get the non-ignored filters, we use the filters query and override
the widget level filters with an empty array so that we only get
dashboard-level filters (without the potential insight-level ones).

Also, a digest of the filters is used to only reload the non-ignored
filters query only when the dashboard filters changed in a way that can
affect the non-ignored filters (the filters' display forms/datasets,
not their selected values/date config).

JIRA: RAIL-3682

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
