### PR TITLE
RELATED: RAIL-3492 - Remove attribute filter must cleanup ignore lists

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
@@ -4,7 +4,7 @@ import { DashboardTester, preloadedTesterFactory } from "../../../../tests/Dashb
 import { DashboardInitialized } from "../../../../events";
 import { selectConfig } from "../../../../state/config/configSelectors";
 import { selectPermissions } from "../../../../state/permissions/permissionsSelectors";
-import { EmptyDashboardIdentifier } from "../../../../tests/fixtures/Dashboard.fixtures";
+import { EmptyDashboardIdentifier, TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 import { selectLayout } from "../../../../state/layout/layoutSelectors";
 import {
     selectFilterContextDefinition,
@@ -60,7 +60,7 @@ describe("initialize dashboard handler", () => {
                 },
                 SimpleDashboardIdentifier,
                 {
-                    initCommand: initializeDashboard(undefined, undefined, "testCorrelation"),
+                    initCommand: initializeDashboard(undefined, undefined, TestCorrelation),
                 },
             ),
         );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
@@ -13,6 +13,7 @@ import { selectFilterContextAttributeFilters } from "../../../state/filterContex
 import { DashboardContext } from "../../../types/commonTypes";
 import { dispatchFilterContextChanged } from "../common";
 import { dispatchDashboardEvent } from "../../../state/_infra/eventDispatcher";
+import { layoutActions } from "../../../state/layout";
 
 export function* removeAttributeFiltersHandler(
     ctx: DashboardContext,
@@ -62,6 +63,10 @@ export function* removeAttributeFiltersHandler(
             // remove filter itself
             filterContextActions.removeAttributeFilter({
                 filterLocalId: removedFilter.attributeFilter.localIdentifier!,
+            }),
+            // house-keeping: ensure the removed attribute filter disappears from widget ignore lists
+            layoutActions.removeIgnoredAttributeFilter({
+                displayFormRefs: [removedFilter.attributeFilter.displayForm],
             }),
         ]);
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`addAttributeFilterHandler should emit the appropriate events for added attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADDED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
   },
 ]
@@ -20,11 +20,11 @@ Array [
 exports[`addAttributeFilterHandler should emit the appropriate events when trying to add a duplicate attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.FAILED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/changeAttributeFilterSelectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/changeAttributeFilterSelectionHandler.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`changeAttributeFilterSelectionHandler.test should emit the appropriate events for changed attribute filter selection 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.SELECTION_CHANGED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
   },
 ]
@@ -20,11 +20,11 @@ Array [
 exports[`changeAttributeFilterSelectionHandler.test should emit the appropriate events when trying to change a non-existent attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.FAILED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`moveAttributeFilterHandler should emit the appropriate events for moved attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
   },
 ]
@@ -20,11 +20,11 @@ Array [
 exports[`moveAttributeFilterHandler should emit the appropriate events when trying to move a non-existent attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.FAILED",
   },
 ]
@@ -33,11 +33,11 @@ Array [
 exports[`moveAttributeFilterHandler should emit the appropriate events when trying to move an attribute filter to an invalid index 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.FAILED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/removeAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/removeAttributeFilterHandler.test.ts.snap
@@ -3,15 +3,15 @@
 exports[`removeAttributeFilterHandler should emit the appropriate events for removed attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
   },
 ]
