### PR TITLE
RELATED: RAIL-3428 - Unify error reporting for commands

### DIFF
--- a/tools/plugin-toolkit/package.json
+++ b/tools/plugin-toolkit/package.json
@@ -30,6 +30,7 @@
     "scripts": {
         "clean": "rm -rf ci dist esm coverage *.log && jest --clearCache",
         "dev": "tsc -p tsconfig.dev.json --watch",
+        "prepublishOnly": "npm run build",
         "build": "bash scripts/build.sh",
         "build-cjs": "tsc -p tsconfig.build.json",
         "test": "jest --watch --passWithNoTests",

--- a/tools/plugin-toolkit/src/addPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/index.ts
@@ -1,9 +1,10 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, isInputValidationError } from "../_base/types";
+import { ActionOptions } from "../_base/types";
 import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import { AddCmdActionConfig, getAddCmdActionConfig } from "./actionConfig";
 import fse from "fs-extra";
-import { IDashboardPlugin, isNotAuthenticated } from "@gooddata/sdk-backend-spi";
+import { IDashboardPlugin } from "@gooddata/sdk-backend-spi";
+import { genericErrorReporter } from "../_base/utils";
 
 function printAddConfigSummary(config: AddCmdActionConfig) {
     const {
@@ -66,16 +67,8 @@ export async function addPluginCmdAction(pluginUrl: string, options: ActionOptio
         const newPluginObject = await createPluginObject(config);
 
         logSuccess(`Created new plugin object with ID: ${newPluginObject.identifier}`);
-    } catch (e) {
-        if (isInputValidationError(e)) {
-            logError(e.message);
-        } else if (isNotAuthenticated(e)) {
-            logError(
-                "Authentication to backend has failed. Please ensure your environment is setup with correct credentials.",
-            );
-        } else {
-            logError(`An error has occurred while adding plugin: ${e.message}`);
-        }
+    } catch (e: any) {
+        genericErrorReporter(e);
 
         process.exit(1);
     }

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,12 +1,12 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, isInputValidationError, TargetAppLanguage } from "../_base/types";
+import { ActionOptions, TargetAppLanguage } from "../_base/types";
 import { logError, logInfo, logWarn } from "../_base/terminal/loggers";
 import kebabCase from "lodash/kebabCase";
 import * as path from "path";
 import fse from "fs-extra";
 import tar from "tar";
 import { getDashboardPluginTemplateArchive } from "../dashboard-plugin-template";
-import { readJsonSync, writeAsJsonSync } from "../_base/utils";
+import { genericErrorReporter, readJsonSync, writeAsJsonSync } from "../_base/utils";
 import { processTigerFiles } from "./processTigerFiles";
 import { getInitCmdActionConfig, InitCmdActionConfig } from "./actionConfig";
 import { FileReplacementSpec, replaceInFiles } from "./replaceInFiles";
@@ -212,12 +212,8 @@ export async function initCmdAction(pluginName: string | undefined, options: Act
 
         logInfo(`A new project for your dashboard plugin is ready in: ${directory}`);
     } catch (e) {
-        if (isInputValidationError(e)) {
-            logError(e.message);
+        genericErrorReporter(e);
 
-            process.exit(1);
-        } else {
-            logError(`An error has occurred during initialization of new project: ${e.message}`);
-        }
+        process.exit(1);
     }
 }

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -1,11 +1,12 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, isInputValidationError } from "../_base/types";
+import { ActionOptions } from "../_base/types";
 import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import fse from "fs-extra";
 import { getLinkCmdActionConfig, LinkCmdActionConfig } from "./actionConfig";
-import { isNotAuthenticated, IDashboardDefinition, IDashboard } from "@gooddata/sdk-backend-spi";
+import { IDashboard, IDashboardDefinition } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
 import ora from "ora";
+import { genericErrorReporter } from "../_base/utils";
 
 function printUseConfigSummary(config: LinkCmdActionConfig) {
     const {
@@ -102,15 +103,7 @@ export async function linkPluginCmdAction(identifier: string, options: ActionOpt
             logSuccess(`Linked dashboard ${config.dashboard} with plugin ${config.identifier}.`);
         }
     } catch (e) {
-        if (isInputValidationError(e)) {
-            logError(e.message);
-        } else if (isNotAuthenticated(e)) {
-            logError(
-                "Authentication to backend has failed. Please ensure your environment is setup with correct credentials.",
-            );
-        } else {
-            logError(`An error has occurred while linking plugin to a dashboard: ${e.message}`);
-        }
+        genericErrorReporter(e);
 
         process.exit(1);
     }

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
@@ -1,16 +1,12 @@
 // (C) 2021 GoodData Corporation
-import { ActionOptions, isInputValidationError } from "../_base/types";
+import { ActionOptions } from "../_base/types";
 import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import fse from "fs-extra";
 import { getUnlinkCmdActionConfig, UnlinkCmdActionConfig } from "./actionConfig";
-import {
-    isNotAuthenticated,
-    IDashboardDefinition,
-    IDashboardWithReferences,
-} from "@gooddata/sdk-backend-spi";
-import { idRef } from "@gooddata/sdk-model";
+import { IDashboardDefinition, IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
+import { areObjRefsEqual, idRef } from "@gooddata/sdk-model";
 import ora from "ora";
-import { areObjRefsEqual } from "@gooddata/sdk-model";
+import { genericErrorReporter } from "../_base/utils";
 
 function printUnlinkConfigSummary(config: UnlinkCmdActionConfig) {
     const {
@@ -115,15 +111,7 @@ export async function unlinkPluginCmdAction(identifier: string, options: ActionO
             logSuccess(`Plugin ${config.identifier} was unlinked from dashboard ${config.dashboard}.`);
         }
     } catch (e) {
-        if (isInputValidationError(e)) {
-            logError(e.message);
-        } else if (isNotAuthenticated(e)) {
-            logError(
-                "Authentication to backend has failed. Please ensure your environment is setup with correct credentials.",
-            );
-        } else {
-            logError(`An error has occurred while linking plugin to a dashboard: ${e.message}`);
-        }
+        genericErrorReporter(e);
 
         process.exit(1);
     }


### PR DESCRIPTION
-  created genericErrorReporter
-  improved the categorization
-  ported code from catalog-export that identifies that host uses self-signed certs; getting nicer error message now

RELATED: RAIL-3428

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
