### PR TITLE
RELATED: RAIL-3811, RAIL-3815 Fix KPI alerts and drill dialog

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3731,10 +3731,10 @@ export const selectIsExecutionResultReadyForExportByRef: (ref: ObjRef) => Output
 export const selectIsExport: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @alpha (undocumented)
-export const selectIsKpiAlertHighlightedByAlertRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
+export const selectIsKpiAlertHighlightedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
 
 // @alpha (undocumented)
-export const selectIsKpiAlertOpenedByAlertRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
+export const selectIsKpiAlertOpenedByWidgetRef: (ref: ObjRef | undefined) => (state: DashboardState) => boolean;
 
 // @alpha
 export const selectIsLayoutEmpty: OutputSelector<DashboardState, boolean, (res: IWidget[]) => boolean>;
@@ -3891,8 +3891,8 @@ export type UiState = {
         expanded: boolean;
     };
     kpiAlerts: {
-        openedAlertRef: ObjRef | undefined;
-        highlightedAlertRef: ObjRef | undefined;
+        openedWidgetRef: ObjRef | undefined;
+        highlightedWidgetRef: ObjRef | undefined;
     };
 };
 

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -149,8 +149,8 @@ export {
     selectIsSaveAsDialogOpen,
     selectFilterBarExpanded,
     selectFilterBarHeight,
-    selectIsKpiAlertOpenedByAlertRef,
-    selectIsKpiAlertHighlightedByAlertRef,
+    selectIsKpiAlertOpenedByWidgetRef,
+    selectIsKpiAlertHighlightedByWidgetRef,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -30,15 +30,15 @@ const setFilterBarExpanded: UiReducer<PayloadAction<boolean>> = (state, action) 
 };
 
 const closeKpiAlertDialog: UiReducer = (state) => {
-    state.kpiAlerts.openedAlertRef = undefined;
+    state.kpiAlerts.openedWidgetRef = undefined;
 };
 
 const openKpiAlertDialog: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
-    state.kpiAlerts.openedAlertRef = action.payload;
+    state.kpiAlerts.openedWidgetRef = action.payload;
 };
 
 const highlightKpiAlert: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
