### PR TITLE
RELATED: RAIL-3657, RAIL-3693 small drilling-related fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/drills/drillingUtils.ts
@@ -85,9 +85,7 @@ function insightDrillDownImplicitDrills(
                 target: matchingCatalogAttribute!.attribute.drillDownStep!,
             },
             predicates: [
-                // add drillable items for both types of objRefs that the header can be
-                HeaderPredicates.identifierMatch(drill.attribute.attributeHeader.identifier),
-                HeaderPredicates.uriMatch(drill.attribute.attributeHeader.uri),
+                HeaderPredicates.localIdentifierMatch(drill.attribute.attributeHeader.localIdentifier),
             ],
         };
     });

--- a/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/widgetDrills/widgetDrillSelectors.ts
@@ -94,9 +94,7 @@ function getDrillDownDefinitionsWithPredicates(
                 target: matchingCatalogAttribute!.attribute.drillDownStep!,
             },
             predicates: [
-                // add drillable items for both types of objRefs that the header can be
-                HeaderPredicates.identifierMatch(drill.attribute.attributeHeader.identifier),
-                HeaderPredicates.uriMatch(drill.attribute.attributeHeader.uri),
+                HeaderPredicates.localIdentifierMatch(drill.attribute.attributeHeader.localIdentifier),
             ],
         };
     });

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
@@ -49,7 +49,7 @@ const selectChartConfig = createSelector(
     (mapboxToken, separators, drillableItems, isExport) => ({
         mapboxToken,
         separators,
-        forceDisableDrillOnAxes: !drillableItems, // to keep in line with KD, enable axes drilling only if using explicit drills
+        forceDisableDrillOnAxes: !drillableItems?.length, // to keep in line with KD, enable axes drilling only if using explicit drills
         isExportMode: isExport,
     }),
 );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -47,7 +47,7 @@ const selectChartConfig = createSelector(
     (mapboxToken, separators, drillableItems, isExport) => ({
         mapboxToken,
         separators,
-        forceDisableDrillOnAxes: !drillableItems, // to keep in line with KD, enable axes drilling only if using explicit drills
+        forceDisableDrillOnAxes: !drillableItems?.length, // to keep in line with KD, enable axes drilling only if using explicit drills
         isExportMode: isExport,
     }),
 );


### PR DESCRIPTION
* RAIL-3657 - fix implicit drill down predicates - now use only localId matches (same as gdc-dashboards)
* RAIL-3693 - fix chart config selector (handle empty drillableItems, not only falsy)

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [x] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
