### PR TITLE
RELATED: RAIL-3731 Fix ignored filters resolution for KPIs

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
@@ -1,6 +1,11 @@
 // (C) 2020-2021 GoodData Corporation
 import { useEffect, useMemo, useState } from "react";
-import { FilterContextItem, isDashboardAttributeFilter, IWidget } from "@gooddata/sdk-backend-spi";
+import {
+    FilterContextItem,
+    isDashboardAttributeFilter,
+    isInsightWidget,
+    IWidget,
+} from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, filterObjRef, IFilter, ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import stringify from "json-stable-stringify";
@@ -101,8 +106,12 @@ function useNonIgnoredFilters(widget: IWidget | undefined) {
 
     useEffect(() => {
         if (widget) {
-            // set [] as filter overrides to ignore filters on insights -> this way we get only the dashboard level filters
-            run(widget, []);
+            if (isInsightWidget(widget)) {
+                // set [] as filter overrides to ignore filters on insights -> this way we get only the dashboard level filters
+                run(widget, []);
+            } else {
+                run(widget);
+            }
         }
     }, [widget, filtersDigest(dashboardFilters, widgetIgnoresDateFilter)]);
 


### PR DESCRIPTION
We only need to override the filters for insights, not for KPIs.

JIRA: RAIL-3731

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
