### PR TITLE
RELATED: RAIL-3702 - Add workspace_id placeholder resolution

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
@@ -25,6 +25,7 @@ import { invalidArgumentsProvided } from "../../events/general";
 
 export enum DRILL_TO_URL_PLACEHOLDER {
     PROJECT_ID = "{project_id}",
+    WORKSPACE_ID = "{workspace_id}",
     INSIGHT_ID = "{insight_id}",
     WIDGET_ID = "{widget_id}",
     DASHBOARD_ID = "{dashboard_id}",
@@ -172,6 +173,7 @@ export function* getInsightIdentifiersReplacements(
 
     const replacements = [
         createIdentifierReplacement(DRILL_TO_URL_PLACEHOLDER.PROJECT_ID, workspace),
+        createIdentifierReplacement(DRILL_TO_URL_PLACEHOLDER.WORKSPACE_ID, workspace),
         createIdentifierReplacement(DRILL_TO_URL_PLACEHOLDER.DASHBOARD_ID, dashboardId),
         createIdentifierReplacement(DRILL_TO_URL_PLACEHOLDER.CLIENT_ID, clientId),
         createIdentifierReplacement(DRILL_TO_URL_PLACEHOLDER.DATA_PRODUCT_ID, dataProductId),


### PR DESCRIPTION
- Add workspace_id placeholder resolution for drillToCustomUrl feature

JIRA: RAIL-3702

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
