### PR TITLE
Remove granularity from date filter resolved values

### DIFF
--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -312,8 +312,6 @@ export namespace EmbeddedGdc {
         // (undocumented)
         from: string;
         // (undocumented)
-        granularity: string;
-        // (undocumented)
         to: string;
     }
     export interface IResolvedFilterValues {

--- a/libs/sdk-embedding/src/iframe/common.ts
+++ b/libs/sdk-embedding/src/iframe/common.ts
@@ -457,7 +457,6 @@ export namespace EmbeddedGdc {
     }
 
     export interface IResolvedDateFilterValue {
-        granularity: string;
         from: string;
         to: string;
     }


### PR DESCRIPTION
JIRA: TNT-200
Granularity is now not used as a key in map and because its value is completely the same as in original filter it can be removed

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
