### PR TITLE
Fix propagation of data-attributes in Bubble components

### DIFF
--- a/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import cx from "classnames";
 import uniqueId from "lodash/uniqueId";
+import pickBy from "lodash/pickBy";
 
 /**
  * @internal
@@ -44,14 +45,6 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
         this.changeBubbleVisibility(false);
     };
 
-    private getClassnames(): string {
-        return cx({
-            "gd-bubble-trigger": true,
-            [this.state.bubbleId]: true,
-            [this.props.className]: !!this.props.className,
-        });
-    }
-
     protected eventListeners(): any {
         return {};
     }
@@ -61,11 +54,18 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
     }
 
     public render(): React.ReactNode {
-        const TagName = this.props.tagName;
+        const { children, eventsOnBubble, className, tagName, ...others } = this.props;
+        const dataAttributes = pickBy(others, (_, key) => key.startsWith("data-"));
+
+        const classNames = cx("gd-bubble-trigger", className, {
+            [this.state.bubbleId]: true,
+        });
+
+        const TagName = tagName;
         let BubbleElement;
         let WrappedTrigger;
 
-        React.Children.map(this.props.children, (child: any) => {
+        React.Children.map(children, (child: any) => {
             if (child) {
                 if (child.type && child.type.identifier === "Bubble") {
                     BubbleElement = child;
@@ -76,7 +76,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
         });
 
         const bubbleProps = {
-            ...(this.props.eventsOnBubble ? this.eventListeners() : {}),
+            ...(eventsOnBubble ? this.eventListeners() : {}),
             alignTo: `.${this.state.bubbleId}`,
             onClose: this.onClose,
         };
@@ -86,7 +86,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
 
         return (
             <React.Fragment>
-                <TagName {...this.eventListeners()} className={this.getClassnames()}>
+                <TagName {...dataAttributes} {...this.eventListeners()} className={classNames}>
                     {WrappedTrigger}
                 </TagName>
                 {BubbleOverlay}

--- a/libs/sdk-ui-kit/src/Bubble/tests/BubbleTrigger.test.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/tests/BubbleTrigger.test.tsx
@@ -153,4 +153,14 @@ describe("BubbleTrigger", () => {
             expect(instance.changeBubbleVisibility).toHaveBeenCalledWith(false);
         });
     });
+
+    it("should propagate data attributes", () => {
+        const wrapper = renderBubbleHoverTrigger({
+            // @ts-expect-error data attributes are allowed in JSX but not directly in props type
+            "data-attribute": "test",
+        });
+
+        const props = wrapper.props();
+        expect(props["data-attribute"]).toBe("test");
+    });
 });


### PR DESCRIPTION
propagate others props to main html element

JIRA: NAS-469

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