@@ -20,11 +20,11 @@ Array [
 exports[`removeAttributeFilterHandler should emit the appropriate events when trying to remove a non-existent attribute filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.FAILED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/addAttributeFilterHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/addAttributeFilterHandler.test.ts
@@ -4,6 +4,7 @@ import { addAttributeFilter } from "../../../../commands";
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester";
 import { selectFilterContextAttributeFilters } from "../../../../state/filterContext/filterContextSelectors";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
+import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 
 describe("addAttributeFilterHandler", () => {
     let Tester: DashboardTester;
@@ -15,7 +16,7 @@ describe("addAttributeFilterHandler", () => {
 
     it("should emit the appropriate events for added attribute filter", async () => {
         Tester.dispatch(
-            addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, "testCorrelation"),
+            addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, TestCorrelation),
         );
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -24,7 +25,7 @@ describe("addAttributeFilterHandler", () => {
 
     it("should set the attribute filter in state when it is added", async () => {
         Tester.dispatch(
-            addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, "testCorrelation"),
+            addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, TestCorrelation),
         );
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -37,7 +38,7 @@ describe("addAttributeFilterHandler", () => {
 
     it("should emit the appropriate events when trying to add a duplicate attribute filter", async () => {
         Tester.dispatch(
-            addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, "testCorrelation"),
+            addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, TestCorrelation),
         );
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
@@ -48,7 +49,7 @@ describe("addAttributeFilterHandler", () => {
         const originalFilters = selectFilterContextAttributeFilters(Tester.state());
 
         Tester.dispatch(
-            addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, "testCorrelation"),
+            addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, TestCorrelation),
         );
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/changeAttributeFilterSelectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/changeAttributeFilterSelectionHandler.test.ts
@@ -3,6 +3,7 @@ import { changeAttributeFilterSelection } from "../../../../commands";
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester";
 import { selectFilterContextAttributeFilters } from "../../../../state/filterContext/filterContextSelectors";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
+import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 
 describe("changeAttributeFilterSelectionHandler.test", () => {
     let Tester: DashboardTester;
@@ -21,7 +22,7 @@ describe("changeAttributeFilterSelectionHandler.test", () => {
                 firstFilterLocalId,
                 { uris: ["testing/uri"] },
                 "NOT_IN",
-                "testCorrelation",
+                TestCorrelation,
             ),
         );
 
@@ -39,7 +40,7 @@ describe("changeAttributeFilterSelectionHandler.test", () => {
                 firstFilterLocalId,
                 { uris: ["testing/uri"] },
                 "NOT_IN",
-                "testCorrelation",
+                TestCorrelation,
             ),
         );
 
@@ -58,7 +59,7 @@ describe("changeAttributeFilterSelectionHandler.test", () => {
                 "NON EXISTENT LOCAL ID",
                 { uris: ["testing/uri"] },
                 "NOT_IN",
-                "testCorrelation",
+                TestCorrelation,
             ),
         );
 
@@ -75,7 +76,7 @@ describe("changeAttributeFilterSelectionHandler.test", () => {
                 "NON EXISTENT LOCAL ID",
                 { uris: ["testing/uri"] },
                 "NOT_IN",
-                "testCorrelation",
+                TestCorrelation,
             ),
         );
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/moveAttributeFilterHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/moveAttributeFilterHandler.test.ts
@@ -3,6 +3,7 @@ import { moveAttributeFilter } from "../../../../commands";
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester";
 import { selectFilterContextAttributeFilters } from "../../../../state/filterContext/filterContextSelectors";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
+import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 
 describe("moveAttributeFilterHandler", () => {
     let Tester: DashboardTester;
@@ -16,7 +17,7 @@ describe("moveAttributeFilterHandler", () => {
         const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
             .localIdentifier!;
 
-        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1, "testCorrelation"));
+        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -27,7 +28,7 @@ describe("moveAttributeFilterHandler", () => {
         const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
             .localIdentifier!;
 
-        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1, "testCorrelation"));
+        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -39,7 +40,7 @@ describe("moveAttributeFilterHandler", () => {
     });
 
     it("should emit the appropriate events when trying to move a non-existent attribute filter", async () => {
-        Tester.dispatch(moveAttributeFilter("NON EXISTENT LOCAL ID", 1, "testCorrelation"));
+        Tester.dispatch(moveAttributeFilter("NON EXISTENT LOCAL ID", 1, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
@@ -49,7 +50,7 @@ describe("moveAttributeFilterHandler", () => {
     it("should NOT alter the attribute filter state when trying to move a non-existent attribute filter", async () => {
         const originalFilters = selectFilterContextAttributeFilters(Tester.state());
 
-        Tester.dispatch(moveAttributeFilter("NON EXISTENT LOCAL ID", 1, "testCorrelation"));
+        Tester.dispatch(moveAttributeFilter("NON EXISTENT LOCAL ID", 1, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
@@ -60,7 +61,7 @@ describe("moveAttributeFilterHandler", () => {
         const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
             .localIdentifier!;
 
-        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1000, "testCorrelation"));
+        Tester.dispatch(moveAttributeFilter(firstFilterLocalId, 1000, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/removeAttributeFilterHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/removeAttributeFilterHandler.test.ts
@@ -5,6 +5,7 @@ import { selectFilterContextAttributeFilters } from "../../../../state/filterCon
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
 import { selectLayout } from "../../../../state/layout/layoutSelectors";
 import { IDashboardAttributeFilterReference, IInsightWidget } from "@gooddata/sdk-backend-spi";
+import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 
 describe("removeAttributeFilterHandler", () => {
     let Tester: DashboardTester;
@@ -18,7 +19,7 @@ describe("removeAttributeFilterHandler", () => {
         const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
             .localIdentifier!;
 
-        Tester.dispatch(removeAttributeFilter(firstFilterLocalId, "testCorrelation"));
+        Tester.dispatch(removeAttributeFilter(firstFilterLocalId, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -29,7 +30,7 @@ describe("removeAttributeFilterHandler", () => {
         const firstFilterLocalId = selectFilterContextAttributeFilters(Tester.state())[0].attributeFilter
             .localIdentifier!;
 
-        Tester.dispatch(removeAttributeFilter(firstFilterLocalId, "testCorrelation"));
+        Tester.dispatch(removeAttributeFilter(firstFilterLocalId, TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
@@ -40,7 +41,7 @@ describe("removeAttributeFilterHandler", () => {
     });
 
     it("should emit the appropriate events when trying to remove a non-existent attribute filter", async () => {
-        Tester.dispatch(removeAttributeFilter("NON EXISTENT LOCAL ID", "testCorrelation"));
+        Tester.dispatch(removeAttributeFilter("NON EXISTENT LOCAL ID", TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
@@ -50,7 +51,7 @@ describe("removeAttributeFilterHandler", () => {
     it("should NOT alter the attribute filter state when trying to remove a non-existent attribute filter", async () => {
         const originalFilters = selectFilterContextAttributeFilters(Tester.state());
 
-        Tester.dispatch(removeAttributeFilter("NON EXISTENT LOCAL ID", "testCorrelation"));
+        Tester.dispatch(removeAttributeFilter("NON EXISTENT LOCAL ID", TestCorrelation));
 
         await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/__snapshots__/changeDateFilterSelectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/__snapshots__/changeDateFilterSelectionHandler.test.ts.snap
@@ -5,15 +5,15 @@ exports[`changeDateFilterSelectionHandler should clear date filter in the state 
 exports[`changeDateFilterSelectionHandler should emit the appropriate events for changed date filter 1`] = `
 Array [
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.SELECTION_CHANGED",
   },
   Object {
-    "correlationId": "testCorrelation",
+    "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
   },
 ]

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/changeDateFilterSelectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/changeDateFilterSelectionHandler.test.ts
@@ -3,6 +3,7 @@ import { changeDateFilterSelection, clearDateFilterSelection } from "../../../..
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester";
 import { selectFilterContextDateFilter } from "../../../../state/filterContext/filterContextSelectors";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
+import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 
 describe("changeDateFilterSelectionHandler", () => {
     let Tester: DashboardTester;
@@ -14,7 +15,7 @@ describe("changeDateFilterSelectionHandler", () => {
 
     it("should emit the appropriate events for changed date filter", async () => {
         Tester.dispatch(
-            changeDateFilterSelection("relative", "GDC.time.month", -3, 0, "someLocalId", "testCorrelation"),
+            changeDateFilterSelection("relative", "GDC.time.month", -3, 0, "someLocalId", TestCorrelation),
         );
         await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 


### PR DESCRIPTION
Removing attribute filter needs to ensure that the removed filter is no longer used on the ignore lists.


---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
