### PR TITLE
RELATED: RAIL-3428 - Link and unlink dashboard plugin commands

### DIFF
--- a/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
+++ b/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
@@ -11,7 +11,7 @@ import {
     IDashboardWithReferences,
     IAnalyticalWorkspace,
 } from "@gooddata/sdk-backend-spi";
-import { extractRootCause } from "../utils";
+import { convertToPluginEntrypoint, extractRootCause } from "../utils";
 import { idRef } from "@gooddata/sdk-model";
 
 export type InputValidator<T = string> = (value: T) => boolean | string;
@@ -119,7 +119,7 @@ export function createHostnameValidator(backend: TargetBackendType): InputValida
  *    -  validator attempts to give some nicer messaging and where possible also provide hints
  */
 export function createPluginUrlValidator(pluginIdentifier: string): AsyncInputValidator {
-    const entryPoint = `${pluginIdentifier}.js`;
+    const entryPoint = convertToPluginEntrypoint(pluginIdentifier);
 
     return async (value: string): Promise<boolean | string> => {
         if (!value.startsWith("https://")) {

--- a/tools/plugin-toolkit/src/_base/terminal/prompts.ts
+++ b/tools/plugin-toolkit/src/_base/terminal/prompts.ts
@@ -158,3 +158,16 @@ export async function promptLanguage(): Promise<TargetAppLanguage> {
     const response = await prompt(question);
     return response.language;
 }
+
+export async function promptPluginParameters(): Promise<string> {
+    const question: DistinctQuestion = {
+        message:
+            "A text editor specified will now open and let you enter parameters for the plugin." +
+            "This is how you can configure how your plugin behaves on the workspace. Save and exit editor when done.",
+        name: "parameters",
+        type: "editor",
+    };
+
+    const response = await prompt(question);
+    return response.parameters;
+}

--- a/tools/plugin-toolkit/src/_base/utils.ts
+++ b/tools/plugin-toolkit/src/_base/utils.ts
@@ -34,13 +34,20 @@ export function safeJoin(initialPath: string, relativePath: string): string {
 }
 
 /**
- * Converts plug name to an identifier that can be used for module federation identifier, directory names,
+ * Converts plugin name to an identifier that can be used for module federation identifier, directory names,
  * asset file names etc.
  *
  * @param name - plugin name as entered by the user
  */
 export function convertToPluginIdentifier(name: string): string {
     return `dp_${snakeCase(name)}`;
+}
+
+/**
+ * Converts plugin identifier to entry point file name
+ */
+export function convertToPluginEntrypoint(pluginIdentifier: string): string {
+    return `${pluginIdentifier}.js`;
 }
 
 /**

--- a/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
@@ -58,7 +58,6 @@ export async function getAddCmdActionConfig(
 
     validateWorkspaceTargetConfig(workspaceTargetConfig);
 
-    const pluginIdentifier = convertToPluginIdentifier(packageJson.name);
     const backendInstance = createBackend({
         hostname,
         backend,
@@ -68,7 +67,7 @@ export async function getAddCmdActionConfig(
     const config: AddCmdActionConfig = {
         ...workspaceTargetConfig,
         pluginUrl,
-        pluginIdentifier,
+        pluginIdentifier: convertToPluginIdentifier(packageJson.name),
         pluginName: packageJson.name,
         pluginDescription: packageJson.description,
         dryRun: options.commandOpts.dryRun ?? false,

--- a/tools/plugin-toolkit/src/index.ts
+++ b/tools/plugin-toolkit/src/index.ts
@@ -5,7 +5,8 @@ import { Command, OptionValues, program } from "commander";
 import * as pkg from "../package.json";
 import { addPluginCmdAction } from "./addPluginCmd";
 import { initCmdAction } from "./initCmd";
-import { usePluginCmdAction } from "./usePluginCmd";
+import { linkPluginCmdAction } from "./linkPluginCmd";
+import { unlinkPluginCmdAction } from "./unlinkPluginCmd";
 
 program
     .version(pkg.version)
@@ -87,13 +88,48 @@ const addPluginCmd: Command = dashboardCmd
         });
     });
 
-const usePluginCmd: Command = dashboardCmd
-    .command("use")
-    .description("Use plugin available in a workspace on a dashboard.")
-    .argument("<plugin-id>", "Plugin id which you want to use on the dashboard")
+const linkPluginCmd: Command = dashboardCmd
+    .command("link")
+    .description("Link plugin available in a workspace with a dashboard in the same workspace.")
+    .argument("<plugin-id>", "Plugin id which you want to link with the dashboard")
     .option(
         "--backend <backend>",
-        "Type of backend to which you want to add the plugin, either GoodData Platform (bear) or GoodData.CN (tiger). " +
+        "Type of backend that you are targeting. Either GoodData Platform (bear) or GoodData.CN (tiger). " +
+            "By default tries to auto-detect the backend type from your project's package.json.",
+    )
+    .option(
+        "--workspace-id <id>",
+        "Identifier of workspace that contains dashboard and plugin that should be linked",
+    )
+    .option("--dashboard-id <id>", "Identifier of dashboard to which you want to link the plugin")
+    .option(
+        "--dry-run",
+        "In dry run mode, the tool will proceed up to the point when first update operation has to " +
+            "be done and then will stop. This is ideal to verify configuration. Dry run is disabled by default",
+        false,
+    )
+    .option(
+        "--with-parameters",
+        "Indicate that the link between dashboard and plugin should be parameterized. When you specify " +
+            "this option the program will open an editor for you to enter parameters that should be passed to the linked " +
+            "plugin as it is loaded on the dashboard.",
+    )
+    .action(async (identifier) => {
+        acceptUntrustedSsl(program.opts());
+
+        await linkPluginCmdAction(identifier, {
+            programOpts: program.opts(),
+            commandOpts: linkPluginCmd.opts(),
+        });
+    });
+
+const unlinkPluginCmd: Command = dashboardCmd
+    .command("unlink")
+    .description("Unlink plugin from a dashboard.")
+    .argument("<plugin-id>", "Identifier of the plugin object which you want to unlink from the dashboard.")
+    .option(
+        "--backend <backend>",
+        "Type of backend that you are targeting. Either GoodData Platform (bear) or GoodData.CN (tiger). " +
             "By default tries to auto-detect the backend type from your project's package.json.",
     )
     .option(
@@ -107,16 +143,12 @@ const usePluginCmd: Command = dashboardCmd
             "be done and then will stop. This is ideal to verify configuration. Dry run is disabled by default",
         false,
     )
-    .option(
-        "--with-parameters",
-        "Tool will prompt for parameters that will be passed to plugin during initialization",
-    )
     .action(async (identifier) => {
         acceptUntrustedSsl(program.opts());
 
-        await usePluginCmdAction(identifier, {
+        await unlinkPluginCmdAction(identifier, {
             programOpts: program.opts(),
-            commandOpts: usePluginCmd.opts(),
+            commandOpts: unlinkPluginCmd.opts(),
         });
     });
 

--- a/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
@@ -21,7 +21,7 @@ import { promptPluginParameters } from "../_base/terminal/prompts";
 import { logError } from "../_base/terminal/loggers";
 import { convertToPluginEntrypoint, convertToPluginIdentifier } from "../_base/utils";
 
-export type UseCmdActionConfig = WorkspaceTargetConfig & {
+export type LinkCmdActionConfig = WorkspaceTargetConfig & {
     /**
      * Plugin _metadata object_ identifier.
      */
@@ -57,7 +57,7 @@ function createDuplicatePluginLinkValidator(
         if (plugins.some((plugin) => plugin.identifier === identifier)) {
             return (
                 `Dashboard ${dashboard.identifier} already uses plugin ${identifier}. ` +
-                "Dashboard can only use each plugin once. Consider using parameterization instead."
+                "Dashboard can only link each plugin once. Consider using parameterization instead."
             );
         }
 
@@ -66,9 +66,9 @@ function createDuplicatePluginLinkValidator(
             const { identifier: otherIdentifier, name } = otherPluginWithSameEp;
 
             return (
-                `Dashboard ${dashboard.identifier} already uses another plugin (${otherIdentifier} - ${name})` +
-                "that has same entry point as the plugin that you want to use. This is likely another version of " +
-                "the same plugin. Adding two versions of the same plugin is not allowed will not work. Note: " +
+                `Dashboard ${dashboard.identifier} is already linked with another plugin (${otherIdentifier} - ${name})` +
+                "that has same entry point as the plugin that you want to link now. This is likely another version of " +
+                "the same plugin. Adding two versions of the same plugin is not supported. Note: " +
                 "renaming the entry point files will not help as you will then encounter load-time errors."
             );
         }
@@ -83,7 +83,7 @@ function createLinkedPluginUrlValidator(pluginIdentifier: string): InputValidato
     return (plugin) => {
         if (!plugin.url.endsWith(entryPoint)) {
             return (
-                `You are trying to use a plugin (${plugin.name}) whose entry point differs from the ` +
+                `You are trying to link a plugin (${plugin.name}) whose entry point differs from the ` +
                 "entry point of the plugin in your current directory."
             );
         }
@@ -92,7 +92,7 @@ function createLinkedPluginUrlValidator(pluginIdentifier: string): InputValidato
     };
 }
 
-async function doAsyncValidations(config: UseCmdActionConfig) {
+async function doAsyncValidations(config: LinkCmdActionConfig) {
     const { backendInstance, workspace, dashboard, identifier, pluginIdentifier } = config;
 
     const asyncValidationProgress = ora({
@@ -126,10 +126,10 @@ async function doAsyncValidations(config: UseCmdActionConfig) {
     }
 }
 
-export async function getUseCmdActionConfig(
+export async function getLinkCmdActionConfig(
     identifier: string,
     options: ActionOptions,
-): Promise<UseCmdActionConfig> {
+): Promise<LinkCmdActionConfig> {
     const workspaceTargetConfig = createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials, env, packageJson } = workspaceTargetConfig;
     const dashboard = getDashboardFromOptions(options) ?? env.DASHBOARD;
@@ -142,7 +142,7 @@ export async function getUseCmdActionConfig(
         credentials,
     });
 
-    const config: UseCmdActionConfig = {
+    const config: LinkCmdActionConfig = {
         ...workspaceTargetConfig,
         identifier,
         dashboard,

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 import { ActionOptions, isInputValidationError } from "../_base/types";
-import { logError, logInfo, logWarn } from "../_base/terminal/loggers";
+import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import fse from "fs-extra";
 import { getLinkCmdActionConfig, LinkCmdActionConfig } from "./actionConfig";
 import { isNotAuthenticated, IDashboardDefinition, IDashboard } from "@gooddata/sdk-backend-spi";
@@ -86,14 +86,20 @@ export async function linkPluginCmdAction(identifier: string, options: ActionOpt
         }
 
         const updateProgress = ora({
-            text: "Link dashboard with a plugin.",
+            text: "Linking dashboard with a plugin.",
         });
 
+        let success = false;
         try {
             updateProgress.start();
             await updateDashboardWithPluginLink(config);
+            success = true;
         } finally {
             updateProgress.stop();
+        }
+
+        if (success) {
+            logSuccess(`Linked dashboard ${config.dashboard} with plugin ${config.identifier}.`);
         }
     } catch (e) {
         if (isInputValidationError(e)) {

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -2,12 +2,12 @@
 import { ActionOptions, isInputValidationError } from "../_base/types";
 import { logError, logInfo, logWarn } from "../_base/terminal/loggers";
 import fse from "fs-extra";
-import { getUseCmdActionConfig, UseCmdActionConfig } from "./actionConfig";
+import { getLinkCmdActionConfig, LinkCmdActionConfig } from "./actionConfig";
 import { isNotAuthenticated, IDashboardDefinition, IDashboard } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
 import ora from "ora";
 
-function printUseConfigSummary(config: UseCmdActionConfig) {
+function printUseConfigSummary(config: LinkCmdActionConfig) {
     const {
         backend,
         hostname,
@@ -19,7 +19,7 @@ function printUseConfigSummary(config: UseCmdActionConfig) {
         credentials: { username },
     } = config;
 
-    logInfo("Everything looks valid. Going to use plugin object on the dashboard.");
+    logInfo("Everything looks valid. Going to link plugin on the dashboard.");
     logInfo(`  Hostname    : ${hostname}   (${backend === "bear" ? "GoodData platform" : "GoodData.CN"})`);
 
     if (backend === "bear") {
@@ -35,7 +35,7 @@ function printUseConfigSummary(config: UseCmdActionConfig) {
     }
 }
 
-async function updateDashboardWithPluginLink(config: UseCmdActionConfig) {
+async function updateDashboardWithPluginLink(config: LinkCmdActionConfig) {
     const { backendInstance, workspace, dashboard, identifier: validIdentifier, parameters } = config;
     const dashboardRef = idRef(dashboard);
 
@@ -61,7 +61,7 @@ async function updateDashboardWithPluginLink(config: UseCmdActionConfig) {
     await backendInstance.workspace(workspace).dashboards().updateDashboard(dashboardObj, updatedDashboard);
 }
 
-export async function usePluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {
+export async function linkPluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {
     if (!fse.existsSync("package.json")) {
         logError(
             "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
@@ -72,7 +72,7 @@ export async function usePluginCmdAction(identifier: string, options: ActionOpti
     }
 
     try {
-        const config: UseCmdActionConfig = await getUseCmdActionConfig(identifier, options);
+        const config: LinkCmdActionConfig = await getLinkCmdActionConfig(identifier, options);
 
         printUseConfigSummary(config);
 
@@ -86,7 +86,7 @@ export async function usePluginCmdAction(identifier: string, options: ActionOpti
         }
 
         const updateProgress = ora({
-            text: "Updating dashboard to use plugin.",
+            text: "Link dashboard with a plugin.",
         });
 
         try {
@@ -103,7 +103,7 @@ export async function usePluginCmdAction(identifier: string, options: ActionOpti
                 "Authentication to backend has failed. Please ensure your environment is setup with correct credentials.",
             );
         } else {
-            logError(`An error has occurred while adding plugin: ${e.message}`);
+            logError(`An error has occurred while linking plugin to a dashboard: ${e.message}`);
         }
 
         process.exit(1);

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/actionConfig.ts
@@ -1,0 +1,123 @@
+// (C) 2021 GoodData Corporation
+import {
+    createWorkspaceTargetConfig,
+    validateWorkspaceTargetConfig,
+    WorkspaceTargetConfig,
+} from "../_base/workspaceTargetConfig";
+import { IAnalyticalBackend, IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
+import { ActionOptions } from "../_base/types";
+import { createBackend } from "../_base/backend";
+import { getDashboardFromOptions } from "../_base/inputHandling/extractors";
+import ora from "ora";
+import {
+    asyncValidOrDie,
+    createDashboardValidator,
+    createWorkspaceValidator,
+    InputValidator,
+} from "../_base/inputHandling/validators";
+import isEmpty from "lodash/isEmpty";
+import { convertToPluginEntrypoint, convertToPluginIdentifier } from "../_base/utils";
+
+export type UnlinkCmdActionConfig = WorkspaceTargetConfig & {
+    /**
+     * Plugin _metadata object_ identifier.
+     */
+    identifier: string;
+
+    /**
+     * Plugin identifier (as used in module naming, entry point naming etc)
+     */
+    pluginIdentifier: string;
+
+    dashboard: string;
+    dryRun: boolean;
+    backendInstance: IAnalyticalBackend;
+};
+
+function createLinkedPluginValidator(
+    identifier: string,
+    pluginIdentifier: string,
+): InputValidator<IDashboardWithReferences> {
+    const entryPoint = convertToPluginEntrypoint(pluginIdentifier);
+
+    return (dashboardWithReferences) => {
+        const {
+            dashboard,
+            references: { plugins },
+        } = dashboardWithReferences;
+
+        if (isEmpty(plugins)) {
+            return `Dashboard ${dashboard.identifier} does not use any plugins.`;
+        }
+
+        const linkedPlugin = plugins.find((plugin) => plugin.identifier === identifier);
+
+        if (!linkedPlugin) {
+            return `Dashboard ${dashboard.identifier} is not linked with plugin ${identifier}.`;
+        }
+
+        if (!linkedPlugin.url.endsWith(entryPoint)) {
+            return (
+                `You are trying to unlink a plugin (${linkedPlugin.name}) whose entry point differs from the ` +
+                "entry point of the plugin in your current directory."
+            );
+        }
+
+        return true;
+    };
+}
+
+async function doAsyncValidations(config: UnlinkCmdActionConfig) {
+    const { backendInstance, workspace, dashboard, identifier, pluginIdentifier } = config;
+
+    const asyncValidationProgress = ora({
+        text: "Performing server-side validations.",
+    });
+    try {
+        asyncValidationProgress.start();
+
+        await backendInstance.authenticate(true);
+        await asyncValidOrDie("workspace", workspace, createWorkspaceValidator(backendInstance));
+        await asyncValidOrDie(
+            "dashboard",
+            dashboard,
+            createDashboardValidator(
+                backendInstance,
+                workspace,
+                createLinkedPluginValidator(identifier, pluginIdentifier),
+            ),
+        );
+    } finally {
+        asyncValidationProgress.stop();
+    }
+}
+
+export async function getUnlinkCmdActionConfig(
+    identifier: string,
+    options: ActionOptions,
+): Promise<UnlinkCmdActionConfig> {
+    const workspaceTargetConfig = createWorkspaceTargetConfig(options);
+    const { hostname, backend, credentials, env, packageJson } = workspaceTargetConfig;
+    const dashboard = getDashboardFromOptions(options) ?? env.DASHBOARD;
+
+    validateWorkspaceTargetConfig(workspaceTargetConfig);
+
+    const backendInstance = createBackend({
+        hostname,
+        backend,
+        credentials,
+    });
+
+    const config: UnlinkCmdActionConfig = {
+        ...workspaceTargetConfig,
+        identifier,
+        pluginIdentifier: convertToPluginIdentifier(packageJson.name),
+        dashboard,
+        dryRun: options.commandOpts.dryRun ?? false,
+        backendInstance,
+    };
+
+    await doAsyncValidations(config);
+
+    return config;
+}

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
@@ -1,0 +1,130 @@
+// (C) 2021 GoodData Corporation
+import { ActionOptions, isInputValidationError } from "../_base/types";
+import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
+import fse from "fs-extra";
+import { getUnlinkCmdActionConfig, UnlinkCmdActionConfig } from "./actionConfig";
+import {
+    isNotAuthenticated,
+    IDashboardDefinition,
+    IDashboardWithReferences,
+} from "@gooddata/sdk-backend-spi";
+import { idRef } from "@gooddata/sdk-model";
+import ora from "ora";
+import { areObjRefsEqual } from "@gooddata/sdk-model";
+
+function printUnlinkConfigSummary(config: UnlinkCmdActionConfig) {
+    const {
+        backend,
+        hostname,
+        workspace,
+        dashboard,
+        identifier,
+        credentials: { username },
+    } = config;
+
+    logInfo("Everything looks valid. Going to unlink plugin from dashboard.");
+    logInfo(`  Hostname    : ${hostname}   (${backend === "bear" ? "GoodData platform" : "GoodData.CN"})`);
+
+    if (backend === "bear") {
+        logInfo(`  Username    : ${username}`);
+    }
+
+    logInfo(`  Workspace   : ${workspace}`);
+    logInfo(`  Dashboard   : ${dashboard}`);
+    logInfo(`  Plugin obj  : ${identifier}`);
+}
+
+async function removeDashboardPluginLink(config: UnlinkCmdActionConfig): Promise<boolean> {
+    const { backendInstance, workspace, dashboard, identifier: validIdentifier } = config;
+    const dashboardRef = idRef(dashboard);
+
+    const dashboardWithReferences: IDashboardWithReferences = await backendInstance
+        .workspace(workspace)
+        .dashboards()
+        .getDashboardWithReferences(dashboardRef, undefined, undefined, ["dashboardPlugin"]);
+    const {
+        dashboard: dashboardObj,
+        references: { plugins: pluginObjects },
+    } = dashboardWithReferences;
+    const pluginToRemove = pluginObjects.find((plugin) => plugin.identifier === validIdentifier);
+
+    if (!pluginToRemove) {
+        // the validation done before confirmed that the plugin is there. if the code cannot find the
+        // plugin now then there must be a race as the plugin disappeared between validation and actual
+        // removal
+        logWarn(`Plugin with identifier ${validIdentifier} was not linked with the dashboard ${dashboard}.`);
+
+        return false;
+    }
+
+    const plugins = dashboardObj.plugins ? [...dashboardObj.plugins] : [];
+    const retainPlugins = plugins.filter((link) => {
+        return !areObjRefsEqual(link.plugin, pluginToRemove.ref);
+    });
+
+    // note: need the cast here as IDashboard filterContext may contain ITempFilter context in some cases...
+    // but that's not going to happen here (because code never asked for export-specific temp filters)
+    const updatedDashboard: IDashboardDefinition = {
+        ...(dashboardObj as IDashboardDefinition),
+        plugins: retainPlugins,
+    };
+
+    await backendInstance.workspace(workspace).dashboards().updateDashboard(dashboardObj, updatedDashboard);
+
+    return true;
+}
+
+export async function unlinkPluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {
+    if (!fse.existsSync("package.json")) {
+        logError(
+            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
+        );
+
+        process.exit(1);
+        return;
+    }
+
+    try {
+        const config: UnlinkCmdActionConfig = await getUnlinkCmdActionConfig(identifier, options);
+
+        printUnlinkConfigSummary(config);
+
+        if (config.dryRun) {
+            logWarn(
+                "Dry run has finished. Dashboard was not updated. Remove '--dry-run' to perform the actual update.",
+            );
+
+            process.exit(0);
+            return;
+        }
+
+        const updateProgress = ora({
+            text: "Removing link between dashboard and plugin.",
+        });
+
+        let result = false;
+        try {
+            updateProgress.start();
+
+            result = await removeDashboardPluginLink(config);
+        } finally {
+            updateProgress.stop();
+        }
+
+        if (result) {
+            logSuccess(`Plugin ${config.identifier} was unlinked from dashboard ${config.dashboard}.`);
+        }
+    } catch (e) {
+        if (isInputValidationError(e)) {
+            logError(e.message);
+        } else if (isNotAuthenticated(e)) {
+            logError(
+                "Authentication to backend has failed. Please ensure your environment is setup with correct credentials.",
+            );
+        } else {
+            logError(`An error has occurred while linking plugin to a dashboard: ${e.message}`);
+        }
+
+        process.exit(1);
+    }
+}

--- a/tools/plugin-toolkit/src/usePluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/usePluginCmd/index.ts
@@ -12,10 +12,12 @@ function printUseConfigSummary(config: UseCmdActionConfig) {
         workspace,
         dashboard,
         identifier,
+        parameters,
+        withParameters,
         credentials: { username },
     } = config;
 
-    logInfo("Everything looks valid. Going to use plugin object to dashboard metadata.");
+    logInfo("Everything looks valid. Going to use plugin object on the dashboard.");
     logInfo(`  Hostname    : ${hostname}   (${backend === "bear" ? "GoodData platform" : "GoodData.CN"})`);
 
     if (backend === "bear") {
@@ -25,6 +27,10 @@ function printUseConfigSummary(config: UseCmdActionConfig) {
     logInfo(`  Workspace   : ${workspace}`);
     logInfo(`  Dashboard   : ${dashboard}`);
     logInfo(`  Plugin obj  : ${identifier}`);
+
+    if (withParameters) {
+        logInfo(`  Parameters  : ${parameters}`);
+    }
 }
 
 export async function usePluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {


### PR DESCRIPTION
- The 'use' command renamed to 'link'. 
- Added 'unlink' command to reverse the operation.
- Expanded the validations done on the dashboard and dashboard plugin during link

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
