### PR TITLE
RELATED: RAIL-3805 Default to URI filters on bear

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/VisualizationConverter.ts
@@ -30,7 +30,8 @@ const isUriLike = (value: string): boolean => /\/gdc\/md\/\S+\/obj\/\S+/.test(va
 
 const convertAttributeElements = (items: string[]): IAttributeElements => {
     if (!items.length) {
-        return { values: [] }; // TODO is this OK or we want to throw?
+        // in case of empty filter assume that it is meant to be an URI-based one as these are much more common on bear
+        return { uris: [] };
     }
     // we assume that all the items either use uris, or values, not both, since there is no way of representing the mixed variant
     const first = items[0];


### PR DESCRIPTION
Since the filters saved by Analytical designer are URI based,
we must assume that empty filters should also be treated as URI filters.

JIRA: RAIL-3805

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
