### PR TITLE
RELATED: RAIL-3428 - Finish init plugin command

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21529,7 +21529,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-rbf1Nv2KFxfUMLK/4CAZsbYPc31zluEDKYc+sDDu1Pkd8Ila88V28CmliQ/r1pmk8KuWYznOTCAfQ2GZ2CJi/Q==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-TkMFbEK9HiYSmxIDXnasfsISbIeTCM8g21DCCcpZqvZyHoUdEzcWwPQEc6n8WQBjwUQ4SH42lanCUfg6P0O5Nw==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -21537,6 +21537,7 @@ packages:
       '@babel/core': 7.14.3
       '@babel/plugin-transform-typescript': 7.14.4_@babel+core@7.14.3
       '@gooddata/eslint-config': 2.1.0_7e427bd3bb4b7d86e24202eabc093566
+      '@types/cross-spawn': 6.0.2
       '@types/fs-extra': 9.0.13
       '@types/inquirer': 7.3.1
       '@types/jest': 26.0.23
@@ -21550,6 +21551,7 @@ packages:
       chalk: 4.1.1
       commander: 8.3.0
       concurrently: 6.2.0
+      cross-spawn: 7.0.3
       dependency-cruiser: 9.26.1
       eslint: 7.28.0
       eslint-plugin-header: 3.1.1_eslint@7.28.0

--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -47,6 +47,7 @@
         "@babel/plugin-transform-typescript": "^7.7.2",
         "chalk": "^4.1.1",
         "commander": "^8.1.0",
+        "cross-spawn": "^7.0.3",
         "fast-glob": "^3.2.7",
         "fs-extra": "^10.0.0",
         "inquirer": "^7.3.3",
