### PR TITLE
RELATED: RAIL-3728 fix mergeElementQueryResults for large arrays

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/mergeElementQueryResults.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/mergeElementQueryResults.ts
@@ -21,7 +21,36 @@ export function mergeElementQueryResults(
     // because the underlying list throws on undefined members
     const holeLength = newElements.offset - currentLength;
     if (holeLength > 0) {
-        mergedItems.splice(currentLength, holeLength, ...new Array(holeLength).fill({ ...emptyListItem }));
+        /**
+         * do NOT rewrite this to splice or concat!
+         * for large arrays this will cause a stack size limit breach
+         *
+         * Illustration:
+         * Say we have an attribute with 250 000 elements. We have the range (0;500) loaded and then we request
+         * the range (240 000; 240 500). This means we need to fill a hole 239 500 items big.
+         * If we do that like
+         *
+         * mergedItems.splice(currentLength, holeLength, ...new Array(holeLength).fill({ ...emptyListItem }));
+         *
+         * then since that gets translated roughly to
+         *
+         * mergedItems.splice.apply(mergedItems, currentLength, holeLength, new Array(holeLength).fill({ ...emptyListItem }));
+         *
+         * it effectively calls the splice function with 239 503 arguments. Each argument has to be placed on
+         * the stack as it is a part of the call frame and even though these are pointers, the sheer number of them
+         * is more than enough to hit the stack size limit.
+         *
+         * Fun fact: Chrome and Safari report this as
+         * > RangeError: Maximum call stack size exceeded
+         * which is technically true, but not as helpful as Firefox's
+         * > RangeError: too many arguments provided for a function call
+         *
+         * So instead, we "fill the hole" one element at the time which does not put any unreasonable pressure on the stack
+         * and should be comparable performance-wise.
+         */
+        for (let i = currentLength; i < currentLength + holeLength; i++) {
+            mergedItems[i] = { ...emptyListItem };
+        }
     }
 
     // insert the newly loaded items at their corresponding places

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/tests/mergeElementQueryResults.test.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/tests/mergeElementQueryResults.test.ts
@@ -124,6 +124,76 @@ describe("mergeElementQueryResults", () => {
         expect(actual).toEqual(expected);
     });
 
+    it("should handle appending to non-empty current elements without a hole with overlap", () => {
+        const current: IElementsQueryResult = {
+            items: [
+                {
+                    title: "Foo",
+                    uri: "some/uri",
+                },
+                {
+                    title: "Bar",
+                    uri: "some/uri",
+                },
+            ],
+            limit: 2,
+            next: jest.fn(),
+            goTo: jest.fn(),
+            all: jest.fn(),
+            allSorted: jest.fn(),
+            offset: 0,
+            totalCount: 3,
+        };
+
+        const incoming: IElementsQueryResult = {
+            items: [
+                {
+                    title: "Bar",
+                    uri: "some/uri",
+                },
+                {
+                    title: "Baz",
+                    uri: "some/uri",
+                },
+            ],
+            limit: 2,
+            next: jest.fn(),
+            goTo: jest.fn(),
+            all: jest.fn(),
+            allSorted: jest.fn(),
+            offset: 1,
+            totalCount: 3,
+        };
+
+        const expected: IElementsQueryResult = {
+            items: [
+                {
+                    title: "Foo",
+                    uri: "some/uri",
+                },
+                {
+                    title: "Bar",
+                    uri: "some/uri",
+                },
+                {
+                    title: "Baz",
+                    uri: "some/uri",
+                },
+            ],
+            limit: 2,
+            next: incoming.next,
+            goTo: incoming.goTo,
+            all: incoming.all,
+            allSorted: incoming.allSorted,
+            offset: 1,
+            totalCount: 3,
+        };
+
+        const actual = mergeElementQueryResults(current, incoming);
+
+        expect(actual).toEqual(expected);
+    });
+
     it("should handle appending to non-empty current elements with a hole", () => {
         const current: IElementsQueryResult = {
             items: [
@@ -237,5 +307,43 @@ describe("mergeElementQueryResults", () => {
         const actual = mergeElementQueryResults(current, incoming);
 
         expect(actual).toEqual(expected);
+    });
+
+    it("should handle appending to non-empty current elements with a hole for huge holes (RAIL-3728)", () => {
+        const current: IElementsQueryResult = {
+            items: [
+                {
+                    title: "Foo",
+                    uri: "some/uri",
+                },
+            ],
+            limit: 1,
+            next: jest.fn(),
+            goTo: jest.fn(),
+            all: jest.fn(),
+            allSorted: jest.fn(),
+            offset: 0,
+            totalCount: 250_000,
+        };
+
+        const incoming: IElementsQueryResult = {
+            items: [
+                {
+                    title: "Bar",
+                    uri: "some/uri",
+                },
+            ],
+            limit: 1,
+            next: jest.fn(),
+            goTo: jest.fn(),
+            all: jest.fn(),
+            allSorted: jest.fn(),
+            offset: 240_000,
+            totalCount: 250_000,
+        };
+
+        const actual = mergeElementQueryResults(current, incoming);
+
+        expect(actual.items[240_000]).toEqual(incoming.items[0]);
     });
 });


### PR DESCRIPTION
Fix cases where we need to splice in a huge array which caused
a call stack size breach. More details are in a comment in the relevant
part of the code.

JIRA: RAIL-3728

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
