### PR TITLE
Explicit dependency of query

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2806,13 +2806,14 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
     // (undocumented)
     readonly payload: {
         readonly widgetRef: ObjRef;
+        readonly dashboardFilters: FilterContextItem[];
     };
     // (undocumented)
     readonly type: "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS";
 }
 
 // @alpha
-export function queryWidgetBrokenAlerts(widgetRef: ObjRef, correlationId?: string): QueryWidgetBrokenAlerts;
+export function queryWidgetBrokenAlerts(widgetRef: ObjRef, dashboardFilters: FilterContextItem[], correlationId?: string): QueryWidgetBrokenAlerts;
 
 // @alpha
 export function queryWidgetFilters(widgetRef: ObjRef, widgetFilterOverrides?: IFilter[], correlationId?: string): QueryInsightWidgetFilters;

--- a/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
@@ -1,5 +1,6 @@
 // (C) 2021 GoodData Corporation
 
+import { FilterContextItem } from "@gooddata/sdk-backend-spi";
 import { IFilter, ObjRef } from "@gooddata/sdk-model";
 import { IBrokenAlertFilterBasicInfo } from "../types/alertTypes";
 import { IDashboardQuery } from "./base";
@@ -53,6 +54,7 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
     readonly type: "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS";
     readonly payload: {
         readonly widgetRef: ObjRef;
+        readonly dashboardFilters: FilterContextItem[];
     };
 }
 
@@ -60,17 +62,23 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
  *  Creates action thought which you can query dashboard component for broken alert filters.
  *
  * @param widgetRef - reference to insight kpi widget
+ * @param dashboardFilters - current dashboard filters
  * @param correlationId - optionally specify correlation id to use for this command.
  * @returns
  *
  * @alpha
  */
-export function queryWidgetBrokenAlerts(widgetRef: ObjRef, correlationId?: string): QueryWidgetBrokenAlerts {
+export function queryWidgetBrokenAlerts(
+    widgetRef: ObjRef,
+    dashboardFilters: FilterContextItem[],
+    correlationId?: string,
+): QueryWidgetBrokenAlerts {
     return {
         type: "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS",
         correlationId,
         payload: {
             widgetRef,
+            dashboardFilters,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetBrokenAlerts.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetBrokenAlerts.ts
@@ -1,6 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 import {
+    FilterContextItem,
     IAttributeDisplayFormMetadataObject,
     IKpiWidget,
     isDashboardAttributeFilter,
@@ -18,7 +19,7 @@ import { IDashboardFilter } from "../../types";
 import { invalidQueryArguments } from "../events/general";
 import { QueryWidgetBrokenAlerts } from "../queries/widgets";
 import { selectAlertByWidgetRef } from "../state/alerts/alertsSelectors";
-import { selectFilterContextFilters } from "../state/filterContext/filterContextSelectors";
+
 import { selectWidgetByRef } from "../state/layout/layoutSelectors";
 import { createQueryService } from "../state/_infra/queryService";
 import { IBrokenAlertFilterBasicInfo } from "../types/alertTypes";
@@ -36,7 +37,7 @@ function* queryService(
     query: QueryWidgetBrokenAlerts,
 ): SagaIterator<IBrokenAlertFilterBasicInfo[]> {
     const {
-        payload: { widgetRef },
+        payload: { widgetRef, dashboardFilters },
         correlationId,
     } = query;
 
@@ -59,10 +60,7 @@ function* queryService(
         alert,
         ctx,
     );
-    const appliedFilters: SagaReturnType<typeof getDashboardFilters> = yield call(
-        getDashboardFilters,
-        kpiWidget,
-    );
+    const appliedFilters = getDashboardFilters(kpiWidget, dashboardFilters);
 
     return getBrokenAlertFiltersBasicInfo(alert, kpiWidget, appliedFilters, displayFormsMap);
 }
@@ -122,10 +120,10 @@ function* resolveDisplayForms(
     return result.resolved;
 }
 
-function* getDashboardFilters(kpiWidget: IKpiWidget): SagaIterator<IDashboardFilter[]> {
-    const dashboardFilters: ReturnType<typeof selectFilterContextFilters> = yield select(
-        selectFilterContextFilters,
-    );
+function getDashboardFilters(
+    kpiWidget: IKpiWidget,
+    dashboardFilters: FilterContextItem[],
+): IDashboardFilter[] {
     const allFilters = filterContextItemsToFiltersForWidget(dashboardFilters, kpiWidget);
 
     return allFilters ?? [];

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetBrokenAlertsQuery.ts
@@ -35,11 +35,8 @@ export const useWidgetBrokenAlertsQuery = (
 
     useEffect(() => {
         if (widget.ref) {
-            runBrokenAlertsQuery(widget.ref);
+            runBrokenAlertsQuery(widget.ref, dashboardFilters);
         }
-
-        // queryWidgetBrokenAlerts as a parameter it needs just widget.ref but internally result depends on alert, widget, dashboardFilters
-        // we have to call query every time when this dependency changed to get fresh results
     }, [alert, widget, dashboardFilters]);
 
     return {


### PR DESCRIPTION
Transform dashboardFilters to the explicit query param to express its dependency on it

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
