### PR TITLE
Fix validElements polling in api-bear-client

### DIFF
--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -218,7 +218,14 @@ export class XhrModule {
         if (response.status === 202 && !settings.dontPollOnResult) {
             // poll on new provided url, fallback to the original one
             // (for example validElements returns 303 first with new url which may then return 202 to poll on)
-            let finalUrl = response.url || url;
+            let responseJson;
+            try {
+                responseJson = JSON.parse(responseBody);
+            } catch (err) {
+                responseJson = {};
+            }
+
+            let finalUrl = responseJson.uri ?? response.url ?? url;
 
             const finalSettings = settings;
 


### PR DESCRIPTION
JIRA: RAIL-3750

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
