### PR TITLE
RELATED: RAIL-3471 - Refactor & prepare for custom widgets contributed by plugins

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -68,6 +68,9 @@ export const AnalyticalBackendErrorTypes: {
 // @public
 export type AnalyticalBackendFactory = (config?: IAnalyticalBackendConfig, implConfig?: any) => IAnalyticalBackend;
 
+// @alpha
+export type AnalyticalWidgetType = "kpi" | "insight";
+
 // @public
 export function attributeDescriptorLocalId(descriptor: IAttributeDescriptor): string;
 
@@ -79,6 +82,9 @@ export type AuthenticationFlow = {
     loginUrl: string;
     returnRedirectParam: string;
 };
+
+// @alpha
+export const BuiltInWidgetTypes: string[];
 
 // @public
 export type CatalogItem = ICatalogAttribute | ICatalogMeasure | ICatalogFact | ICatalogDateDataset;
@@ -187,6 +193,12 @@ export interface IAnalyticalBackend {
 // @public
 export interface IAnalyticalBackendConfig {
     readonly hostname?: string;
+}
+
+// @alpha
+export interface IAnalyticalWidget extends IBaseWidget, IWidgetDescription, IFilterableWidget, IDrillableWidget {
+    // (undocumented)
+    readonly type: AnalyticalWidgetType;
 }
 
 // @public
@@ -306,6 +318,11 @@ export interface IBackendCapabilities {
     supportsObjectUris?: boolean;
     supportsRankingFilter?: boolean;
     supportsRankingFilterWithMeasureValueFilter?: boolean;
+}
+
+// @alpha
+export interface IBaseWidget {
+    readonly type: string;
 }
 
 // @public
@@ -640,6 +657,11 @@ export interface IDrill {
 }
 
 // @alpha
+export interface IDrillableWidget {
+    readonly drills: DrillDefinition[];
+}
+
+// @alpha
 export interface IDrillFromAttribute extends IDrillOrigin {
     attribute: ObjRefInScope;
     type: "drillFromAttribute";
@@ -786,6 +808,12 @@ export interface IFactMetadataObject extends IMetadataObject {
 }
 
 // @alpha
+export interface IFilterableWidget {
+    readonly dateDataSet?: ObjRef;
+    readonly ignoreDashboardFilters: IDashboardFilterReference[];
+}
+
+// @alpha
 export interface IFilterContext extends IFilterContextBase, IDashboardObjectIdentity {
 }
 
@@ -856,7 +884,7 @@ export interface IInsightWidget extends IInsightWidgetBase, IDashboardObjectIden
 }
 
 // @alpha (undocumented)
-export interface IInsightWidgetBase extends IWidgetBase {
+export interface IInsightWidgetBase extends IAnalyticalWidget {
     readonly drills: InsightDrillDefinition[];
     readonly insight: ObjRef;
     readonly properties?: VisualizationProperties;
@@ -873,7 +901,7 @@ export interface IKpiWidget extends IKpiWidgetBase, IDashboardObjectIdentity {
 }
 
 // @alpha (undocumented)
-export interface IKpiWidgetBase extends IWidgetBase {
+export interface IKpiWidgetBase extends IAnalyticalWidget {
     readonly drills: KpiDrillDefinition[];
     readonly kpi: ILegacyKpi;
     // (undocumented)
@@ -1682,17 +1710,13 @@ export interface IWidgetAlertDefinition extends IWidgetAlertBase, Partial<IDashb
 }
 
 // @alpha
-export interface IWidgetBase {
-    readonly dateDataSet?: ObjRef;
-    readonly description: string;
-    readonly drills: DrillDefinition[];
-    readonly ignoreDashboardFilters: IDashboardFilterReference[];
-    readonly title: string;
-    readonly type: WidgetType;
-}
+export type IWidgetDefinition = IKpiWidgetDefinition | IInsightWidgetDefinition;
 
 // @alpha
-export type IWidgetDefinition = IKpiWidgetDefinition | IInsightWidgetDefinition;
+export interface IWidgetDescription {
+    readonly description: string;
+    readonly title: string;
+}
 
 // @alpha
 export interface IWidgetReferences {
@@ -2058,11 +2082,11 @@ export function widgetRef(widget: IWidget): ObjRef;
 // @alpha
 export function widgetTitle(widget: IWidget): string;
 
-// @alpha
-export type WidgetType = "kpi" | "insight";
+// @alpha @deprecated (undocumented)
+export type WidgetType = AnalyticalWidgetType;
 
 // @alpha
-export function widgetType(widget: IWidget): WidgetType;
+export function widgetType(widget: IWidget): AnalyticalWidgetType;
 
 // @alpha
 export function widgetUri(widget: IWidget): string;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -260,21 +260,28 @@ export {
     walkLayout,
 } from "./workspace/dashboards/utils";
 export {
-    IWidget,
-    IWidgetDefinition,
-    IInsightWidget,
-    IInsightWidgetBase,
-    IInsightWidgetDefinition,
+    IWidgetDescription,
+    IDrillableWidget,
+    BuiltInWidgetTypes,
+    IFilterableWidget,
+    IBaseWidget,
+} from "./workspace/dashboards/baseWidget";
+export {
+    AnalyticalWidgetType,
+    WidgetType,
+    IAnalyticalWidget,
     IKpiWidget,
     IKpiWidgetBase,
     IKpiWidgetDefinition,
-    WidgetType,
+    IInsightWidget,
+    IInsightWidgetBase,
+    IInsightWidgetDefinition,
+} from "./workspace/dashboards/analyticalWidgets";
+export {
+    IWidget,
+    IWidgetDefinition,
     isWidget,
     isWidgetDefinition,
-    isInsightWidget,
-    isInsightWidgetDefinition,
-    isKpiWidget,
-    isKpiWidgetDefinition,
     IWidgetReferences,
     SupportedWidgetReferenceTypes,
     widgetUri,
@@ -282,7 +289,10 @@ export {
     widgetRef,
     widgetTitle,
     widgetType,
-    IWidgetBase,
+    isKpiWidgetDefinition,
+    isKpiWidget,
+    isInsightWidgetDefinition,
+    isInsightWidget,
 } from "./workspace/dashboards/widget";
 export {
     ILegacyKpi,

--- a/libs/sdk-backend-spi/src/workspace/dashboards/analyticalWidgets.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/analyticalWidgets.ts
@@ -1,0 +1,97 @@
+// (C) 2021 GoodData Corporation
+import { ILegacyKpi } from "./kpi";
+import { InsightDrillDefinition, KpiDrillDefinition } from "./drills";
+import { IDashboardObjectIdentity } from "./common";
+import { IBaseWidget, IDrillableWidget, IFilterableWidget, IWidgetDescription } from "./baseWidget";
+import { ObjRef, VisualizationProperties } from "@gooddata/sdk-model";
+
+/**
+ * Reserved type names used for dashboard's built-in analytical widgets.
+ *
+ * @alpha
+ */
+export type AnalyticalWidgetType = "kpi" | "insight";
+
+/**
+ * @deprecated use {@link AnalyticalWidgetType} instead
+ * @alpha
+ */
+export type WidgetType = AnalyticalWidgetType;
+
+/**
+ * Analytical Widgets are a sub-type of dashboard widgets that display analytics. Be it charts rendering
+ * insights (reports) or KPIs rendering measure values optionally with their comparison.
+ *
+ * @alpha
+ */
+export interface IAnalyticalWidget
+    extends IBaseWidget,
+        IWidgetDescription,
+        IFilterableWidget,
+        IDrillableWidget {
+    readonly type: AnalyticalWidgetType;
+}
+
+/**
+ * @alpha
+ */
+export interface IKpiWidgetBase extends IAnalyticalWidget {
+    readonly type: "kpi";
+
+    /**
+     * Temporary place for legacy kpi properties
+     */
+    readonly kpi: ILegacyKpi;
+
+    /**
+     * Drill interactions configured for the kpi widget.
+     */
+    readonly drills: KpiDrillDefinition[];
+}
+
+/**
+ * @alpha
+ */
+export interface IKpiWidget extends IKpiWidgetBase, IDashboardObjectIdentity {}
+
+/**
+ * @alpha
+ */
+export interface IKpiWidgetDefinition extends IKpiWidgetBase, Partial<IDashboardObjectIdentity> {}
+
+/**
+ * @alpha
+ */
+export interface IInsightWidgetBase extends IAnalyticalWidget {
+    readonly type: "insight";
+
+    /**
+     * Widget insight object reference (when widget is not kpi)
+     */
+    readonly insight: ObjRef;
+
+    /**
+     * Overrides for visualization-specific properties.
+     * Insight rendered in context of this widget
+     * will use these properties instead of its own.
+     *
+     * This is now only supported for the PivotTable.
+     *
+     */
+    readonly properties?: VisualizationProperties;
+
+    /**
+     * Drill interactions configured for the insight widget.
+     */
+    readonly drills: InsightDrillDefinition[];
+}
+
+/**
+ * @alpha
+ */
+export interface IInsightWidget extends IInsightWidgetBase, IDashboardObjectIdentity {}
+
+/**
+ * @alpha
+ */
+export interface IInsightWidgetDefinition extends IInsightWidgetBase, Partial<IDashboardObjectIdentity> {}

--- a/libs/sdk-backend-spi/src/workspace/dashboards/baseWidget.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/baseWidget.ts
@@ -1,0 +1,77 @@
+// (C) 2021 GoodData Corporation
+
+import { IDashboardFilterReference } from "./filterContext";
+import { ObjRef } from "@gooddata/sdk-model";
+import { DrillDefinition } from "./drills";
+
+/**
+ * Defines properties that are used for filterable widgets. Filterable widgets allow users to specify:
+ *
+ * -  Date data set that should be used for date-filtering the data for the widget
+ * -  An ignore-list containing references to dashboard attribute filters that should be ignored by
+ *    the widget.
+ *
+ * @alpha
+ */
+export interface IFilterableWidget {
+    /**
+     * Ignore particular dashboard filters in the current widget
+     */
+    readonly ignoreDashboardFilters: IDashboardFilterReference[];
+
+    /**
+     * Date data set widget is connected to
+     */
+    readonly dateDataSet?: ObjRef;
+}
+
+/**
+ * Defines properties that are used for drillable widgets. Such widgets allow user clicking on
+ * different parts of the widget and through this interaction navigate to other insights or dashboards.
+ *
+ * @alpha
+ */
+export interface IDrillableWidget {
+    /**
+     * Widget drills
+     */
+    readonly drills: DrillDefinition[];
+}
+
+/**
+ * Defines properties that are used to store widget's descriptive metadata.
+ *
+ * @alpha
+ */
+export interface IWidgetDescription {
+    /**
+     * Widget title
+     */
+    readonly title: string;
+
+    /**
+     * Widget description
+     */
+    readonly description: string;
+}
+
+/**
+ * Base type for dashboard widgets.
+ *
+ * @alpha
+ */
+export interface IBaseWidget {
+    /**
+     * Type of widget. This can be assigned by widget creator and can be any string up to 256 characters.
+     *
+     * @remarks see {@link BuiltInWidgetTypes} for list of built-in widget types.
+     */
+    readonly type: string;
+}
+
+/**
+ * List of built-in widget types. These type names are reserved and must not be used by custom widgets.
+ *
+ * @alpha
+ */
+export const BuiltInWidgetTypes: string[] = ["kpi", "insight"];

--- a/libs/sdk-backend-spi/src/workspace/dashboards/widget.ts
+++ b/libs/sdk-backend-spi/src/workspace/dashboards/widget.ts
@@ -1,118 +1,16 @@
 // (C) 2020-2021 GoodData Corporation
-import { ObjRef, isObjRef, ObjectType, VisualizationProperties } from "@gooddata/sdk-model";
+import { isObjRef, ObjectType, ObjRef } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
-import { IDashboardFilterReference } from "./filterContext";
-import { DrillDefinition, InsightDrillDefinition, KpiDrillDefinition } from "./drills";
-import { ILegacyKpi } from "./kpi";
-import { IDashboardObjectIdentity } from "./common";
 import invariant from "ts-invariant";
 import { CatalogItem } from "../fromModel/ldm/catalog";
-
-/**
- * Temporary type to distinguish between kpi and insight
- * @alpha
- */
-export type WidgetType = "kpi" | "insight";
-
-/**
- * Widgets are insights or kpis with additional settings - drilling and alerting
- * @alpha
- */
-export interface IWidgetBase {
-    /**
-     * Widget title
-     */
-    readonly title: string;
-
-    /**
-     * Widget description
-     */
-    readonly description: string;
-
-    /**
-     * Ignore particular dashboard filters in the current widget
-     */
-    readonly ignoreDashboardFilters: IDashboardFilterReference[];
-
-    /**
-     * Date data set widget is connected to
-     */
-    readonly dateDataSet?: ObjRef;
-
-    /**
-     * Widget type - kpi or insight
-     */
-    readonly type: WidgetType;
-
-    /**
-     * Widget drills
-     */
-    readonly drills: DrillDefinition[];
-}
-
-/**
- * @alpha
- */
-export interface IKpiWidgetBase extends IWidgetBase {
-    readonly type: "kpi";
-
-    /**
-     * Temporary place for legacy kpi properties
-     */
-    readonly kpi: ILegacyKpi;
-
-    /**
-     * Drill interactions configured for the kpi widget.
-     */
-    readonly drills: KpiDrillDefinition[];
-}
-
-/**
- * @alpha
- */
-export interface IKpiWidget extends IKpiWidgetBase, IDashboardObjectIdentity {}
-
-/**
- * @alpha
- */
-export interface IKpiWidgetDefinition extends IKpiWidgetBase, Partial<IDashboardObjectIdentity> {}
-
-/**
- * @alpha
- */
-export interface IInsightWidgetBase extends IWidgetBase {
-    readonly type: "insight";
-
-    /**
-     * Widget insight object reference (when widget is not kpi)
-     */
-    readonly insight: ObjRef;
-
-    /**
-     * Overrides for visualization-specific properties.
-     * Insight rendered in context of this widget
-     * will use these properties instead of its own.
-     *
-     * This is now only supported for the PivotTable.
-     *
-     */
-    readonly properties?: VisualizationProperties;
-
-    /**
-     * Drill interactions configured for the insight widget.
-     */
-    readonly drills: InsightDrillDefinition[];
-}
-
-/**
- * @alpha
- */
-export interface IInsightWidget extends IInsightWidgetBase, IDashboardObjectIdentity {}
-
-/**
- * @alpha
- */
-export interface IInsightWidgetDefinition extends IInsightWidgetBase, Partial<IDashboardObjectIdentity> {}
+import {
+    AnalyticalWidgetType,
+    IAnalyticalWidget,
+    IInsightWidget,
+    IInsightWidgetDefinition,
+    IKpiWidget,
+    IKpiWidgetDefinition,
+} from "./analyticalWidgets";
 
 /**
  * See {@link IWidget}]
@@ -165,42 +63,13 @@ export function isWidget(obj: unknown): obj is IWidget {
 }
 
 /**
- * Type-guard testing whether the provided object is an instance of {@link IInsightWidget}.
- * @alpha
- */
-export function isInsightWidget(obj: unknown): obj is IInsightWidget {
-    return isWidget(obj) && (obj as IInsightWidget).type === "insight";
-}
-
-/**
- * Type-guard testing whether the provided object is an instance of {@link IInsightWidgetDefinition}.
- * @alpha
- */
-export function isInsightWidgetDefinition(obj: unknown): obj is IInsightWidgetDefinition {
-    return isWidgetDefinition(obj) && (obj as IInsightWidget).type === "insight";
-}
-
-/**
- * Type-guard testing whether the provided object is an instance of {@link IKpiWidget}.
- * @alpha
- */
-export function isKpiWidget(obj: unknown): obj is IKpiWidget {
-    return isWidget(obj) && (obj as IKpiWidget).type === "kpi";
-}
-
-/**
- * Type-guard testing whether the provided object is an instance of {@link IKpiWidget}.
- * @alpha
- */
-export function isKpiWidgetDefinition(obj: unknown): obj is IKpiWidgetDefinition {
-    return isWidgetDefinition(obj) && (obj as IKpiWidget).type === "kpi";
-}
-
-/**
  * @internal
  */
 function hasWidgetProps(obj: unknown): boolean {
-    return !isEmpty(obj) && ((obj as IWidgetBase).type === "kpi" || (obj as IWidgetBase).type === "insight");
+    return (
+        !isEmpty(obj) &&
+        ((obj as IAnalyticalWidget).type === "kpi" || (obj as IAnalyticalWidget).type === "insight")
+    );
 }
 
 /**
@@ -249,7 +118,7 @@ export function widgetRef(widget: IWidget): ObjRef {
  * @returns the widget type
  * @alpha
  */
-export function widgetType(widget: IWidget): WidgetType {
+export function widgetType(widget: IWidget): AnalyticalWidgetType {
     invariant(widget, "widget to get type of must be specified");
 
     return widget.type;
@@ -266,4 +135,36 @@ export function widgetTitle(widget: IWidget): string {
     invariant(widget, "widget to get title of must be specified");
 
     return widget.title;
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IInsightWidget}.
+ * @alpha
+ */
+export function isInsightWidget(obj: unknown): obj is IInsightWidget {
+    return isWidget(obj) && (obj as IInsightWidget).type === "insight";
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IInsightWidgetDefinition}.
+ * @alpha
+ */
+export function isInsightWidgetDefinition(obj: unknown): obj is IInsightWidgetDefinition {
+    return isWidgetDefinition(obj) && (obj as IInsightWidget).type === "insight";
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IKpiWidget}.
+ * @alpha
+ */
+export function isKpiWidget(obj: unknown): obj is IKpiWidget {
+    return isWidget(obj) && (obj as IKpiWidget).type === "kpi";
+}
+
+/**
+ * Type-guard testing whether the provided object is an instance of {@link IKpiWidget}.
+ * @alpha
+ */
+export function isKpiWidgetDefinition(obj: unknown): obj is IKpiWidgetDefinition {
+    return isWidgetDefinition(obj) && (obj as IKpiWidget).type === "kpi";
 }

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -36,6 +36,7 @@ options = {
             "src/presentation/saveAs/types.ts",
             "src/presentation/topBar/types.ts",
             "src/presentation/widget/types.ts",
+            "src/model",
         ]),
         depCruiser.moduleWithDependencies("dialogs", "src/presentation/dialogs", [
             "src/_staging/*",
@@ -56,6 +57,7 @@ options = {
             "src/presentation/localization",
         ]),
         depCruiser.moduleWithDependencies("layout", "src/presentation/layout", [
+            "src/_staging/*",
             "src/model",
             "src/presentation/constants",
             "src/presentation/dashboardContexts",

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -30,6 +30,7 @@ import { IAttributeElements } from '@gooddata/sdk-model';
 import { IAttributeMetadataObject } from '@gooddata/sdk-backend-spi';
 import { IAvailableDrillTargets } from '@gooddata/sdk-ui';
 import { IBackendCapabilities } from '@gooddata/sdk-backend-spi';
+import { IBaseWidget } from '@gooddata/sdk-backend-spi';
 import { ICatalogAttribute } from '@gooddata/sdk-backend-spi';
 import { ICatalogDateAttribute } from '@gooddata/sdk-backend-spi';
 import { ICatalogDateDataset } from '@gooddata/sdk-backend-spi';
@@ -1068,7 +1069,7 @@ export interface DashboardInsightWidgetVisPropertiesChanged extends IDashboardEv
 }
 
 // @alpha
-export type DashboardItemDefinition = ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition> | StashedDashboardItemsId;
+export type DashboardItemDefinition = ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition | ICustomWidgetDefinition> | StashedDashboardItemsId;
 
 // @internal (undocumented)
 export const DashboardKpi: () => JSX.Element;
@@ -1811,7 +1812,7 @@ export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayou
 export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDashboardWidget>;
 
 // @alpha
-export type ExtendedDashboardWidget = IWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
+export type ExtendedDashboardWidget = IWidget | ICustomWidget;
 
 // @internal (undocumented)
 export const FilterBar: () => JSX.Element;
@@ -1946,6 +1947,22 @@ export interface ICustomDashboardEvent<TPayload = any> {
     };
     readonly payload?: TPayload;
     readonly type: string;
+}
+
+// @alpha
+export interface ICustomWidget extends ICustomWidgetBase, IDashboardObjectIdentity {
+}
+
+// @alpha
+export interface ICustomWidgetBase extends IBaseWidget {
+    // (undocumented)
+    readonly customType: string;
+    // (undocumented)
+    readonly type: "customWidget";
+}
+
+// @alpha
+export interface ICustomWidgetDefinition extends ICustomWidgetBase, Partial<IDashboardObjectIdentity> {
 }
 
 // @alpha (undocumented)
@@ -2341,8 +2358,8 @@ export type InsightDateDatasets = {
 };
 
 // @alpha (undocumented)
-export type InsightPlaceholderWidget = {
-    readonly type: "insightPlaceholder";
+export type InsightPlaceholderWidget = ICustomWidgetBase & {
+    readonly customType: "insightPlaceholder";
 };
 
 // @alpha
@@ -2398,6 +2415,12 @@ export interface IScheduledEmailDialogProps {
 
 // @alpha
 export function isCustomDashboardEvent(obj: unknown): obj is ICustomDashboardEvent;
+
+// @alpha
+export function isCustomWidget(obj: unknown): obj is ICustomWidget;
+
+// @alpha
+export function isCustomWidgetDefinition(obj: unknown): obj is ICustomWidget;
 
 // @alpha
 export const isDashboardAlertCreated: (obj: unknown) => obj is DashboardAlertCreated;
@@ -2666,8 +2689,8 @@ export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kp
 export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent | undefined;
 
 // @alpha (undocumented)
-export type KpiPlaceholderWidget = {
-    readonly type: "kpiPlaceholder";
+export type KpiPlaceholderWidget = ICustomWidgetBase & {
+    readonly customType: "kpiPlaceholder";
 };
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1448,7 +1448,7 @@ export interface DashboardWasReset extends IDashboardEvent {
 }
 
 // @internal (undocumented)
-export const DashboardWidget: () => JSX.Element;
+export const DashboardWidget: React_2.FC;
 
 // @alpha
 export interface DashboardWidgetExecutionFailed extends IDashboardEvent {
@@ -1505,7 +1505,7 @@ export interface DashboardWidgetProps {
     showHeader?: boolean;
     showMenu?: boolean;
     // (undocumented)
-    widget?: IWidget;
+    widget?: ExtendedDashboardWidget;
     // (undocumented)
     workspace?: string;
 }
@@ -1813,6 +1813,9 @@ export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDas
 
 // @alpha
 export type ExtendedDashboardWidget = IWidget | ICustomWidget;
+
+// @alpha
+export function extendedWidgetDebugStr(widget: ExtendedDashboardWidget): string;
 
 // @internal (undocumented)
 export const FilterBar: () => JSX.Element;
@@ -3235,9 +3238,6 @@ export const selectAttributesWithDrillDown: OutputSelector<DashboardState, (ICat
 // @alpha
 export const selectBackendCapabilities: OutputSelector<DashboardState, IBackendCapabilities, (res: BackendCapabilitiesState) => IBackendCapabilities>;
 
-// @internal
-export const selectBasicLayout: OutputSelector<DashboardState, IDashboardLayout<IWidget>, (res: IDashboardLayout<ExtendedDashboardWidget>) => IDashboardLayout<IWidget>>;
-
 // @alpha
 export const selectCanCreateAnalyticalDashboard: OutputSelector<DashboardState, boolean, (res: IWorkspacePermissions) => boolean>;
 
@@ -4179,7 +4179,7 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
 };
 
 // @alpha (undocumented)
-export type WidgetComponentProvider = (widget: IWidget) => CustomDashboardWidgetComponent | undefined;
+export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent | undefined;
 
 // @alpha
 export type WidgetFilterOperation = FilterOpEnableDateFilter | FilterOpDisableDateFilter | FilterOpReplaceAttributeIgnores | FilterOpIgnoreAttributeFilter | FilterOpUnignoreAttributeFilter | FilterOpReplaceAll;

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
@@ -9,7 +9,7 @@ import {
     ISettings,
     isInsightWidget,
     isKpiWidget,
-    WidgetType,
+    AnalyticalWidgetType,
 } from "@gooddata/sdk-backend-spi";
 import { IInsight, insightRef, serializeObjRef } from "@gooddata/sdk-model";
 import compact from "lodash/compact";
@@ -24,7 +24,7 @@ import { ObjRefMap } from "../metadata/objRefMap";
 function extractContentFromWidget(
     widget: IDashboardWidget,
     insightsById: Record<string, IInsight>,
-): { type: WidgetType; content?: MeasurableWidgetContent } {
+): { type: AnalyticalWidgetType; content?: MeasurableWidgetContent } {
     if (isInsightWidget(widget)) {
         const insightRef = widget.insight;
 

--- a/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dashboard/dashboardLayout.ts
@@ -59,6 +59,14 @@ function dashboardLayoutItemSanitize<T = IDashboardWidget>(
         size: { xl },
     } = item;
 
+    // ignore items that point to no widget; this is model-level version of the fix to RAIL-3669
+    if (!widget) {
+        // eslint-disable-next-line no-console
+        console.log(`Found item ${item} that does not contain any widget. Removing from layout.`);
+
+        return undefined;
+    }
+
     // only sanitize known widget types
     if (!isInsightWidget(widget) || !isKpiWidget(widget)) {
         return item;

--- a/libs/sdk-ui-dashboard/src/index.ts
+++ b/libs/sdk-ui-dashboard/src/index.ts
@@ -26,3 +26,4 @@ export {
     IDashboardKpiCustomizer,
     DashboardStateChangeCallback,
 } from "./plugins/customizer";
+export { InsightPlaceholderWidget, KpiPlaceholderWidget } from "./widgets/placeholders/types";

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -51,6 +51,12 @@ function createDashboard(ctx: DashboardContext, saveAsCtx: DashboardSaveAsContex
     return ctx.backend.workspace(ctx.workspace).dashboards().createDashboard(saveAsCtx.dashboardToSave);
 }
 
+/*
+ * TODO: custom widget persistence; we need a new backend capability that indicates whether the
+ *  backend can persist custom widget content (tiger can already, bear cannot). Based on that
+ *  capability, this code should use either the selectBasicLayout (that strips any custom widgets) or
+ *  selectLayout (that keeps custom widgets).
+ */
 function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<DashboardSaveAsContext> {
     const { title } = cmd.payload;
     const titleProp = title ? { title } : {};

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveDashboardHandler.ts
@@ -70,6 +70,12 @@ function updateDashboard(ctx: DashboardContext, saveCtx: DashboardSaveContext): 
         .updateDashboard(persistedDashboard, dashboardToSave);
 }
 
+/*
+ * TODO: custom widget persistence; we need a new backend capability that indicates whether the
+ *  backend can persist custom widget content (tiger can already, bear cannot). Based on that
+ *  capability, this code should use either the selectBasicLayout (that strips any custom widgets) or
+ *  selectLayout (that keeps custom widgets).
+ */
 function* createDashboardSaveContext(cmd: SaveDashboard): SagaIterator<DashboardSaveContext> {
     const persistedDashboard: ReturnType<typeof selectPersistedDashboard> = yield select(
         selectPersistedDashboard,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addLayoutSectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addLayoutSectionHandler.test.ts.snap
@@ -42,36 +42,3 @@ Object {
   "type": "IDashboardLayoutSection",
 }
 `;
-
-exports[`add layout section handler for an empty dashboard should add a new section and initialize its items 1`] = `
-Object {
-  "header": undefined,
-  "items": Array [
-    Object {
-      "size": Object {
-        "xl": Object {
-          "gridWidth": 2,
-        },
-      },
-      "type": "IDashboardLayoutItem",
-      "widget": Object {
-        "customType": "kpiPlaceholder",
-        "type": "customWidget",
-      },
-    },
-    Object {
-      "size": Object {
-        "xl": Object {
-          "gridWidth": 2,
-        },
-      },
-      "type": "IDashboardLayoutItem",
-      "widget": Object {
-        "customType": "insightPlaceholder",
-        "type": "customWidget",
-      },
-    },
-  ],
-  "type": "IDashboardLayoutSection",
-}
-`;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addLayoutSectionHandler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/__snapshots__/addLayoutSectionHandler.test.ts.snap
@@ -55,7 +55,8 @@ Object {
       },
       "type": "IDashboardLayoutItem",
       "widget": Object {
-        "type": "kpiPlaceholder",
+        "customType": "kpiPlaceholder",
+        "type": "customWidget",
       },
     },
     Object {
@@ -66,7 +67,8 @@ Object {
       },
       "type": "IDashboardLayoutItem",
       "widget": Object {
-        "type": "insightPlaceholder",
+        "customType": "insightPlaceholder",
+        "type": "customWidget",
       },
     },
   ],

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
@@ -21,7 +21,7 @@ import {
     TestKpiPlaceholderItem,
 } from "../../../tests/fixtures/Layout.fixtures";
 import { ActivityDateDatasetRef } from "../../../tests/fixtures/CatalogAvailability.fixtures";
-import { IWidgetBase } from "@gooddata/sdk-backend-spi";
+import { IAnalyticalWidget } from "@gooddata/sdk-backend-spi";
 
 describe("add layout section handler", () => {
     describe("for an empty dashboard", () => {
@@ -102,7 +102,7 @@ describe("add layout section handler", () => {
                 "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
             );
 
-            expect((event.payload.section.items[0].widget as IWidgetBase).dateDataSet).toEqual(
+            expect((event.payload.section.items[0].widget as IAnalyticalWidget).dateDataSet).toEqual(
                 ActivityDateDatasetRef,
             );
         });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addLayoutSectionHandler.test.ts
@@ -80,7 +80,10 @@ describe("add layout section handler", () => {
                 addLayoutSection(0, undefined, [TestKpiPlaceholderItem, TestInsightPlaceholderItem]),
                 "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
             );
-            expect(event.payload.section).toMatchSnapshot();
+            expect(event.payload.section.items).toMatchObject([
+                TestKpiPlaceholderItem,
+                TestInsightPlaceholderItem,
+            ]);
 
             const layout = selectLayout(Tester.state());
             expect(layout.sections[0]).toEqual(event.payload.section);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addSectionItemsHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/addSectionItemsHandler.test.ts
@@ -122,10 +122,14 @@ describe("add section items handler", () => {
 
             expect(event.payload.sectionIndex).toEqual(1);
             expect(event.payload.startIndex).toEqual(0);
-            expect(event.payload.itemsAdded).toEqual([TestKpiPlaceholderItem]);
+            expect(event.payload.itemsAdded).toMatchObject([TestKpiPlaceholderItem]);
 
             const section = selectLayout(Tester.state()).sections[TestSectionIdx];
-            expect(section.items).toEqual([TestKpiPlaceholderItem, expect.any(Object), expect.any(Object)]);
+            expect(section.items).toMatchObject([
+                TestKpiPlaceholderItem,
+                expect.any(Object),
+                expect.any(Object),
+            ]);
         });
 
         it("should add new item in between to items in an existing section", async () => {
@@ -136,10 +140,14 @@ describe("add section items handler", () => {
 
             expect(event.payload.sectionIndex).toEqual(1);
             expect(event.payload.startIndex).toEqual(1);
-            expect(event.payload.itemsAdded).toEqual([TestKpiPlaceholderItem]);
+            expect(event.payload.itemsAdded).toMatchObject([TestKpiPlaceholderItem]);
 
             const section = selectLayout(Tester.state()).sections[TestSectionIdx];
-            expect(section.items).toEqual([expect.any(Object), TestKpiPlaceholderItem, expect.any(Object)]);
+            expect(section.items).toMatchObject([
+                expect.any(Object),
+                TestKpiPlaceholderItem,
+                expect.any(Object),
+            ]);
         });
 
         it("should add new item as last item in an existing section", async () => {
@@ -150,10 +158,14 @@ describe("add section items handler", () => {
 
             expect(event.payload.sectionIndex).toEqual(1);
             expect(event.payload.startIndex).toEqual(2);
-            expect(event.payload.itemsAdded).toEqual([TestKpiPlaceholderItem]);
+            expect(event.payload.itemsAdded).toMatchObject([TestKpiPlaceholderItem]);
 
             const section = selectLayout(Tester.state()).sections[TestSectionIdx];
-            expect(section.items).toEqual([expect.any(Object), expect.any(Object), TestKpiPlaceholderItem]);
+            expect(section.items).toMatchObject([
+                expect.any(Object),
+                expect.any(Object),
+                TestKpiPlaceholderItem,
+            ]);
         });
 
         it("should be undoable", async () => {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/replaceSectionItemHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/replaceSectionItemHandler.test.ts
@@ -90,9 +90,9 @@ describe("replace section item handler", () => {
             );
 
             expect(event.payload.previousItem).toEqual(SecondSectionFirstItem);
-            expect(event.payload.items).toEqual([TestKpiPlaceholderItem]);
+            expect(event.payload.items).toMatchObject([TestKpiPlaceholderItem]);
             const section = selectLayout(Tester.state()).sections[1];
-            expect(section.items).toEqual([TestKpiPlaceholderItem, SecondSectionSecondItem]);
+            expect(section.items).toMatchObject([TestKpiPlaceholderItem, SecondSectionSecondItem]);
         });
 
         it("should replace existing item in section with single item", async () => {
@@ -102,9 +102,9 @@ describe("replace section item handler", () => {
             );
 
             expect(event.payload.previousItem).toEqual(ThirdSectionFirstItem);
-            expect(event.payload.items).toEqual([TestKpiPlaceholderItem]);
+            expect(event.payload.items).toMatchObject([TestKpiPlaceholderItem]);
             const section = selectLayout(Tester.state()).sections[2];
-            expect(section.items).toEqual([TestKpiPlaceholderItem]);
+            expect(section.items).toMatchObject([TestKpiPlaceholderItem]);
         });
 
         it("should replace existing item and store previous item in stash", async () => {
@@ -135,7 +135,7 @@ describe("replace section item handler", () => {
             expect(event.payload.previousItem).toEqual(SecondSectionSecondItem);
             expect(event.payload.items).toEqual([SecondSectionFirstItem]);
             const section = selectLayout(Tester.state()).sections[1];
-            expect(section.items).toEqual([TestKpiPlaceholderItem, SecondSectionFirstItem]);
+            expect(section.items).toMatchObject([TestKpiPlaceholderItem, SecondSectionFirstItem]);
         });
 
         it("should resolve stashed item first, then overwrite stash with new item", async () => {
@@ -217,7 +217,7 @@ describe("replace section item handler", () => {
                 "GDC.DASH/EVT.FLUID_LAYOUT.LAYOUT_CHANGED",
             );
 
-            expect(lastReplaceUndone.payload.layout.sections[1].items).toEqual([
+            expect(lastReplaceUndone.payload.layout.sections[1].items).toMatchObject([
                 TestKpiPlaceholderItem,
                 SecondSectionSecondItem,
             ]);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetFilterSettingsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeInsightWidgetFilterSettingsHandler.ts
@@ -9,7 +9,11 @@ import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import { validateExistingInsightWidget } from "./validation/widgetValidations";
 import { layoutActions } from "../../store/layout";
 import { insightWidgetFilterSettingsChanged } from "../../events/insight";
-import { IDashboardAttributeFilterReference, IInsightWidget, IWidgetBase } from "@gooddata/sdk-backend-spi";
+import {
+    IDashboardAttributeFilterReference,
+    IInsightWidget,
+    IAnalyticalWidget,
+} from "@gooddata/sdk-backend-spi";
 import { FilterValidators, processFilterOp } from "./common/filterOperations";
 import {
     validateAttributeFiltersToIgnore,
@@ -42,7 +46,7 @@ export function* changeInsightWidgetFilterSettingsHandler(
     const result: SagaReturnType<typeof processFilterOp> = yield call(
         processFilterOp,
         ctx,
-        InsightWidgetFilterValidations as FilterValidators<IWidgetBase>,
+        InsightWidgetFilterValidations as FilterValidators<IAnalyticalWidget>,
         cmd,
         insightWidget,
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeKpiWidgetFilterSettingsHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/changeKpiWidgetFilterSettingsHandler.ts
@@ -8,7 +8,7 @@ import { selectWidgetsMap } from "../../store/layout/layoutSelectors";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import { validateExistingKpiWidget } from "./validation/widgetValidations";
 import { layoutActions } from "../../store/layout";
-import { IDashboardAttributeFilterReference, IKpiWidget, IWidgetBase } from "@gooddata/sdk-backend-spi";
+import { IDashboardAttributeFilterReference, IKpiWidget, IAnalyticalWidget } from "@gooddata/sdk-backend-spi";
 import { FilterValidators, processFilterOp } from "./common/filterOperations";
 import {
     validateAttributeFiltersToIgnore,
@@ -42,7 +42,7 @@ export function* changeKpiWidgetFilterSettingsHandler(
     const result: SagaReturnType<typeof processFilterOp> = yield call(
         processFilterOp,
         ctx,
-        KpiWidgetFilterValidations as FilterValidators<IWidgetBase>,
+        KpiWidgetFilterValidations as FilterValidators<IAnalyticalWidget>,
         cmd,
         kpiWidget,
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/filterOperations.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/filterOperations.ts
@@ -4,7 +4,7 @@ import {
     IDashboardAttributeFilter,
     IDashboardFilterReference,
     isDashboardAttributeFilterReference,
-    IWidgetBase,
+    IAnalyticalWidget,
 } from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import { DashboardContext } from "../../../types/commonTypes";
@@ -38,9 +38,9 @@ function getIgnoredAttributeFilters(
 
 function* replaceFilterSettings(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
     op: FilterOpReplaceAll,
 ): SagaIterator<FilterOpResult> {
     let dateDataSet: ICatalogDateDataset | undefined;
@@ -73,9 +73,9 @@ function* replaceFilterSettings(
 
 function* disableDateFilter(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
 ): SagaIterator<FilterOpResult> {
     const replaceEquivalent: FilterOpReplaceAll = {
         type: "replace",
@@ -88,9 +88,9 @@ function* disableDateFilter(
 
 function* enableDateFilter(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
     op: FilterOpEnableDateFilter,
 ): SagaIterator<FilterOpResult> {
     const replaceEquivalent: FilterOpReplaceAll = {
@@ -104,9 +104,9 @@ function* enableDateFilter(
 
 function* replaceAttributeIgnores(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
     op: FilterOpReplaceAttributeIgnores,
 ): SagaIterator<FilterOpResult> {
     const replaceEquivalent: FilterOpReplaceAll = {
@@ -120,9 +120,9 @@ function* replaceAttributeIgnores(
 
 function* ignoreAttributeFilter(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
     op: FilterOpIgnoreAttributeFilter,
 ): SagaIterator<FilterOpResult> {
     const replaceIntermediate: FilterOpReplaceAll = {
@@ -162,9 +162,9 @@ function* ignoreAttributeFilter(
 
 function* unignoreAttributeFilter(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: IDashboardCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
     op: FilterOpUnignoreAttributeFilter,
 ): SagaIterator<FilterOpResult> {
     const replaceIntermediate: FilterOpReplaceAll = {
@@ -219,19 +219,19 @@ export type FilterOpResult = {
     ignoredFilters?: IDashboardAttributeFilter[];
 };
 
-export type DateDatasetValidator<T extends IWidgetBase> = (
+export type DateDatasetValidator<T extends IAnalyticalWidget> = (
     ctx: DashboardContext,
     cmd: IDashboardCommand,
     widget: T,
     ref: ObjRef,
 ) => SagaIterator<ICatalogDateDataset>;
-export type AttributeFilterValidator<T extends IWidgetBase> = (
+export type AttributeFilterValidator<T extends IAnalyticalWidget> = (
     ctx: DashboardContext,
     cmd: IDashboardCommand,
     widget: T,
     refs: ObjRef[],
 ) => SagaIterator<IDashboardAttributeFilter[] | undefined>;
-export type FilterValidators<T extends IWidgetBase> = {
+export type FilterValidators<T extends IAnalyticalWidget> = {
     dateDatasetValidator: DateDatasetValidator<T>;
     attributeFilterValidator: AttributeFilterValidator<T>;
 };
@@ -285,9 +285,9 @@ export type FilterOpCommand = IDashboardCommand & {
  */
 export function* processFilterOp(
     ctx: DashboardContext,
-    validators: FilterValidators<IWidgetBase>,
+    validators: FilterValidators<IAnalyticalWidget>,
     cmd: FilterOpCommand,
-    widget: IWidgetBase,
+    widget: IAnalyticalWidget,
 ): SagaIterator<FilterOpResult> {
     const {
         payload: { operation },

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/validation/filterValidation.ts
@@ -20,7 +20,7 @@ import {
     IDashboardAttributeFilter,
     IInsightWidget,
     IKpiWidget,
-    IWidgetBase,
+    IAnalyticalWidget,
 } from "@gooddata/sdk-backend-spi";
 import { IDashboardCommand } from "../../../commands";
 
@@ -141,7 +141,7 @@ export function* validateDatasetForKpiWidgetDateFilter(
 export function* validateAttributeFiltersToIgnore(
     ctx: DashboardContext,
     cmd: IDashboardCommand,
-    _widget: IWidgetBase,
+    _widget: IAnalyticalWidget,
     toIgnore: ObjRef[],
 ): SagaIterator<IDashboardAttributeFilter[]> {
     const resolvedDisplayForms: SagaReturnType<typeof resolveDisplayFormMetadata> = yield call(

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -178,10 +178,13 @@ export {
     IResolvedFilterValues,
 } from "./types/commonTypes";
 export {
+    ICustomWidget,
+    ICustomWidgetDefinition,
+    ICustomWidgetBase,
+    isCustomWidgetDefinition,
+    isCustomWidget,
     ExtendedDashboardItem,
     ExtendedDashboardWidget,
-    InsightPlaceholderWidget,
-    KpiPlaceholderWidget,
     DashboardItemDefinition,
     StashedDashboardItemsId,
     ExtendedDashboardLayoutSection,

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -84,7 +84,6 @@ export { LayoutState, LayoutStash } from "./store/layout/layoutState";
 export {
     selectLayout,
     selectStash,
-    selectBasicLayout,
     selectWidgetByRef,
     selectWidgetsMap,
     selectAllInsightWidgets,
@@ -184,6 +183,7 @@ export {
     isCustomWidgetDefinition,
     isCustomWidget,
     ExtendedDashboardItem,
+    extendedWidgetDebugStr,
     ExtendedDashboardWidget,
     DashboardItemDefinition,
     StashedDashboardItemsId,

--- a/libs/sdk-ui-dashboard/src/model/store/insights/insightsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/insights/insightsSelectors.ts
@@ -12,6 +12,13 @@ const entitySelectors = insightsAdapter.getSelectors((state: DashboardState) => 
 /**
  * Selects all insights used on the dashboard.
  *
+ * Note: if you are aiming to lookup insights using an ObjRef, then you should instead use the map returned
+ * by {@link selectInsightsMap}. If you are aiming to lookup a single insight by its ref, use {@link selectInsightByRef}.
+ * Using these selectors is both faster and safer as they take ObjRef type into account and look up the insight
+ * depending on the type of the ref.
+ *
+ * @remarks see {@link selectInsightsMap} or {@link selectInsightByRef} for a faster and safer ways to get
+ * an insight by its ObjRef.
  * @alpha
  */
 export const selectInsights = entitySelectors.selectAll;

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -66,9 +66,11 @@ function isItemWithBaseWidget(
 /**
  * This selector returns the basic dashboard layout that does not contain any client-side extensions.
  *
- * TODO: we need to get to a point where this selector is not needed. the layout component needs to recognize that the
- *  layout may contain client-side customizations. Furthermore, the dashboard saving should be enhanced so that the
- *  client-side customization can also be persisted.
+ * This selector exists because analytical backend impls are not yet ready to handle persistence of custom
+ * widgets (that may have arbitrary payloads). The selector is used only in save and saveAs command handlers,
+ * where it obtains the layout without any custom widgets and persists that. Note that the save/saveAs
+ * handlers will not wipe the custom widgets from the state during the save - so at this point the custom
+ * widgets are treated as client-side extensions.
  *
  * @internal
  */

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/Layout.fixtures.ts
@@ -1,5 +1,4 @@
 // (C) 2021 GoodData Corporation
-import { InsightPlaceholderWidget, KpiPlaceholderWidget } from "../../types/layoutTypes";
 import {
     IDashboardLayoutItem,
     IDashboardLayoutSectionHeader,
@@ -10,13 +9,16 @@ import {
 } from "@gooddata/sdk-backend-spi";
 import { idRef, IInsight, insightId, isObjRef, ObjRef } from "@gooddata/sdk-model";
 import { PivotTableWithRowAndColumnAttributes } from "./Insights.fixtures";
+import { InsightPlaceholderWidget, KpiPlaceholderWidget } from "../../../widgets/placeholders/types";
 
 export const TestSectionHeader: IDashboardLayoutSectionHeader = {
     title: "Test Section",
     description: "Section added for test purposes",
 };
-export const TestKpiPlaceholderWidget: KpiPlaceholderWidget = {
-    type: "kpiPlaceholder",
+
+const TestKpiPlaceholderWidget: KpiPlaceholderWidget = {
+    type: "customWidget",
+    customType: "kpiPlaceholder",
 };
 export const TestKpiPlaceholderItem: IDashboardLayoutItem<KpiPlaceholderWidget> = {
     type: "IDashboardLayoutItem",
@@ -27,8 +29,10 @@ export const TestKpiPlaceholderItem: IDashboardLayoutItem<KpiPlaceholderWidget> 
         },
     },
 };
-export const TestInsightPlaceholderWidget: InsightPlaceholderWidget = {
-    type: "insightPlaceholder",
+
+const TestInsightPlaceholderWidget: InsightPlaceholderWidget = {
+    type: "customWidget",
+    customType: "insightPlaceholder",
 };
 export const TestInsightPlaceholderItem: IDashboardLayoutItem<InsightPlaceholderWidget> = {
     type: "IDashboardLayoutItem",

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -1,54 +1,72 @@
 // (C) 2021 GoodData Corporation
 
 import {
+    IBaseWidget,
     IDashboardLayoutItem,
     IDashboardLayoutSection,
+    IDashboardObjectIdentity,
     IWidget,
     IWidgetDefinition,
 } from "@gooddata/sdk-backend-spi";
 import isEmpty from "lodash/isEmpty";
 
 /**
- * @alpha
- */
-export type KpiPlaceholderWidget = {
-    readonly type: "kpiPlaceholder";
-};
-
-/**
- * Tests whether an object is a {@link KpiPlaceholderWidget}.
+ * Base type for custom widgets. Custom widgets may extend this and add extra properties to hold widget-specific
+ * configuration.
  *
- * @param obj - object to test
  * @alpha
  */
-export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidget {
-    return !isEmpty(obj) && (obj as KpiPlaceholderWidget).type === "kpiPlaceholder";
+export interface ICustomWidgetBase extends IBaseWidget {
+    readonly type: "customWidget";
+    readonly customType: string;
 }
 
 /**
+ * Custom widget with assigned identity.
+ *
  * @alpha
  */
-export type InsightPlaceholderWidget = {
-    readonly type: "insightPlaceholder";
-};
+export interface ICustomWidget extends ICustomWidgetBase, IDashboardObjectIdentity {}
 
 /**
- * Tests whether an object is a {@link InsightPlaceholderWidget}.
+ * Definition of custom widget. The definition may not specify identity. In that case a temporary identity
+ * will be assigned to the widget as it is added onto a dashboard.
+ *
+ * @alpha
+ */
+export interface ICustomWidgetDefinition extends ICustomWidgetBase, Partial<IDashboardObjectIdentity> {}
+
+/**
+ * Type-guard that tests whether an object is an instance of {@link ICustomWidget}.
  *
  * @param obj - object to test
  * @alpha
  */
-export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlaceholderWidget {
-    return !isEmpty(obj) && (obj as InsightPlaceholderWidget).type === "insightPlaceholder";
+export function isCustomWidget(obj: unknown): obj is ICustomWidget {
+    const w = obj as ICustomWidget;
+
+    return !isEmpty(w) && w.type === "customWidget" && w.customType !== undefined && w.ref !== undefined;
+}
+
+/**
+ * Type-guard that tests whether an object is an instance of {@link ICustomWidgetDefinition}.
+ *
+ * @param obj - object to test
+ * @alpha
+ */
+export function isCustomWidgetDefinition(obj: unknown): obj is ICustomWidget {
+    const w = obj as ICustomWidget;
+
+    return !isEmpty(w) && w.type === "customWidget" && w.customType !== undefined && w.ref === undefined;
 }
 
 /**
  * Extension of the default {@link @gooddata/sdk-backend-spi#IWidget} type to also include view-only
- * widget types for KPI placeholder and Insight placeholder.
+ * custom widget types.
  *
  * @alpha
  */
-export type ExtendedDashboardWidget = IWidget | KpiPlaceholderWidget | InsightPlaceholderWidget;
+export type ExtendedDashboardWidget = IWidget | ICustomWidget;
 
 /**
  * Specialization of the IDashboardLayoutItem which also includes the extended dashboard widgets - KPI and
@@ -91,7 +109,7 @@ export type RelativeIndex = number;
  * @alpha
  */
 export type DashboardItemDefinition =
-    | ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition>
+    | ExtendedDashboardItem<ExtendedDashboardWidget | IWidgetDefinition | ICustomWidgetDefinition>
     | StashedDashboardItemsId;
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -5,6 +5,7 @@ import {
     IDashboardLayoutItem,
     IDashboardLayoutSection,
     IDashboardObjectIdentity,
+    isWidget,
     IWidget,
     IWidgetDefinition,
 } from "@gooddata/sdk-backend-spi";
@@ -58,6 +59,25 @@ export function isCustomWidgetDefinition(obj: unknown): obj is ICustomWidget {
     const w = obj as ICustomWidget;
 
     return !isEmpty(w) && w.type === "customWidget" && w.customType !== undefined && w.ref === undefined;
+}
+
+/**
+ * Dumps debug information about a widget into a string.
+ *
+ * @param widget - widget to dump info from
+ * @alpha
+ */
+export function extendedWidgetDebugStr(widget: ExtendedDashboardWidget): string {
+    const widgetId = `${widget.identifier}`;
+    let widgetType: string = "unknown widget type";
+
+    if (isWidget(widget)) {
+        widgetType = widget.type;
+    } else {
+        widgetType = `${widget.type}/${widget.customType}`;
+    }
+
+    return `${widgetId}(${widgetType})`;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/dashboardItemUtils.ts
@@ -3,6 +3,7 @@ import {
     DashboardItemDefinition,
     ExtendedDashboardItem,
     InternalDashboardItemDefinition,
+    isCustomWidgetDefinition,
 } from "../types/layoutTypes";
 import { idRef, ObjRef } from "@gooddata/sdk-model";
 import {
@@ -75,7 +76,11 @@ export function addTemporaryIdentityToWidgets(
             return item;
         }
 
-        if (isInsightWidgetDefinition(item.widget) || isKpiWidgetDefinition(item.widget)) {
+        if (
+            isInsightWidgetDefinition(item.widget) ||
+            isKpiWidgetDefinition(item.widget) ||
+            isCustomWidgetDefinition(item.widget)
+        ) {
             const temporaryIdentity = generateTemporaryIdentityForWidget();
 
             return {

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -8,7 +8,6 @@ import {
     IKpiWidget,
     ILegacyKpi,
     isProtectedDataError,
-    IWidget,
 } from "@gooddata/sdk-backend-spi";
 import { ToastMessageContextProvider, ToastMessages, useToastMessage } from "@gooddata/sdk-ui-kit";
 import { ErrorComponent as DefaultError, LoadingComponent as DefaultLoading } from "@gooddata/sdk-ui";
@@ -44,6 +43,7 @@ import {
     clearDateFilterSelection,
     DashboardStoreProvider,
     exportDashboardToPdf,
+    ExtendedDashboardWidget,
     renameDashboard,
     selectDashboardLoading,
     selectDashboardTitle,
@@ -369,7 +369,7 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
     );
 
     const widgetProvider = useCallback(
-        (widget: IWidget): CustomDashboardWidgetComponent => {
+        (widget: ExtendedDashboardWidget): CustomDashboardWidgetComponent => {
             const userSpecified = props.WidgetComponentProvider?.(widget);
             return userSpecified ?? DefaultDashboardWidgetInner;
         },

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -7,13 +7,18 @@ import {
     IKpiWidget,
     ILegacyKpi,
     ITheme,
-    IWidget,
     IWorkspacePermissions,
 } from "@gooddata/sdk-backend-spi";
 import { IInsight, ObjRef } from "@gooddata/sdk-model";
 import { IErrorProps, ILoadingProps } from "@gooddata/sdk-ui";
 
-import { DashboardConfig, DashboardDispatch, DashboardEventHandler, DashboardState } from "../../model";
+import {
+    DashboardConfig,
+    DashboardDispatch,
+    DashboardEventHandler,
+    DashboardState,
+    ExtendedDashboardWidget,
+} from "../../model";
 import {
     CustomDashboardAttributeFilterComponent,
     CustomDashboardDateFilterComponent,
@@ -38,7 +43,9 @@ import { CustomSaveAsDialogComponent } from "../saveAs";
 /**
  * @alpha
  */
-export type WidgetComponentProvider = (widget: IWidget) => CustomDashboardWidgetComponent | undefined;
+export type WidgetComponentProvider = (
+    widget: ExtendedDashboardWidget,
+) => CustomDashboardWidgetComponent | undefined;
 
 /**
  * @alpha

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
@@ -20,15 +20,10 @@ import {
     CustomDashboardDateFilterComponent,
     CustomFilterBarComponent,
 } from "../filterBar/types";
-import {
-    IDashboardAttributeFilter,
-    IInsightWidget,
-    IKpiWidget,
-    ILegacyKpi,
-    IWidget,
-} from "@gooddata/sdk-backend-spi";
+import { IDashboardAttributeFilter, IInsightWidget, IKpiWidget, ILegacyKpi } from "@gooddata/sdk-backend-spi";
 import { CustomSaveAsDialogComponent } from "../saveAs/types";
 import { IInsight } from "@gooddata/sdk-model";
+import { ExtendedDashboardWidget } from "../../model";
 
 /**
  * @internal
@@ -37,7 +32,7 @@ interface IDashboardComponentsContext {
     ErrorComponent: React.ComponentType<IErrorProps>;
     LoadingComponent: React.ComponentType<ILoadingProps>;
     LayoutComponent: React.ComponentType<DashboardLayoutProps>;
-    WidgetComponentProvider: (widget: IWidget) => CustomDashboardWidgetComponent;
+    WidgetComponentProvider: (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
     InsightComponentProvider: (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightComponent;
     KpiComponentProvider: (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
     ButtonBarComponent: CustomButtonBarComponent;

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
@@ -14,16 +14,17 @@ import {
 } from "@gooddata/sdk-backend-spi";
 import { Overlay } from "@gooddata/sdk-ui-kit";
 import { DashboardDrillDefinition, isDrillDownDefinition } from "../../../types";
-import { IInsight, insightRef, insightTitle, ObjRef, areObjRefsEqual } from "@gooddata/sdk-model";
+import { IInsight, insightTitle, ObjRef } from "@gooddata/sdk-model";
 import { isDrillToUrl } from "../types";
 import { DrillSelectListBody } from "./DrillSelectListBody";
 import { getDrillDownAttributeTitle, getTotalDrillToUrlCount } from "../utils/drillDownUtils";
 import { DrillSelectContext, DrillType, DrillSelectItem } from "./types";
-import { useDashboardSelector, selectListedDashboards } from "../../../model";
+import { useDashboardSelector, selectListedDashboards, selectInsightsMap } from "../../../model";
 import { dashboardMatch } from "../utils/dashboardPredicate";
-import { selectDashboardTitle, selectInsights } from "../../../model";
+import { selectDashboardTitle } from "../../../model";
 import { DRILL_SELECT_DROPDOWN_Z_INDEX } from "../../constants";
 import { getDrillOriginLocalIdentifier } from "../../../_staging/drills/drillingUtils";
+import { ObjRefMap } from "../../../_staging/metadata/objRefMap";
 
 export interface DrillSelectDropdownProps extends DrillSelectContext {
     dropDownAnchorClass: string;
@@ -38,7 +39,7 @@ export const DrillSelectDropdown: React.FC<DrillSelectDropdownProps> = (props) =
     const intl = useIntl();
     const listedDashboards = useDashboardSelector(selectListedDashboards);
     const dashboardTitle = useDashboardSelector(selectDashboardTitle);
-    const insights = useDashboardSelector(selectInsights);
+    const insights = useDashboardSelector(selectInsightsMap);
 
     const drillSelectItems = useMemo(
         () =>
@@ -78,7 +79,7 @@ const getDashboardTitle = (dashboardRef: ObjRef, dashboardList: IListedDashboard
 export const createDrillSelectItems = (
     drillDefinitions: DashboardDrillDefinition[],
     drillEvent: IDrillEvent,
-    insights: IInsight[],
+    insights: ObjRefMap<IInsight>,
     dashboardList: IListedDashboard[],
     dashboardTitle: string,
     intl: IntlShape,
@@ -103,9 +104,7 @@ export const createDrillSelectItems = (
             };
         }
         if (isDrillToInsight(drillDefinition)) {
-            const targetInsight = insights.find((i) =>
-                areObjRefsEqual(drillDefinition.target, insightRef(i)),
-            );
+            const targetInsight = insights.get(drillDefinition.target);
             const title = targetInsight && insightTitle(targetInsight);
 
             return {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -8,7 +8,7 @@ import {
     isDashboardLayout,
     isInsightWidget,
     widgetType as getWidgetType,
-    WidgetType,
+    AnalyticalWidgetType,
     isKpiWidget,
     IDashboardWidget,
 } from "@gooddata/sdk-backend-spi";
@@ -37,7 +37,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
         return insights.find((i) => areObjRefsEqual(i.insight.ref, insightRef));
     };
 
-    let widgetType: WidgetType;
+    let widgetType: AnalyticalWidgetType;
     let insight: IInsight;
     let content: IInsight | ILegacyKpi;
     const widget = item.widget();

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -1,19 +1,22 @@
 // (C) 2020 GoodData Corporation
 import React from "react";
 import {
-    IWidget,
     isWidget,
-    UnexpectedError,
     ILegacyKpi,
-    isDashboardLayout,
     isInsightWidget,
     widgetType as getWidgetType,
     AnalyticalWidgetType,
     isKpiWidget,
-    IDashboardWidget,
+    ISettings,
+    IDashboardLayoutSize,
 } from "@gooddata/sdk-backend-spi";
 import { IInsight } from "@gooddata/sdk-model";
-import { selectInsightsMap, selectSettings, useDashboardSelector } from "../../model";
+import {
+    ExtendedDashboardWidget,
+    selectInsightsMap,
+    selectSettings,
+    useDashboardSelector,
+} from "../../model";
 import { DashboardWidgetPropsProvider, DashboardWidget, DashboardWidgetProps } from "../widget";
 import {
     getDashboardLayoutItemHeight,
@@ -21,25 +24,17 @@ import {
     getDashboardLayoutWidgetDefaultHeight,
     IDashboardLayoutWidgetRenderer,
 } from "./DefaultDashboardLayoutRenderer";
+import { ObjRefMap } from "../../_staging/metadata/objRefMap";
 
-/**
- * @internal
- */
-export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
-    IDashboardWidget,
-    Pick<DashboardWidgetProps, "onError" | "onDrill" | "onFiltersChange">
-> = (props) => {
-    const { item, screen, DefaultWidgetRenderer, onDrill, onFiltersChange, onError } = props;
-    const insights = useDashboardSelector(selectInsightsMap);
-    const settings = useDashboardSelector(selectSettings);
-
+function calculateWidgetMinHeight(
+    widget: ExtendedDashboardWidget,
+    currentSize: IDashboardLayoutSize,
+    insights: ObjRefMap<IInsight>,
+    settings: ISettings,
+): number | undefined {
     let widgetType: AnalyticalWidgetType;
     let insight: IInsight;
     let content: IInsight | ILegacyKpi;
-    const widget = item.widget();
-    if (isDashboardLayout(widget)) {
-        throw new UnexpectedError("Nested layouts not yet supported.");
-    }
 
     if (isWidget(widget)) {
         widgetType = getWidgetType(widget);
@@ -52,20 +47,35 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
         content = widget.kpi;
     }
 
-    const currentSize = item.size()[screen]!;
-
-    const minHeight =
+    return (
         getDashboardLayoutItemHeight(currentSize) ||
         (!currentSize.heightAsRatio
             ? getDashboardLayoutWidgetDefaultHeight(settings, widgetType!, content!)
-            : undefined);
+            : undefined)
+    );
+}
+
+/**
+ * @internal
+ */
+export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
+    ExtendedDashboardWidget,
+    Pick<DashboardWidgetProps, "onError" | "onDrill" | "onFiltersChange">
+> = (props) => {
+    const { item, screen, DefaultWidgetRenderer, onDrill, onFiltersChange, onError } = props;
+    const insights = useDashboardSelector(selectInsightsMap);
+    const settings = useDashboardSelector(selectSettings);
+    // TODO: we should probably do something more meaningful when item has no widget; should that even
+    //  be allowed? undefined widget will make things explode down the line away so..
+    const widget = item.widget()!;
+    const currentSize = item.size()[screen]!;
+    const minHeight = calculateWidgetMinHeight(widget, currentSize, insights, settings);
     const height =
         currentSize.heightAsRatio && !currentSize.gridHeight
             ? getDashboardLayoutItemHeightForRatioAndScreen(currentSize, screen)
             : undefined;
 
     const allowOverflow = !!currentSize.heightAsRatio;
-
     const className = settings.enableKDWidgetCustomHeight ? "custom-height" : undefined;
 
     return (
@@ -83,7 +93,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 onDrill={onDrill}
                 onError={onError}
                 onFiltersChange={onFiltersChange}
-                widget={widget as IWidget}
+                widget={widget as ExtendedDashboardWidget}
             >
                 <DashboardWidget />
             </DashboardWidgetPropsProvider>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -12,8 +12,8 @@ import {
     isKpiWidget,
     IDashboardWidget,
 } from "@gooddata/sdk-backend-spi";
-import { ObjRef, IInsight, areObjRefsEqual } from "@gooddata/sdk-model";
-import { selectInsights, selectSettings, useDashboardSelector } from "../../model";
+import { IInsight } from "@gooddata/sdk-model";
+import { selectInsightsMap, selectSettings, useDashboardSelector } from "../../model";
 import { DashboardWidgetPropsProvider, DashboardWidget, DashboardWidgetProps } from "../widget";
 import {
     getDashboardLayoutItemHeight,
@@ -30,12 +30,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     Pick<DashboardWidgetProps, "onError" | "onDrill" | "onFiltersChange">
 > = (props) => {
     const { item, screen, DefaultWidgetRenderer, onDrill, onFiltersChange, onError } = props;
-    const insights = useDashboardSelector(selectInsights);
+    const insights = useDashboardSelector(selectInsightsMap);
     const settings = useDashboardSelector(selectSettings);
-
-    const getInsightByRef = (insightRef: ObjRef): IInsight | undefined => {
-        return insights.find((i) => areObjRefsEqual(i.insight.ref, insightRef));
-    };
 
     let widgetType: AnalyticalWidgetType;
     let insight: IInsight;
@@ -49,7 +45,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
         widgetType = getWidgetType(widget);
     }
     if (isInsightWidget(widget)) {
-        insight = getInsightByRef(widget.insight)!;
+        insight = insights.get(widget.insight)!;
         content = insight;
     }
     if (isKpiWidget(widget)) {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -8,22 +8,16 @@ import {
     IDashboardLayout,
     IDashboardWidget,
 } from "@gooddata/sdk-backend-spi";
-import {
-    ObjRef,
-    IInsight,
-    insightId,
-    insightUri,
-    areObjRefsEqual,
-    objRefToString,
-} from "@gooddata/sdk-model";
+import { ObjRef, IInsight, insightId, insightUri, objRefToString } from "@gooddata/sdk-model";
 
 import {
-    selectInsights,
     selectSettings,
-    selectBasicLayout,
     useDashboardSelector,
     selectIsExport,
     selectIsLayoutEmpty,
+    selectLayout,
+    ExtendedDashboardWidget,
+    selectInsightsMap,
 } from "../../model";
 import { useDashboardComponentsContext } from "../dashboardContexts";
 
@@ -48,7 +42,9 @@ import { DashboardLayoutPropsProvider, useDashboardLayoutProps } from "./Dashboa
  * @param layout - dashboard layout to modify
  * @returns transformed layout
  */
-function getDashboardLayoutForExport(layout: IDashboardLayout): IDashboardLayout {
+function getDashboardLayoutForExport(
+    layout: IDashboardLayout<ExtendedDashboardWidget>,
+): IDashboardLayout<ExtendedDashboardWidget> {
     const dashLayout = DashboardLayoutBuilder.for(layout);
     const layoutFacade = dashLayout.facade();
     const sections = layoutFacade.sections();
@@ -87,15 +83,15 @@ function selectAllItemsWithInsights<TWidget = IDashboardWidget>(
 export const DefaultDashboardLayoutInner = (): JSX.Element => {
     const { onFiltersChange, onDrill, onError, ErrorComponent: CustomError } = useDashboardLayoutProps();
 
-    const layout = useDashboardSelector(selectBasicLayout);
+    const layout = useDashboardSelector(selectLayout);
     const isLayoutEmpty = useDashboardSelector(selectIsLayoutEmpty);
     const settings = useDashboardSelector(selectSettings);
-    const insights = useDashboardSelector(selectInsights);
+    const insights = useDashboardSelector(selectInsightsMap);
     const { ErrorComponent } = useDashboardComponentsContext({ ErrorComponent: CustomError });
     const isExport = useDashboardSelector(selectIsExport);
 
     const getInsightByRef = (insightRef: ObjRef): IInsight | undefined => {
-        return insights.find((i) => areObjRefsEqual(i.insight.ref, insightRef));
+        return insights.get(insightRef);
     };
 
     const transformedLayout = useMemo(() => {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/sizing.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/sizing.ts
@@ -15,7 +15,7 @@ import {
     IDashboardLayout,
     IDashboardLayoutSection,
     isLegacyKpiWithoutComparison,
-    WidgetType,
+    AnalyticalWidgetType,
     isLegacyKpi,
     ISettings,
     ILegacyKpi,
@@ -454,7 +454,7 @@ export type MeasurableWidgetContent = IInsightDefinition | ILegacyKpi;
 
 const getSizeInfo = (
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): IVisualizationSizeInfo => {
     if (widgetType === "kpi") {
@@ -514,7 +514,7 @@ const getKpiSizeInfo = (settings: ISettings, kpi?: MeasurableWidgetContent): IVi
 
 export function getDashboardLayoutWidgetMinGridWidth(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -523,7 +523,7 @@ export function getDashboardLayoutWidgetMinGridWidth(
 
 export function getDashboardLayoutWidgetDefaultGridWidth(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -532,7 +532,7 @@ export function getDashboardLayoutWidgetDefaultGridWidth(
 
 export function getDashboardLayoutWidgetDefaultHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -541,7 +541,7 @@ export function getDashboardLayoutWidgetDefaultHeight(
 
 export function getDashboardLayoutWidgetMinGridHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -550,7 +550,7 @@ export function getDashboardLayoutWidgetMinGridHeight(
 
 export function getDashboardLayoutWidgetMaxGridHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -598,7 +598,7 @@ function removeGridHeightFromItemSize<TWidget>(item: IDashboardLayoutItem<TWidge
 export function validateDashboardLayoutWidgetSize(
     currentWidth: number,
     currentHeight: number | undefined,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent: MeasurableWidgetContent,
     settings: ISettings,
 ): {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/tests/sizing.test.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/tests/sizing.test.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import chunk from "lodash/chunk";
 import flatMap from "lodash/flatMap";
-import { IDashboardLayoutSize, ScreenSize, WidgetType } from "@gooddata/sdk-backend-spi";
+import { IDashboardLayoutSize, ScreenSize, AnalyticalWidgetType } from "@gooddata/sdk-backend-spi";
 import { newKpiWidget } from "@gooddata/sdk-backend-base";
 import {
     getDashboardLayoutItemHeightForRatioAndScreen,
@@ -301,7 +301,7 @@ describe("sizing", () => {
                     expect(
                         getDashboardLayoutWidgetMinGridWidth(
                             settings,
-                            widgetType as WidgetType,
+                            widgetType as AnalyticalWidgetType,
                             newInsightDefinition(`local:${visType}`),
                         ),
                     ).toBe(width);

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/utils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/utils.ts
@@ -1,5 +1,5 @@
 // (C) 2020-2021 GoodData Corporation
-import { WidgetType } from "@gooddata/sdk-backend-spi";
+import { AnalyticalWidgetType } from "@gooddata/sdk-backend-spi";
 import { VisType } from "@gooddata/sdk-ui";
 
 const typeVisTypeCssClassMapping: {
@@ -23,7 +23,7 @@ const typeVisTypeCssClassMapping: {
     pushpin: "viz-type-pushpin",
 };
 
-export function getVisTypeCssClass(widgetType: WidgetType, type?: VisType): string {
+export function getVisTypeCssClass(widgetType: AnalyticalWidgetType, type?: VisType): string {
     if (widgetType === "kpi") {
         return "viz-type-kpi";
     }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
@@ -1,15 +1,54 @@
 // (C) 2020 GoodData Corporation
-import React from "react";
+import React, { useMemo } from "react";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import { useDashboardWidgetProps } from "./DashboardWidgetPropsContext";
+import { extendedWidgetDebugStr } from "../../../model";
+import { DefaultDashboardWidgetInner } from "./DefaultDashboardWidget";
+import { isDashboardWidget } from "@gooddata/sdk-backend-spi";
+
+const BadWidgetType: React.FC = () => {
+    return <div>Missing renderer</div>;
+};
+
+const MissingWidget: React.FC = () => {
+    return <div>Missing widget</div>;
+};
 
 /**
  * @internal
  */
-export const DashboardWidget = (): JSX.Element => {
+export const DashboardWidget: React.FC = (): JSX.Element => {
     const { WidgetComponentProvider } = useDashboardComponentsContext();
     const { widget } = useDashboardWidgetProps();
-    const WidgetComponent = WidgetComponentProvider(widget!);
+    const WidgetComponent = useMemo((): React.ComponentType => {
+        // TODO: we need to get rid of this; the widget being optional at this point is the problem; the parent
+        //  components (or possibly the model) should deal with layout items that have no valid widgets associated
+        //  and thus short-circuit.
+        if (!widget) {
+            return MissingWidget;
+        }
+
+        const Component = WidgetComponentProvider(widget);
+
+        if (Component) {
+            return Component;
+        }
+
+        if (isDashboardWidget(widget)) {
+            return DefaultDashboardWidgetInner;
+        } else if (widget) {
+            // eslint-disable-next-line no-console
+            console.warn(`Unable to render widget ${extendedWidgetDebugStr(widget)}`);
+
+            return BadWidgetType;
+        } else {
+            // TODO: same as the above note
+            // eslint-disable-next-line no-console
+            console.warn("Attempting render an undefined widget.");
+
+            return MissingWidget;
+        }
+    }, [widget]);
 
     return <WidgetComponent />;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -2,11 +2,11 @@
 import React, { useCallback, useState } from "react";
 import cx from "classnames";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { areObjRefsEqual, insightVisualizationUrl } from "@gooddata/sdk-model";
+import { insightVisualizationUrl } from "@gooddata/sdk-model";
 import { IInsightWidget, ScreenSize, widgetTitle } from "@gooddata/sdk-backend-spi";
 import { OnError, OnExportReady, OnLoadingChanged, VisType } from "@gooddata/sdk-ui";
 
-import { selectInsights, selectExecutionResultByRef, useDashboardSelector } from "../../../model";
+import { selectExecutionResultByRef, useDashboardSelector, selectInsightsMap } from "../../../model";
 import {
     DashboardItem,
     DashboardItemHeadline,
@@ -36,11 +36,11 @@ interface IDefaultDashboardInsightWidgetProps {
 const DefaultDashboardInsightWidgetCore: React.FC<
     IDefaultDashboardInsightWidgetProps & WrappedComponentProps
 > = ({ widget, screen, onError, onExportReady, onLoadingChanged, intl }) => {
-    const insights = useDashboardSelector(selectInsights);
+    const insights = useDashboardSelector(selectInsightsMap);
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-    const insight = insights.find((i) => areObjRefsEqual(i.insight.ref, widget.insight))!;
+    const insight = insights.get(widget.insight)!;
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
 
     const execution = useDashboardSelector(selectExecutionResultByRef(widget.ref));

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -68,7 +68,7 @@ export const DefaultDashboardWidgetInner = (): JSX.Element => {
         });
     }, [effectiveBackend, dispatchEvent]);
 
-    if (!isDashboardWidget) {
+    if (!isDashboardWidget(widget)) {
         throw new UnexpectedError(
             "Cannot render custom widget with DefaultWidgetRenderer! Please handle custom widget rendering in your widgetRenderer.",
         );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
@@ -1,16 +1,17 @@
 // (C) 2020-2021 GoodData Corporation
 import { ComponentType } from "react";
-import { FilterContextItem, IAnalyticalBackend, IWidget, ScreenSize } from "@gooddata/sdk-backend-spi";
+import { FilterContextItem, IAnalyticalBackend, ScreenSize } from "@gooddata/sdk-backend-spi";
 import { IErrorProps, ILoadingProps, OnError } from "@gooddata/sdk-ui";
 
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../../types";
 import { ObjRef, ObjRefInScope } from "@gooddata/sdk-model";
+import { ExtendedDashboardWidget } from "../../../model";
 
 /**
  * @internal
  */
 export interface DashboardWidgetProps {
-    widget?: IWidget;
+    widget?: ExtendedDashboardWidget;
     screen: ScreenSize;
     /**
      * Specify date data set to use when passing dashboard date filter to rendered visualization.

--- a/libs/sdk-ui-dashboard/src/widgets/README.md
+++ b/libs/sdk-ui-dashboard/src/widgets/README.md
@@ -1,0 +1,4 @@
+# Dashboard Component Optional And Experimental Widget Types
+
+This directory contains implementations of additional widget types that you may want to use on a dashboard next to the built-in
+analytical widgets such as KPI or Insight widget.

--- a/libs/sdk-ui-dashboard/src/widgets/index.tsx
+++ b/libs/sdk-ui-dashboard/src/widgets/index.tsx
@@ -1,1 +1,0 @@
-// (C) 2021 GoodData Corporation

--- a/libs/sdk-ui-dashboard/src/widgets/index.tsx
+++ b/libs/sdk-ui-dashboard/src/widgets/index.tsx
@@ -1,0 +1,1 @@
+// (C) 2021 GoodData Corporation

--- a/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
+++ b/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
@@ -1,0 +1,37 @@
+// (C) 2021 GoodData Corporation
+import isEmpty from "lodash/isEmpty";
+import { ICustomWidgetBase } from "../../model";
+
+/**
+ * @alpha
+ */
+export type KpiPlaceholderWidget = ICustomWidgetBase & {
+    readonly customType: "kpiPlaceholder";
+};
+
+/**
+ * Tests whether an object is a {@link KpiPlaceholderWidget}.
+ *
+ * @param obj - object to test
+ * @alpha
+ */
+export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidget {
+    return !isEmpty(obj) && (obj as KpiPlaceholderWidget).customType === "kpiPlaceholder";
+}
+
+/**
+ * @alpha
+ */
+export type InsightPlaceholderWidget = ICustomWidgetBase & {
+    readonly customType: "insightPlaceholder";
+};
+
+/**
+ * Tests whether an object is a {@link InsightPlaceholderWidget}.
+ *
+ * @param obj - object to test
+ * @alpha
+ */
+export function isInsightPlaceholderWidget(obj: unknown): obj is InsightPlaceholderWidget {
+    return !isEmpty(obj) && (obj as InsightPlaceholderWidget).customType === "insightPlaceholder";
+}

--- a/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
+++ b/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
@@ -7,6 +7,7 @@
 /// <reference types="react" />
 
 import { AnalyticalBackendError } from '@gooddata/sdk-backend-spi';
+import { AnalyticalWidgetType } from '@gooddata/sdk-backend-spi';
 import { DrillDefinition } from '@gooddata/sdk-backend-spi';
 import { ExplicitDrill } from '@gooddata/sdk-ui';
 import { FilterContextItem } from '@gooddata/sdk-backend-spi';
@@ -65,7 +66,6 @@ import { UseCancelablePromiseState } from '@gooddata/sdk-ui';
 import { UseCancelablePromiseStatus } from '@gooddata/sdk-ui';
 import { ValueOrUpdateCallback } from '@gooddata/sdk-backend-base';
 import { VisType } from '@gooddata/sdk-ui';
-import { WidgetType } from '@gooddata/sdk-backend-spi';
 import { WrappedComponentProps } from 'react-intl';
 
 // @beta
@@ -543,7 +543,7 @@ export function useDashboardPdfExporter({ backend, workspace, onError, onCancel,
 export function useDashboardWidgetExecution({ dashboard, widget: widgetRef, filters, backend, workspace, }: IUseDashboardWidgetExecutionConfig): UseCancelablePromiseState<IPreparedExecution, GoodDataSdkError>;
 
 // @internal (undocumented)
-export function validateDashboardLayoutWidgetSize(currentWidth: number, currentHeight: number | undefined, widgetType: WidgetType, widgetContent: MeasurableWidgetContent, settings: ISettings): {
+export function validateDashboardLayoutWidgetSize(currentWidth: number, currentHeight: number | undefined, widgetType: AnalyticalWidgetType, widgetContent: MeasurableWidgetContent, settings: ISettings): {
     validWidth: number;
     validHeight: number;
 };

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardRenderer.tsx
@@ -16,7 +16,7 @@ import {
     isInsightWidget,
     IDashboardLayout,
     widgetType as getWidgetType,
-    WidgetType,
+    AnalyticalWidgetType,
     isKpiWidget,
 } from "@gooddata/sdk-backend-spi";
 import {
@@ -207,7 +207,7 @@ export const DashboardRenderer: React.FC<IDashboardRendererProps> = memo(functio
             widgetRenderer={(renderProps) => {
                 const { item, screen, DefaultWidgetRenderer } = renderProps;
                 let visType: VisType;
-                let widgetType: WidgetType;
+                let widgetType: AnalyticalWidgetType;
                 let insight: IInsight;
                 let content: IInsight | ILegacyKpi;
                 const widget = item.widget();

--- a/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/utils.ts
+++ b/libs/sdk-ui-ext/src/dashboardView/DashboardWidgetRenderer/utils.ts
@@ -1,5 +1,5 @@
 // (C) 2020-2021 GoodData Corporation
-import { WidgetType } from "@gooddata/sdk-backend-spi";
+import { AnalyticalWidgetType } from "@gooddata/sdk-backend-spi";
 import { VisType } from "@gooddata/sdk-ui";
 
 const typeVisTypeCssClassMapping: {
@@ -23,7 +23,7 @@ const typeVisTypeCssClassMapping: {
     pushpin: "viz-type-pushpin",
 };
 
-export function getVisTypeCssClass(widgetType: WidgetType, type?: VisType): string {
+export function getVisTypeCssClass(widgetType: AnalyticalWidgetType, type?: VisType): string {
     if (widgetType === "kpi") {
         return "viz-type-kpi";
     }

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/sizing.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/sizing.ts
@@ -15,7 +15,7 @@ import {
     IDashboardLayout,
     IDashboardLayoutSection,
     isLegacyKpiWithoutComparison,
-    WidgetType,
+    AnalyticalWidgetType,
     isLegacyKpi,
     ISettings,
     ILegacyKpi,
@@ -438,7 +438,7 @@ export type MeasurableWidgetContent = IInsightDefinition | ILegacyKpi;
 
 const getSizeInfo = (
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): IVisualizationSizeInfo => {
     if (widgetType === "kpi") {
@@ -498,7 +498,7 @@ const getKpiSizeInfo = (settings: ISettings, kpi?: MeasurableWidgetContent): IVi
 
 export function getDashboardLayoutWidgetMinGridWidth(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -508,7 +508,7 @@ export function getDashboardLayoutWidgetMinGridWidth(
 
 export function getDashboardLayoutWidgetDefaultGridWidth(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -518,7 +518,7 @@ export function getDashboardLayoutWidgetDefaultGridWidth(
 
 export function getDashboardLayoutWidgetDefaultHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent, // undefined for placeholders
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -527,7 +527,7 @@ export function getDashboardLayoutWidgetDefaultHeight(
 
 export function getDashboardLayoutWidgetMinGridHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -536,7 +536,7 @@ export function getDashboardLayoutWidgetMinGridHeight(
 
 export function getDashboardLayoutWidgetMaxGridHeight(
     settings: ISettings,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent?: MeasurableWidgetContent,
 ): number {
     const sizeInfo = getSizeInfo(settings, widgetType, widgetContent);
@@ -584,7 +584,7 @@ function removeGridHeightFromItemSize<TWidget>(item: IDashboardLayoutItem<TWidge
 export function validateDashboardLayoutWidgetSize(
     currentWidth: number,
     currentHeight: number | undefined,
-    widgetType: WidgetType,
+    widgetType: AnalyticalWidgetType,
     widgetContent: MeasurableWidgetContent,
     settings: ISettings,
 ): {

--- a/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/sizing.test.ts
+++ b/libs/sdk-ui-ext/src/internal/dashboardEmbedding/DashboardLayout/utils/tests/sizing.test.ts
@@ -1,7 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import chunk from "lodash/chunk";
 import flatMap from "lodash/flatMap";
-import { IDashboardLayoutSize, ScreenSize, WidgetType } from "@gooddata/sdk-backend-spi";
+import { IDashboardLayoutSize, ScreenSize, AnalyticalWidgetType } from "@gooddata/sdk-backend-spi";
 import { newKpiWidget } from "@gooddata/sdk-backend-base";
 import {
     getDashboardLayoutItemHeightForRatioAndScreen,
@@ -301,7 +301,7 @@ describe("sizing", () => {
                     expect(
                         getDashboardLayoutWidgetMinGridWidth(
                             settings,
-                            widgetType as WidgetType,
+                            widgetType as AnalyticalWidgetType,
                             newInsightDefinition(`local:${visType}`),
                         ),
                     ).toBe(width);


### PR DESCRIPTION
-  Breaking change of the alpha level API
-  Decomposition in the IWidgetBase area; IWidgetBase renamed to IAnalyticalWidget
-  The different parts were separated into new interfaces.. IBaseWidget, IFilterableWidget, IDrillableWidget, IWidgetDescription
-  These new types can be used to construct custom widgets
-  Split widget.ts into multiple smaller files:
   -  Base stuff in baseWidget.ts
   -  All KPI and Insight widget related code is now in analyticalWidgets.ts
-  Modifications in dashboard component so that it uses ExtendedDashboardWidget in presentation components and is able to work with it when rendering.
-  Calls out to widget component providers to get renderer

JIRA: RAIL-3471

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
