### PR TITLE
Drilling - reflect feature flags, fix Kpi drilling with no-data

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1372,6 +1372,7 @@ export interface ISettings {
     enableTableColumnsGrowToFit?: boolean;
     enableTableColumnsManualResizing?: boolean;
     enableWeekFilters?: boolean;
+    hideKpiDrillInEmbedded?: boolean;
     platformEdition?: PlatformEdition;
     responsiveUiDateFormat?: string;
 }

--- a/libs/sdk-backend-spi/src/common/settings.ts
+++ b/libs/sdk-backend-spi/src/common/settings.ts
@@ -14,6 +14,11 @@ export interface ISettings {
     disableKpiDashboardHeadlineUnderline?: boolean;
 
     /**
+     * Disables Kpi widget drills in embedded mode.
+     */
+    hideKpiDrillInEmbedded?: boolean;
+
+    /**
      * Allows configuration of axis name position and visibility for Pluggable Visualizations.
      */
     enableAxisNameConfiguration?: boolean;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3451,7 +3451,7 @@ export const selectConfig: OutputSelector<DashboardState, ResolvedDashboardConfi
 export const selectConfiguredAndImplicitDrillsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: IImplicitDrillWithPredicates[], res2: IImplicitDrillWithPredicates[], res3: IImplicitDrillWithPredicates[]) => IImplicitDrillWithPredicates[]>;
 
 // @internal (undocumented)
-export const selectConfiguredDrillsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res: IDrillToLegacyDashboard[] | InsightDrillDefinition[] | undefined) => IImplicitDrillWithPredicates[]>;
+export const selectConfiguredDrillsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: IDrillToLegacyDashboard[] | InsightDrillDefinition[], res2: boolean, res3: boolean, res4: boolean, res5: boolean, res6: boolean, res7: boolean, res8: boolean) => IImplicitDrillWithPredicates[]>;
 
 // @alpha
 export const selectDashboardDescription: OutputSelector<DashboardState, string, (res: Pick<IDashboard<IDashboardWidget>, "title" | "description" | "tags">) => string>;
@@ -3548,6 +3548,9 @@ export const selectEffectiveDateFilterOptions: OutputSelector<DashboardState, ID
 export const selectEffectiveDateFilterTitle: OutputSelector<DashboardState, string | undefined, (res1: boolean, res2: IDashboardDateFilterConfig_2 | undefined) => string | undefined>;
 
 // @alpha
+export const selectEnableClickableAttributeURL: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
+// @alpha
 export const selectEnableCompanyLogoInEmbeddedUI: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha
@@ -3557,7 +3560,16 @@ export const selectEnableFilterValuesResolutionInDrillEvents: OutputSelector<Das
 export const selectEnableKPIDashboardDrillToDashboard: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha
+export const selectEnableKPIDashboardDrillToInsight: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
+// @alpha
+export const selectEnableKPIDashboardDrillToURL: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
+// @alpha
 export const selectEnableKPIDashboardExportPDF: OutputSelector<DashboardState, string | number | boolean | object, (res: ResolvedDashboardConfig) => string | number | boolean | object>;
+
+// @alpha
+export const selectEnableKPIDashboardImplicitDrillDown: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha
 export const selectEnableKPIDashboardSaveAsNew: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
@@ -3597,6 +3609,9 @@ export const selectFilterContextFilters: OutputSelector<DashboardState, FilterCo
 
 // @alpha
 export const selectFilterContextIdentity: OutputSelector<DashboardState, IDashboardObjectIdentity | undefined, (res: FilterContextState) => IDashboardObjectIdentity | undefined>;
+
+// @alpha
+export const selectHideKpiDrillInEmbedded: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal (undocumented)
 export const selectImplicitDrillsByAvailableDrillTargets: (availableDrillTargets: IAvailableDrillTargets | undefined) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: (ICatalogAttribute | ICatalogDateAttribute)[], res2: ICatalogAttribute[]) => IImplicitDrillWithPredicates[]>;
@@ -3697,7 +3712,7 @@ export const selectUser: OutputSelector<DashboardState, IUser, (res: UserState) 
 export const selectWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IKpiWidget | IInsightWidget | undefined, (res: ObjRefMap<IWidget>) => IKpiWidget | IInsightWidget | undefined>;
 
 // @alpha
