### PR TITLE
RAIL-3651 Adjust KPI loading to align with KD

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiContent/KpiValue.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiContent/KpiValue.tsx
@@ -79,7 +79,7 @@ class KpiValue extends PureComponent<IKpiValueProps & WrappedComponentProps> {
 
     renderValue() {
         const { isLoading, error, disableKpiDrillUnderline, enableCompactSize, clientHeight } = this.props;
-        if (isLoading) {
+        if (isLoading || this.isValueUnhandledNull()) {
             return <LoadingDots className={"kpi-value-loading gd-loading-dots-centered"} />;
         }
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -41,7 +41,6 @@ import {
 } from "@gooddata/sdk-ui";
 
 import { filterContextItemsToFiltersForWidget } from "../../../../converters";
-import { useDashboardComponentsContext } from "../../../dashboardContexts";
 import {
     selectPermissions,
     selectSettings,
@@ -131,9 +130,6 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     const currentUser = useDashboardSelector(selectUser);
     const permissions = useDashboardSelector(selectPermissions);
     const settings = useDashboardSelector(selectSettings);
-    const { LoadingComponent } = useDashboardComponentsContext({
-        LoadingComponent: props.LoadingComponent,
-    });
     const drillableItems = useDashboardSelector(selectDrillableItems);
     const disableDefaultDrills = useDashboardSelector(selectDisableDefaultDrills);
 
@@ -200,10 +196,6 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     }, [isLoading, onRequestAsyncRender, onResolveAsyncRender]);
 
     const { kpiAlertDialogClosed, kpiAlertDialogOpened } = useDashboardUserInteraction();
-
-    if (isLoading) {
-        return <LoadingComponent />;
-    }
 
     const kpiResult = !result?.dataView.totalCount[0]
         ? getNoDataKpiResult(result, primaryMeasure)


### PR DESCRIPTION
- Show loading indicator inside the KPI widget instead of show loading indicator only

JIRA: RAIL-3651

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
