### PR TITLE
RELATED: RAIL-3471 Make dashboard template customizable

### DIFF
--- a/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
+++ b/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
@@ -8,10 +8,6 @@ const ExtraPlugins: IEmbeddedPlugin[] = [{ factory: PluginFactory }];
 
 export const PluginLoader = (): JSX.Element => {
     return (
-        <DashboardStub
-            dashboard={idRef("aeO5PVgShc0T")}
-            loadingMode="staticOnly"
-            extraPlugins={ExtraPlugins}
-        />
+        <DashboardStub dashboard={idRef(DASHBOARD_ID)} loadingMode="staticOnly" extraPlugins={ExtraPlugins} />
     );
 };

--- a/tools/dashboard-plugin-template/src/typings.d.ts
+++ b/tools/dashboard-plugin-template/src/typings.d.ts
@@ -7,3 +7,4 @@ declare const BACKEND_URL: string;
 declare const PORT: number;
 declare const SCOPE_NAME: string;
 declare const WORKSPACE: string;
+declare const DASHBOARD_ID: string;

--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -7,26 +7,8 @@ const { DefinePlugin, ProvidePlugin } = require("webpack");
 const path = require("path");
 const deps = require("./package.json").dependencies;
 
-const BACKEND_URL = "https://live-examples-proxy.herokuapp.com";
 const PORT = 3001;
 const SCOPE_NAME = "plugin";
-const WORKSPACE = "xms7ga4tf3g3nzucd8380o2bev8oeknp";
-
-const proxy = {
-    "/gdc": {
-        changeOrigin: true,
-        cookieDomainRewrite: "localhost",
-        secure: false,
-        target: BACKEND_URL,
-        headers: {
-            host: BACKEND_URL,
-            origin: null,
-        },
-        onProxyReq(proxyReq) {
-            proxyReq.setHeader("accept-encoding", "identity");
-        },
-    },
-};
 
 // add all the gooddata packages that absolutely need to be shared and singletons because of contexts
 const gooddataSharePackagesEntries = Object.keys(deps)
@@ -38,6 +20,26 @@ const gooddataSharePackagesEntries = Object.keys(deps)
 
 module.exports = (_env, argv) => {
     const isProduction = argv.mode === "production";
+
+    const effectiveBackendUrl = process.env.BACKEND_URL || "https://live-examples-proxy.herokuapp.com";
+    const effectiveWorkspace = process.env.WORKSPACE || "xms7ga4tf3g3nzucd8380o2bev8oeknp";
+    const effectiveDashboardId = process.env.DASHBOARD_ID || "aeO5PVgShc0T";
+
+    const proxy = {
+        "/gdc": {
+            changeOrigin: true,
+            cookieDomainRewrite: "localhost",
+            secure: false,
+            target: effectiveBackendUrl,
+            headers: {
+                host: effectiveBackendUrl,
+                origin: null,
+            },
+            onProxyReq(proxyReq) {
+                proxyReq.setHeader("accept-encoding", "identity");
+            },
+        },
+    };
 
     const commonConfig = {
         mode: isProduction ? "production" : "development",
@@ -133,10 +135,11 @@ module.exports = (_env, argv) => {
                 process: "process/browser",
             }),
             new DefinePlugin({
-                BACKEND_URL: JSON.stringify(BACKEND_URL),
+                BACKEND_URL: JSON.stringify(effectiveBackendUrl),
                 PORT: JSON.stringify(PORT),
                 SCOPE_NAME: JSON.stringify(SCOPE_NAME),
-                WORKSPACE: JSON.stringify(WORKSPACE),
+                WORKSPACE: JSON.stringify(effectiveWorkspace),
+                DASHBOARD_ID: JSON.stringify(effectiveDashboardId),
             }),
         ],
     };


### PR DESCRIPTION
Allows to change backend, workspace and dashboardId by setting environment variables.

JIRA: RAIL-3471

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
