### PR TITLE
RELATED: TNT-169 Fix switching to area chart

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -262,7 +262,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
             BucketNames.STACK,
         ]).filter((attribute) => !stacks.includes(attribute));
 
-        const maxViews = stacks.length ? 1 : viewByMaxItemCount;
+        const maxViews = stacks.length || measures.length > 1 ? 1 : viewByMaxItemCount;
         const views = allAttributesWithoutStacks.slice(0, maxViews);
 
         return {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -150,6 +150,26 @@ describe("PluggableAreaChart", () => {
                     },
                 ],
                 [
+                    "from table to area chart: no dates but 2 attributes and 2 measures",
+                    referencePointMocks.tableTotalsReferencePoint,
+                    {
+                        buckets: [
+                            referencePointMocks.tableTotalsReferencePoint.buckets[0],
+                            {
+                                localIdentifier: "view",
+                                items: referencePointMocks.tableTotalsReferencePoint.buckets[1].items.slice(
+                                    0,
+                                    1,
+                                ),
+                            },
+                            {
+                                localIdentifier: "stack",
+                                items: [],
+                            },
+                        ],
+                    },
+                ],
+                [
                     "from table to area chart: date1 in rows ans date2 columns",
                     referencePointMocks.oneDateInRowsAndOneDateInColumnsReferencePoint,
                     {


### PR DESCRIPTION
Limit number of attributes to 1 when there are multiple measures in the
original reference point.

JIRA: TNT-169


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)