### PR TITLE
RELATED: RAIL-3713 Fix Apply alert filters to Dashboard

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1127,6 +1127,9 @@ export const isAbsoluteDateFilterForm: (obj: unknown) => obj is IAbsoluteDateFil
 export const isAbsoluteDateFilterPreset: (obj: unknown) => obj is IAbsoluteDateFilterPreset;
 
 // @alpha
+export function isAllTimeDashboardDateFilter(obj: unknown): boolean;
+
+// @alpha
 export const isAllTimeDateFilterOption: (obj: unknown) => obj is IAllTimeDateFilterOption;
 
 // @public
@@ -1926,6 +1929,15 @@ export type MetadataObject = IAttributeMetadataObject | IAttributeDisplayFormMet
 
 // @public
 export const metadataObjectId: (metadataObject: MetadataObject) => string;
+
+// @alpha
+export function newAbsoluteDashboardDateFilter(from: DateString, to: DateString): IDashboardDateFilter;
+
+// @alpha
+export function newAllTimeDashboardDateFilter(): IDashboardDateFilter;
+
+// @alpha
+export function newRelativeDashboardDateFilter(granularity: DateFilterGranularity, from: number, to: number): IDashboardDateFilter;
 
 // @public
 export class NoDataError extends AnalyticalBackendError {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -231,6 +231,10 @@ export {
     isDashboardDateFilterReference,
     IFilterContextBase,
     dashboardFilterReferenceObjRef,
+    isAllTimeDashboardDateFilter,
+    newAbsoluteDashboardDateFilter,
+    newAllTimeDashboardDateFilter,
+    newRelativeDashboardDateFilter,
 } from "./workspace/dashboards/filterContext";
 export {
     IDashboardLayout,

--- a/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/filterContext.ts
@@ -1,6 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import { ObjRef, isObjRef, IAttributeElements } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
+import isNil from "lodash/isNil";
 import { IDashboardObjectIdentity } from "./common";
 import { DateFilterGranularity, DateString } from "../dateFilterConfigs/types";
 
@@ -124,6 +125,69 @@ export interface IDashboardDateFilter {
  */
 export function isDashboardDateFilter(obj: unknown): obj is IDashboardDateFilter {
     return !isEmpty(obj) && !!(obj as IDashboardDateFilter).dateFilter;
+}
+
+/**
+ * Creates a new relative dashboard date filter.
+ *
+ * @param granularity - granularity of the filters (month, year, etc.)
+ * @param from - start of the interval – negative numbers mean the past, zero means today, positive numbers mean the future
+ * @param to - end of the interval – negative numbers mean the past, zero means today, positive numbers mean the future
+ * @alpha
+ */
+export function newRelativeDashboardDateFilter(
+    granularity: DateFilterGranularity,
+    from: number,
+    to: number,
+): IDashboardDateFilter {
+    return {
+        dateFilter: {
+            type: "relative",
+            granularity,
+            from,
+            to,
+        },
+    };
+}
+
+/**
+ * Creates a new absolute dashboard date filter.
+ *
+ * @param from - start of the interval in ISO-8601 calendar date format
+ * @param to - end of the interval in ISO-8601 calendar date format
+ * @alpha
+ */
+export function newAbsoluteDashboardDateFilter(from: DateString, to: DateString): IDashboardDateFilter {
+    return {
+        dateFilter: {
+            type: "absolute",
+            granularity: "GDC.time.date",
+            from,
+            to,
+        },
+    };
+}
+
+/**
+ * Creates a new all time date filter. This filter is used to indicate that there should be no filtering on the dates.
+ *
+ * @alpha
+ */
+export function newAllTimeDashboardDateFilter(): IDashboardDateFilter {
+    return {
+        dateFilter: {
+            type: "relative",
+            granularity: "GDC.time.date",
+        },
+    };
+}
+
+/**
+ * Type-guard testing whether the provided object is an All time dashboard date filter.
+ * @alpha
+ */
+export function isAllTimeDashboardDateFilter(obj: unknown): boolean {
+    return isDashboardDateFilter(obj) && isNil(obj.dateFilter.from) && isNil(obj.dateFilter.to);
 }
 
 /**

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -284,13 +284,14 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
         filters: IDashboardFilter_2[];
+        resetOthers: boolean;
     };
     // (undocumented)
     readonly type: "GDC.DASH/CMD.FILTER_CONTEXT.CHANGE_SELECTION";
 }
 
 // @alpha
-export function changeFilterContextSelection(filters: IDashboardFilter_2[], correlationId?: string): ChangeFilterContextSelection;
+export function changeFilterContextSelection(filters: IDashboardFilter_2[], resetOthers?: boolean, correlationId?: string): ChangeFilterContextSelection;
 
 // @alpha (undocumented)
 export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {
@@ -1067,7 +1068,7 @@ export interface DashboardKpiProps {
     LoadingComponent?: React_2.ComponentType<ILoadingProps>;
     onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
     workspace?: string;
 }
 
@@ -1455,7 +1456,7 @@ export interface DashboardWidgetProps {
     // (undocumented)
     onError?: OnError;
     // (undocumented)
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
     onWidgetClicked?: () => void;
     // (undocumented)
     screen: ScreenSize;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -39,7 +39,6 @@ import { IDashboardAttributeFilter } from '@gooddata/sdk-backend-spi';
 import { IDashboardAttributeFilterParent } from '@gooddata/sdk-backend-spi';
 import { IDashboardDateFilter } from '@gooddata/sdk-backend-spi';
 import { IDashboardDateFilterConfig as IDashboardDateFilterConfig_2 } from '@gooddata/sdk-backend-spi';
-import { IDashboardFilter as IDashboardFilter_2 } from '@gooddata/sdk-ui-ext';
 import { IDashboardLayout } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutItem } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutSection } from '@gooddata/sdk-backend-spi';
@@ -283,7 +282,7 @@ export function changeDrillableItems(drillableItems: ExplicitDrill[], correlatio
 export interface ChangeFilterContextSelection extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
-        filters: IDashboardFilter_2[];
+        filters: (IDashboardFilter | FilterContextItem)[];
         resetOthers: boolean;
     };
     // (undocumented)
@@ -291,7 +290,7 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
 }
 
 // @alpha
-export function changeFilterContextSelection(filters: IDashboardFilter_2[], resetOthers?: boolean, correlationId?: string): ChangeFilterContextSelection;
+export function changeFilterContextSelection(filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean, correlationId?: string): ChangeFilterContextSelection;
 
 // @alpha (undocumented)
 export interface ChangeInsightWidgetFilterSettings extends IDashboardCommand {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1067,7 +1067,7 @@ export interface DashboardKpiProps {
     LoadingComponent?: React_2.ComponentType<ILoadingProps>;
     onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
-    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
     workspace?: string;
 }
 
@@ -1156,7 +1156,7 @@ export interface DashboardLayoutProps {
     // (undocumented)
     onError?: OnError;
     // (undocumented)
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
 }
 
 // @internal (undocumented)
@@ -1455,7 +1455,7 @@ export interface DashboardWidgetProps {
     // (undocumented)
     onError?: OnError;
     // (undocumented)
-    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
     onWidgetClicked?: () => void;
     // (undocumented)
     screen: ScreenSize;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
@@ -60,15 +60,16 @@ export function* changeFilterContextSelectionHandler(
         );
 
         // for filters that have not been handled by the loop above, create a clear selection actions
-        currentAttributeFilters
-            .filter((filter) => !handledLocalIds.has(filter.attributeFilter.localIdentifier!))
-            .forEach((filter) => {
-                updateActions.push(
-                    filterContextActions.clearAttributeFilterSelection({
-                        filterLocalId: filter.attributeFilter.localIdentifier!,
-                    }),
-                );
-            });
+        const unhandledFilters = currentAttributeFilters.filter(
+            (filter) => !handledLocalIds.has(filter.attributeFilter.localIdentifier!),
+        );
+        if (unhandledFilters.length > 0) {
+            updateActions.push(
+                filterContextActions.clearAttributeFiltersSelection({
+                    filterLocalIds: unhandledFilters.map((filter) => filter.attributeFilter.localIdentifier!),
+                }),
+            );
+        }
     }
 
     if (dateFilter) {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/changeFilterContextSelectionHandler.ts
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import { call, put, select } from "redux-saga/effects";
+import { all, call, put, select } from "redux-saga/effects";
 import { SagaIterator } from "redux-saga";
 import { DashboardContext } from "../../types/commonTypes";
 import { ChangeFilterContextSelection } from "../../commands";
@@ -12,17 +12,53 @@ import { batchActions } from "redux-batched-actions";
 import { AnyAction } from "@reduxjs/toolkit";
 import { dispatchFilterContextChanged } from "./common";
 import partition from "lodash/partition";
-import { isAttributeFilter, objRefToString, filterObjRef } from "@gooddata/sdk-model";
+import uniqBy from "lodash/uniqBy";
+import { isAttributeFilter, objRefToString, filterObjRef, isRelativeDateFilter } from "@gooddata/sdk-model";
 import {
     filterAttributeElements,
     isNegativeAttributeFilter,
     isAbsoluteDateFilter,
 } from "@gooddata/sdk-model";
 import { isAllTimeDateFilter } from "@gooddata/sdk-model";
-import { DateFilterGranularity } from "@gooddata/sdk-backend-spi";
+import {
+    DateFilterGranularity,
+    FilterContextItem,
+    isAllTimeDashboardDateFilter,
+    isDashboardAttributeFilter,
+    isDashboardDateFilter,
+    newAbsoluteDashboardDateFilter,
+    newAllTimeDashboardDateFilter,
+    newRelativeDashboardDateFilter,
+    NotSupported,
+    IDashboardAttributeFilter,
+    IDashboardDateFilter,
+} from "@gooddata/sdk-backend-spi";
 import { IUpsertDateFilterPayload } from "../../state/filterContext/filterContextReducers";
-import uniqBy from "lodash/uniqBy";
-import flow from "lodash/flow";
+import { IDashboardFilter } from "../../../types";
+
+function dashboardFilterToFilterContextItem(filter: IDashboardFilter): FilterContextItem {
+    if (isAttributeFilter(filter)) {
+        return {
+            attributeFilter: {
+                negativeSelection: isNegativeAttributeFilter(filter),
+                displayForm: filterObjRef(filter),
+                attributeElements: filterAttributeElements(filter),
+            },
+        };
+    } else if (isAbsoluteDateFilter(filter)) {
+        return newAbsoluteDashboardDateFilter(filter.absoluteDateFilter.from, filter.absoluteDateFilter.to);
+    } else if (isAllTimeDateFilter(filter)) {
+        return newAllTimeDashboardDateFilter();
+    } else if (isRelativeDateFilter(filter)) {
+        return newRelativeDashboardDateFilter(
+            filter.relativeDateFilter.granularity as DateFilterGranularity,
+            filter.relativeDateFilter.from,
+            filter.relativeDateFilter.to,
+        );
+    }
+
+    throw new NotSupported("Unsupported filter type! Please provide valid dashboard filter.");
+}
 
 export function* changeFilterContextSelectionHandler(
     ctx: DashboardContext,
@@ -30,14 +66,42 @@ export function* changeFilterContextSelectionHandler(
 ): SagaIterator<void> {
     const { filters, resetOthers } = cmd.payload;
 
-    const uniqueFilters = uniqBy(filters, flow(filterObjRef, objRefToString));
+    const normalizedFilters: FilterContextItem[] = filters.map((filter) => {
+        if (isDashboardAttributeFilter(filter) || isDashboardDateFilter(filter)) {
+            return filter;
+        } else {
+            return dashboardFilterToFilterContextItem(filter);
+        }
+    });
 
-    const [attributeFilters, [dateFilter]] = partition(uniqueFilters, isAttributeFilter);
+    const uniqueFilters = uniqBy(normalizedFilters, (filter) => {
+        const identification = isDashboardAttributeFilter(filter)
+            ? filter.attributeFilter.displayForm
+            : filter.dateFilter.dataSet;
+        return identification ? objRefToString(identification) : identification;
+    });
 
+    const [[dateFilter], attributeFilters] = partition(uniqueFilters, isDashboardDateFilter);
+
+    const [attributeFilterUpdateActions, dateFilterUpdateActions]: AnyAction[][] = yield all([
+        call(getAttributeFiltersUpdateActions, attributeFilters, resetOthers),
+        call(getDateFilterUpdateActions, dateFilter, resetOthers),
+    ]);
+
+    yield put(batchActions([...attributeFilterUpdateActions, ...dateFilterUpdateActions]));
+
+    yield call(dispatchFilterContextChanged, ctx, cmd);
+}
+
+function* getAttributeFiltersUpdateActions(
+    attributeFilters: IDashboardAttributeFilter[],
+    resetOthers: boolean,
+): SagaIterator<AnyAction[]> {
     const updateActions: AnyAction[] = [];
     const handledLocalIds = new Set<string>();
+
     for (const attributeFilter of attributeFilters) {
-        const filterRef = filterObjRef(attributeFilter);
+        const filterRef = attributeFilter.attributeFilter.displayForm;
         const dashboardFilter: ReturnType<
             ReturnType<typeof selectFilterContextAttributeFilterByDisplayForm>
         > = yield select(selectFilterContextAttributeFilterByDisplayForm(filterRef));
@@ -45,9 +109,9 @@ export function* changeFilterContextSelectionHandler(
         if (dashboardFilter) {
             updateActions.push(
                 filterContextActions.updateAttributeFilterSelection({
-                    elements: filterAttributeElements(attributeFilter),
+                    elements: attributeFilter.attributeFilter.attributeElements,
                     filterLocalId: dashboardFilter.attributeFilter.localIdentifier!,
-                    negativeSelection: isNegativeAttributeFilter(attributeFilter),
+                    negativeSelection: attributeFilter.attributeFilter.negativeSelection,
                 }),
             );
             handledLocalIds.add(dashboardFilter.attributeFilter.localIdentifier!);
@@ -72,31 +136,27 @@ export function* changeFilterContextSelectionHandler(
         }
     }
 
+    return updateActions;
+}
+
+function getDateFilterUpdateActions(
+    dateFilter: IDashboardDateFilter | undefined,
+    resetOthers: boolean,
+): AnyAction[] {
     if (dateFilter) {
-        let upsertPayload: IUpsertDateFilterPayload;
-        if (isAllTimeDateFilter(dateFilter)) {
-            upsertPayload = { type: "allTime" };
-        } else if (isAbsoluteDateFilter(dateFilter)) {
-            upsertPayload = {
-                type: "absolute",
-                granularity: "GDC.time.date",
-                from: dateFilter.absoluteDateFilter.from,
-                to: dateFilter.absoluteDateFilter.to,
-            };
-        } else {
-            upsertPayload = {
-                type: "relative",
-                granularity: dateFilter.relativeDateFilter.granularity as DateFilterGranularity,
-                from: dateFilter.relativeDateFilter.from,
-                to: dateFilter.relativeDateFilter.to,
-            };
-        }
-        updateActions.push(filterContextActions.upsertDateFilter(upsertPayload));
-    } else {
-        updateActions.push(filterContextActions.upsertDateFilter({ type: "allTime" }));
+        const upsertPayload: IUpsertDateFilterPayload = isAllTimeDashboardDateFilter(dateFilter)
+            ? { type: "allTime" }
+            : {
+                  type: dateFilter.dateFilter.type,
+                  granularity: dateFilter.dateFilter.granularity,
+                  from: dateFilter.dateFilter.from,
+                  to: dateFilter.dateFilter.to,
+              };
+
+        return [filterContextActions.upsertDateFilter(upsertPayload)];
+    } else if (resetOthers) {
+        return [filterContextActions.upsertDateFilter({ type: "allTime" })];
     }
 
-    yield put(batchActions(updateActions));
-
-    yield call(dispatchFilterContextChanged, ctx, cmd);
+    return [];
 }

--- a/libs/sdk-ui-dashboard/src/model/commands/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/filters.ts
@@ -3,11 +3,12 @@ import {
     DateFilterGranularity,
     DateFilterType,
     DateString,
+    FilterContextItem,
     IDashboardAttributeFilterParent,
 } from "@gooddata/sdk-backend-spi";
 import { IAttributeElements, ObjRef } from "@gooddata/sdk-model";
 import { IDashboardCommand } from "./base";
-import { IDashboardFilter } from "@gooddata/sdk-ui-ext";
+import { IDashboardFilter } from "../../types";
 
 /**
  * @alpha
@@ -442,9 +443,9 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
         /**
          * Filters to apply to the current dashboard filter context.
          */
-        filters: IDashboardFilter[];
+        filters: (IDashboardFilter | FilterContextItem)[];
         /**
-         * Should filters not mentioned in the payload reset to All items selected? Defaults to false.
+         * Should filters not mentioned in the payload reset to All items selected/All time? Defaults to false.
          */
         resetOthers: boolean;
     };
@@ -459,12 +460,12 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
  *
  * @alpha
  * @param filters - attribute filters and date filter to apply.
- * @param resetOthers - should filters not mentioned in the payload reset to All items selected? Defaults to false.
+ * @param resetOthers - should filters not mentioned in the payload reset to All items selected/All time? Defaults to false.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns change filter selection command
  */
 export function changeFilterContextSelection(
-    filters: IDashboardFilter[],
+    filters: (IDashboardFilter | FilterContextItem)[],
     resetOthers: boolean = false,
     correlationId?: string,
 ): ChangeFilterContextSelection {

--- a/libs/sdk-ui-dashboard/src/model/commands/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/filters.ts
@@ -443,6 +443,10 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
          * Filters to apply to the current dashboard filter context.
          */
         filters: IDashboardFilter[];
+        /**
+         * Should filters not mentioned in the payload reset to All items selected? Defaults to false.
+         */
+        resetOthers: boolean;
     };
 }
 
@@ -455,11 +459,13 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
  *
  * @alpha
  * @param filters - attribute filters and date filter to apply.
+ * @param resetOthers - should filters not mentioned in the payload reset to All items selected? Defaults to false.
  * @param correlationId - optionally specify correlation id. It will be included in all events that will be emitted during the command processing.
  * @returns change filter selection command
  */
 export function changeFilterContextSelection(
     filters: IDashboardFilter[],
+    resetOthers: boolean = false,
     correlationId?: string,
 ): ChangeFilterContextSelection {
     return {
@@ -467,6 +473,7 @@ export function changeFilterContextSelection(
         correlationId,
         payload: {
             filters,
+            resetOthers,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
@@ -250,33 +250,35 @@ const setAttributeFilterParents: FilterContextReducer<PayloadAction<ISetAttribut
     ).attributeFilter.filterElementsBy = [...parentFilters];
 };
 
-export interface IClearAttributeFilterSelectionPayload {
-    readonly filterLocalId: string;
+export interface IClearAttributeFiltersSelectionPayload {
+    readonly filterLocalIds: string[];
 }
 
-const clearAttributeFilterSelection: FilterContextReducer<
-    PayloadAction<IClearAttributeFilterSelectionPayload>
+const clearAttributeFiltersSelection: FilterContextReducer<
+    PayloadAction<IClearAttributeFiltersSelectionPayload>
 > = (state, action) => {
-    invariant(state.filterContextDefinition, "Attempt to edit uninitialized filter context");
+    const { filterLocalIds } = action.payload;
 
-    const { filterLocalId } = action.payload;
+    filterLocalIds.forEach((filterLocalId) => {
+        invariant(state.filterContextDefinition, "Attempt to edit uninitialized filter context");
+        const currentFilterIndex = state.filterContextDefinition.filters.findIndex(
+            (item) =>
+                isDashboardAttributeFilter(item) && item.attributeFilter.localIdentifier === filterLocalId,
+        );
 
-    const currentFilterIndex = state.filterContextDefinition.filters.findIndex(
-        (item) => isDashboardAttributeFilter(item) && item.attributeFilter.localIdentifier === filterLocalId,
-    );
+        invariant(currentFilterIndex >= 0, "Attempt to clear selection of a non-existing filter");
 
-    invariant(currentFilterIndex >= 0, "Attempt to clear selection of a non-existing filter");
+        const currentFilter = state.filterContextDefinition.filters[
+            currentFilterIndex
+        ] as IDashboardAttributeFilter;
 
-    const currentFilter = state.filterContextDefinition.filters[
-        currentFilterIndex
-    ] as IDashboardAttributeFilter;
-
-    currentFilter.attributeFilter.negativeSelection = true;
-    currentFilter.attributeFilter.attributeElements = isAttributeElementsByRef(
-        currentFilter.attributeFilter.attributeElements,
-    )
-        ? { uris: [] }
-        : { values: [] };
+        currentFilter.attributeFilter.negativeSelection = true;
+        currentFilter.attributeFilter.attributeElements = isAttributeElementsByRef(
+            currentFilter.attributeFilter.attributeElements,
+        )
+            ? { uris: [] }
+            : { values: [] };
+    });
 };
 
 export const filterContextReducers = {
@@ -287,6 +289,6 @@ export const filterContextReducers = {
     moveAttributeFilter,
     updateAttributeFilterSelection,
     setAttributeFilterParents,
-    clearAttributeFilterSelection,
+    clearAttributeFiltersSelection,
     upsertDateFilter,
 };

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextReducers.ts
@@ -84,6 +84,10 @@ const upsertDateFilter: FilterContextReducer<PayloadAction<IUpsertDateFilterPayl
         isDashboardDateFilter(item),
     );
 
+    /**
+     * TODO: This will cause problems once we support dateDataset-specific date filters (then, we might want
+     * to keep even the all time filters to carry the information about the selected dateDataset).
+     */
     if (action.payload.type === "allTime") {
         if (existingFilterIndex >= 0) {
             // if allTime remove the date filter altogether

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -306,6 +306,7 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
 
 const DashboardInner: React.FC<IDashboardProps> = (props: IDashboardProps) => {
     const locale = useDashboardSelector(selectLocale);
+
     const onFiltersChange = useDispatchDashboardCommand(changeFilterContextSelection);
 
     return (

--- a/libs/sdk-ui-dashboard/src/presentation/layout/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/types.ts
@@ -1,6 +1,7 @@
 // (C) 2020-2021 GoodData Corporation
 import { ComponentType } from "react";
 import { IErrorProps, OnError } from "@gooddata/sdk-ui";
+import { FilterContextItem } from "@gooddata/sdk-backend-spi";
 
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../types";
 
@@ -10,7 +11,7 @@ import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../types";
 export interface DashboardLayoutProps {
     ErrorComponent?: React.ComponentType<IErrorProps>;
     // TODO: is this necessary? (there are events for it)
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
     onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -8,6 +8,7 @@ import isNumber from "lodash/isNumber";
 import flowRight from "lodash/flowRight";
 import round from "lodash/round";
 import {
+    FilterContextItem,
     IAnalyticalBackend,
     IKpiWidget,
     ISeparators,
@@ -79,7 +80,7 @@ interface IKpiExecutorProps {
      * the filters ignored for execution)
      */
     allFilters?: IDashboardFilter[];
-    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
     onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
     backend: IAnalyticalBackend;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -79,7 +79,7 @@ interface IKpiExecutorProps {
      * the filters ignored for execution)
      */
     allFilters?: IDashboardFilter[];
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
     onDrill?: OnFiredDashboardViewDrillEvent;
     onError?: OnError;
     backend: IAnalyticalBackend;
@@ -344,6 +344,7 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
                                           alert?.filterContext?.filters ?? [],
                                           kpiWidget,
                                       ),
+                                      true,
                                   )
                             : undefined
                     }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
@@ -40,7 +40,7 @@ export interface DashboardKpiProps {
      * Optionally, specify a callback that will be triggered when the filters should be changed.
      * (e.g. to apply filters of a KPI alert to the whole dashboard)
      */
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
 
     /**
      * Called when user triggers a drill on a visualization.

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
@@ -40,7 +40,7 @@ export interface DashboardKpiProps {
      * Optionally, specify a callback that will be triggered when the filters should be changed.
      * (e.g. to apply filters of a KPI alert to the whole dashboard)
      */
-    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
 
     /**
      * Called when user triggers a drill on a visualization.

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
@@ -1,6 +1,6 @@
 // (C) 2020-2021 GoodData Corporation
 import { ComponentType } from "react";
-import { IAnalyticalBackend, IWidget, ScreenSize } from "@gooddata/sdk-backend-spi";
+import { FilterContextItem, IAnalyticalBackend, IWidget, ScreenSize } from "@gooddata/sdk-backend-spi";
 import { IErrorProps, ILoadingProps, OnError } from "@gooddata/sdk-ui";
 
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../../types";
@@ -30,7 +30,7 @@ export interface DashboardWidgetProps {
     onDrill?: OnFiredDashboardViewDrillEvent;
 
     onError?: OnError;
-    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
     /**
      * Callback that the component MUST call when the widget is clicked.
      */

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
@@ -30,7 +30,7 @@ export interface DashboardWidgetProps {
     onDrill?: OnFiredDashboardViewDrillEvent;
 
     onError?: OnError;
-    onFiltersChange?: (filters: IDashboardFilter[]) => void;
+    onFiltersChange?: (filters: IDashboardFilter[], resetOthers?: boolean) => void;
     /**
      * Callback that the component MUST call when the widget is clicked.
      */

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -14,6 +14,7 @@ import {
 } from "@gooddata/sdk-model";
 import { IDrillEvent, OnFiredDrillEvent } from "@gooddata/sdk-ui";
 
+// TODO consider adding FilterContextItem to this union so that user can use either sdk-model or FilterContextItem variants of the filters
 /**
  * Supported dashboard filter type.
  * @beta


### PR DESCRIPTION
Makes sure that filters added since the alert was created are reset to All when the Apply alert filters to Dashboard button is clicked.

JIRA: RAIL-3713

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
