### PR TITLE
RELATED: RAIL-3808 fix SonarQube warnings

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
@@ -331,7 +331,8 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
 
         it("should fail if trying to modify/add drillToCustomUrl with not existing display form identifier hardcoded in target", async () => {
             const invalidTargetDrill = cloneDeep(DrillToCustomUrlFromMeasureDefinition);
-            invalidTargetDrill.target.url = "http://www.site.org?dep={attribute_title(label.owner.missing)}";
+            invalidTargetDrill.target.url =
+                "https://www.example.org?dep={attribute_title(label.owner.missing)}";
 
             const drills = [invalidTargetDrill];
             const event: DashboardCommandFailed<ModifyDrillsForInsightWidget> =

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/SimpleDashboard.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/SimpleDashboard.fixtures.ts
@@ -290,7 +290,7 @@ export const DrillToCustomUrlFromMeasureDefinition: IDrillToCustomUrl = {
         },
     },
     target: {
-        url: "http://www.site.org?dep={attribute_title(label.owner.department)}",
+        url: "https://www.example.org?dep={attribute_title(label.owner.department)}",
     },
 };
 

--- a/libs/sdk-ui-tests-e2e/scripts/create_github_report.js
+++ b/libs/sdk-ui-tests-e2e/scripts/create_github_report.js
@@ -56,7 +56,7 @@ function createSuitesMessage(testResults) {
     return "" + "|Status|Name|Tests|Failures|Time|\n" + "|:--:|:--|:--:|:--:|--:|\n" + result.join("\n");
 }
 
-async function main() {
+async function createGitHubReport() {
     const testResults = await getTestResults();
 
     const result =
@@ -71,4 +71,4 @@ async function main() {
     await util.promisify(fs.writeFile)(GITHUB_MESSAGE_FILE, result).catch(handleError);
 }
 
-main();
+module.exports = createGitHubReport;

--- a/libs/sdk-ui-tests-e2e/scripts/run_isolated_compose.js
+++ b/libs/sdk-ui-tests-e2e/scripts/run_isolated_compose.js
@@ -6,8 +6,6 @@ This file is supposed to run within the Cypress container, controlling the execu
  */
 const dotenv = require("dotenv");
 
-const childProcess = require("child_process");
-
 const {
     wiremockStartRecording,
     wiremockStopRecording,
@@ -23,6 +21,7 @@ const {
     saveRecordingsWorkspaceId,
 } = require("./recordings.js");
 const { runCypress } = require("./cypress.js");
+const createGitHubReport = require("./create_github_report.js");
 const wiremockHost = "backend-mock:8080";
 
 async function main() {
@@ -82,7 +81,7 @@ async function main() {
                 sanitizeCredentials();
             }
 
-            childProcess.execSync(`node scripts/create_github_report.js`);
+            await createGitHubReport();
 
             process.exit(e);
         });


### PR DESCRIPTION
* prevent use of http third-party URLs in tests
* prevent free-hand command execution in e2e test scripts

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [x] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
