### PR TITLE
RELATED: RAIL-3473 add support for dashboard plugins to tiger

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -406,6 +406,13 @@ export namespace AnalyticalDashboardModelV2 {
         version: "2";
     }
     // (undocumented)
+    export interface IDashboardPlugin {
+        // (undocumented)
+        url: string;
+        // (undocumented)
+        version: "2";
+    }
+    // (undocumented)
     export interface IFilterContext {
         // (undocumented)
         filters: IFilterContext["filters"];
@@ -414,6 +421,8 @@ export namespace AnalyticalDashboardModelV2 {
     }
     // (undocumented)
     export function isAnalyticalDashboard(dashboard: unknown): dashboard is IAnalyticalDashboard;
+    // (undocumented)
+    export function isDashboardPlugin(plugin: unknown): plugin is IDashboardPlugin;
     // (undocumented)
     export function isFilterContext(filterContext: unknown): filterContext is IFilterContext;
 }
@@ -6693,7 +6702,7 @@ export type MetadataGetEntitiesParams = {
 };
 
 // @internal
-export type MetadataGetEntitiesResult = JsonApiVisualizationObjectOutList | JsonApiAnalyticalDashboardOutList | JsonApiDatasetOutList | JsonApiAttributeOutList | JsonApiLabelOutList | JsonApiMetricOutList | JsonApiFactOutList | JsonApiFilterContextOutList;
+export type MetadataGetEntitiesResult = JsonApiVisualizationObjectOutList | JsonApiAnalyticalDashboardOutList | JsonApiDashboardPluginOutList | JsonApiDatasetOutList | JsonApiAttributeOutList | JsonApiLabelOutList | JsonApiMetricOutList | JsonApiFactOutList | JsonApiFilterContextOutList;
 
 // @public
 export interface MetadataRequestArgs {

--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -403,12 +403,23 @@ export namespace AnalyticalDashboardModelV2 {
         // (undocumented)
         layout?: IDashboardLayout;
         // (undocumented)
+        plugins?: IDashboardPluginLink[];
+        // (undocumented)
         version: "2";
     }
     // (undocumented)
     export interface IDashboardPlugin {
         // (undocumented)
         url: string;
+        // (undocumented)
+        version: "2";
+    }
+    // (undocumented)
+    export interface IDashboardPluginLink {
+        // (undocumented)
+        parameters?: string;
+        // (undocumented)
+        plugin: ObjRef;
         // (undocumented)
         version: "2";
     }
@@ -423,6 +434,8 @@ export namespace AnalyticalDashboardModelV2 {
     export function isAnalyticalDashboard(dashboard: unknown): dashboard is IAnalyticalDashboard;
     // (undocumented)
     export function isDashboardPlugin(plugin: unknown): plugin is IDashboardPlugin;
+    // (undocumented)
+    export function isDashboardPluginLink(pluginLink: unknown): pluginLink is IDashboardPluginLink;
     // (undocumented)
     export function isFilterContext(filterContext: unknown): filterContext is IFilterContext;
 }
@@ -4513,6 +4526,9 @@ export const isAfmObjectIdentifier: (value: unknown) => value is AfmObjectIdenti
 
 // @public (undocumented)
 export function isAttributeHeader(header: ResultDimensionHeader): header is AttributeHeader;
+
+// @public (undocumented)
+export function isDashboardPluginsItem(dashboardPlugin: unknown): dashboardPlugin is JsonApiDashboardPluginOutWithLinks;
 
 // @public (undocumented)
 export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn;

--- a/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardModelV2.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardModelV2.ts
@@ -20,11 +20,20 @@ export namespace AnalyticalDashboardModelV2 {
         filters: IFilterContextSPI["filters"];
     }
 
+    export interface IDashboardPlugin {
+        version: "2";
+        url: string;
+    }
+
     export function isAnalyticalDashboard(dashboard: unknown): dashboard is IAnalyticalDashboard {
         return !isEmpty(dashboard) && (dashboard as IAnalyticalDashboard).version === "2";
     }
 
     export function isFilterContext(filterContext: unknown): filterContext is IFilterContext {
         return !isEmpty(filterContext) && (filterContext as IFilterContext).version === "2";
+    }
+
+    export function isDashboardPlugin(plugin: unknown): plugin is IDashboardPlugin {
+        return !isEmpty(plugin) && (plugin as IDashboardPlugin).version === "2";
     }
 }