@@ -58,6 +59,7 @@
     },
     "devDependencies": {
         "@gooddata/eslint-config": "^2.1.0",
+        "@types/cross-spawn": "^6.0.2",
         "@types/fs-extra": "^9.0.13",
         "@types/inquirer": "^7.3.1",
         "@types/jest": "^26.0.12",

--- a/tools/plugin-toolkit/src/_base/cli/loggers.ts
+++ b/tools/plugin-toolkit/src/_base/cli/loggers.ts
@@ -18,19 +18,19 @@ export function log(key: string, value: string): void {
 }
 
 export function logError(message: string): void {
-    console.log(chalk`{white.bold.bgRed  ✘ ERROR } ${message}`);
+    console.log(chalk`{white.bold.bgRed ✘} ${message}`);
 }
 
 export function logSuccess(message: string): void {
-    console.log(chalk`{white.bold.bgGreen  ✔ SUCCESS } ${message}`);
+    console.log(chalk`{white.bold.bgGreen ✔} ${message}`);
 }
 
 export function logWarn(message: string): void {
-    console.log(chalk`{blue.yellow    WARN  } ${message}`);
+    console.log(chalk`{blue.yellow ⚠} ${message}`);
 }
 
 export function logInfo(message: string): void {
-    console.log(chalk`{blue.bold    INFO  } ${message}`);
+    console.log(chalk`{blue.bold 🛈} ${message}`);
 }
 
 export function logBox(message: string, padding: number = 2): void {

--- a/tools/plugin-toolkit/src/_base/cli/prompts.ts
+++ b/tools/plugin-toolkit/src/_base/cli/prompts.ts
@@ -1,6 +1,6 @@
 // (C) 2007-2021 GoodData Corporation
 import { DistinctQuestion, prompt } from "inquirer";
-import { TargetAppFlavor, TargetBackendType } from "../types";
+import { TargetAppLanguage, TargetBackendType } from "../types";
 import { createHostnameValidator, pluginNameValidator } from "./validators";
 import { sanitizeHostname } from "./sanitizers";
 
@@ -43,9 +43,31 @@ export async function promptWorkspaceId(choices: WorkspaceChoices[]): Promise<st
     return response.id;
 }
 
+export async function promptWorkspaceIdWithoutChoice(): Promise<string> {
+    const question: DistinctQuestion = {
+        type: "input",
+        name: "id",
+        message: `Enter identifier of a workspace to use during plugin development:`,
+    };
+
+    const response = await prompt(question);
+    return response.id;
+}
+
+export async function promptDashboardIdWithoutChoice(): Promise<string> {
+    const question: DistinctQuestion = {
+        type: "input",
+        name: "id",
+        message: `Enter identifier of a dashboard to use during plugin development:`,
+    };
+
+    const response = await prompt(question);
+    return response.id;
+}
+
 export async function promptName(object: string = "dashboard plugin"): Promise<string> {
     const question: DistinctQuestion = {
-        message: `What is your ${object} name?`,
+        message: `Enter ${object} name:`,
         name: "name",
         type: "input",
         validate: pluginNameValidator,
@@ -58,15 +80,12 @@ export async function promptName(object: string = "dashboard plugin"): Promise<s
 export async function promptHostname(backend: TargetBackendType): Promise<string> {
     if (backend === "bear") {
         const question: DistinctQuestion = {
-            message: "What is your hostname?",
+            message: "Select GoodData platform hostname:",
             name: "hostname",
             type: "list",
             choices: [
                 {
                     value: "https://secure.gooddata.com",
-                },
-                {
-                    value: "https://developer.na.gooddata.com",
                 },
                 {
                     value: "https://salesengineering.na.gooddata.com",
@@ -85,8 +104,9 @@ export async function promptHostname(backend: TargetBackendType): Promise<string
         }
     }
 
+    const displayName = backend === "bear" ? "GoodData platform" : "GoodData.CN";
     const question: DistinctQuestion = {
-        message: "Enter custom hostname",
+        message: `Enter ${displayName} hostname:`,
         name: "hostname",
         type: "input",
         validate: createHostnameValidator(backend),
@@ -99,12 +119,12 @@ export async function promptHostname(backend: TargetBackendType): Promise<string
 
 export async function promptBackend(): Promise<TargetBackendType> {
     const question: DistinctQuestion = {
-        message: "What is your application desired platform (backend)?",
+        message: "Select backend type that you use:",
         name: "backend",
         type: "list",
         choices: [
             {
-                name: "SaaS (codename 'Bear')",
+                name: "GoodData platform (codename 'Bear')",
                 value: "bear",
             },
             {
@@ -118,10 +138,10 @@ export async function promptBackend(): Promise<TargetBackendType> {
     return response.backend;
 }
 
-export async function promptFlavor(): Promise<TargetAppFlavor> {
+export async function promptLanguage(): Promise<TargetAppLanguage> {
     const question: DistinctQuestion = {
-        message: "What is your application desired flavor?",
-        name: "flavor",
+        message: "Select programming language that you want to use in your plugin:",
+        name: "language",
         type: "list",
         choices: [
             {
@@ -136,5 +156,5 @@ export async function promptFlavor(): Promise<TargetAppFlavor> {
     };
 
     const response = await prompt(question);
-    return response.flavor;
+    return response.language;
 }

--- a/tools/plugin-toolkit/src/_base/cli/validators.ts
+++ b/tools/plugin-toolkit/src/_base/cli/validators.ts
@@ -54,12 +54,12 @@ export function backendTypeValidator(value: string): boolean | string {
     return "Invalid backend type. Specify 'bear' for GoodData Platform or 'tiger' for GoodData.CN.";
 }
 
-export function flavorValidator(value: string): boolean | string {
+export function languageValidator(value: string): boolean | string {
     if (value === "js" || value === "ts") {
         return true;
     }
 
-    return "Invalid flavor. Specify 'ts' for TypeScript or 'js' for JavaScript.";
+    return "Invalid language. Specify 'ts' for TypeScript or 'js' for JavaScript.";
 }
 
 export function validOrDie(inputName: string, value: string, validator: InputValidator): void {

--- a/tools/plugin-toolkit/src/_base/cli/validators.ts
+++ b/tools/plugin-toolkit/src/_base/cli/validators.ts
@@ -62,6 +62,14 @@ export function languageValidator(value: string): boolean | string {
     return "Invalid language. Specify 'ts' for TypeScript or 'js' for JavaScript.";
 }
 
+export function packageManagerValidator(value: string): boolean | string {
+    if (value === "npm" || value === "yarn") {
+        return true;
+    }
+
+    return "Invalid package manager. Specify 'npm' or 'yarn'.";
+}
+
 export function validOrDie(inputName: string, value: string, validator: InputValidator): void {
     const result = validator(value);
 

--- a/tools/plugin-toolkit/src/_base/types.ts
+++ b/tools/plugin-toolkit/src/_base/types.ts
@@ -9,3 +9,4 @@ export type ActionOptions = {
 
 export type TargetBackendType = "bear" | "tiger";
 export type TargetAppLanguage = "ts" | "js";
+export type SupportedPackageManager = "npm" | "yarn";

--- a/tools/plugin-toolkit/src/_base/types.ts
+++ b/tools/plugin-toolkit/src/_base/types.ts
@@ -8,4 +8,4 @@ export type ActionOptions = {
 };
 
 export type TargetBackendType = "bear" | "tiger";
-export type TargetAppFlavor = "ts" | "js";
+export type TargetAppLanguage = "ts" | "js";

--- a/tools/plugin-toolkit/src/dashboard-plugin-template.ts
+++ b/tools/plugin-toolkit/src/dashboard-plugin-template.ts
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import { TargetAppFlavor } from "./_base/types";
+import { TargetAppLanguage } from "./_base/types";
 import * as path from "path";
 
 /*
@@ -7,6 +7,6 @@ import * as path from "path";
  * that contain the template project.
  */
 
-export function getDashboardPluginTemplateArchive(flavor: TargetAppFlavor): string {
-    return path.join(__dirname, `dashboard-plugin-template.${flavor}.tgz`);
+export function getDashboardPluginTemplateArchive(language: TargetAppLanguage): string {
+    return path.join(__dirname, `dashboard-plugin-template.${language}.tgz`);
 }

--- a/tools/plugin-toolkit/src/index.ts
+++ b/tools/plugin-toolkit/src/index.ts
@@ -21,16 +21,24 @@ const initCmd: Command = dashboardCmd
     .description("Initialize a new dashboard plugin")
     .argument("[plugin-name]", "Name of the plugin to create")
     .option(
+        "--backend <backend>",
+        "Type of backend against which you want to develop the plugin, either GoodData Platform (bear) or GoodData.CN (tiger)",
+    )
+    .option(
+        "--language <language>",
+        "Programming language to use for plugin. Either TypeScript (ts) or JavaScript (js)",
+    )
+    .option(
+        "--workspace-id <workspace>",
+        "Identifier of workspace that contains dashboard that you want to enhance using a plugin",
+    )
+    .option("--dashboard-id <dashboard>", "Identifier of dashboard that you want to enhance using a plugin")
+    .option(
         "--target-dir <path>",
         "Path to the directory to create the plugin in. If not " +
             "specified, program will create a new subdirectory with name derived from plugin name in the current working directory.",
     )
     .option("--skip-install", "Skip yarn installing the plugin dependencies", false)
-    .option(
-        "--backend <backend>",
-        "Type of backend that this plugin targets, either GoodData Platform (bear) or GoodData.CN (tiger)",
-    )
-    .option("--flavor <flavor>", "Language flavor of the plugin, either TypeScript (ts) or JavaScript (js)")
     .action(async (pluginName) => {
         acceptUntrustedSsl(program.opts());
 
@@ -42,9 +50,13 @@ const initCmd: Command = dashboardCmd
 
 const addPluginCmd: Command = dashboardCmd
     .command("store")
-    .description("Store plugin in a workspace so that it can be used on the dashboards in that workspace.")
-    .option("--username <email>", "Your username that you use to log in to GoodData platform.")
-    .option("--workspace-id <id>", "Workspace id to which you want to add the plugin.")
+    .description("Store plugin in a workspace so that it can be used on the dashboards in that workspace")
+    .argument(
+        "[plugin-url]",
+        "URL of location where the plugin assets are hosted. The URL must use https protocol",
+    )
+    .option("--username <email>", "Your username that you use to log in to GoodData platform")
+    .option("--workspace-id <id>", "Identifier of workspace to which you want to add the plugin")
     .action(async () => {
         acceptUntrustedSsl(program.opts());
 
@@ -56,15 +68,18 @@ const addPluginCmd: Command = dashboardCmd
 
 const usePluginCmd: Command = dashboardCmd
     .command("use")
-    .argument("[plugin-id]", "Plugin id which you want to use on the dashboard.")
-    .option("--username <email>", "Your username that you use to log in to GoodData platform.")
-    .option("--workspace-id <id>", "Workspace id that contains dashboard that should use the plugin.")
-    .option("--dashboard-id <id>", "Dashboard id on which you want to use the plugin.")
+    .description("Use plugin available in a workspace on a dashboard.")
+    .argument("[plugin-id]", "Plugin id which you want to use on the dashboard")
+    .option("--username <email>", "Your username that you use to log in to GoodData platform")
+    .option(
+        "--workspace-id <id>",
+        "Identifier of workspace that contains dashboard that should use the plugin",
+    )
+    .option("--dashboard-id <id>", "Identifier of dashboard on which you want to use the plugin")
     .option(
         "--with-parameters",
-        "Tool will prompt for parameters that will be passed to plugin during initialization.",
+        "Tool will prompt for parameters that will be passed to plugin during initialization",
     )
-    .description("Use plugin available in a workspace on a dashboard.")
     .action(async () => {
         acceptUntrustedSsl(program.opts());
 

--- a/tools/plugin-toolkit/src/index.ts
+++ b/tools/plugin-toolkit/src/index.ts
@@ -36,9 +36,10 @@ const initCmd: Command = dashboardCmd
     .option(
         "--target-dir <path>",
         "Path to the directory to create the plugin in. If not " +
-            "specified, program will create a new subdirectory with name derived from plugin name in the current working directory.",
+            "specified, program will create a new subdirectory with name derived from plugin name in the current working directory",
     )
-    .option("--skip-install", "Skip yarn installing the plugin dependencies", false)
+    .option("--package-manager <package-manager>", "Package manager to use in the plugin project", "npm")
+    .option("--skip-install", "Skip installing the plugin dependencies", false)
     .action(async (pluginName) => {
         acceptUntrustedSsl(program.opts());
 

--- a/tools/plugin-toolkit/src/initCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/initCmd/actionConfig.ts
@@ -1,13 +1,13 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, TargetAppFlavor, TargetBackendType } from "../_base/types";
+import { ActionOptions, TargetAppLanguage, TargetBackendType } from "../_base/types";
 import {
     backendTypeValidator,
-    flavorValidator,
+    languageValidator,
     createHostnameValidator,
     pluginNameValidator,
     validOrDie,
 } from "../_base/cli/validators";
-import { promptBackend, promptFlavor, promptHostname, promptName } from "../_base/cli/prompts";
+import { promptBackend, promptLanguage, promptHostname, promptName } from "../_base/cli/prompts";
 import snakeCase from "lodash/snakeCase";
 
 function getHostname(backend: TargetBackendType | undefined, options: ActionOptions): string | undefined {
@@ -37,16 +37,16 @@ function getBackend(options: ActionOptions): TargetBackendType | undefined {
     return backend as TargetBackendType;
 }
 
-function getFlavor(options: ActionOptions): TargetAppFlavor | undefined {
-    const { flavor } = options.commandOpts;
+function getLanguage(options: ActionOptions): TargetAppLanguage | undefined {
+    const { language } = options.commandOpts;
 
-    if (!flavor) {
+    if (!language) {
         return undefined;
     }
 
-    validOrDie("flavor", flavor, flavorValidator);
+    validOrDie("language", language, languageValidator);
 
-    return flavor as TargetAppFlavor;
+    return language as TargetAppLanguage;
 }
 
 //
@@ -58,7 +58,7 @@ export type InitCmdActionConfig = {
     pluginIdentifier: string;
     backend: TargetBackendType;
     hostname: string;
-    flavor: TargetAppFlavor;
+    language: TargetAppLanguage;
     targetDir: string | undefined;
     skipInstall: boolean;
 };
@@ -83,10 +83,10 @@ export async function getInitCmdActionConfig(
 
     const backendFromOptions = getBackend(options);
     const hostnameFromOptions = getHostname(backendFromOptions, options);
-    const flavorFromOptions = getFlavor(options);
+    const languageFromOptions = getLanguage(options);
     const backend = backendFromOptions ?? (await promptBackend());
     const hostname = hostnameFromOptions ?? (await promptHostname(backend));
-    const flavor = flavorFromOptions ?? (await promptFlavor());
+    const language = languageFromOptions ?? (await promptLanguage());
     const name = pluginName ?? (await promptName());
 
     // validate hostname once again; this is to catch the case when hostname is provided as
@@ -99,7 +99,7 @@ export async function getInitCmdActionConfig(
         pluginIdentifier: `dp_${snakeCase(name)}`,
         backend,
         hostname,
-        flavor,
+        language,
         targetDir: options.commandOpts.targetDir,
         skipInstall: options.commandOpts.skipInstall ?? false,
     };

--- a/tools/plugin-toolkit/src/initCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/initCmd/actionConfig.ts
@@ -1,11 +1,12 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, TargetAppLanguage, TargetBackendType } from "../_base/types";
+import { ActionOptions, SupportedPackageManager, TargetAppLanguage, TargetBackendType } from "../_base/types";
 import {
     backendTypeValidator,
     languageValidator,
     createHostnameValidator,
     pluginNameValidator,
     validOrDie,
+    packageManagerValidator,
 } from "../_base/cli/validators";
 import {
     promptBackend,
@@ -80,6 +81,18 @@ function getLanguage(options: ActionOptions): TargetAppLanguage | undefined {
     return language as TargetAppLanguage;
 }
 
+function getPackageManager(options: ActionOptions): SupportedPackageManager {
+    const { packageManager } = options.commandOpts;
+
+    if (!packageManager) {
+        return "npm";
+    }
+
+    validOrDie("packageManager", packageManager, packageManagerValidator);
+
+    return packageManager as SupportedPackageManager;
+}
+
 //
 //
 //
@@ -87,6 +100,7 @@ function getLanguage(options: ActionOptions): TargetAppLanguage | undefined {
 export type InitCmdActionConfig = {
     name: string;
     pluginIdentifier: string;
+    packageManager: SupportedPackageManager;
     backend: TargetBackendType;
     hostname: string;
     workspace: string;
@@ -119,6 +133,7 @@ export async function getInitCmdActionConfig(
     const languageFromOptions = getLanguage(options);
     const workspaceFromOptions = getWorkspace(options);
     const dashboardFromOptions = getDashboard(options);
+    const packageManagerFromOptions = getPackageManager(options);
     const backend = backendFromOptions ?? (await promptBackend());
     const hostname = hostnameFromOptions ?? (await promptHostname(backend));
     const language = languageFromOptions ?? (await promptLanguage());
@@ -139,6 +154,7 @@ export async function getInitCmdActionConfig(
         workspace,
         dashboard,
         language,
+        packageManager: packageManagerFromOptions,
         targetDir: options.commandOpts.targetDir,
         skipInstall: options.commandOpts.skipInstall ?? false,
     };

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, TargetAppFlavor } from "../_base/types";
+import { ActionOptions, TargetAppLanguage } from "../_base/types";
 import { logError, logInfo } from "../_base/cli/loggers";
 import kebabCase from "lodash/kebabCase";
 import * as path from "path";
@@ -16,10 +16,10 @@ import { FileReplacementSpec, replaceInFiles } from "./replaceInFiles";
 //
 //
 
-function unpackProject(target: string, flavor: TargetAppFlavor) {
+function unpackProject(target: string, language: TargetAppLanguage) {
     return fse.mkdirp(target).then((_) => {
         return tar.x({
-            file: getDashboardPluginTemplateArchive(flavor),
+            file: getDashboardPluginTemplateArchive(language),
             strip: 1,
             cwd: target,
         });
@@ -73,7 +73,7 @@ function renamePluginDirectories(target: string, config: InitCmdActionConfig) {
 }
 
 function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): Promise<void> {
-    const { backend, hostname, pluginIdentifier, flavor } = config;
+    const { backend, hostname, pluginIdentifier, language } = config;
     const isTiger = backend === "tiger";
     const replacements: FileReplacementSpec = {
         "webpack.config.js": [
@@ -97,7 +97,7 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
                 },
             ],
             harness: {
-                [`PluginLoader.${flavor}x`]: [
+                [`PluginLoader.${language}x`]: [
                     {
                         regex: /"\.\.\/plugin"/g,
                         value: `"../${pluginIdentifier}"`,
@@ -125,10 +125,10 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
  * @param config - config for the initialization action
  */
 async function prepareProject(config: InitCmdActionConfig) {
-    const { name, targetDir, flavor, backend } = config;
+    const { name, targetDir, language, backend } = config;
     const target = targetDir ? targetDir : path.resolve(process.cwd(), kebabCase(name));
 
-    await unpackProject(target, flavor);
+    await unpackProject(target, language);
     modifyPackageJson(target, config);
 
     await processTigerFiles(target, backend === "tiger");

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -73,7 +73,7 @@ function renamePluginDirectories(target: string, config: InitCmdActionConfig) {
 }
 
 function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): Promise<void> {
-    const { backend, hostname, pluginIdentifier, language } = config;
+    const { backend, hostname, workspace, dashboard, pluginIdentifier, language } = config;
     const isTiger = backend === "tiger";
     const replacements: FileReplacementSpec = {
         "webpack.config.js": [
@@ -87,6 +87,14 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
             {
                 regex: /BACKEND_URL=/g,
                 value: `BACKEND_URL=${hostname}`,
+            },
+            {
+                regex: /WORKSPACE=/g,
+                value: `WORKSPACE=${workspace}`,
+            },
+            {
+                regex: /DASHBOARD_ID=/g,
+                value: `DASHBOARD_ID=${dashboard}`,
             },
         ],
         src: {
@@ -146,6 +154,8 @@ export async function initCmdAction(pluginName: string | undefined, options: Act
         if (isInputValidationError(e)) {
             logError(e.message);
             process.exit(1);
+        } else {
+            logError(`An error has occurred during initialization of new project: ${e.message}`);
         }
     }
 }

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -125,8 +125,8 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
  * @param config - config for the initialization action
  */
 async function prepareProject(config: InitCmdActionConfig) {
-    const { pluginIdentifier, targetDir, flavor, backend } = config;
-    const target = targetDir ? targetDir : path.resolve(process.cwd(), kebabCase(pluginIdentifier));
+    const { name, targetDir, flavor, backend } = config;
+    const target = targetDir ? targetDir : path.resolve(process.cwd(), kebabCase(name));
 
     await unpackProject(target, flavor);
     modifyPackageJson(target, config);

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -146,6 +146,14 @@ async function prepareProject(config: InitCmdActionConfig) {
 
 export async function initCmdAction(pluginName: string | undefined, options: ActionOptions): Promise<void> {
     try {
+        logInfo(
+            "You are about to create project for a new dashboard plugin. Please be note that the " +
+                "values of backend, hostname, workspace-id and dashboard-id options that you enter at this point " +
+                "will be used primarily during development and testing of your new plugin. You will be able to " +
+                "use the new plugin in production on other backend, workspace or dashboard regardless " +
+                "of the choices you make at this point.",
+        );
+
         const config = await getInitCmdActionConfig(pluginName, options);
 
         logInfo(`initCmdAction ${JSON.stringify(config, null, 4)}`);


### PR DESCRIPTION
-  added workspace & dashboard parameters & prompts
-  added logic to auto-install package dependencies (or skip the install)
-  tweaked logging/messaging to use just unicode characters for info/warn/error instead of the long texts
-  added extra info messages so that ppl are not scared of some things
-  renamed 'flavor' (as used in boilerplate) to 'language' as that seems more 'standard' to me.. flavor is for icecream

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
