### PR TITLE
REATED: SD-1887: Fixing the Hubspot Form can't populate values with jQuery object

### DIFF
--- a/libs/sdk-ui-kit/src/Dialog/HubspotConversionTouchPointDialogBase.tsx
+++ b/libs/sdk-ui-kit/src/Dialog/HubspotConversionTouchPointDialogBase.tsx
@@ -35,6 +35,13 @@ export interface IHubspotFormField {
 }
 
 /**
+ * @internal
+ */
+export interface IHubspotJqueryFormField {
+    [key: string]: ArrayLike<IHubspotFormField> | string;
+}
+
+/**
  * @public
  */
 export interface IHubspotFormValue {
@@ -148,11 +155,15 @@ export const HubspotConversionTouchPointDialogBase: React.FC<IHubspotConversionT
         target: `#${hubspotFormTargetId}`,
         locale: intl.locale.split("-").shift() as HubSpotFormLocale,
         onFormSubmitted: onHubspotFormSubmitted,
-        onFormReady: ($form: IHubspotFormField[]) => {
+        onFormReady: ($form: ArrayLike<IHubspotFormField> | IHubspotJqueryFormField) => {
             setIsFormReady(true);
+            let fields = $form;
+            if (fields["jquery"] && fields[0]?.length > 0) {
+                fields = fields[0];
+            }
             // populating the values for hidden fields
-            for (let i = 0; i < $form.length; i += 1) {
-                const inputField = $form[i];
+            for (let i = 0; i < fields.length; i += 1) {
+                const inputField = fields[i];
                 if (!inputField) {
                     continue;
                 }


### PR DESCRIPTION
Fixing the Hubspot Form can't populate values with jQuery object
JIRA: SD-1887

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [x] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [x] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