--- a/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardModelV2.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/AnalyticalDashboardModelV2.ts
@@ -13,6 +13,7 @@ export namespace AnalyticalDashboardModelV2 {
         layout?: IDashboardLayout;
         filterContextRef?: ObjRef;
         dateFilterConfig?: IDashboardDateFilterConfig;
+        plugins?: IDashboardPluginLink[];
     }
 
     export interface IFilterContext {
@@ -25,6 +26,12 @@ export namespace AnalyticalDashboardModelV2 {
         url: string;
     }
 
+    export interface IDashboardPluginLink {
+        version: "2";
+        plugin: ObjRef;
+        parameters?: string;
+    }
+
     export function isAnalyticalDashboard(dashboard: unknown): dashboard is IAnalyticalDashboard {
         return !isEmpty(dashboard) && (dashboard as IAnalyticalDashboard).version === "2";
     }
@@ -35,5 +42,9 @@ export namespace AnalyticalDashboardModelV2 {
 
     export function isDashboardPlugin(plugin: unknown): plugin is IDashboardPlugin {
         return !isEmpty(plugin) && (plugin as IDashboardPlugin).version === "2";
+    }
+
+    export function isDashboardPluginLink(pluginLink: unknown): pluginLink is IDashboardPluginLink {
+        return !isEmpty(pluginLink) && (pluginLink as IDashboardPluginLink).version === "2";
     }
 }

--- a/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
+++ b/libs/api-client-tiger/src/gd-tiger-model/typeGuards.ts
@@ -10,6 +10,10 @@ import {
 import {
     JsonApiFilterContextIn,
     JsonApiVisualizationObjectOutWithLinks,
+    JsonApiDashboardPluginOutWithLinks,
+    JsonApiDashboardPluginOutWithLinksTypeEnum,
+    JsonApiFilterContextInTypeEnum,
+    JsonApiVisualizationObjectOutWithLinksTypeEnum,
 } from "../generated/metadata-json-api";
 
 export type ResultDimensionHeader = ResultDimension["headers"][number];
@@ -34,9 +38,21 @@ export function isResultAttributeHeader(
 export function isVisualizationObjectsItem(
     visualizationObject: unknown,
 ): visualizationObject is JsonApiVisualizationObjectOutWithLinks {
-    return (visualizationObject as JsonApiVisualizationObjectOutWithLinks).type === "visualizationObject";
+    return (
+        (visualizationObject as JsonApiVisualizationObjectOutWithLinks).type ===
+        JsonApiVisualizationObjectOutWithLinksTypeEnum.VisualizationObject
+    );
 }
 
 export function isFilterContextData(filterContext: unknown): filterContext is JsonApiFilterContextIn {
-    return (filterContext as JsonApiFilterContextIn).type === "filterContext";
+    return (filterContext as JsonApiFilterContextIn).type === JsonApiFilterContextInTypeEnum.FilterContext;
+}
+
+export function isDashboardPluginsItem(
+    dashboardPlugin: unknown,
+): dashboardPlugin is JsonApiDashboardPluginOutWithLinks {
+    return (
+        (dashboardPlugin as JsonApiDashboardPluginOutWithLinks).type ===
+        JsonApiDashboardPluginOutWithLinksTypeEnum.DashboardPlugin
+    );
 }

--- a/libs/api-client-tiger/src/index.ts
+++ b/libs/api-client-tiger/src/index.ts
@@ -28,6 +28,7 @@ export {
     isResultAttributeHeader,
     isVisualizationObjectsItem,
     isFilterContextData,
+    isDashboardPluginsItem,
     ResultDimensionHeader,
 } from "./gd-tiger-model/typeGuards";
 

--- a/libs/api-client-tiger/src/metadataUtilities.ts
+++ b/libs/api-client-tiger/src/metadataUtilities.ts
@@ -9,6 +9,7 @@ import { jsonApiHeaders } from "./constants";
 import {
     JsonApiAnalyticalDashboardOutList,
     JsonApiAttributeOutList,
+    JsonApiDashboardPluginOutList,
     JsonApiDatasetOutList,
     JsonApiFactOutList,
     JsonApiFilterContextOutList,
@@ -65,6 +66,7 @@ export type MetadataGetEntitiesOptions = {
 export type MetadataGetEntitiesResult =
     | JsonApiVisualizationObjectOutList
     | JsonApiAnalyticalDashboardOutList
+    | JsonApiDashboardPluginOutList
     | JsonApiDatasetOutList
     | JsonApiAttributeOutList
     | JsonApiLabelOutList
@@ -148,7 +150,8 @@ export class MetadataUtilities {
         return {
             data: flatMap(pages, (page) => page.data) as any,
             included: uniqBy(
-                flatMap(pages, (page) => page.included ?? []),
+                // we need the as any because the JsonApiDashboardPluginOutList does not have the "included" property
+                flatMap(pages, (page) => (page as any).included ?? []),
                 (item: any) => `${item.id}_${item.type}`,
             ) as any,
         } as T;

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/AnalyticalDashboardConverter.ts
@@ -9,8 +9,16 @@ import {
     JsonApiAnalyticalDashboardOutWithLinks,
     JsonApiFilterContextOutDocument,
     JsonApiFilterContextOutWithLinks,
+    JsonApiDashboardPluginOutDocument,
+    JsonApiDashboardPluginOutWithLinks,
 } from "@gooddata/api-client-tiger";
-import { FilterContextItem, IDashboard, IFilterContext, IListedDashboard } from "@gooddata/sdk-backend-spi";
+import {
+    FilterContextItem,
+    IDashboard,
+    IDashboardPlugin,
+    IFilterContext,
+    IListedDashboard,
+} from "@gooddata/sdk-backend-spi";
 
 import {
     convertDashboard as convertDashboardV1,
@@ -21,6 +29,8 @@ import {
     convertDashboard as convertDashboardV2,
     convertFilterContextFilters as convertFilterContextFiltersV2,
     convertFilterContextFromBackend as convertFilterContextFromBackendV2,
+    convertDashboardPlugin as convertDashboardPluginV2,
+    convertDashboardPluginWithLinks as convertDashboardPluginWithLinksV2,
 } from "./v2/AnalyticalDashboardConverter";
 import { idRef, ObjectType } from "@gooddata/sdk-model";
 import { isInheritedObject } from "../utils";
@@ -81,6 +91,34 @@ export function convertFilterContextFromBackend(
     }
 
     invariant(false, "Unknown filter context version");
+}
+
+export function convertDashboardPluginFromBackend(
+    plugin: JsonApiDashboardPluginOutDocument,
+): IDashboardPlugin {
+    const content = plugin.data.attributes!.content;
+
+    // V1 does not support plugins
+
+    if (AnalyticalDashboardModelV2.isDashboardPlugin(content)) {
+        return convertDashboardPluginV2(plugin);
+    }
+
+    invariant(false, "Unknown dashboard plugin version");
+}
+
+export function convertDashboardPluginWithLinksFromBackend(
+    plugin: JsonApiDashboardPluginOutWithLinks,
+): IDashboardPlugin {
+    const content = plugin.attributes!.content;
+
+    // V1 does not support plugins
+
+    if (AnalyticalDashboardModelV2.isDashboardPlugin(content)) {
+        return convertDashboardPluginWithLinksV2(plugin);
+    }
+
+    invariant(false, "Unknown dashboard plugin version");
 }
 
 function convertFilterContextFilters(

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
@@ -12,6 +12,7 @@ import {
     IDashboardDateFilterConfig,
     IDashboardLayout,
     IDashboardPlugin,
+    IDashboardPluginLink,
     IDashboardWidget,
     IFilterContext,
     LayoutPath,
@@ -54,6 +55,17 @@ function setWidgetRefsInLayout(layout: IDashboardLayout<IDashboardWidget> | unde
 interface IAnalyticalDashboardContent {
     layout?: IDashboardLayout;
     dateFilterConfig?: IDashboardDateFilterConfig;
+    plugins?: IDashboardPluginLink[];
+}
+
+function convertDashboardPluginLink(
+    pluginLink: AnalyticalDashboardModelV2.IDashboardPluginLink,
+): IDashboardPluginLink {
+    return {
+        type: "IDashboardPluginLink",
+        plugin: cloneWithSanitizedIds(pluginLink.plugin),
+        parameters: pluginLink.parameters,
+    };
 }
 
 function getConvertedAnalyticalDashboardContent(
@@ -62,6 +74,7 @@ function getConvertedAnalyticalDashboardContent(
     return {
         dateFilterConfig: cloneWithSanitizedIds(analyticalDashboard.dateFilterConfig),
         layout: setWidgetRefsInLayout(cloneWithSanitizedIds(analyticalDashboard.layout)),
+        plugins: analyticalDashboard.plugins?.map(convertDashboardPluginLink),
     };
 }
 
@@ -72,7 +85,7 @@ export function convertDashboard(
     const { id, attributes = {} } = analyticalDashboard.data;
     const { title = "", description = "", content } = attributes;
 
-    const { dateFilterConfig, layout } = getConvertedAnalyticalDashboardContent(
+    const { dateFilterConfig, layout, plugins } = getConvertedAnalyticalDashboardContent(
         content as AnalyticalDashboardModelV2.IAnalyticalDashboard,
     );
 
@@ -93,6 +106,7 @@ export function convertDashboard(
         filterContext,
         dateFilterConfig,
         layout,
+        plugins,
     };
 }
 

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/analyticalDashboards/v2/AnalyticalDashboardConverter.ts
@@ -2,6 +2,8 @@
 import {
     AnalyticalDashboardModelV2,
     JsonApiAnalyticalDashboardOutDocument,
+    JsonApiDashboardPluginOutDocument,
+    JsonApiDashboardPluginOutWithLinks,
     JsonApiFilterContextOutDocument,
 } from "@gooddata/api-client-tiger";
 import {
@@ -9,6 +11,7 @@ import {
     IDashboard,
     IDashboardDateFilterConfig,
     IDashboardLayout,
+    IDashboardPlugin,
     IDashboardWidget,
     IFilterContext,
     LayoutPath,
@@ -113,4 +116,40 @@ export function convertFilterContextFilters(
     content: AnalyticalDashboardModelV2.IFilterContext,
 ): FilterContextItem[] {
     return cloneWithSanitizedIds(content.filters);
+}
+
+export function convertDashboardPlugin(plugin: JsonApiDashboardPluginOutDocument): IDashboardPlugin {
+    const { id, type, attributes } = plugin.data;
+    const { title = "", description = "", content, tags } = attributes!;
+    const { url } = content as AnalyticalDashboardModelV2.IDashboardPlugin;
+
+    return {
+        ref: idRef(id, type as ObjectType),
+        identifier: id,
+        uri: plugin.links!.self,
+        name: title,
+        description,
+        tags: tags ?? [],
+        type: "IDashboardPlugin",
+        url,
+    };
+}
+
+export function convertDashboardPluginWithLinks(
+    plugin: JsonApiDashboardPluginOutWithLinks,
+): IDashboardPlugin {
+    const { id, type, attributes } = plugin;
+    const { title = "", description = "", content, tags } = attributes!;
+    const { url } = content as AnalyticalDashboardModelV2.IDashboardPlugin;
+
+    return {
+        ref: idRef(id, type as ObjectType),
+        identifier: id,
+        uri: plugin.links!.self,
+        name: title,
+        description,
+        tags: tags ?? [],
+        type: "IDashboardPlugin",
+        url,
+    };
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
@@ -4,6 +4,7 @@ import {
     IDashboardDefinition,
     IDashboardLayout,
     IDashboardPluginDefinition,
+    IDashboardPluginLink,
     IDashboardWidget,
     IFilterContextDefinition,
     LayoutPath,
@@ -43,6 +44,7 @@ export function convertAnalyticalDashboard(
         dateFilterConfig: cloneWithSanitizedIds(dashboard.dateFilterConfig),
         filterContextRef: cloneWithSanitizedIds(filterContextRef),
         layout: cloneWithSanitizedIds(layout),
+        plugins: dashboard.plugins?.map(convertDashboardPluginLinkToBackend),
         version: "2",
     };
 }
@@ -61,6 +63,16 @@ export function convertDashboardPluginToBackend(
 ): AnalyticalDashboardModelV2.IDashboardPlugin {
     return {
         url: plugin.url,
+        version: "2",
+    };
+}
+
+export function convertDashboardPluginLinkToBackend(
+    pluginLink: IDashboardPluginLink,
+): AnalyticalDashboardModelV2.IDashboardPluginLink {
+    return {
+        plugin: cloneWithSanitizedIds(pluginLink.plugin),
+        parameters: pluginLink.parameters,
         version: "2",
     };
 }

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/AnalyticalDashboardConverter.ts
@@ -3,6 +3,7 @@ import { AnalyticalDashboardModelV2 } from "@gooddata/api-client-tiger";
 import {
     IDashboardDefinition,
     IDashboardLayout,
+    IDashboardPluginDefinition,
     IDashboardWidget,
     IFilterContextDefinition,
     LayoutPath,
@@ -51,6 +52,15 @@ export function convertFilterContextToBackend(
 ): AnalyticalDashboardModelV2.IFilterContext {
     return {
         filters: cloneWithSanitizedIds(filterContext.filters),
+        version: "2",
+    };
+}
+
+export function convertDashboardPluginToBackend(
+    plugin: IDashboardPluginDefinition,
+): AnalyticalDashboardModelV2.IDashboardPlugin {
+    return {
+        url: plugin.url,
         version: "2",
     };
 }

--- a/libs/sdk-backend-tiger/src/types/index.ts
+++ b/libs/sdk-backend-tiger/src/types/index.ts
@@ -21,7 +21,11 @@ export type TigerAfmType = "label" | "metric" | "dataset" | "fact" | "attribute"
  *
  * @public
  */
-export type TigerMetadataType = "analyticalDashboard" | "visualizationObject" | "filterContext";
+export type TigerMetadataType =
+    | "analyticalDashboard"
+    | "visualizationObject"
+    | "filterContext"
+    | "dashboardPlugin";
 
 /**
  * Tiger entity types

--- a/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
+++ b/libs/sdk-backend-tiger/src/types/refTypeMapping.ts
@@ -20,6 +20,7 @@ export const tigerIdTypeToObjectType: {
     analyticalDashboard: "analyticalDashboard",
     visualizationObject: "insight",
     filterContext: "filterContext",
+    dashboardPlugin: "dashboardPlugin",
 };
 
 export const objectTypeToTigerIdType = invert(tigerIdTypeToObjectType) as {

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1273,7 +1273,7 @@ export type ObjectType = "measure" | "fact" | "attribute" | "displayForm" | "dat
 /**
 * @deprecated will be removed in the next major release, use "insight" instead
 */
-| "visualizationObject" | "filterContext";
+| "visualizationObject" | "filterContext" | "dashboardPlugin";
 
 // @public
 export type ObjRef = UriRef | IdentifierRef;

--- a/libs/sdk-model/src/objRef/index.ts
+++ b/libs/sdk-model/src/objRef/index.ts
@@ -49,7 +49,8 @@ export type ObjectType =
      * @deprecated will be removed in the next major release, use "insight" instead
      */
     | "visualizationObject"
-    | "filterContext";
+    | "filterContext"
+    | "dashboardPlugin";
 
 /**
  * Model object reference using object's unique identifier.


### PR DESCRIPTION
* Implement CRUD on dashboardPlugin objects
* Add support for sideloading them for dashboards
* Add support for linking them to dashboards
* Do not fail on `loadUserData` for dashboards anymore, just warn and ignore the option

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
