### PR TITLE
RELATED: NAS-2414 - Implement measures service on dummy backend

### DIFF
--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -42,6 +42,10 @@ import {
     IAttributeMetadataObject,
     IElementsQueryFactory,
     IMetadataObject,
+    IMeasureMetadataObjectDefinition,
+    IMeasureExpressionToken,
+    IMeasureMetadataObject,
+    IMeasureReferencing,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -228,7 +232,7 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
             return new DummyWorkspaceAttributesService(workspace);
         },
         measures(): IWorkspaceMeasuresService {
-            throw new NotSupported("not supported");
+            return new DummyWorkspaceMeasuresService(workspace);
         },
         facts(): IWorkspaceFactsService {
             throw new NotSupported("not supported");
@@ -498,5 +502,42 @@ class DummyWorkspaceAttributesService implements IWorkspaceAttributesService {
     }
     getAttributeDatasetMeta(_ref: ObjRef): Promise<IMetadataObject> {
         throw new NotSupported("not supported");
+    }
+}
+
+class DummyWorkspaceMeasuresService implements IWorkspaceMeasuresService {
+    constructor(public readonly workspace: string) {}
+
+    createMeasure(measure: IMeasureMetadataObjectDefinition): Promise<IMeasureMetadataObject> {
+        return Promise.resolve({
+            id: "test_metric_id",
+            uri: "test_metric_id",
+            ref: idRef("test_metric_id", "measure"),
+            type: "measure",
+            title: measure.title || "",
+            description: measure.description || "",
+            deprecated: measure.deprecated || false,
+            expression: measure.expression || "",
+            format: measure.format || "",
+            production: measure.production || false,
+            isLocked: measure.isLocked || false,
+            unlisted: measure.unlisted || false,
+        });
+    }
+
+    deleteMeasure(_measureRef: ObjRef): Promise<void> {
+        return Promise.resolve(undefined);
+    }
+
+    getMeasureExpressionTokens(_ref: ObjRef): Promise<IMeasureExpressionToken[]> {
+        return Promise.resolve([]);
+    }
+
+    getMeasureReferencingObjects(_measureRef: ObjRef): Promise<IMeasureReferencing> {
+        return Promise.resolve({});
+    }
+
+    updateMeasure(measure: IMeasureMetadataObject): Promise<IMeasureMetadataObject> {
+        return Promise.resolve({ ...measure });
     }
 }

--- a/libs/sdk-backend-base/src/dummyBackend/tests/index.test.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/tests/index.test.ts
@@ -3,6 +3,7 @@
 import { IWorkspaceDescriptor } from "@gooddata/sdk-backend-spi";
 
 import { dummyBackend } from "../index";
+import { idRef } from "@gooddata/sdk-model";
 
 describe("dummyBackend", () => {
     describe("workspace", () => {
@@ -18,6 +19,87 @@ describe("dummyBackend", () => {
                     description: "Description",
                     isDemo: false,
                 } as IWorkspaceDescriptor);
+            });
+        });
+
+        describe("measures", () => {
+            it("should return created measure", async () => {
+                const service = await dummyBackend().workspace(WORKSPACE_ID).measures();
+
+                expect(
+                    await service.createMeasure({
+                        title: "Measure 1",
+                        description: "Test",
+                        type: "measure",
+                        expression: "",
+                        format: "",
+                    }),
+                ).toEqual({
+                    deprecated: false,
+                    description: "Test",
+                    expression: "",
+                    format: "",
+                    id: "test_metric_id",
+                    isLocked: false,
+                    production: false,
+                    ref: { identifier: "test_metric_id", type: "measure" },
+                    title: "Measure 1",
+                    type: "measure",
+                    unlisted: false,
+                    uri: "test_metric_id",
+                });
+            });
+
+            it("should return updated measure", async () => {
+                const service = await dummyBackend().workspace(WORKSPACE_ID).measures();
+
+                expect(
+                    await service.updateMeasure({
+                        id: "test",
+                        ref: idRef("", "measure"),
+                        uri: "",
+                        title: "Measure 1",
+                        description: "Test",
+                        type: "measure",
+                        expression: "",
+                        format: "",
+                        deprecated: false,
+                        isLocked: false,
+                        production: false,
+                        unlisted: false,
+                    }),
+                ).toEqual({
+                    deprecated: false,
+                    description: "Test",
+                    expression: "",
+                    format: "",
+                    id: "test",
+                    isLocked: false,
+                    production: false,
+                    ref: { identifier: "", type: "measure" },
+                    title: "Measure 1",
+                    type: "measure",
+                    unlisted: false,
+                    uri: "",
+                });
+            });
+
+            it("should return delete state", async () => {
+                const service = await dummyBackend().workspace(WORKSPACE_ID).measures();
+
+                expect(async () => await service.deleteMeasure(idRef("", "measure"))).not.toThrow();
+            });
+
+            it("should return expression tokens", async () => {
+                const service = await dummyBackend().workspace(WORKSPACE_ID).measures();
+
+                expect(await service.getMeasureExpressionTokens(idRef("", "measure"))).toEqual([]);
+            });
+
+            it("should return referencing empty object", async () => {
+                const service = await dummyBackend().workspace(WORKSPACE_ID).measures();
+
+                expect(await service.getMeasureReferencingObjects(idRef("", "measure"))).toEqual({});
             });
         });
     });


### PR DESCRIPTION
Implementation of dummy backend for simple usage in metric editor unit tests

JIRA: NAS-2414
---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
