### PR TITLE
Omit settings ignored on User level

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/settings/tests/__snapshots__/settings.test.ts.snap
+++ b/libs/sdk-backend-bear/src/backend/workspace/settings/tests/__snapshots__/settings.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mergeWorkspaceAndUserSettings should omit ignored user setting and keep project one 1`] = `
+Object {
+  "enableAnalyticalDashboardPermissions": "projectValue",
+  "userSetting": "userValue",
+  "workspaceSetting": "projectValue",
+}
+`;
+
+exports[`mergeWorkspaceAndUserSettings should prioritize user setting over project one 1`] = `
+Object {
+  "setting": "userValue",
+  "userSetting": "userValue",
+  "workspaceSetting": "projectValue",
+}
+`;

--- a/libs/sdk-backend-bear/src/backend/workspace/settings/tests/settings.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/settings/tests/settings.test.ts
@@ -1,0 +1,28 @@
+// (C) 2021 GoodData Corporation
+import { mergeWorkspaceAndUserSettings } from "../settings";
+
+describe("mergeWorkspaceAndUserSettings", () => {
+    it("should prioritize user setting over project one", () => {
+        const workspaceSettings = {
+            workspaceSetting: "projectValue",
+            setting: "projectValue",
+        };
+        const userSettings = {
+            userSetting: "userValue",
+            setting: "userValue",
+        };
+        expect(mergeWorkspaceAndUserSettings(workspaceSettings, userSettings)).toMatchSnapshot();
+    });
+
+    it("should omit ignored user setting and keep project one", () => {
+        const workspaceSettings = {
+            workspaceSetting: "projectValue",
+            enableAnalyticalDashboardPermissions: "projectValue",
+        };
+        const userSettings = {
+            userSetting: "userValue",
+            enableAnalyticalDashboardPermissions: "userValue",
+        };
+        expect(mergeWorkspaceAndUserSettings(workspaceSettings, userSettings)).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
JIRA: TNT-330
For some features User level settings don't make sense and we want them to be configurable only on Project and above

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
