### PR TITLE
RELATED: RAIL-3680 Fix useDashboardQueryProcessing cancelling

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3775,7 +3775,6 @@ export const useDashboardQueryProcessing: <TQuery extends DashboardQueries, TQue
     onBeforeRun?: ((query: TQuery) => void) | undefined;
 }) => {
     run: (...args: TQueryCreatorArgs) => void;
-    cancel: () => void;
     status?: "error" | "running" | "success" | "rejected" | undefined;
     result?: IDashboardQueryResult<TQuery> | undefined;
     error?: GoodDataSdkError | undefined;

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardQueryProcessing.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardQueryProcessing.ts
@@ -1,5 +1,5 @@
 // (C) 2020-2021 GoodData Corporation
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { GoodDataSdkError, UnexpectedSdkError } from "@gooddata/sdk-ui";
 
@@ -39,7 +39,6 @@ export const useDashboardQueryProcessing = <
     onBeforeRun?: (query: TQuery) => void;
 }): {
     run: (...args: TQueryCreatorArgs) => void;
-    cancel: () => void;
     status?: QueryProcessingStatus;
     result?: IDashboardQueryResult<TQuery>;
     error?: GoodDataSdkError;
@@ -103,13 +102,16 @@ export const useDashboardQueryProcessing = <
         [queryCreator, onSuccess, onError, onRejected, onBeforeRun],
     );
 
-    const cancel = useCallback(() => {
-        canceled.current = true;
+    // cancel any "in-flight" queries once the parent component is unmounting to prevent react warnings
+    // about updating unmounted components
+    useEffect(() => {
+        return () => {
+            canceled.current = true;
+        };
     }, []);
 
     return {
         run,
-        cancel,
         ...state,
     };
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
@@ -24,7 +24,6 @@ export const useWidgetBrokenAlertsQuery = (
 
     const {
         run: runBrokenAlertsQuery,
-        cancel,
         result,
         status,
         error,
@@ -38,10 +37,6 @@ export const useWidgetBrokenAlertsQuery = (
         if (widget.ref) {
             runBrokenAlertsQuery(widget.ref);
         }
-
-        return () => {
-            cancel();
-        };
 
         // queryWidgetBrokenAlerts as a parameter it needs just widget.ref but internally result depends on alert, widget, dashboardFilters
         // we have to call query every time when this dependency changed to get fresh results


### PR DESCRIPTION
We only want to cancel the inflight queries on component unmount to
prevent the react warning, so there is no need to expose the cancel
callback (which was used incorrectly in useWidgetBrokenAlertsQuery,
because it was called on *every* run of the query, not just on unmount).

Now the cancel is handled internally (as it is an internal implementation
detail of that hook) and correctly (only being run on unmount).

JIRA: RAIL-3680

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