-export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IDrillToLegacyDashboard[] | InsightDrillDefinition[] | undefined, (res: IKpiWidget | IInsightWidget | undefined) => IDrillToLegacyDashboard[] | InsightDrillDefinition[] | undefined>;
+export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IDrillToLegacyDashboard[] | InsightDrillDefinition[], (res: IKpiWidget | IInsightWidget | undefined) => IDrillToLegacyDashboard[] | InsightDrillDefinition[]>;
 
 // @internal
 export const selectWidgetsMap: OutputSelector<DashboardState, ObjRefMap<IWidget>, (res: IDashboardLayout<ExtendedDashboardWidget>) => ObjRefMap<IWidget>>;

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -223,10 +223,37 @@ export const selectEnableClickableAttributeURL = createSelector(selectConfig, (s
 });
 
 /**
+ * Returns whether drill to url is enabled
+ *
+ * @alpha
+ */
+export const selectEnableKPIDashboardDrillToURL = createSelector(selectConfig, (state) => {
+    return state.settings?.enableKPIDashboardDrillToURL ?? false;
+});
+
+/**
+ * Returns whether drill to insight is enabled
+ *
+ * @alpha
+ */
+export const selectEnableKPIDashboardDrillToInsight = createSelector(selectConfig, (state) => {
+    return state.settings?.enableKPIDashboardDrillToInsight ?? false;
+});
+
+/**
  * Returns whether implicit drill to attributes url enabled
  *
  * @alpha
  */
 export const selectEnableKPIDashboardImplicitDrillDown = createSelector(selectConfig, (state) => {
     return state.settings?.enableKPIDashboardImplicitDrillDown ?? false;
+});
+
+/**
+ * Returns whether Kpi drills in embedded mode are disabled.
+ *
+ * @alpha
+ */
+export const selectHideKpiDrillInEmbedded = createSelector(selectConfig, (state) => {
+    return state.settings?.hideKpiDrillInEmbedded ?? false;
 });

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -30,6 +30,11 @@ export {
     selectEnableKPIDashboardExportPDF,
     selectEnableKPIDashboardDrillToDashboard,
     selectEnableKPIDashboardSaveAsNew,
+    selectEnableClickableAttributeURL,
+    selectEnableKPIDashboardDrillToInsight,
+    selectEnableKPIDashboardDrillToURL,
+    selectEnableKPIDashboardImplicitDrillDown,
+    selectHideKpiDrillInEmbedded,
 } from "./config/configSelectors";
 export { PermissionsState } from "./permissions/permissionsState";
 export {

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -130,7 +130,7 @@ export const selectWidgetByRef = createMemoizedSelector((ref: ObjRef | undefined
  * @alpha
  */
 export const selectWidgetDrills = createMemoizedSelector((ref: ObjRef | undefined) =>
-    createSelector(selectWidgetByRef(ref), (widget) => widget?.drills),
+    createSelector(selectWidgetByRef(ref), (widget) => widget?.drills ?? []),
 );
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -42,7 +42,6 @@ import {
 
 import { filterContextItemsToFiltersForWidget } from "../../../../converters";
 import {
-    selectDisableDefaultDrills,
     selectDrillableItems,
     selectPermissions,
     selectSettings,
@@ -51,6 +50,7 @@ import {
     useDashboardSelector,
     useDashboardUserInteraction,
     useWidgetExecutionsHandler,
+    selectConfiguredDrillsByWidgetRef,
 } from "../../../../model";
 import { DashboardItemHeadline } from "../../../presentationComponents";
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../../../types";
@@ -132,7 +132,7 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     const permissions = useDashboardSelector(selectPermissions);
     const settings = useDashboardSelector(selectSettings);
     const drillableItems = useDashboardSelector(selectDrillableItems);
-    const disableDefaultDrills = useDashboardSelector(selectDisableDefaultDrills);
+    const widgetDrills = useDashboardSelector(selectConfiguredDrillsByWidgetRef(kpiWidget.ref));
 
     const { result: brokenAlertsBasicInfo } = useWidgetBrokenAlertsQuery(kpiWidget, alert);
 
@@ -209,14 +209,11 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
 
     const predicates = convertDrillableItemsToPredicates(drillableItems);
     const isDrillable =
-        kpiResult &&
         kpiResult?.measureDescriptor &&
         result &&
         status !== "error" &&
-        (disableDefaultDrills
-            ? isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result)
-            : kpiWidget.drills.length > 0 ||
-              isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result));
+        (isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result) ||
+            widgetDrills.length > 0);
 
     const enableCompactSize = settings.enableKDWidgetCustomHeight;
 


### PR DESCRIPTION
RAIL-3647: Keep Kpi widget drillable with no-data
RAIL-3648: Drills - reflect set feature flags


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
