### PR TITLE
NAS-313 Display attribute/ metric name instead of id in preview syntax

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
@@ -127,6 +127,7 @@ export class BearWorkspaceMeasures implements IWorkspaceMeasuresService {
                 return {
                     type: meta.type,
                     value: meta.title,
+                    id: meta.id,
                     ref: meta.ref,
                 };
             }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1050,6 +1050,7 @@ export type InsightReferenceTypes = Exclude<ObjectType, "insight" | "tag">;
 
 // @public
 export interface IObjectExpressionToken {
+    id?: string;
     ref: ObjRef;
     type: ObjectType;
     value: string;

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { ObjectType, ObjRef } from "@gooddata/sdk-model";
 
 /**
@@ -61,6 +61,11 @@ export interface IObjectExpressionToken {
      * Title of the object
      */
     value: string;
+
+    /**
+     * Id of the object
+     */
+    id?: string;
 
     /**
      * Ref of the object

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -90,6 +90,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
         return {
             type: typeMapping[objectType],
             value,
+            id: objectId,
             ref: idRef(identifier),
         };
     }


### PR DESCRIPTION
<!--


-->

Pass object id so we can use it to link to the metric in metric editor.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
