### PR TITLE
RELATED: NAS-2440 - Implement native dom api functions on pure input

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -942,6 +942,20 @@ export interface IDocumentHeaderProps {
 }
 
 // @internal (undocumented)
+export interface IDomNative {
+    // (undocumented)
+    focus: (options?: {
+        preventScroll?: boolean;
+    }) => void;
+}
+
+// @internal (undocumented)
+export interface IDomNativeProps {
+    // (undocumented)
+    autofocus?: boolean;
+}
+
+// @internal (undocumented)
 export interface IDropdownBodyRenderProps {
     // (undocumented)
     closeDropdown: () => void;
@@ -2146,9 +2160,11 @@ export class Input extends React_2.PureComponent<InputPureProps, InputState> {
 }
 
 // @internal (undocumented)
-export class InputPure extends React_2.PureComponent<InputPureProps> {
+export class InputPure extends React_2.PureComponent<InputPureProps> implements IDomNative {
     // (undocumented)
     componentDidMount(): void;
+    // (undocumented)
+    componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: {
         autofocus: boolean;
@@ -2173,6 +2189,10 @@ export class InputPure extends React_2.PureComponent<InputPureProps> {
         labelPositionTop: boolean;
         value: string;
     };
+    // (undocumented)
+    focus(options?: {
+        preventScroll?: boolean;
+    }): void;
     // (undocumented)
     getInputClassNames(): string;
     // (undocumented)
@@ -2200,9 +2220,7 @@ export class InputPure extends React_2.PureComponent<InputPureProps> {
 }
 
 // @internal (undocumented)
-export interface InputPureProps {
-    // (undocumented)
-    autofocus: boolean;
+export interface InputPureProps extends IDomNativeProps {
     // (undocumented)
     className: string;
     // (undocumented)
@@ -2223,6 +2241,8 @@ export interface InputPureProps {
     labelPositionTop: boolean;
     // (undocumented)
     maxlength: number;
+    // (undocumented)
+    nativeLikeAutofocus?: boolean;
     // (undocumented)
     onBlur: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/Form/focus.ts
+++ b/libs/sdk-ui-kit/src/Form/focus.ts
@@ -1,0 +1,31 @@
+// (C) 2020-2021 GoodData Corporation
+
+export default function tryFocus(handler: () => HTMLElement | null): number {
+    return createInterval(
+        () => isVisible(handler()),
+        () => handler().focus(),
+    );
+}
+
+function createInterval(check: () => boolean, done: () => void) {
+    const timer = window.setInterval(() => {
+        if (check()) {
+            done();
+            window.clearInterval(timer);
+        }
+    }, 25);
+
+    return timer;
+}
+
+function isVisible(element: HTMLElement | null): boolean {
+    if (element) {
+        const style = window.getComputedStyle(element);
+        const notHidden = style.visibility !== "hidden";
+        const notNone = style.display !== "none";
+        const hasSize = element.offsetHeight > 0;
+
+        return notHidden && notNone && hasSize;
+    }
+    return false;
+}

--- a/libs/sdk-ui-kit/src/Form/tests/Input.test.tsx
+++ b/libs/sdk-ui-kit/src/Form/tests/Input.test.tsx
@@ -171,5 +171,82 @@ describe("Input", () => {
 
             expect(onEnterKeyPress).toHaveBeenCalledTimes(1);
         });
+
+        describe("autofocus", () => {
+            beforeEach(() => {
+                const el = document.activeElement as HTMLElement;
+                if (el) {
+                    el.blur();
+                }
+            });
+
+            it("should autofocus input with timer 100ms", () => {
+                jest.useFakeTimers();
+
+                renderInput({
+                    autofocus: true,
+                });
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(20);
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(200);
+
+                expect(document.activeElement.tagName).toBe("INPUT");
+
+                jest.useRealTimers();
+            });
+
+            it("should autofocus input with native like behaviour in visible element", () => {
+                jest.useFakeTimers();
+
+                const wrapper = renderInput({
+                    autofocus: true,
+                    nativeLikeAutofocus: true,
+                });
+                const el = wrapper.find("input").getDOMNode<HTMLInputElement>();
+                jest.spyOn(el, "offsetHeight", "get").mockReturnValue(25);
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(200);
+
+                expect(document.activeElement.tagName).toBe("INPUT");
+
+                jest.useRealTimers();
+            });
+
+            it("should autofocus input with native like behaviour in visible element but after long time", () => {
+                jest.useFakeTimers();
+
+                const wrapper = renderInput({
+                    autofocus: true,
+                    nativeLikeAutofocus: true,
+                });
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(20);
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(200);
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                const el = wrapper.find("input").getDOMNode<HTMLInputElement>();
+                jest.spyOn(el, "offsetHeight", "get").mockReturnValue(25);
+
+                expect(document.activeElement.tagName).toBe("BODY");
+
+                jest.advanceTimersByTime(100);
+
+                expect(document.activeElement.tagName).toBe("INPUT");
+
+                jest.useRealTimers();
+            });
+        });
     });
 });

--- a/libs/sdk-ui-kit/src/index.ts
+++ b/libs/sdk-ui-kit/src/index.ts
@@ -11,6 +11,7 @@
 export * from "./typings/utilities";
 export * from "./typings/positioning";
 export * from "./typings/domUtilities";
+export * from "./typings/domNative";
 export * from "./typings/overlay";
 export * from "./utils/constants";
 export * from "./utils/featureFlags";

--- a/libs/sdk-ui-kit/src/typings/domNative.ts
+++ b/libs/sdk-ui-kit/src/typings/domNative.ts
@@ -1,0 +1,15 @@
+// (C) 2020-2021 GoodData Corporation
+
+/**
+ * @internal
+ */
+export interface IDomNative {
+    focus: (options?: { preventScroll?: boolean }) => void;
+}
+
+/**
+ * @internal
+ */
+export interface IDomNativeProps {
+    autofocus?: boolean;
+}


### PR DESCRIPTION
Implementation of native methods from interface IDomNative on PureInput
Added IDomNativeProps to extends props on PureInput
This can be used in another native like elements

New property "nativeLikeAutofocus" that try to focus element after is visible on page (is not hidden and has some size). This optional must be enabled to start behave this new way.

Also, component PureInput clean timers and intervals to if is destroyed.

JIRA: NAS-2440

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
