### PR TITLE
RAIL-3792 CSS for attributeFilter items

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
@@ -5,6 +5,7 @@ import uniqueId from "lodash/uniqueId";
 import cx from "classnames";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { IAttributeDropdownListItemProps } from "@gooddata/sdk-ui-filters";
+import { stringUtils } from "@gooddata/util";
 
 const AttributeDropdownListItem: React.FC<IAttributeDropdownListItemProps> = (props) => {
     const { source } = props;
@@ -14,6 +15,7 @@ const AttributeDropdownListItem: React.FC<IAttributeDropdownListItemProps> = (pr
 
     const className = cx("gd-list-item", "attribute-filter-item", "has-only-visible", {
         "is-selected": props.selected,
+        [`s-${stringUtils.simplifyText(props.source.title)}`]: true,
     });
 
     function handleSelect() {


### PR DESCRIPTION
- Add s-classes to AttributeFilterButton items for graphene support

JIRA: RAIL-3792

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
