### PR TITLE
New function to remove insight to report translations

### DIFF
--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -1517,6 +1517,9 @@ export class ProtectedReportSdkError extends GoodDataSdkError {
 // @public
 export const RawExecute: React_2.ComponentClass<IRawExecuteProps, any>;
 
+// @beta (undocumented)
+export const removeAllInsightToReportTranslations: (translations: Record<string, string>) => Record<string, string>;
+
 // @beta
 export function resolveUseCancelablePromisesError<TError>(states: UseCancelablePromiseState<unknown, TError>[]): TError | undefined;
 

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -175,6 +175,7 @@ export {
     ITranslationsCustomizationProviderProps,
     TranslationsCustomizationProvider,
     pickCorrectInsightWording,
+    removeAllInsightToReportTranslations,
 } from "./localization/TranslationsCustomizationProvider";
 
 /*

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/index.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/index.ts
@@ -8,4 +8,4 @@ export {
     ITranslationsCustomizationProviderProps,
     TranslationsCustomizationProvider,
 } from "./TranslationsCustomizationProvider";
-export { pickCorrectInsightWording } from "./utils";
+export { pickCorrectInsightWording, removeAllInsightToReportTranslations } from "./utils";

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 
-import { pickCorrectInsightWording } from "../utils";
+import { pickCorrectInsightWording, removeAllInsightToReportTranslations } from "../utils";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { ITranslations } from "../../../localization/IntlWrapper";
 
@@ -28,4 +28,17 @@ describe("pickCorrectInsightWording", () => {
             expect(result).toMatchSnapshot();
         },
     );
+});
+
+describe("removeAllInsightToReportTranslations", () => {
+    const mockTranslationWithoutExtraWords: ITranslations = {
+        "mock.translation": "Insight",
+    };
+    it("should remove all insight to report words", () => {
+        const result = removeAllInsightToReportTranslations({
+            ...mockTranslationWithoutExtraWords,
+            ...mockTranslation,
+        });
+        expect(result).toMatchObject(mockTranslationWithoutExtraWords);
+    });
 });

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
@@ -23,3 +23,19 @@ export const pickCorrectInsightWording = (
         ...modifiedTranslations,
     };
 };
+
+/**
+ * @beta
+ */
+export const removeAllInsightToReportTranslations = (
+    translations: Record<string, string>,
+): Record<string, string> => {
+    Object.keys(translations).forEach((key) => {
+        if (key.includes("|report") || key.includes("|insight")) {
+            delete translations[key];
+        }
+    });
+    return {
+        ...translations,
+    };
+};


### PR DESCRIPTION
JIRA: TNT-231

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
