### PR TITLE
Change isUnderStrictControl together with shareStatus

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -534,11 +534,16 @@ export const convertDashboard = (
               }
             : {};
 
-    const flagsProp = isUnderStrictControl
-        ? {
-              flags: ["strictAccessControl"],
-          }
-        : {};
+    let flagsProp = {};
+    if (isUnderStrictControl !== undefined) {
+        flagsProp = isUnderStrictControl
+            ? {
+                  flags: ["strictAccessControl"],
+              }
+            : {
+                  flags: [],
+              };
+    }
 
     return {
         analyticalDashboard: {

--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -28,6 +28,7 @@ options = {
                 "src/presentation/constants",
                 "src/presentation/topBar",
                 "src/presentation/widget",
+                "src/types.ts",
             ],
         ),
         depCruiser.moduleWithDependencies("dashboardContexts", "src/presentation/dashboardContexts", [
@@ -98,6 +99,7 @@ options = {
             "src/presentation/dashboardContexts",
             "src/presentation/localization",
             "src/model",
+            "src/types.ts",
         ]),
         depCruiser.moduleWithDependencies("widget", "src/presentation/widget", [
             "src/_staging/*",

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -426,14 +426,14 @@ export function changeLayoutSectionHeader(index: number, header: IDashboardLayou
 export interface ChangeSharing extends IDashboardCommand {
     // (undocumented)
     readonly payload: {
-        readonly newShareStatus: ShareStatus;
+        readonly newShareProps: IShareProps;
     };
     // (undocumented)
     readonly type: "GDC.DASH/CMD.SHARING.CHANGE";
 }
 
 // @alpha
-export function changeSharing(newShareStatus: ShareStatus, correlationId?: string): ChangeSharing;
+export function changeSharing(newShareProps: IShareProps, correlationId?: string): ChangeSharing;
 
 // @alpha
 export function clearDateFilterSelection(correlationId?: string): ChangeDateFilterSelection;
@@ -1461,7 +1461,7 @@ export type DashboardSelectorEvaluator = <TResult>(selector: DashboardSelector<T
 export interface DashboardSharingChanged extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
-        newShareStatus: ShareStatus;
+        newShareProps: IShareProps;
     };
     // (undocumented)
     readonly type: "GDC.DASH/EVT.SHARING.CHANGED";
@@ -2864,7 +2864,15 @@ export const isDrillTargetsAdded: (obj: unknown) => obj is DrillTargetsAdded;
 // @alpha (undocumented)
 export interface IShareButtonProps {
     // (undocumented)
-    onShareButtonClick: (newShareStatus: ShareStatus) => void;
+    onShareButtonClick: (newShareProps: IShareProps) => void;
+}
+
+// @alpha
+export interface IShareProps {
+    // (undocumented)
+    isUnderStrictControl: boolean;
+    // (undocumented)
+    shareStatus: ShareStatus;
 }
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/changeSharingHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/changeSharingHandler.ts
@@ -26,8 +26,7 @@ type DashboardSaveSharingContext = {
 };
 
 function* createDashboardSaveSharingContext(cmd: ChangeSharing): SagaIterator<DashboardSaveSharingContext> {
-    const { newShareStatus } = cmd.payload;
-    const shareProp = { shareStatus: newShareStatus };
+    const { newShareProps } = cmd.payload;
 
     const persistedDashboard: ReturnType<typeof selectPersistedDashboard> = yield select(
         selectPersistedDashboard,
@@ -47,7 +46,7 @@ function* createDashboardSaveSharingContext(cmd: ChangeSharing): SagaIterator<Da
     };
     const dashboardToSave: IDashboardDefinition = {
         ...dashboardFromState,
-        ...shareProp,
+        ...newShareProps,
     };
 
     return {
@@ -109,11 +108,11 @@ export function* changeSharingHandler(
     );
 
     const result: SagaReturnType<typeof saveSharing> = yield call(saveSharing, ctx, saveSharingCtx);
-    const { dashboard, batch } = result;
+    const { batch } = result;
 
     if (batch) {
         yield put(batch);
     }
 
-    return dashboardSharingChanged(ctx, dashboard.shareStatus, cmd.correlationId);
+    return dashboardSharingChanged(ctx, cmd.payload.newShareProps, cmd.correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/changeSharingHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/tests/changeSharingHandler.test.ts
@@ -17,18 +17,33 @@ describe("change dashboard sharing handler", () => {
 
         it("should save new dashboard share status", async () => {
             const event: DashboardSharingChanged = await Tester.dispatchAndWaitFor(
-                changeSharing("public", TestCorrelation),
+                changeSharing(
+                    {
+                        shareStatus: "public",
+                        isUnderStrictControl: false,
+                    },
+                    TestCorrelation,
+                ),
                 "GDC.DASH/EVT.SHARING.CHANGED",
             );
 
-            expect(event.payload.newShareStatus).toEqual("public");
+            expect(event.payload.newShareProps).toEqual({
+                shareStatus: "public",
+                isUnderStrictControl: false,
+            });
             const newState = Tester.state();
             expect(selectDashboardShareStatus(newState)).toEqual("public");
         });
 
         it("should emit correct events", async () => {
             await Tester.dispatchAndWaitFor(
-                changeSharing("public", TestCorrelation),
+                changeSharing(
+                    {
+                        shareStatus: "public",
+                        isUnderStrictControl: false,
+                    },
+                    TestCorrelation,
+                ),
                 "GDC.DASH/EVT.SHARING.CHANGED",
             );
             expect(Tester.emittedEventsDigest()).toMatchSnapshot();
@@ -45,7 +60,13 @@ describe("change dashboard sharing handler", () => {
 
         it("should fail", async () => {
             const event: DashboardCommandFailed<ChangeSharing> = await Tester.dispatchAndWaitFor(
-                changeSharing("public", TestCorrelation),
+                changeSharing(
+                    {
+                        shareStatus: "public",
+                        isUnderStrictControl: false,
+                    },
+                    TestCorrelation,
+                ),
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
             expect(event.payload.reason).toBe("USER_ERROR");

--- a/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/dashboard.ts
@@ -1,8 +1,9 @@
 // (C) 2021 GoodData Corporation
 
 import { DashboardConfig } from "../types/commonTypes";
-import { IWorkspacePermissions, ShareStatus } from "@gooddata/sdk-backend-spi";
+import { IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import { IDashboardCommand } from "./base";
+import { IShareProps } from "../../types";
 
 /**
  * The initial load of the dashboard will use this correlation id.
@@ -197,7 +198,7 @@ export function renameDashboard(newTitle: string, correlationId?: string): Renam
 export interface ChangeSharing extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.SHARING.CHANGE";
     readonly payload: {
-        readonly newShareStatus: ShareStatus;
+        readonly newShareProps: IShareProps;
     };
 }
 
@@ -205,17 +206,17 @@ export interface ChangeSharing extends IDashboardCommand {
  * Creates the ChangeSharing command. Dispatching this command will result in change of sharing status of dashboard. The changes
  * will be done in-memory and also propagated to the backend.
  *
- * @param newShareStatus - new dashboard share status
+ * @param newShareProps - new dashboard share props
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha
  */
-export function changeSharing(newShareStatus: ShareStatus, correlationId?: string): ChangeSharing {
+export function changeSharing(newShareProps: IShareProps, correlationId?: string): ChangeSharing {
     return {
         type: "GDC.DASH/CMD.SHARING.CHANGE",
         correlationId,
         payload: {
-            newShareStatus,
+            newShareProps,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/dashboard.ts
@@ -1,9 +1,10 @@
 // (C) 2021 GoodData Corporation
 
-import { IDashboard, IWorkspacePermissions, ShareStatus } from "@gooddata/sdk-backend-spi";
+import { IDashboard, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
 import { IInsight } from "@gooddata/sdk-model";
 
 import { DateFilterConfigValidationResult } from "../../_staging/dateFilterConfig/validation";
+import { IShareProps } from "../../types";
 import { DashboardConfig, DashboardContext } from "../types/commonTypes";
 
 import { IDashboardEvent } from "./base";
@@ -446,13 +447,13 @@ export const isDashboardExportToPdfResolved = eventGuard<DashboardExportToPdfRes
 export interface DashboardSharingChanged extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.SHARING.CHANGED";
     readonly payload: {
-        newShareStatus: ShareStatus;
+        newShareProps: IShareProps;
     };
 }
 
 export function dashboardSharingChanged(
     ctx: DashboardContext,
-    newShareStatus: ShareStatus,
+    newShareProps: IShareProps,
     correlationId?: string,
 ): DashboardSharingChanged {
     return {
@@ -460,7 +461,7 @@ export function dashboardSharingChanged(
         ctx,
         correlationId,
         payload: {
-            newShareStatus,
+            newShareProps,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -8,7 +8,6 @@ import {
     IKpiWidget,
     ILegacyKpi,
     isProtectedDataError,
-    ShareStatus,
 } from "@gooddata/sdk-backend-spi";
 import { ToastMessageContextProvider, ToastMessages, useToastMessage } from "@gooddata/sdk-ui-kit";
 import { ErrorComponent as DefaultError, LoadingComponent as DefaultLoading } from "@gooddata/sdk-ui";
@@ -93,6 +92,7 @@ import { downloadFile } from "../../_staging/fileUtils/downloadFile";
 import { DefaultSaveAsDialogInner, SaveAsDialog, SaveAsDialogPropsProvider } from "../saveAs";
 import { IInsight } from "@gooddata/sdk-model";
 import { DEFAULT_FILTER_BAR_HEIGHT } from "../constants";
+import { IShareProps } from "../../types";
 
 const useFilterBar = (): {
     filters: FilterContextItem[];
@@ -163,8 +163,8 @@ const useTopBar = () => {
     });
 
     const onShareButtonClick = useCallback(
-        (newShareStatus: ShareStatus) => {
-            runChangeSharing(newShareStatus);
+        (newShareProps: IShareProps) => {
+            runChangeSharing(newShareProps);
         },
         [runChangeSharing],
     );

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/DefaultShareButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/DefaultShareButton.tsx
@@ -13,20 +13,31 @@ import {
 } from "../../../model";
 
 import { HiddenShareButton } from "./HiddenShareButton";
+import { IShareProps } from "../../../types";
 
 const DefaultShareButtonCore: React.FC<WrappedComponentProps> = ({ intl }): JSX.Element | null => {
     const { onShareButtonClick } = useShareButtonProps();
     const settings = useDashboardSelector(selectSettings);
     const hasPermission = useDashboardSelector(selectCanManageACL);
     // TODO INE temp switching of share status. Will be replaced by Share dialog in TNT-257
+    // TODO INE remove this hardcoded switching of isUnderStrictControl in TNT-292
     const currentShareStatus = useDashboardSelector(selectDashboardShareStatus);
+    const newShareProps: IShareProps =
+        currentShareStatus === "private"
+            ? {
+                  shareStatus: "public",
+                  isUnderStrictControl: false,
+              }
+            : {
+                  shareStatus: "private",
+                  isUnderStrictControl: true,
+              };
+
     if (settings.enableAnalyticalDashboardPermissions && hasPermission) {
         return (
             <>
                 <Button
-                    onClick={() =>
-                        onShareButtonClick(currentShareStatus === "private" ? "public" : "private")
-                    }
+                    onClick={() => onShareButtonClick(newShareProps)}
                     value={
                         currentShareStatus === "private"
                             ? intl.formatMessage({ id: "share.button.text" })

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/types.ts
@@ -1,12 +1,12 @@
 // (C) 2021 GoodData Corporation
-import { ShareStatus } from "@gooddata/sdk-backend-spi";
 import { ComponentType } from "react";
+import { IShareProps } from "../../../types";
 
 /**
  * @alpha
  */
 export interface IShareButtonProps {
-    onShareButtonClick: (newShareStatus: ShareStatus) => void;
+    onShareButtonClick: (newShareProps: IShareProps) => void;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-import { DrillDefinition, IWidget } from "@gooddata/sdk-backend-spi";
+import { DrillDefinition, IWidget, ShareStatus } from "@gooddata/sdk-backend-spi";
 import {
     IAbsoluteDateFilter,
     IInsight,
@@ -121,4 +121,13 @@ export interface IDrillToUrlPlaceholder {
     placeholder: string;
     identifier: string;
     toBeEncoded: boolean;
+}
+
+/**
+ * @alpha
+ * All sharing props describing sharing change from share dialog in future
+ */
+export interface IShareProps {
+    shareStatus: ShareStatus;
+    isUnderStrictControl: boolean;
 }


### PR DESCRIPTION
JIRA: TNT-328
To share dashboard and also allow others to open it and see it isUnderStrictControl flag needs to be turned off too during process of making the dashboard public

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
