### PR TITLE
RELATED: RAIL-3775 Fix attribute filter loader styles

### DIFF
--- a/libs/sdk-ui-filters/styles/scss/attributeFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/attributeFilter.scss
@@ -10,6 +10,7 @@ $gdc-goodstrap-basepath: "~@gooddata/goodstrap/lib/";
 @import "~@gooddata/sdk-ui-kit/styles/scss/typo-mixins";
 @import "~@gooddata/sdk-ui-kit/styles/scss/form";
 @import "~@gooddata/sdk-ui-kit/styles/scss/button";
+@import "~@gooddata/sdk-ui-kit/styles/scss/loadingMask";
 @import "~fixed-data-table-2/dist/fixed-data-table.css";
 
 $transition-length: 0.2s;


### PR DESCRIPTION
The necessary loadingMask styles are now explicitly imported.

JIRA: RAIL-3775

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
