### PR TITLE
FEATURE: Optionally propagate mouse events into overlay from dialog

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -772,7 +772,7 @@ export interface IConfirmDialogBaseProps extends IDialogBaseProps {
     // (undocumented)
     submitButtonTooltipText?: string;
     // (undocumented)
-    warning?: string | React.ReactElement;
+    warning?: string | React_2.ReactElement;
 }
 
 // @internal (undocumented)
@@ -856,7 +856,7 @@ export interface IDateTimeConfigOptions {
 // @internal (undocumented)
 export interface IDialogBaseProps {
     // (undocumented)
-    children?: React.ReactNode;
+    children?: React_2.ReactNode;
     // (undocumented)
     className?: string;
     containerClassName?: string;
@@ -865,7 +865,13 @@ export interface IDialogBaseProps {
     // (undocumented)
     onCancel?: (data?: any) => void;
     // (undocumented)
+    onClick?: (e: React_2.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    // (undocumented)
     onClose?: (data?: any) => void;
+    // (undocumented)
+    onMouseOver?: (e: React_2.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    // (undocumented)
+    onMouseUp?: (e: React_2.MouseEvent<HTMLDivElement, MouseEvent>) => void;
     // (undocumented)
     onSubmit?: (data?: any) => void;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/Dialog.tsx
@@ -9,7 +9,7 @@ import { IDialogBaseProps } from "./typings";
  */
 export class Dialog extends Component<IDialogBaseProps> {
     public render(): JSX.Element {
-        const { containerClassName, ...dialogProps } = this.props;
+        const { containerClassName, onClick, onMouseUp, onMouseOver, ...dialogProps } = this.props;
 
         return (
             <Overlay
@@ -21,6 +21,9 @@ export class Dialog extends Component<IDialogBaseProps> {
                 isModal
                 positionType="fixed"
                 containerClassName={containerClassName}
+                onMouseUp={onMouseUp}
+                onMouseOver={onMouseOver}
+                onClick={onClick}
             >
                 <DialogBase {...dialogProps} />
             </Overlay>

--- a/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/tests/Dialog.test.tsx
@@ -16,4 +16,45 @@ describe("Dialog", () => {
         expect(wrapper.find(".dialogTest").hostNodes()).toHaveLength(1);
         expect(wrapper.find(".containerTestClass").hostNodes()).toHaveLength(1);
     });
+
+    describe("should call optional callbacks", () => {
+        it("onClick", () => {
+            const handler = jest.fn();
+            const wrapper = mount(
+                <Dialog className="dialogTest" onClick={handler}>
+                    DialogTest content
+                </Dialog>,
+            );
+
+            expect(wrapper.find(".dialogTest").hostNodes()).toHaveLength(1);
+            wrapper.find(".dialogTest").hostNodes().simulate("click");
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("onMouseUp", () => {
+            const handler = jest.fn();
+            const wrapper = mount(
+                <Dialog className="dialogTest" onMouseUp={handler}>
+                    DialogTest content
+                </Dialog>,
+            );
+
+            expect(wrapper.find(".dialogTest").hostNodes()).toHaveLength(1);
+            wrapper.find(".dialogTest").hostNodes().simulate("mouseup");
+            expect(handler).toHaveBeenCalled();
+        });
+
+        it("onMouseOver", () => {
+            const handler = jest.fn();
+            const wrapper = mount(
+                <Dialog className="dialogTest" onMouseOver={handler}>
+                    DialogTest content
+                </Dialog>,
+            );
+
+            expect(wrapper.find(".dialogTest").hostNodes()).toHaveLength(1);
+            wrapper.find(".dialogTest").hostNodes().simulate("mouseover");
+            expect(handler).toHaveBeenCalled();
+        });
+    });
 });

--- a/libs/sdk-ui-kit/src/Dialog/typings.ts
+++ b/libs/sdk-ui-kit/src/Dialog/typings.ts
@@ -1,5 +1,6 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 
+import React from "react";
 import { ArrowOffsets } from "../Bubble";
 import { IAlignPoint } from "../typings/positioning";
 
@@ -9,15 +10,18 @@ import { IAlignPoint } from "../typings/positioning";
 export interface IDialogBaseProps {
     children?: React.ReactNode;
     className?: string;
-    /**
-     * className will be placed to the container, which wraps overlay background and dialog content elements
-     */
-    containerClassName?: string;
     displayCloseButton?: boolean;
     submitOnEnterKey?: boolean;
     onCancel?: (data?: any) => void;
     onClose?: (data?: any) => void;
     onSubmit?: (data?: any) => void;
+    /**
+     * These properties will be placed to the container, which wraps overlay background and dialog content elements
+     */
+    containerClassName?: string;
+    onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onMouseOver?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onMouseUp?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
 }
 
 /**


### PR DESCRIPTION
Propagate these events
 - onClick
 - onMouseOver
 - onMouseUp

 Added these handlers to allow override default stopPropagation behaviour because of meditor monaco editor needs use mouseup handler

JIRA: NAS-328

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
