### PR TITLE
RELATED: RAIL-3730, RAIL-3701 - Enablement for the fixes in KD

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1276,7 +1276,7 @@ export interface DashboardMetaState {
 }
 
 // @alpha (undocumented)
-export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta | QueryInsightWidgetFilters | QueryWidgetBrokenAlerts;
+export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta | QueryInsightWidgetFilters | QueryWidgetBrokenAlerts | QueryFilterContextDisplayForms;
 
 // @alpha
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult> extends IDashboardEvent {
@@ -1318,7 +1318,7 @@ export interface DashboardQueryStarted extends IDashboardEvent {
 }
 
 // @alpha (undocumented)
-export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS";
+export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.FILTER_CONTEXT.DISPLAY_FORMS";
 
 // @alpha
 export interface DashboardRenamed extends IDashboardEvent {
@@ -1787,6 +1787,11 @@ export const FilterBar: () => JSX.Element;
 
 // @internal (undocumented)
 export const FilterBarPropsProvider: React_2.FC<IFilterBarProps>;
+
+// @alpha (undocumented)
+export interface FilterContextDisplayForms {
+    readonly displayForms: IAttributeDisplayFormMetadataObject[];
+}
 
 // @internal
 export function filterContextItemsToFiltersForWidget(filterContextItems: FilterContextItem[], widget: IWidgetDefinition): IDashboardFilter[];
@@ -2748,6 +2753,15 @@ export function queryDateDatasetsForInsight(insightOrRef: ObjRef | IInsight, cor
 // @alpha
 export function queryDateDatasetsForMeasure(measureRef: ObjRef, correlationId?: string): QueryMeasureDateDatasets;
 
+// @alpha (undocumented)
+export interface QueryFilterContextDisplayForms extends IDashboardQuery<FilterContextDisplayForms> {
+    // (undocumented)
+    readonly type: "GDC.DASH/QUERY.FILTER_CONTEXT.DISPLAY_FORMS";
+}
+
+// @alpha
+export function queryFilterContextDisplayForms(correlationId?: string): QueryFilterContextDisplayForms;
+
 // @alpha
 export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
     // (undocumented)
@@ -3233,6 +3247,13 @@ export const selectFilterContextDateFilter: OutputSelector<DashboardState, IDash
 
 // @alpha
 export const selectFilterContextDefinition: OutputSelector<DashboardState, IFilterContextDefinition, (res: FilterContextState) => IFilterContextDefinition>;
+
+// @alpha
+export const selectFilterContextDisplayForms: OutputSelector<DashboardState, FilterContextDisplayForms, (res: {
+status: "error" | "loading" | "success";
+result?: FilterContextDisplayForms | undefined;
+error?: string | undefined;
+} | undefined) => FilterContextDisplayForms>;
 
 // @alpha
 export const selectFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition) => FilterContextItem[]>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -611,7 +611,7 @@ export interface DashboardAttributeFilterSelectionChanged extends IDashboardEven
 }
 
 // @alpha
-export interface DashboardCommandFailed<TCommand extends IDashboardCommand> extends IDashboardEvent {
+export interface DashboardCommandFailed<TCommand extends IDashboardCommand = IDashboardCommand> extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
         readonly reason: ActionFailedErrorReason;
@@ -3070,6 +3070,9 @@ export const selectAllInsightWidgets: OutputSelector<DashboardState, IInsightWid
 export const selectAllKpiWidgets: OutputSelector<DashboardState, IKpiWidget[], (res: IWidget[]) => IKpiWidget[]>;
 
 // @alpha
+export const selectAttributeFilterDisplayForms: OutputSelector<DashboardState, IAttributeDisplayFormMetadataObject[], (res: FilterContextState) => IAttributeDisplayFormMetadataObject[]>;
+
+// @alpha
 export const selectAttributeFilterDisplayFormsMap: OutputSelector<DashboardState, ObjRefMap<IAttributeDisplayFormMetadataObject>, (res: FilterContextState) => ObjRefMap<IAttributeDisplayFormMetadataObject>>;
 
 // @alpha (undocumented)
@@ -3310,6 +3313,9 @@ export const selectIsLayoutEmpty: OutputSelector<DashboardState, boolean, (res: 
 export const selectIsReadOnly: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha (undocumented)
+export const selectIsSaveAsDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
+
+// @alpha (undocumented)
 export const selectIsScheduleEmailDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @alpha
@@ -3411,15 +3417,20 @@ export interface TriggerEvent extends IDashboardCommand {
 // @alpha
 export function triggerEvent(eventBody: DashboardEventBody<IDashboardEvent | ICustomDashboardEvent>, correlationId?: string): TriggerEvent;
 
-// @alpha
+// @internal
 export const uiActions: CaseReducerActions<    {
 openScheduleEmailDialog: CaseReducer<UiState, AnyAction>;
 closeScheduleEmailDialog: CaseReducer<UiState, AnyAction>;
+openSaveAsDialog: CaseReducer<UiState, AnyAction>;
+closeSaveAsDialog: CaseReducer<UiState, AnyAction>;
 }>;
 
 // @alpha (undocumented)
 export type UiState = {
     scheduleEmailDialog: {
+        open: boolean;
+    };
+    saveAsDialog: {
         open: boolean;
     };
 };

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1310,6 +1310,10 @@ export interface DashboardQueryRejected extends IDashboardEvent {
 // @alpha
 export interface DashboardQueryStarted extends IDashboardEvent {
     // (undocumented)
+    readonly payload: {
+        readonly query: IDashboardQuery;
+    };
+    // (undocumented)
     readonly type: "GDC.DASH/EVT.QUERY.STARTED";
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1276,7 +1276,7 @@ export interface DashboardMetaState {
 }
 
 // @alpha (undocumented)
-export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta | QueryInsightWidgetFilters | QueryWidgetBrokenAlerts | QueryFilterContextDisplayForms;
+export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta | QueryInsightWidgetFilters | QueryWidgetBrokenAlerts;
 
 // @alpha
 export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult> extends IDashboardEvent {
@@ -1318,7 +1318,7 @@ export interface DashboardQueryStarted extends IDashboardEvent {
 }
 
 // @alpha (undocumented)
-export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS" | "GDC.DASH/QUERY.FILTER_CONTEXT.DISPLAY_FORMS";
+export type DashboardQueryType = "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS" | "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META" | "GDC.DASH/QUERY.MEASURE.DATE.DATASETS" | "GDC.DASH/QUERY.WIDGET.FILTERS" | "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS";
 
 // @alpha
 export interface DashboardRenamed extends IDashboardEvent {
@@ -1788,11 +1788,6 @@ export const FilterBar: () => JSX.Element;
 // @internal (undocumented)
 export const FilterBarPropsProvider: React_2.FC<IFilterBarProps>;
 
-// @alpha (undocumented)
-export interface FilterContextDisplayForms {
-    readonly displayForms: IAttributeDisplayFormMetadataObject[];
-}
-
 // @internal
 export function filterContextItemsToFiltersForWidget(filterContextItems: FilterContextItem[], widget: IWidgetDefinition): IDashboardFilter[];
 
@@ -1804,6 +1799,7 @@ export interface FilterContextSelection {
 
 // @alpha (undocumented)
 export interface FilterContextState {
+    attributeFilterDisplayForms?: IAttributeDisplayFormMetadataObject[];
     filterContextDefinition?: IFilterContextDefinition;
     filterContextIdentity?: IDashboardObjectIdentity;
 }
@@ -2647,6 +2643,9 @@ export function newDashboardEventPredicate<T extends DashboardEvents["type"]>(ev
 }) => boolean): (event: Action) => boolean;
 
 // @alpha
+export function newDisplayFormMap(items: ReadonlyArray<IAttributeDisplayFormMetadataObject>, strictTypeCheck?: boolean): ObjRefMap<IAttributeDisplayFormMetadataObject>;
+
+// @alpha
 export const newDrillToSameDashboardHandler: (dashboardRef: ObjRef) => DashboardEventHandler<DashboardDrillToDashboardResolved>;
 
 // @alpha
@@ -2752,15 +2751,6 @@ export function queryDateDatasetsForInsight(insightOrRef: ObjRef | IInsight, cor
 
 // @alpha
 export function queryDateDatasetsForMeasure(measureRef: ObjRef, correlationId?: string): QueryMeasureDateDatasets;
-
-// @alpha (undocumented)
-export interface QueryFilterContextDisplayForms extends IDashboardQuery<FilterContextDisplayForms> {
-    // (undocumented)
-    readonly type: "GDC.DASH/QUERY.FILTER_CONTEXT.DISPLAY_FORMS";
-}
-
-// @alpha
-export function queryFilterContextDisplayForms(correlationId?: string): QueryFilterContextDisplayForms;
 
 // @alpha
 export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
@@ -3079,6 +3069,9 @@ export const selectAllInsightWidgets: OutputSelector<DashboardState, IInsightWid
 // @alpha
 export const selectAllKpiWidgets: OutputSelector<DashboardState, IKpiWidget[], (res: IWidget[]) => IKpiWidget[]>;
 
+// @alpha
+export const selectAttributeFilterDisplayFormsMap: OutputSelector<DashboardState, ObjRefMap<IAttributeDisplayFormMetadataObject>, (res: FilterContextState) => ObjRefMap<IAttributeDisplayFormMetadataObject>>;
+
 // @alpha (undocumented)
 export const selectAttributesWithDrillDown: OutputSelector<DashboardState, (ICatalogAttribute | ICatalogDateAttribute)[], (res1: ICatalogAttribute[], res2: ICatalogDateAttribute[]) => (ICatalogAttribute | ICatalogDateAttribute)[]>;
 
@@ -3247,13 +3240,6 @@ export const selectFilterContextDateFilter: OutputSelector<DashboardState, IDash
 
 // @alpha
 export const selectFilterContextDefinition: OutputSelector<DashboardState, IFilterContextDefinition, (res: FilterContextState) => IFilterContextDefinition>;
-
-// @alpha
-export const selectFilterContextDisplayForms: OutputSelector<DashboardState, FilterContextDisplayForms, (res: {
-status: "error" | "loading" | "success";
-result?: FilterContextDisplayForms | undefined;
-error?: string | undefined;
-} | undefined) => FilterContextDisplayForms>;
 
 // @alpha
 export const selectFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition) => FilterContextItem[]>;

--- a/libs/sdk-ui-dashboard/src/_staging/catalog/displayFormMap.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/catalog/displayFormMap.ts
@@ -1,0 +1,51 @@
+// (C) 2021 GoodData Corporation
+
+import {
+    IAttributeDisplayFormMetadataObject,
+    ICatalogAttribute,
+    ICatalogDateDataset,
+    IWorkspaceCatalog,
+} from "@gooddata/sdk-backend-spi";
+import { newDisplayFormMap, ObjRefMap } from "../metadata/objRefMap";
+import flatMap from "lodash/flatMap";
+
+/**
+ * Factory function that extracts all display forms from catalog entities and returns a map indexing display
+ * form `ref` to display form metadata object.
+ *
+ * The lookups into the map can be done by any type of ObjRef.
+ *
+ * @param attributes - catalog attributes
+ * @param dateDatasets - catalog date datasets
+ * @param strictTypeChecking - optionally indicate whether strict type checking should be done using 'type' property of input `idRef`; default is false - the type information will be ignored
+ * @alpha
+ */
+export function createDisplayFormMap(
+    attributes: ICatalogAttribute[],
+    dateDatasets: ICatalogDateDataset[],
+    strictTypeChecking: boolean = false,
+): ObjRefMap<IAttributeDisplayFormMetadataObject> {
+    const nonDateDisplayForms = flatMap(attributes, (a) => [...a.displayForms, ...a.geoPinDisplayForms]);
+    const dateDisplayForms = flatMap(dateDatasets, (d) =>
+        flatMap(d.dateAttributes, (a) => a.attribute.displayForms),
+    );
+
+    return newDisplayFormMap([...nonDateDisplayForms, ...dateDisplayForms], strictTypeChecking);
+}
+
+/**
+ * Factory function that extracts all display forms from workspace catalog and returns a map indexing
+ * display form's `ref` to display form metadata object.
+ *
+ * The lookups into the map can be done by any type of ObjRef.
+ *
+ * @param catalog - workspace catalog
+ * @param strictTypeChecking - optionally indicate whether strict type checking should be done using 'type' property of input `idRef`; default is false - the type information will be ignored
+ * @alpha
+ */
+export function createDisplayFormMapFromCatalog(
+    catalog: IWorkspaceCatalog,
+    strictTypeChecking: boolean = false,
+): ObjRefMap<IAttributeDisplayFormMetadataObject> {
+    return createDisplayFormMap(catalog.attributes(), catalog.dateDatasets(), strictTypeChecking);
+}

--- a/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
@@ -171,6 +171,7 @@ const metadataObjectExtractors = {
  *
  * @param items - items to add into mapping
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newCatalogDateDatasetMap(
     items: ReadonlyArray<ICatalogDateDataset>,
@@ -192,6 +193,7 @@ export function newCatalogDateDatasetMap(
  *
  * @param items - items to add into mapping
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newCatalogAttributeMap(
     items: ReadonlyArray<ICatalogAttribute | ICatalogDateAttribute>,
@@ -213,6 +215,7 @@ export function newCatalogAttributeMap(
  *
  * @param items - items to add into mapping
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newCatalogMeasureMap(
     items: ReadonlyArray<ICatalogMeasure>,
@@ -234,6 +237,7 @@ export function newCatalogMeasureMap(
  *
  * @param items - items to add into map
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newDisplayFormMap(
     items: ReadonlyArray<IAttributeDisplayFormMetadataObject>,
@@ -253,6 +257,7 @@ export function newDisplayFormMap(
  *
  * @param items - items to add into map
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newAttributeMap(
     items: IAttributeMetadataObject[],
@@ -279,6 +284,7 @@ export function newAttributeMap(
  * @param items - items to insert
  * @param type - type of objects, may be undefined
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newMapForObjectWithIdentity<T extends { identifier: Identifier; uri: string; ref: ObjRef }>(
     items: T[],
@@ -301,6 +307,7 @@ export function newMapForObjectWithIdentity<T extends { identifier: Identifier; 
  *
  * @param items - items to add into mapping
  * @param strictTypeCheck - whether to do strict type checking when getting by identifierRef
+ * @alpha
  */
 export function newInsightMap(
     items: ReadonlyArray<IInsight>,

--- a/libs/sdk-ui-dashboard/src/index.ts
+++ b/libs/sdk-ui-dashboard/src/index.ts
@@ -5,7 +5,9 @@
 
 // exported only for api-extractor's sake
 export { DateFilterConfigValidationResult } from "./_staging/dateFilterConfig/validation";
-export { ObjRefMap, ObjRefMapConfig } from "./_staging/metadata/objRefMap";
+
+// ObjRefMap & factories will be part of the public API.. although in different package
+export { ObjRefMap, ObjRefMapConfig, newDisplayFormMap } from "./_staging/metadata/objRefMap";
 
 // TODO remove export after values resolver call from KD is obsolete
 export { resolveFilterValues } from "./model/commandHandlers/drill/common/filterValuesResolver";

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/alerts/tests/__snapshots__/removeAlertsHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/alerts/tests/__snapshots__/removeAlertsHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`removeDrillsForInsightWidgetHandler remove should emit the appropriate events for remove alerts and propagate correlationId 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.ALERTS.REMOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -30,6 +30,8 @@ import {
     actionsToInitializeNewDashboard,
 } from "../common/stateInitializers";
 import { executionResultsActions } from "../../../state/executionResults";
+import { resolveFilterDisplayForms } from "../../../utils/filterResolver";
+import { createDisplayFormMapFromCatalog } from "../../../../_staging/catalog/displayFormMap";
 
 function loadDashboardFromBackend(
     ctx: DashboardContext,
@@ -83,6 +85,16 @@ function* loadExistingDashboard(
         dashboard.dateFilterConfig,
     );
 
+    const initActions: SagaReturnType<typeof resolveFilterDisplayForms> = yield call(
+        actionsToInitializeExistingDashboard,
+        ctx,
+        dashboard,
+        insights,
+        config.settings,
+        effectiveDateFilterConfig.config,
+        createDisplayFormMapFromCatalog(catalog),
+    );
+
     const batch: BatchAction = batchActions(
         [
             backendCapabilitiesActions.setBackendCapabilities(backend.capabilities),
@@ -95,12 +107,7 @@ function* loadExistingDashboard(
                 facts: catalog.facts(),
                 measures: catalog.measures(),
             }),
-            ...actionsToInitializeExistingDashboard(
-                dashboard,
-                insights,
-                config.settings,
-                effectiveDateFilterConfig.config,
-            ),
+            ...initActions,
             alertsActions.setAlerts(alerts),
             insightsActions.setInsights(insights),
             dateFilterConfigActions.setDateFilterConfig({
@@ -188,6 +195,7 @@ export function* initializeDashboardHandler(
         }
 
         yield put(result.batch);
+
         yield put(loadingActions.setLoadingSuccess());
 
         return result.event;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -74,6 +74,7 @@ function* loadExistingDashboard(
         dashboard,
         references: { insights },
     } = dashboardWithReferences;
+
     const effectiveDateFilterConfig: DateFilterMergeResult = yield call(
         mergeDateFilterConfigWithOverrides,
         ctx,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -221,6 +221,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/handler.test.ts
@@ -7,6 +7,7 @@ import { selectPermissions } from "../../../../state/permissions/permissionsSele
 import { EmptyDashboardIdentifier, TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
 import { selectLayout } from "../../../../state/layout/layoutSelectors";
 import {
+    selectAttributeFilterDisplayForms,
     selectFilterContextDefinition,
     selectFilterContextIdentity,
 } from "../../../../state/filterContext/filterContextSelectors";
@@ -88,6 +89,15 @@ describe("initialize dashboard handler", () => {
             const filterContextIdentity = selectFilterContextIdentity(Tester.state());
 
             expect(filterContextIdentity).toBeDefined();
+        });
+
+        it("should resolve attribute filter display forms", () => {
+            const displayForms = selectAttributeFilterDisplayForms(Tester.state());
+
+            // no need for in-depth checking; just verify that the display forms are there
+            // and there is expected number of them (equal to number of attr filters)
+            expect(displayForms).not.toEqual([]);
+            expect(displayForms.length).toBe(2);
         });
 
         it("should store the original persisted dashboard", () => {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/resetDashboardHandler.ts
@@ -4,7 +4,7 @@ import { ResetDashboard } from "../../commands";
 import { SagaIterator } from "redux-saga";
 import { DashboardWasReset } from "../../events";
 import { selectPersistedDashboard } from "../../state/meta/metaSelectors";
-import { put, select } from "redux-saga/effects";
+import { call, put, select } from "redux-saga/effects";
 import { dashboardWasReset } from "../../events/dashboard";
 import { selectInsights } from "../../state/insights/insightsSelectors";
 import { selectEffectiveDateFilterConfig } from "../../state/dateFilterConfig/dateFilterConfigSelectors";
@@ -43,7 +43,14 @@ export function* resetDashboardHandler(
             selectEffectiveDateFilterConfig,
         );
 
-        batch = actionsToInitializeExistingDashboard(persistedDashboard, insights, settings, effectiveConfig);
+        batch = yield call(
+            actionsToInitializeExistingDashboard,
+            ctx,
+            persistedDashboard,
+            insights,
+            settings,
+            effectiveConfig,
+        );
     } else {
         /*
          * For dashboard that is not persisted, the dashboard component is reset to an 'empty' state.

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/deleteDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/deleteDashboardHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`delete dashboard handler for an existing dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.DELETE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/exportDashboardToPdfHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/exportDashboardToPdfHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`export dashboard to PDF handler should emit events in correct order and carry-over correlationId 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.EXPORT.PDF",
     "correlationId": "correlation-id",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/renameDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/renameDashboardHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`rename dashboard handler for any dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.RENAME",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/resetDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/resetDashboardHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`reset dashboard handler for a new dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.RESET",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -16,6 +17,7 @@ Array [
 exports[`reset dashboard handler for an existing dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.RESET",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveAsDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveAsDashboardHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`save as dashboard handler for a new dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.SAVEAS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveDashboardHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/__snapshots__/saveDashboardHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`save dashboard handler for a new dashboard should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.SAVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
@@ -2,30 +2,26 @@
 
 import { call, select, SagaReturnType } from "redux-saga/effects";
 import { SagaIterator } from "redux-saga";
-import { ObjRef } from "@gooddata/sdk-model";
+import { IFilter, ObjRef } from "@gooddata/sdk-model";
 import { selectEnableFilterValuesResolutionInDrillEvents } from "../../state/config/configSelectors";
 import { DashboardContext, FiltersInfo } from "../../types/commonTypes";
 import { resolveFilterValues } from "./common/filterValuesResolver";
 import { queryWidgetFilters } from "../../queries";
-import { QueryWidgetFiltersService } from "../../queryServices/queryWidgetFilters";
 import { isDashboardFilter } from "../../../types";
+import { query } from "../../state/_infra/queryCall";
 
 export function* getDrillToUrlFiltersWithResolvedValues(
     ctx: DashboardContext,
     widgetRef: ObjRef,
 ): SagaIterator<FiltersInfo> {
     // empty widgetFilterOverrides array is passed to override all insight filters
-    const query = queryWidgetFilters(widgetRef, []);
-    const effectiveFilters: SagaReturnType<typeof QueryWidgetFiltersService.generator> = yield call(
-        QueryWidgetFiltersService.generator,
-        ctx,
-        query,
-    );
+    const effectiveFilters: IFilter[] = yield call(query, queryWidgetFilters(widgetRef, []));
     const filters = effectiveFilters.filter(isDashboardFilter);
 
     const enableFilterValuesResolutionInDrillEvents: SagaReturnType<
         typeof selectEnableFilterValuesResolutionInDrillEvents
     > = yield select(selectEnableFilterValuesResolutionInDrillEvents);
+
     if (enableFilterValuesResolutionInDrillEvents) {
         const resolvedFilterValues: SagaReturnType<typeof resolveFilterValues> = yield call(
             resolveFilterValues,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/test/__snapshots__/addDrillTargetsHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drillTargets/test/__snapshots__/addDrillTargetsHandler.test.ts.snap
@@ -5,6 +5,7 @@ exports[`addDrillTargetsHandler should add drill target to the state for given w
 exports[`addDrillTargetsHandler should emit the appropriate events for add drill target 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.DRILL_TARGETS.ADD",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/removeAttributeFiltersHandler.ts
@@ -64,6 +64,8 @@ export function* removeAttributeFiltersHandler(
             filterContextActions.removeAttributeFilter({
                 filterLocalId: removedFilter.attributeFilter.localIdentifier!,
             }),
+            // remove filter's display form metadata object
+            filterContextActions.removeAttributeFilterDisplayForms(removedFilter.attributeFilter.displayForm),
             // house-keeping: ensure the removed attribute filter disappears from widget ignore lists
             layoutActions.removeIgnoredAttributeFilter({
                 displayFormRefs: [removedFilter.attributeFilter.displayForm],

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`addAttributeFilterHandler should emit the appropriate events for added attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -20,6 +21,7 @@ Array [
 exports[`addAttributeFilterHandler should emit the appropriate events when trying to add a duplicate attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/addAttributeFilterHandler.test.ts.snap
@@ -18,20 +18,6 @@ Array [
 ]
 `;
 
-exports[`addAttributeFilterHandler should emit the appropriate events when trying to add a duplicate attribute filter 1`] = `
-Array [
-  Object {
-    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD",
-    "correlationId": "testCorrelationId",
-    "type": "GDC.DASH/EVT.COMMAND.STARTED",
-  },
-  Object {
-    "correlationId": "testCorrelationId",
-    "type": "GDC.DASH/EVT.COMMAND.FAILED",
-  },
-]
-`;
-
 exports[`addAttributeFilterHandler should set the attribute filter in state when it is added 1`] = `
 Object {
   "attributeFilter": Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/changeAttributeFilterSelectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/changeAttributeFilterSelectionHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`changeAttributeFilterSelectionHandler.test should emit the appropriate events for changed attribute filter selection 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -20,6 +21,7 @@ Array [
 exports[`changeAttributeFilterSelectionHandler.test should emit the appropriate events when trying to change a non-existent attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/moveAttributeFilterHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`moveAttributeFilterHandler should emit the appropriate events for moved attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -20,6 +21,7 @@ Array [
 exports[`moveAttributeFilterHandler should emit the appropriate events when trying to move a non-existent attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -33,6 +35,7 @@ Array [
 exports[`moveAttributeFilterHandler should emit the appropriate events when trying to move an attribute filter to an invalid index 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/removeAttributeFilterHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/removeAttributeFilterHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`removeAttributeFilterHandler should emit the appropriate events for removed attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -20,6 +21,7 @@ Array [
 exports[`removeAttributeFilterHandler should emit the appropriate events when trying to remove a non-existent attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/setAttributeFilterParentHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/__snapshots__/setAttributeFilterParentHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`setAttributeFilterParentHandler should emit the appropriate events for valid set attribute filter parent command 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -20,6 +21,7 @@ Array [
 exports[`setAttributeFilterParentHandler should emit the appropriate events when trying to set parent of a non-existent attribute filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/addAttributeFilterHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/attributeFilter/tests/addAttributeFilterHandler.test.ts
@@ -2,9 +2,14 @@
 import { ReferenceLdm } from "@gooddata/reference-workspace";
 import { addAttributeFilter } from "../../../../commands";
 import { DashboardTester, preloadedTesterFactory } from "../../../../tests/DashboardTester";
-import { selectFilterContextAttributeFilters } from "../../../../state/filterContext/filterContextSelectors";
+import {
+    selectAttributeFilterDisplayFormsMap,
+    selectFilterContextAttributeFilters,
+} from "../../../../state/filterContext/filterContextSelectors";
 import { SimpleDashboardIdentifier } from "../../../../tests/fixtures/SimpleDashboard.fixtures";
 import { TestCorrelation } from "../../../../tests/fixtures/Dashboard.fixtures";
+import { uriRef } from "@gooddata/sdk-model";
+import { DashboardCommandFailed } from "../../../../events";
 
 describe("addAttributeFilterHandler", () => {
     let Tester: DashboardTester;
@@ -15,43 +20,54 @@ describe("addAttributeFilterHandler", () => {
     );
 
     it("should emit the appropriate events for added attribute filter", async () => {
-        Tester.dispatch(
+        await Tester.dispatchAndWaitFor(
             addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, TestCorrelation),
+            "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
         );
-        await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
         expect(Tester.emittedEventsDigest()).toMatchSnapshot();
     });
 
     it("should set the attribute filter in state when it is added", async () => {
-        Tester.dispatch(
+        await Tester.dispatchAndWaitFor(
             addAttributeFilter(ReferenceLdm.Product.Name.attribute.displayForm, 0, TestCorrelation),
+            "GDC.DASH/EVT.FILTER_CONTEXT.CHANGED",
         );
-        await Tester.waitFor("GDC.DASH/EVT.FILTER_CONTEXT.CHANGED");
 
         expect(selectFilterContextAttributeFilters(Tester.state())[0]).toMatchSnapshot({
             attributeFilter: {
                 localIdentifier: expect.any(String),
             },
         });
+        const displayFormMap = selectAttributeFilterDisplayFormsMap(Tester.state());
+        expect(displayFormMap.has(ReferenceLdm.Product.Name.attribute.displayForm)).toBeTruthy();
     });
 
     it("should emit the appropriate events when trying to add a duplicate attribute filter", async () => {
-        Tester.dispatch(
+        const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
             addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
         );
-        await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
-        expect(Tester.emittedEventsDigest()).toMatchSnapshot();
+        expect(event.payload.reason).toEqual("USER_ERROR");
+    });
+
+    it("should fail if adding filter for invalid display form", async () => {
+        const event: DashboardCommandFailed = await Tester.dispatchAndWaitFor(
+            addAttributeFilter(uriRef("does-not-exit"), 0, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
+        );
+
+        expect(event.payload.reason).toEqual("USER_ERROR");
     });
 
     it("should NOT alter the attribute filter state when trying to add a duplicate attribute filter", async () => {
         const originalFilters = selectFilterContextAttributeFilters(Tester.state());
 
-        Tester.dispatch(
+        await Tester.dispatchAndWaitFor(
             addAttributeFilter(ReferenceLdm.Department.attribute.displayForm, 0, TestCorrelation),
+            "GDC.DASH/EVT.COMMAND.FAILED",
         );
-        await Tester.waitFor("GDC.DASH/EVT.COMMAND.FAILED");
 
         expect(selectFilterContextAttributeFilters(Tester.state())).toEqual(originalFilters);
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/__snapshots__/changeDateFilterSelectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/dateFilter/tests/__snapshots__/changeDateFilterSelectionHandler.test.ts.snap
@@ -5,6 +5,7 @@ exports[`changeDateFilterSelectionHandler should clear date filter in the state 
 exports[`changeDateFilterSelectionHandler should emit the appropriate events for changed date filter 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FILTER_CONTEXT.DATE_FILTER.CHANGE_SELECTION",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addSectionItemsHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addSectionItemsHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`add section items handler for dashboard with existing sections should emit events correctly 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.ADD_ITEMS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/changeLayoutSectionHeaderHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/changeLayoutSectionHeaderHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`change layout section header handler for any dashboard should emit the correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.CHANGE_SECTION_HEADER",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/moveLayoutSectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/moveLayoutSectionHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`move section command handler for dashboard with three sections should emit correct event 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_SECTION",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/removeLayoutSectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/removeLayoutSectionHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`remove layout section handler for any dashboard should emit the correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_SECTION",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/removeSectionItemHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/removeSectionItemHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`remove layout section item handler for dashboard with existing sections should emit correct events during eager removal 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_ITEM",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/replaceSectionItemHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/replaceSectionItemHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`replace section item handler for dashboard with existing sections should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.FLUID_LAYOUT.REPLACE_ITEM",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/render/tests/__snapshots__/renderingWorker.test.ts.snap
@@ -7,6 +7,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -19,6 +20,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -27,6 +29,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -35,6 +38,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -43,6 +47,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -64,6 +69,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -76,6 +82,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -84,6 +91,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -92,6 +100,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -100,6 +109,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -108,6 +118,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -116,6 +127,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.RESOLVED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -137,6 +149,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -149,6 +162,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -157,6 +171,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -178,6 +193,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -190,6 +206,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -198,6 +215,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -206,6 +224,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -227,6 +246,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -239,6 +259,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -247,6 +268,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.ASYNC.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -268,6 +290,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -295,6 +318,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -307,6 +331,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -324,6 +349,7 @@ Array [
     "type": "GDC.DASH/EVT.RENDER.REQUESTED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.INITIALIZE",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
@@ -336,6 +362,7 @@ Array [
     "type": "GDC.DASH/EVT.INITIALIZED",
   },
   Object {
+    "commandType": "GDC.DASH/CMD.RENDER.ASYNC.REQUEST",
     "correlationId": undefined,
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetFilterSettingsHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetFilterSettingsHandler.test.ts.snap
@@ -3,23 +3,28 @@
 exports[`change insight widget filter settings handler for replace settings operation should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META",
     "type": "GDC.DASH/EVT.QUERY.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META",
     "type": "GDC.DASH/EVT.QUERY.COMPLETED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.COMPLETED",
   },
   Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetHeaderHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetHeaderHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`change insight widget header handler for dashboard with KPIs and insights should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_HEADER",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetVisPropertiesHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeInsightWidgetVisPropertiesHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`change insight widget vis properties handler for dashboard with KPIs and insights should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetComparisonHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetComparisonHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`change KPI widget comparison handler for dashboard with KPIs and insights should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.KPI_WIDGET.CHANGE_COMPARISON",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetFilterSettingsHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetFilterSettingsHandler.test.ts.snap
@@ -3,15 +3,18 @@
 exports[`change KPI widget filter settings handler for replace settings operation should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.KPI_WIDGET.CHANGE_FILTER_SETTINGS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.MEASURE.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.MEASURE.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.COMPLETED",
   },
   Object {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetHeaderHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetHeaderHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`change KPI widget header handler for dashboard with KPIs and insights should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.KPI_WIDGET.CHANGE_HEADER",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetMeasure.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/changeKpiWidgetMeasure.test.ts.snap
@@ -3,15 +3,18 @@
 exports[`change KPI widget measure handler for KPI with date dataset should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.MEASURE.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.STARTED",
   },
   Object {
     "correlationId": undefined,
+    "queryType": "GDC.DASH/QUERY.MEASURE.DATE.DATASETS",
     "type": "GDC.DASH/EVT.QUERY.COMPLETED",
   },
   Object {
@@ -24,6 +27,7 @@ Array [
 exports[`change KPI widget measure handler for any KPI should emit correct events 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/modifyDrillsForInsightWidgetHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`modifyDrillsForInsightWidgetHandler modify should emit the appropriate events for modify drill for Insight Widget command 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/__snapshots__/removeDrillsForInsightWidgetHandler.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`removeDrillsForInsightWidgetHandler remove should emit the appropriate events for remove drill for Insight Widget command 1`] = `
 Array [
   Object {
+    "commandType": "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS",
     "correlationId": "testCorrelationId",
     "type": "GDC.DASH/EVT.COMMAND.STARTED",
   },

--- a/libs/sdk-ui-dashboard/src/model/events/general.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/general.ts
@@ -60,7 +60,8 @@ export type ActionFailedErrorReason = "USER_ERROR" | "INTERNAL_ERROR";
  *
  * @alpha
  */
-export interface DashboardCommandFailed<TCommand extends IDashboardCommand> extends IDashboardEvent {
+export interface DashboardCommandFailed<TCommand extends IDashboardCommand = IDashboardCommand>
+    extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.COMMAND.FAILED";
     readonly payload: {
         /**

--- a/libs/sdk-ui-dashboard/src/model/events/general.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/general.ts
@@ -282,13 +282,23 @@ export const isDashboardQueryFailed = eventGuard<DashboardQueryFailed>("GDC.DASH
  */
 export interface DashboardQueryStarted extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.STARTED";
+    readonly payload: {
+        readonly query: IDashboardQuery;
+    };
 }
 
-export function queryStarted(ctx: DashboardContext, correlationId?: string): DashboardQueryStarted {
+export function queryStarted(
+    ctx: DashboardContext,
+    query: IDashboardQuery,
+    correlationId?: string,
+): DashboardQueryStarted {
     return {
         type: "GDC.DASH/EVT.QUERY.STARTED",
         ctx,
         correlationId,
+        payload: {
+            query,
+        },
     };
 }
 

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -153,7 +153,7 @@ export {
 } from "./state/executionResults/executionResultsSelectors";
 export { IExecutionResultEnvelope } from "./state/executionResults/types";
 export { UiState } from "./state/ui/uiState";
-export { selectIsScheduleEmailDialogOpen } from "./state/ui/uiSelectors";
+export { selectIsScheduleEmailDialogOpen, selectIsSaveAsDialogOpen } from "./state/ui/uiSelectors";
 export { uiActions } from "./state/ui";
 
 export { selectDateDatasetsForInsight } from "./queryServices/queryInsightDateDatasets";

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -59,6 +59,8 @@ export {
     selectFilterContextFilters,
     selectFilterContextDateFilter,
     selectFilterContextAttributeFilters,
+    selectAttributeFilterDisplayFormsMap,
+    selectAttributeFilterDisplayForms,
 } from "./state/filterContext/filterContextSelectors";
 export {
     // Core drills

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/queryCall.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/queryCall.ts
@@ -9,9 +9,10 @@ import { SagaIterator } from "redux-saga";
  * Runs the provided query and returns its result.
  *
  * @param q - query to run
+ * @param refresh - indicates whether the query should ignore cached results and re-load data from backend
  */
-export function* query<TResult>(q: IDashboardQuery<TResult>): SagaIterator<TResult> {
-    const { promise, envelope } = queryEnvelopeWithPromise(q);
+export function* query<TResult>(q: IDashboardQuery<TResult>, refresh = false): SagaIterator<TResult> {
+    const { promise, envelope } = queryEnvelopeWithPromise(q, refresh);
     const waitForResult = (): Promise<TResult> => {
         return promise;
     };
@@ -22,4 +23,13 @@ export function* query<TResult>(q: IDashboardQuery<TResult>): SagaIterator<TResu
     yield put(envelope);
 
     return yield call(waitForResult);
+}
+
+/**
+ * Runs the provided query, forcing refresh of any results that may be cached in the state, and returns its result.
+ *
+ * @param q - query to run
+ */
+export function* queryFresh<TResult>(q: IDashboardQuery<TResult>): SagaIterator<TResult> {
+    return yield call(query, q, true);
 }

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/queryProcessing.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/queryProcessing.ts
@@ -50,6 +50,7 @@ type QueryEnvelopeEventHandlers<TQuery extends IDashboardQuery> = {
 type QueryEnvelope<TQuery extends IDashboardQuery> = Readonly<QueryEnvelopeEventHandlers<TQuery>> & {
     readonly type: typeof QueryEnvelopeActionTypeName;
     readonly query: IDashboardQuery;
+    readonly refresh?: boolean;
 };
 
 function isQueryEnvelope(obj: unknown): obj is QueryEnvelope<any> {
@@ -62,10 +63,12 @@ function isQueryEnvelope(obj: unknown): obj is QueryEnvelope<any> {
 export function queryEnvelope<TQuery extends IDashboardQuery>(
     query: TQuery,
     eventHandlers?: Partial<QueryEnvelopeEventHandlers<TQuery>>,
+    refresh: boolean = false,
 ): QueryEnvelope<TQuery> {
     return {
         type: QueryEnvelopeActionTypeName,
         query,
+        refresh,
         onError: eventHandlers?.onError ?? noop,
         onStart: eventHandlers?.onStart ?? noop,
         onSuccess: eventHandlers?.onSuccess ?? noop,
@@ -77,6 +80,7 @@ export function queryEnvelope<TQuery extends IDashboardQuery>(
  */
 export function queryEnvelopeWithPromise<TQuery extends IDashboardQuery>(
     query: TQuery,
+    refresh: boolean = false,
 ): {
     promise: Promise<IDashboardQueryResult<TQuery>>;
     envelope: QueryEnvelope<TQuery>;
@@ -88,7 +92,7 @@ export function queryEnvelopeWithPromise<TQuery extends IDashboardQuery>(
         queryEnvelopeEventHandlers.onError = reject;
     });
 
-    const envelope = queryEnvelope(query, queryEnvelopeEventHandlers);
+    const envelope = queryEnvelope(query, queryEnvelopeEventHandlers, refresh);
 
     return {
         promise,
@@ -124,6 +128,7 @@ function* processQuery(
             service.generator,
             ctx,
             envelope.query,
+            envelope.refresh ?? false,
         );
 
         try {

--- a/libs/sdk-ui-dashboard/src/model/state/_infra/queryProcessing.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/_infra/queryProcessing.ts
@@ -122,7 +122,7 @@ function* processQuery(
             );
         }
 
-        yield dispatchDashboardEvent(queryStarted(ctx, correlationId));
+        yield dispatchDashboardEvent(queryStarted(ctx, query, correlationId));
 
         const result: SagaIterator<typeof service.generator> = yield call(
             service.generator,

--- a/libs/sdk-ui-dashboard/src/model/state/catalog/catalogSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/catalog/catalogSelectors.ts
@@ -10,10 +10,10 @@ import {
     newCatalogAttributeMap,
     newCatalogDateDatasetMap,
     newCatalogMeasureMap,
-    newDisplayFormMap,
 } from "../../../_staging/metadata/objRefMap";
 import { selectBackendCapabilities } from "../backendCapabilities/backendCapabilitiesSelectors";
 import { DashboardState } from "../types";
+import { createDisplayFormMap } from "../../../_staging/catalog/displayFormMap";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -92,15 +92,7 @@ export const selectAllCatalogDateDatasetsMap = createSelector(
 export const selectAllCatalogDisplayFormsMap = createSelector(
     [selectCatalogAttributes, selectCatalogDateDatasets, selectBackendCapabilities],
     (attributes, dateDatasets, capabilities) => {
-        const nonDateDisplayForms = flatMap(attributes, (a) => [...a.displayForms, ...a.geoPinDisplayForms]);
-        const dateDisplayForms = flatMap(dateDatasets, (d) =>
-            flatMap(d.dateAttributes, (a) => a.attribute.displayForms),
-        );
-
-        return newDisplayFormMap(
-            [...nonDateDisplayForms, ...dateDisplayForms],
-            capabilities.hasTypeScopedIdentifiers,
-        );
+        return createDisplayFormMap(attributes, dateDatasets, capabilities.hasTypeScopedIdentifiers);
     },
 );
 

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextSelectors.ts
@@ -11,6 +11,7 @@ import {
     isDashboardDateFilter,
 } from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, ObjRef, serializeObjRef } from "@gooddata/sdk-model";
+import { newDisplayFormMap } from "../../../_staging/metadata/objRefMap";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -55,6 +56,34 @@ export const selectFilterContextIdentity = createSelector(selectSelf, (filterCon
     );
 
     return filterContextState.filterContextIdentity;
+});
+
+/**
+ * Selects list of display form metadata objects referenced by attribute filters.
+ *
+ * @alpha
+ */
+export const selectAttributeFilterDisplayForms = createSelector(selectSelf, (filterContextState) => {
+    invariant(
+        filterContextState.attributeFilterDisplayForms,
+        "attempting to access uninitialized filter context state",
+    );
+
+    return filterContextState.attributeFilterDisplayForms;
+});
+
+/**
+ * Selects map of display form metadata objects referenced by attribute filters.
+ *
+ * @alpha
+ */
+export const selectAttributeFilterDisplayFormsMap = createSelector(selectSelf, (filterContextState) => {
+    invariant(
+        filterContextState.attributeFilterDisplayForms,
+        "attempting to access uninitialized filter context state",
+    );
+
+    return newDisplayFormMap(filterContextState.attributeFilterDisplayForms);
 });
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/filterContext/filterContextState.ts
@@ -1,6 +1,10 @@
 // (C) 2021 GoodData Corporation
 
-import { IDashboardObjectIdentity, IFilterContextDefinition } from "@gooddata/sdk-backend-spi";
+import {
+    IAttributeDisplayFormMetadataObject,
+    IDashboardObjectIdentity,
+    IFilterContextDefinition,
+} from "@gooddata/sdk-backend-spi";
 
 /**
  * @alpha
@@ -23,9 +27,15 @@ export interface FilterContextState {
      *    persistent and lives only for that particular export operation.
      */
     filterContextIdentity?: IDashboardObjectIdentity;
+
+    /**
+     * Display form metadata objects for all attribute filters in the `filterContextDefinition`
+     */
+    attributeFilterDisplayForms?: IAttributeDisplayFormMetadataObject[];
 }
 
 export const filterContextInitialState: FilterContextState = {
     filterContextDefinition: undefined,
     filterContextIdentity: undefined,
+    attributeFilterDisplayForms: undefined,
 };

--- a/libs/sdk-ui-dashboard/src/model/state/ui/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/ui/index.ts
@@ -13,6 +13,7 @@ export const uiSliceReducer = uiSlice.reducer;
 
 /**
  * Actions to control ui state of the dashboard.
- * @alpha
+ *
+ * @internal
  */
 export const uiActions = uiSlice.actions;

--- a/libs/sdk-ui-dashboard/src/model/state/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/ui/uiReducers.ts
@@ -12,7 +12,17 @@ const closeScheduleEmailDialog: UiReducer = (state) => {
     state.scheduleEmailDialog.open = false;
 };
 
+const openSaveAsDialog: UiReducer = (state) => {
+    state.saveAsDialog.open = true;
+};
+
+const closeSaveAsDialog: UiReducer = (state) => {
+    state.saveAsDialog.open = false;
+};
+
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
+    openSaveAsDialog,
+    closeSaveAsDialog,
 };

--- a/libs/sdk-ui-dashboard/src/model/state/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/ui/uiSelectors.ts
@@ -15,3 +15,8 @@ export const selectIsScheduleEmailDialogOpen = createSelector(
     selectSelf,
     (state) => state.scheduleEmailDialog.open,
 );
+
+/**
+ * @alpha
+ */
+export const selectIsSaveAsDialogOpen = createSelector(selectSelf, (state) => state.saveAsDialog.open);

--- a/libs/sdk-ui-dashboard/src/model/state/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/state/ui/uiState.ts
@@ -7,10 +7,16 @@ export type UiState = {
     scheduleEmailDialog: {
         open: boolean;
     };
+    saveAsDialog: {
+        open: boolean;
+    };
 };
 
 export const uiInitialState: UiState = {
     scheduleEmailDialog: {
+        open: false,
+    },
+    saveAsDialog: {
         open: false,
     },
 };

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -6,7 +6,13 @@ import { DashboardState } from "../state/types";
 import { DashboardContext } from "../types/commonTypes";
 import { recordedBackend, RecordedBackendConfig } from "@gooddata/sdk-backend-mockingbird";
 import { ReferenceRecordings } from "@gooddata/reference-workspace";
-import { DashboardEvents, DashboardEventType } from "../events";
+import {
+    DashboardEvents,
+    DashboardEventType,
+    isDashboardCommandStarted,
+    isDashboardQueryCompleted,
+    isDashboardQueryStarted,
+} from "../events";
 import { Middleware, PayloadAction } from "@reduxjs/toolkit";
 import noop from "lodash/noop";
 import {
@@ -303,6 +309,22 @@ export class DashboardTester {
      */
     public emittedEventsDigest(): ReadonlyArray<{ type: string; correlationId?: string }> {
         return this.capturedEvents.map((evt) => {
+            if (isDashboardQueryStarted(evt) || isDashboardQueryCompleted(evt)) {
+                return {
+                    type: evt.type,
+                    correlationId: evt.correlationId,
+                    queryType: evt.payload.query.type,
+                };
+            }
+
+            if (isDashboardCommandStarted(evt)) {
+                return {
+                    type: evt.type,
+                    correlationId: evt.correlationId,
+                    commandType: evt.payload.command.type,
+                };
+            }
+
             return {
                 type: evt.type,
                 correlationId: evt.correlationId,

--- a/libs/sdk-ui-dashboard/src/model/utils/displayFormResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/displayFormResolver.ts
@@ -30,14 +30,17 @@ export type DisplayFormResolutionResult = {
  *
  * @param ctx dashboard context in which the resolution is done
  * @param refs ObjRefs of display forms; the type of ObjRef can be either uri or id ref, the function will resolve it regardless
+ * @param displayForms optionally specify mapping of display forms to use for in-memory resolution of refs to metadata objects; if
+ *  not specified, the generator will retrieve all catalog display forms from state
  */
 export function* resolveDisplayFormMetadata(
     ctx: DashboardContext,
     refs: ObjRef[],
+    displayForms?: ObjRefMap<IAttributeDisplayFormMetadataObject>,
 ): SagaIterator<DisplayFormResolutionResult> {
-    const catalogDisplayForms: ReturnType<typeof selectAllCatalogDisplayFormsMap> = yield select(
-        selectAllCatalogDisplayFormsMap,
-    );
+    const catalogDisplayForms: ReturnType<typeof selectAllCatalogDisplayFormsMap> = displayForms
+        ? displayForms
+        : yield select(selectAllCatalogDisplayFormsMap);
 
     const resolvedDisplayForms: IAttributeDisplayFormMetadataObject[] = [];
     const tryLoadDisplayForms: ObjRef[] = [];

--- a/libs/sdk-ui-dashboard/src/model/utils/filterResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/filterResolver.ts
@@ -1,0 +1,53 @@
+// (C) 2021 GoodData Corporation
+import {
+    FilterContextItem,
+    IAttributeDisplayFormMetadataObject,
+    isDashboardAttributeFilter,
+} from "@gooddata/sdk-backend-spi";
+import { ObjRefMap } from "../../_staging/metadata/objRefMap";
+import { call, SagaReturnType } from "redux-saga/effects";
+import { resolveDisplayFormMetadata } from "./displayFormResolver";
+import isEmpty from "lodash/isEmpty";
+import { objRefToString } from "@gooddata/sdk-model";
+import { DashboardContext } from "../types/commonTypes";
+import { SagaIterator } from "redux-saga";
+import invariant from "ts-invariant";
+
+/**
+ * This generator function resolves display form metadata objects for all attribute filters in the provided `filters`
+ * parameter. The resolver will first check in-memory `displayForms` mapping; if some used display forms are not
+ * found, it will consult the backend.
+ *
+ * @param ctx - dashboard context where the resolution is being done
+ * @param filters - list of dashboard filters; resolver will extract just the attribute filters from here
+ * @param displayForms - in-memory mapping of known display forms to use during the initial lookup; if not specified, the
+ *  code will obtain all catalog display forms; note: this parameter is really only useful during the dashboard initialization
+ *  where the catalog is not yet set. once the dashboard is initialized, the parameter is not needed
+ */
+export function* resolveFilterDisplayForms(
+    ctx: DashboardContext,
+    filters: FilterContextItem[],
+    displayForms?: ObjRefMap<IAttributeDisplayFormMetadataObject>,
+): SagaIterator<IAttributeDisplayFormMetadataObject[]> {
+    const displayFormRefs = filters
+        .filter(isDashboardAttributeFilter)
+        .map((filter) => filter.attributeFilter.displayForm);
+
+    const resolvedDisplayForms: SagaReturnType<typeof resolveDisplayFormMetadata> = yield call(
+        resolveDisplayFormMetadata,
+        ctx,
+        displayFormRefs,
+        displayForms,
+    );
+
+    // TODO: this is too strict; instead of exploding, the resolver should communicate that some filters are invalid so
+    //  that the upstream code can remove the filter from the filter context
+    invariant(
+        isEmpty(resolvedDisplayForms.missing),
+        `Unable to resolve display forms used in filter context filters: ${resolvedDisplayForms.missing
+            .map((m) => objRefToString(m))
+            .join(", ")}.`,
+    );
+
+    return Array.from(resolvedDisplayForms.resolved.values());
+}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import React, { useCallback, useMemo, useRef } from "react";
 import {
     FilterContextItem,
     IDashboardAttributeFilter,
@@ -18,12 +18,12 @@ import {
     useDashboardComponentsContext,
 } from "../dashboardContexts";
 import {
+    CustomDashboardAttributeFilterComponent,
     DefaultDashboardAttributeFilterInner,
     DefaultDashboardDateFilterInner,
-    CustomDashboardAttributeFilterComponent,
     DefaultFilterBarInner,
-    FilterBarPropsProvider,
     FilterBar,
+    FilterBarPropsProvider,
 } from "../filterBar";
 import {
     DefaultDashboardInsightInner,
@@ -35,22 +35,23 @@ import { IntlWrapper } from "../localization";
 import {
     changeAttributeFilterSelection,
     changeDateFilterSelection,
+    changeFilterContextSelection,
     clearDateFilterSelection,
+    DashboardStoreProvider,
+    exportDashboardToPdf,
     renameDashboard,
     selectDashboardLoading,
     selectDashboardTitle,
     selectFilterContextFilters,
+    selectIsLayoutEmpty,
+    selectIsSaveAsDialogOpen,
+    selectIsScheduleEmailDialogOpen,
     selectLocale,
+    uiActions,
+    useDashboardCommandProcessing,
     useDashboardDispatch,
     useDashboardSelector,
-    DashboardStoreProvider,
-    changeFilterContextSelection,
     useDispatchDashboardCommand,
-    useDashboardCommandProcessing,
-    exportDashboardToPdf,
-    selectIsLayoutEmpty,
-    uiActions,
-    selectIsScheduleEmailDialogOpen,
 } from "../../model";
 import {
     DefaultScheduledEmailDialogInner,
@@ -59,12 +60,12 @@ import {
 } from "../scheduledEmail";
 import {
     DefaultButtonBarInner,
-    DefaultTitleInner,
     DefaultMenuButtonInner,
+    DefaultTitleInner,
     DefaultTopBarInner,
-    TopBarPropsProvider,
-    TopBar,
     IMenuButtonItem,
+    TopBar,
+    TopBarPropsProvider,
 } from "../topBar";
 
 import { defaultDashboardThemeModifier } from "./defaultDashboardThemeModifier";
@@ -141,8 +142,9 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
     const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
     const openScheduleEmailingDialog = () => dispatch(uiActions.openScheduleEmailDialog());
     const closeScheduleEmailingDialog = () => dispatch(uiActions.closeScheduleEmailDialog());
-
-    const [isSaveAsDialogOpen, setIsSaveAsDialogOpen] = useState(false);
+    const isSaveAsDialogOpen = useDashboardSelector(selectIsSaveAsDialogOpen);
+    const openSaveAsDialog = () => dispatch(uiActions.openSaveAsDialog());
+    const closeSaveAsDialog = () => dispatch(uiActions.closeSaveAsDialog());
 
     const lastExportMessageId = useRef("");
     const { run: exportDashboard } = useDashboardCommandProcessing({
@@ -195,7 +197,7 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
             return;
         }
 
-        setIsSaveAsDialogOpen(true);
+        openSaveAsDialog();
     }, [dashboardRef]);
 
     const defaultOnExportToPdf = useCallback(() => {
@@ -254,17 +256,17 @@ const DashboardHeader = (props: IDashboardProps): JSX.Element => {
     }, []);
 
     const onSaveAsError = useCallback(() => {
-        setIsSaveAsDialogOpen(false);
+        closeSaveAsDialog();
         addError({ id: "messages.dashboardSaveFailed" });
     }, []);
 
     const onSaveAsSuccess = useCallback(() => {
-        setIsSaveAsDialogOpen(false);
+        closeSaveAsDialog();
         addSuccess({ id: "messages.dashboardSaveSuccess" });
     }, []);
 
     const onSaveAsCancel = useCallback(() => {
-        setIsSaveAsDialogOpen(false);
+        closeSaveAsDialog();
     }, []);
 
     return (

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBar.tsx
@@ -82,5 +82,9 @@ export const DefaultFilterBarInner = (): JSX.Element => {
  * @alpha
  */
 export const DefaultFilterBar = (props: IFilterBarProps): JSX.Element => {
-    return <FilterBarPropsProvider {...props}></FilterBarPropsProvider>;
+    return (
+        <FilterBarPropsProvider {...props}>
+            <DefaultFilterBarInner />
+        </FilterBarPropsProvider>
+    );
 };


### PR DESCRIPTION
-  Save As dialog can be open using UI action
-  Filter context now contains resolved display form metadata objects; these are needed so that custom filter bar component in KD can filter out components based on metadata object

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
