### PR TITLE
AttributeFilter components fix

### DIFF
--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterButtonExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterButtonExample.tsx
@@ -90,14 +90,11 @@ export class AttributeFilterButtonExample extends Component<unknown, IAttributeF
 
     public render(): React.ReactNode {
         const { filters } = this.state;
+        const filter = filters?.[0] ?? newNegativeAttributeFilter(Ldm.LocationResort, []);
 
         return (
             <div className="s-attribute-filter">
-                <AttributeFilterButton
-                    filter={newNegativeAttributeFilter(Ldm.LocationResort, [])}
-                    onApply={this.onApply}
-                    onError={this.onError}
-                />
+                <AttributeFilterButton filter={filter} onApply={this.onApply} onError={this.onError} />
                 <div style={{ height: 300 }} className="s-line-chart">
                     <LineChart
                         measures={[LdmExt.TotalSales2]}

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdownList.tsx
@@ -1,11 +1,11 @@
 // (C) 2019 GoodData Corporation
-import React from "react";
+import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { IAttributeElement } from "@gooddata/sdk-backend-spi";
 import { LegacyInvertableList, LoadingMask } from "@gooddata/sdk-ui-kit";
 
 import { AttributeFilterItem } from "./AttributeFilterItem";
-import { AttributeListItem } from "./types";
+import { AttributeListItem, isNonEmptyListItem } from "./types";
 
 const ITEM_HEIGHT = 28;
 export const MAX_SELECTION_SIZE = 500;
@@ -50,6 +50,11 @@ export const AttributeDropdownList: React.FC<IAttributeDropdownListProps> = ({
         return <ListError />;
     }
 
+    const getItemKey = useCallback((i: AttributeListItem) => {
+        const isSelectionByUri = !!selectedItems[0]?.uri;
+        return isNonEmptyListItem(i) ? (isSelectionByUri ? i.uri : i.title) : "empty";
+    }, []);
+
     return (
         <LegacyInvertableList
             items={items}
@@ -69,6 +74,7 @@ export const AttributeDropdownList: React.FC<IAttributeDropdownListProps> = ({
             height={ITEM_HEIGHT * VISIBLE_ITEMS_COUNT}
             onRangeChange={onRangeChange}
             onSelect={onSelect}
+            getItemKey={getItemKey}
         />
     );
 };

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -7,6 +7,7 @@ import {
 } from "@gooddata/sdk-backend-spi";
 import { IntlShape } from "react-intl";
 import isFunction from "lodash/isFunction";
+import keyBy from "lodash/keyBy";
 import {
     AttributeListItem,
     EmptyListItem,
@@ -49,8 +50,20 @@ export const getNoneTitleIntl = (intl: IntlShape): string => {
     return intl.formatMessage({ id: "gs.filterLabel.none" });
 };
 
-export const getItemsTitles = (selectedFilterOptions: IAttributeElement[]): string => {
-    return selectedFilterOptions.map((selectedOption) => selectedOption.title).join(", ");
+export const getItemsTitles = (
+    selectedFilterOptions: IAttributeElement[],
+    validOptions: IAttributeElement[],
+): string => {
+    const validOptionsByUri = keyBy(validOptions, "uri");
+    const validOptionsByTitle = keyBy(validOptions, "title");
+    return selectedFilterOptions
+        .map(
+            (selectedOption) =>
+                selectedOption.title ??
+                validOptionsByUri[selectedOption.uri]?.title ??
+                validOptionsByTitle[selectedOption.title]?.title,
+        )
+        .join(", ");
 };
 
 export const updateSelectedOptionsWithData = (


### PR DESCRIPTION
- Keep attribute elements selection
- Do not show elements as selected when searching

JIRA: RAIL-3739, RAIL-3740, RAIL-3741, RAIL-3743,

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
