### PR TITLE
Date filter context: avoid invalid update

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/dateFilterOptionMapping.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/dateFilterOptionMapping.ts
@@ -180,7 +180,7 @@ function findDateFilterOptionById(id: string, dateFilterOptions: IDateFilterOpti
     return flattenDateFilterOptions(dateFilterOptions).find((option) => option.localIdentifier === id);
 }
 
-function findDateFilterOptionByValue(
+export function findDateFilterOptionByValue(
     dateFilter: IDashboardDateFilter,
     dateFilterOptions: IDateFilterOptionsByType,
 ) {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/common.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/filterContext/common.ts
@@ -2,12 +2,15 @@
 
 import { SagaIterator } from "redux-saga";
 import { select } from "redux-saga/effects";
+import { IDashboardDateFilter } from "@gooddata/sdk-backend-spi";
 
 import { IDashboardCommand } from "../../commands/base";
 import { filterContextChanged } from "../../events/filters";
 import { selectFilterContextDefinition } from "../../store/filterContext/filterContextSelectors";
 import { DashboardContext } from "../../types/commonTypes";
 import { dispatchDashboardEvent } from "../../store/_infra/eventDispatcher";
+import { selectEffectiveDateFilterOptions } from "../../store/dateFilterConfig/dateFilterConfigSelectors";
+import { findDateFilterOptionByValue } from "../../../_staging/dateFilterConfig/dateFilterOptionMapping";
 
 export function* dispatchFilterContextChanged(
     ctx: DashboardContext,
@@ -18,4 +21,29 @@ export function* dispatchFilterContextChanged(
     );
 
     yield dispatchDashboardEvent(filterContextChanged(ctx, filterContext, cmd.correlationId));
+}
+
+export function* canApplyDateFilter(dateFilter: IDashboardDateFilter): SagaIterator<boolean> {
+    const effectiveDateFilterOptions: ReturnType<typeof selectEffectiveDateFilterOptions> = yield select(
+        selectEffectiveDateFilterOptions,
+    );
+
+    const targetOption = findDateFilterOptionByValue(dateFilter, effectiveDateFilterOptions);
+
+    if (!targetOption) {
+        if (dateFilter.dateFilter.type === "absolute") {
+            return !!effectiveDateFilterOptions?.absoluteForm?.visible;
+        } else if (dateFilter.dateFilter.type === "relative") {
+            if (
+                dateFilter.dateFilter.granularity === "GDC.time.date" &&
+                dateFilter.dateFilter.from === undefined &&
+                dateFilter.dateFilter.to === undefined
+            ) {
+                return !!effectiveDateFilterOptions?.allTime?.visible;
+            }
+            return !!effectiveDateFilterOptions?.relativeForm?.visible;
+        }
+    }
+
+    return !!targetOption;
 }

--- a/libs/sdk-ui-dashboard/src/model/commands/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/filters.ts
@@ -69,7 +69,7 @@ export interface ChangeDateFilterSelection extends IDashboardCommand {
 
 /**
  * Creates the ChangeDateFilterSelection command. Dispatching this command will result in change of dashboard's
- * date filter.
+ * date filter, or error in case of invalid update (e.g. hidden date filter option by dateFilterConfig).
  *
  * @param type - date filter type; absolute filters use exact start and end dates, while relative filters use offsets from today
  * @param granularity - granularity on which the filter works; days, weeks, months, quarters or years.
@@ -165,7 +165,8 @@ export interface AddAttributeFilter extends IDashboardCommand {
 
 /**
  * Creates the AddAttributeFilter command. Dispatching this command will result in the addition
- * of another attribute filter to the dashboard's filter bar, at desired position.
+ * of another attribute filter to the dashboard's filter bar, at desired position,
+ * or error in case of invalid update (e.g. wrong or duplicated displayForm)
  *
  * The filter will be set for the display form provided by reference. When created, the filter will be
  * no-op - all the elements will be selected.
@@ -309,7 +310,7 @@ export interface ChangeAttributeFilterSelection extends IDashboardCommand {
 
 /**
  * Creates the ChangeAttributeFilterSelection command. Dispatching this command will result in application
- * of element selection for the dashboard attribute filter with the provided id.
+ * of element selection for the dashboard attribute filter with the provided id, or error in case of invalid update (e.g. non-existing filterLocalId).
  *
  * The attribute elements can be provided either using their URI (primary key) or value. Together with the
  * elements you must indicate the selection type - either 'IN' or 'NOT_IN'.
@@ -457,6 +458,7 @@ export interface ChangeFilterContextSelection extends IDashboardCommand {
  *
  * Only filters that are stored in the filter context can be applied (filters that are visible in the filter bar).
  * Filters will be matched via display form ref, duplicities will be omitted.
+ * Date filter that does not match any visible option by the current date filter config will be also omitted.
  *
  * @alpha
  * @param filters - attribute filters and date filter to apply.


### PR DESCRIPTION
Mimic KD behavior, where:
- it's impossible to set date filter that is invalid by effective dateFilterConfig (eg by drills and post messages)
- stored filterContext date filter is still applied, even if it's not valid by effective dateFilterConfig

JIRA RAIL-3637

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
