### PR TITLE
Prevent re-loading of all attribute filters on single filter change

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/DefaultDashboardAttributeFilter.tsx
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import React from "react";
+import React, { useMemo } from "react";
 import { AttributeFilterButton, IAttributeDropdownBodyExtendedProps } from "@gooddata/sdk-ui-filters";
 
 import {
@@ -23,13 +23,11 @@ export const DefaultDashboardAttributeFilterInner = (): JSX.Element => {
     const { filter, onFilterChanged } = useDashboardAttributeFilterProps();
     const { parentFilters, parentFilterOverAttribute } = useParentFilters(filter);
     const locale = useDashboardSelector(selectLocale);
+    const attributeFilter = useMemo(() => dashboardAttributeFilterToAttributeFilter(filter), [filter]);
 
     return (
         <AttributeFilterButton
-            // TODO: https://jira.intgdc.com/browse/RAIL-2174
-            // AttributeFilterButton is not updated after attribute filter elements change.
-            // Same issue is in the AttributeFilter.
-            filter={dashboardAttributeFilterToAttributeFilter(filter)}
+            filter={attributeFilter}
             onApply={(newFilter) => {
                 onFilterChanged(
                     attributeFilterToDashboardAttributeFilter(


### PR DESCRIPTION
RAIL-3688

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
