### PR TITLE
RAIL-3776 Make default position for dashboard header relative

### DIFF
--- a/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
+++ b/libs/sdk-ui-dashboard/styles/scss/filterBar.scss
@@ -29,7 +29,7 @@
     }
 
     @media #{$medium-up} {
-        position: absolute;
+        position: sticky;
         top: 0;
         right: 0;
         left: 0;


### PR DESCRIPTION
- Fix default CSS positioning in SDK dashboard so it behaves correctly on its own

JIRA: RAIL-3776

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