-    state.kpiAlerts.highlightedAlertRef = action.payload;
+    state.kpiAlerts.highlightedWidgetRef = action.payload;
 };
 
 export const uiReducers = {

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -2,7 +2,7 @@
 
 import { createSelector } from "@reduxjs/toolkit";
 import { ObjRef } from "@gooddata/sdk-model";
-import { selectAlertsMap } from "../alerts/alertsSelectors";
+import { selectWidgetsMap } from "../layout/layoutSelectors";
 import { DashboardState } from "../types";
 import { createMemoizedSelector } from "../_infra/selectors";
 
@@ -34,32 +34,34 @@ export const selectFilterBarHeight = createSelector(selectSelf, (state) => state
  */
 export const selectFilterBarExpanded = createSelector(selectSelf, (state) => state.filterBar.expanded);
 
-const selectHighlightedKpiAlertRef = createSelector(
+const selectHighlightedKpiWidgetRef = createSelector(
     selectSelf,
-    (state) => state.kpiAlerts.highlightedAlertRef,
+    (state) => state.kpiAlerts.highlightedWidgetRef,
 );
 
-const selectOpenedKpiAlertRef = createSelector(selectSelf, (state) => state.kpiAlerts.openedAlertRef);
+const selectOpenedKpiWidgetRef = createSelector(selectSelf, (state) => state.kpiAlerts.openedWidgetRef);
 
 /**
  * @alpha
  */
-export const selectIsKpiAlertOpenedByAlertRef = createMemoizedSelector(
+export const selectIsKpiAlertOpenedByWidgetRef = createMemoizedSelector(
     (ref: ObjRef | undefined): ((state: DashboardState) => boolean) => {
-        return createSelector(selectAlertsMap, selectOpenedKpiAlertRef, (alerts, openedAlertRef) => {
+        return createSelector(selectWidgetsMap, selectOpenedKpiWidgetRef, (widgets, openedWidgetRef) => {
             if (!ref) {
                 return false;
             }
-            const openedAlert = openedAlertRef && alerts.get(openedAlertRef);
-            if (!openedAlert) {
-                return false;
-            }
-            const targetAlert = alerts.get(ref);
-            if (!targetAlert) {
+
+            const openedWidget = openedWidgetRef && widgets.get(openedWidgetRef);
+            if (!openedWidget) {
                 return false;
             }
 
-            return targetAlert.identifier === openedAlert.identifier;
+            const targetWidget = widgets.get(ref);
+            if (!targetWidget) {
+                return false;
+            }
+
+            return targetWidget.identifier === openedWidget.identifier;
         });
     },
 );
@@ -67,25 +69,27 @@ export const selectIsKpiAlertOpenedByAlertRef = createMemoizedSelector(
 /**
  * @alpha
  */
-export const selectIsKpiAlertHighlightedByAlertRef = createMemoizedSelector(
+export const selectIsKpiAlertHighlightedByWidgetRef = createMemoizedSelector(
     (ref: ObjRef | undefined): ((state: DashboardState) => boolean) => {
         return createSelector(
-            selectAlertsMap,
-            selectHighlightedKpiAlertRef,
-            (alerts, highlightedAlertRef) => {
+            selectWidgetsMap,
+            selectHighlightedKpiWidgetRef,
+            (widgets, highlightedWidgetRef) => {
                 if (!ref) {
                     return false;
                 }
-                const highlightedAlert = highlightedAlertRef && alerts.get(highlightedAlertRef);
-                if (!highlightedAlert) {
-                    return false;
-                }
-                const targetAlert = alerts.get(ref);
-                if (!targetAlert) {
+
+                const highlightedWidget = highlightedWidgetRef && widgets.get(highlightedWidgetRef);
+                if (!highlightedWidget) {
                     return false;
                 }
 
-                return targetAlert.identifier === highlightedAlert.identifier;
+                const targetWidget = widgets.get(ref);
+                if (!targetWidget) {
+                    return false;
+                }
+
+                return targetWidget.identifier === highlightedWidget.identifier;
             },
         );
     },

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -16,8 +16,8 @@ export type UiState = {
         expanded: boolean;
     };
     kpiAlerts: {
-        openedAlertRef: ObjRef | undefined;
-        highlightedAlertRef: ObjRef | undefined;
+        openedWidgetRef: ObjRef | undefined;
+        highlightedWidgetRef: ObjRef | undefined;
     };
 };
 
@@ -33,7 +33,7 @@ export const uiInitialState: UiState = {
         expanded: false,
     },
     kpiAlerts: {
-        highlightedAlertRef: undefined,
-        openedAlertRef: undefined,
+        highlightedWidgetRef: undefined,
+        openedWidgetRef: undefined,
     },
 };

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectListItem.tsx
@@ -1,6 +1,7 @@
 // (C) 2019-2021 GoodData Corporation
 import React, { SyntheticEvent } from "react";
 import cx from "classnames";
+import compact from "lodash/compact";
 import { Icon } from "@gooddata/sdk-ui-kit";
 import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 import { ITheme } from "@gooddata/sdk-backend-spi";
@@ -43,7 +44,9 @@ export const DrillSelectListItem = (props: DrillSelectListItemProps): JSX.Elemen
     const IconComponent = Icon[DRILL_ICON_NAME[type]];
 
     const attributeLabel = attributeValue ? `(${attributeValue})` : "";
-    const title = `${name} ${attributeLabel}`;
+
+    // make sure there is no trailing space in case attributeLabel is empty
+    const title = compact([name, attributeLabel]).join(" ");
 
     return (
         <a onClick={onClick} className={itemClassName} title={title}>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -53,8 +53,8 @@ import {
     selectConfiguredDrillsByWidgetRef,
     uiActions,
     useDashboardDispatch,
-    selectIsKpiAlertOpenedByAlertRef,
-    selectIsKpiAlertHighlightedByAlertRef,
+    selectIsKpiAlertOpenedByWidgetRef,
+    selectIsKpiAlertHighlightedByWidgetRef,
 } from "../../../../model";
 import { DashboardItemHeadline } from "../../../presentationComponents";
 import { IDashboardFilter, OnFiredDashboardViewDrillEvent } from "../../../../types";
@@ -137,15 +137,13 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     const settings = useDashboardSelector(selectSettings);
     const drillableItems = useDashboardSelector(selectDrillableItems);
     const widgetDrills = useDashboardSelector(selectConfiguredDrillsByWidgetRef(kpiWidget.ref));
-    const isAlertDialogOpen = useDashboardSelector(selectIsKpiAlertOpenedByAlertRef(alert?.ref));
-    const isAlertHighlighted = useDashboardSelector(selectIsKpiAlertHighlightedByAlertRef(alert?.ref));
+    const isAlertDialogOpen = useDashboardSelector(selectIsKpiAlertOpenedByWidgetRef(kpiWidget.ref));
+    const isAlertHighlighted = useDashboardSelector(selectIsKpiAlertHighlightedByWidgetRef(kpiWidget.ref));
 
     const dispatch = useDashboardDispatch();
     const openAlertDialog = useCallback(() => {
-        if (alert?.ref) {
-            dispatch(uiActions.openKpiAlertDialog(alert.ref));
-        }
-    }, [alert]);
+        dispatch(uiActions.openKpiAlertDialog(kpiWidget.ref));
+    }, [kpiWidget]);
     const closeAlertDialog = useCallback(() => {
         dispatch(uiActions.closeKpiAlertDialog());
     }, []);


### PR DESCRIPTION
* RAIL-3811 - We have to identify the opened/highlighted alerts by widget, not alert to handle cases when a widget has no alert yet.
* RAIL-3815 - Prevent trailing spaces in drill dialog

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
