### PR TITLE
RELATED: RAIL-3428 - Add config for mapbox token to use during plugin development

### DIFF
--- a/tools/dashboard-plugin-template/.env.secrets.template
+++ b/tools/dashboard-plugin-template/.env.secrets.template
@@ -26,3 +26,10 @@
 #
 # Note: you can also set the value of TIGER_API_TOKEN env variable outside of this file.
 #TIGER_API_TOKEN=
+
+# Specify Mapbox token to use when rendering geo-charts during plugin development and testing in the harness.
+#
+# If you do not specify the token, the geo charts will only render as a placeholder. Note that when plugin
+# runs in the context of GoodData KPI Dashboards, the mapbox token will be available in the execution context. This
+# setting is purely for development.
+#MAPBOX_TOKEN=

--- a/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
+++ b/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
@@ -4,15 +4,20 @@ import { idRef } from "@gooddata/sdk-model";
 import { DashboardStub, IEmbeddedPlugin } from "@gooddata/sdk-ui-loaders";
 import PluginFactory from "../plugin";
 import { DEFAULT_DASHBOARD_ID } from "./constants";
+import { DashboardConfig } from "@gooddata/sdk-ui-dashboard";
 
-const ExtraPlugins: IEmbeddedPlugin[] = [{ factory: PluginFactory }];
+const Plugins: IEmbeddedPlugin[] = [{ factory: PluginFactory }];
+const Config: DashboardConfig = {
+    mapboxToken: process.env.MAPBOX_TOKEN,
+};
 
 export const PluginLoader = (): JSX.Element => {
     return (
         <DashboardStub
             dashboard={idRef(process.env.DASHBOARD_ID ?? DEFAULT_DASHBOARD_ID)}
             loadingMode="staticOnly"
-            extraPlugins={ExtraPlugins}
+            config={Config}
+            extraPlugins={Plugins}
         />
     );
 };


### PR DESCRIPTION
-  MAPBOX_TOKEN is a new env variable that can be specified in .env.secrets or as session env variable
-  it will be propagated over to dashboard component with config

RELATED: RAIL-3428

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
