### PR TITLE
AttributeFilterButton - fix sync issues

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -287,13 +287,15 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     });
 
     useEffect(() => {
-        const initialSelection = getInitialSelectedOptions();
-        const initialIsInverted = getInitialIsInverted();
-
         setState((prevValue) => {
             let resultState = prevValue;
+            const initialSelection = getInitialSelectedOptions();
+            const initialIsInverted = getInitialIsInverted();
 
-            if (!isEqual(prevValue.appliedFilterOptions, initialSelection)) {
+            if (
+                !isEqual(prevValue.appliedFilterOptions, initialSelection) ||
+                !isEqual(prevValue.selectedFilterOptions, initialSelection)
+            ) {
                 resultState = {
                     ...resultState,
                     selectedFilterOptions: initialSelection,
@@ -305,6 +307,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 resultState = {
                     ...resultState,
                     isInverted: initialIsInverted,
+                    appliedIsInverted: initialIsInverted,
                 };
             }
             // if no change returning prevValue effectively skips the setState
@@ -347,7 +350,14 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 }));
             },
         },
-        [state.validOptions, state.offset, state.limit, resolvedParentFilters],
+        [
+            state.selectedFilterOptions,
+            state.appliedFilterOptions,
+            state.validOptions,
+            state.offset,
+            state.limit,
+            resolvedParentFilters,
+        ],
     );
 
     const {
@@ -427,6 +437,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                     selectedFilterOptions: [],
                     appliedFilterOptions: [],
                     isInverted,
+                    appliedIsInverted: isInverted,
                 };
             });
         } else {


### PR DESCRIPTION
- fix sync inconsistency between external props & internal state

JIRA: RAIL-3652

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
