### PR TITLE
RELATED: RAIL-3805 Fix filter merging in widget filters query

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -20,6 +20,7 @@ import {
     isRankingFilter,
     isSimpleMeasure,
     measureFilters,
+    newAllTimeFilter,
     ObjectType,
     ObjRef,
     objRefToString,
@@ -240,6 +241,13 @@ function* queryForInsightWidget(
     const widgetAwareDashboardFilters: ReturnType<typeof widgetAwareDashboardFiltersSelector> = yield select(
         widgetAwareDashboardFiltersSelector,
     );
+
+    // add all time filter explicitly in case the widgetAwareDashboardFilters are empty
+    // this will cause the all time filter to be used instead of the insight date filter
+    // if the dashboard date filter is not ignored by the widget
+    if (!widgetAwareDashboardFilters.length && widget.dateDataSet) {
+        widgetAwareDashboardFilters.push(newAllTimeFilter(widget.dateDataSet));
+    }
 
     // use the widgetFilterOverrides if specified instead of insight filters
     const effectiveInsightFilters = widgetFilterOverrides ?? insightFilters(insight);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFiltersQuery.ts
@@ -33,7 +33,7 @@ import {
  */
 export const useWidgetFiltersQuery = (
     widget: IWidget | undefined,
-    filters: IFilter[] | undefined,
+    filters?: IFilter[],
 ): {
     result?: IFilter[];
     status?: QueryProcessingStatus;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
@@ -2,12 +2,7 @@
 import React, { CSSProperties, useCallback, useMemo, useState } from "react";
 import { IUserWorkspaceSettings, widgetRef } from "@gooddata/sdk-backend-spi";
 import { createSelector } from "@reduxjs/toolkit";
-import {
-    insightFilters,
-    insightSetFilters,
-    insightVisualizationUrl,
-    objRefToString,
-} from "@gooddata/sdk-model";
+import { insightSetFilters, insightVisualizationUrl, objRefToString } from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     IPushData,
@@ -125,7 +120,7 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         result: filtersForInsight,
         status: filtersStatus,
         error: filtersError,
-    } = useWidgetFiltersQuery(widget, insight && insightFilters(insight));
+    } = useWidgetFiltersQuery(widget);
 
     const insightWithAddedFilters = useMemo(
         () => insightSetFilters(insight, filtersForInsight),


### PR DESCRIPTION
When insight has a date filter set to something, and is used on a dashboard (and does not ignore date filter there), then
when dashboard date filter was set to All time, original insight date filter would be used.

That is wrong, it should be overriden by the dashboard level All time filter.

JIRA: RAIL-3805

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
