### PR TITLE
RELATED: RAIL-3428 - Init dashboard fixes

### DIFF
--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -21,7 +21,8 @@
         "dist/**/*.js",
         "dist/**/*.json",
         "dist/**/*.d.ts",
-        "dist/**/*.map"
+        "dist/**/*.map",
+        "dist/**/*.tgz"
     ],
     "config": {
         "eslint": "-c .eslintrc.js --ext ts src/"

--- a/tools/plugin-toolkit/src/initCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/initCmd/actionConfig.ts
@@ -134,12 +134,12 @@ export async function getInitCmdActionConfig(
     const workspaceFromOptions = getWorkspace(options);
     const dashboardFromOptions = getDashboard(options);
     const packageManagerFromOptions = getPackageManager(options);
+    const name = pluginName ?? (await promptName());
     const backend = backendFromOptions ?? (await promptBackend());
     const hostname = hostnameFromOptions ?? (await promptHostname(backend));
     const language = languageFromOptions ?? (await promptLanguage());
     const workspace = workspaceFromOptions ?? (await promptWorkspaceIdWithoutChoice());
     const dashboard = dashboardFromOptions ?? (await promptDashboardIdWithoutChoice());
-    const name = pluginName ?? (await promptName());
 
     // validate hostname once again; this is to catch the case when hostname is provided as
     // option but the backend is not and user is prompted for it. the user may select backend


### PR DESCRIPTION
-  Archives with template were not in package json => not in published package
-  Tool asks for plugin name at the end; that looks a bit awkward

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
