### PR TITLE
Dashboard component - expose onStateChange callback

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2027,6 +2027,7 @@ export interface IDashboardProps {
     LoadingComponent?: ComponentType<ILoadingProps>;
     MenuButtonComponent?: CustomMenuButtonComponent;
     menuButtonConfig?: IMenuButtonConfiguration;
+    onStateChange?: (state: DashboardState, dispatch: DashboardDispatch) => void;
     permissions?: IWorkspacePermissions;
     SaveAsDialogComponent?: CustomSaveAsDialogComponent;
     ScheduledEmailDialogComponent?: CustomScheduledEmailDialogComponent;
@@ -2053,6 +2054,7 @@ export interface IDashboardStoreProviderProps {
     config?: DashboardConfig;
     dashboardRef?: ObjRef;
     eventHandlers?: DashboardEventHandler[];
+    onStateChange?: (state: DashboardState, dispatch: DashboardDispatch) => void;
     permissions?: IWorkspacePermissions;
     workspace?: string;
 }

--- a/libs/sdk-ui-dashboard/src/model/react/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/types.ts
@@ -2,6 +2,7 @@
 import { IAnalyticalBackend, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 import { DashboardEventHandler } from "../events/eventHandler";
+import { DashboardDispatch, DashboardState } from "../state/types";
 import { DashboardConfig } from "../types/commonTypes";
 
 /**
@@ -54,4 +55,9 @@ export interface IDashboardStoreProviderProps {
      * logged-in user.
      */
     permissions?: IWorkspacePermissions;
+
+    /**
+     * Optionally specify callback that will be called each time the state changes.
+     */
+    onStateChange?: (state: DashboardState, dispatch: DashboardDispatch) => void;
 }

--- a/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useInitializeDashboardStore.ts
@@ -55,6 +55,7 @@ export const useInitializeDashboardStore = (
                 },
                 initialEventHandlers: props.eventHandlers,
                 backgroundWorkers,
+                onStateChange: props.onStateChange,
             });
             dashStore.store.dispatch(
                 initializeDashboard(props.config, props.permissions, InitialLoadCorrelationId),

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -371,6 +371,7 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
             eventHandlers={props.eventHandlers}
             config={props.config}
             permissions={props.permissions}
+            onStateChange={props.onStateChange}
         >
             <ToastMessageContextProvider>
                 <ExportDialogContextProvider>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -9,7 +9,7 @@ import {
 import { ObjRef } from "@gooddata/sdk-model";
 import { IErrorProps, ILoadingProps } from "@gooddata/sdk-ui";
 
-import { DashboardConfig, DashboardEventHandler } from "../../model";
+import { DashboardConfig, DashboardDispatch, DashboardEventHandler, DashboardState } from "../../model";
 import {
     CustomDashboardAttributeFilterComponent,
     CustomDashboardDateFilterComponent,
@@ -278,4 +278,9 @@ export interface IDashboardProps {
      * the "theme" prop.
      */
     themeModifier?: (theme: ITheme) => ITheme;
+
+    /**
+     * Optionally specify callback that will be called each time the state changes.
+     */
+    onStateChange?: (state: DashboardState, dispatch: DashboardDispatch) => void;
 }


### PR DESCRIPTION
- The user can thus reach the latest state of the selectors

JIRA: RAIL-3385

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
