### PR TITLE
RELATED: RAIL-3828, RAIL-3830 dashboard fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/saveAsDashboardHandler.ts
@@ -19,7 +19,7 @@ import { metaActions } from "../../store/meta";
 import {
     selectDashboardDescriptor,
     selectPersistedDashboard,
-    selectPersistedDashboardFilterContext,
+    selectPersistedDashboardFilterContextAsFilterContextDefinition,
 } from "../../store/meta/metaSelectors";
 import { DashboardContext } from "../../types/commonTypes";
 import { PromiseFnReturnType } from "../../types/sagas";
@@ -78,7 +78,7 @@ function* createDashboardSaveAsContext(cmd: SaveDashboardAs): SagaIterator<Dashb
     const filterContextDefinition: ReturnType<typeof selectFilterContextDefinition> = yield select(
         !useOriginalFilterContext || !originalDashboardDescription
             ? selectFilterContextDefinition
-            : selectPersistedDashboardFilterContext,
+            : selectPersistedDashboardFilterContextAsFilterContextDefinition,
     );
 
     const layout: ReturnType<typeof selectBasicLayout> = yield select(selectBasicLayout);

--- a/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
@@ -1,6 +1,7 @@
 // (C) 2021 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { idRef, uriRef } from "@gooddata/sdk-model";
+import { IFilterContextDefinition, isTempFilterContext } from "@gooddata/sdk-backend-spi";
 import invariant from "ts-invariant";
 import { DashboardState } from "../types";
 
@@ -44,6 +45,36 @@ export const selectPersistedDashboard = createSelector(selectSelf, (state) => {
 export const selectPersistedDashboardFilterContext = createSelector(selectSelf, (state) => {
     return state.persistedDashboard?.filterContext;
 });
+
+/**
+ * Selects persisted IFilterContextDefinition - that is the IFilterContext or ITempFilterContext that
+ * was used to initialize the original filters of the dashboard component during the initial load of the
+ * dashboard but removes ref, uri and identifier, effectively creating a clone of the stored value
+ * that can be used independently.
+ *
+ * Note that this may be undefined when the dashboard component works with a dashboard that has not yet
+ * been persisted (typically newly created dashboard being edited).
+ */
+export const selectPersistedDashboardFilterContextAsFilterContextDefinition = createSelector(
+    selectPersistedDashboardFilterContext,
+    (filterContext): IFilterContextDefinition | undefined => {
+        if (!filterContext) {
+            return undefined;
+        }
+
+        if (isTempFilterContext(filterContext)) {
+            const { ref: _, uri: __, ...definition } = filterContext;
+            return {
+                ...definition,
+                title: "filterContext",
+                description: "",
+            };
+        } else {
+            const { identifier: _, ref: __, uri: ___, ...definition } = filterContext;
+            return definition;
+        }
+    },
+);
 
 /**
  * Selects ref of the persisted dashboard object that backs and is rendered-by the dashboard component.


### PR DESCRIPTION
* RAIL-3828 - Fix export to PDF: Properly override saved filter for the export if currently using All time filter. This is what gdc-dashboards do.
* RAIL-3830 - Properly clone filter contexts in saveAsCopy. Previously, when useOriginalFilterContext was set, the copied dashboard would use the same filterContext object. That is incorrect, we want to create a new object, just with the same filters as the persisted one.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
