### PR TITLE
RELATED: RAIL-3824 - Fixes for plugin naming & validation

### DIFF
--- a/tools/plugin-toolkit/scripts/preparePackageJson.ts
+++ b/tools/plugin-toolkit/scripts/preparePackageJson.ts
@@ -47,8 +47,8 @@ const ExplicitTypeScriptDependencies = [
 
 function removeGdStuff(packageJson: Record<string, any>) {
     packageJson.name = "<plugin-name>";
-    packageJson.author = "<plugin-author>";
-    packageJson.description = "<plugin-description>";
+    packageJson.author = "";
+    packageJson.description = "";
 
     delete packageJson.repository;
     delete packageJson.config;

--- a/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
+++ b/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
@@ -25,8 +25,17 @@ export type AsyncInputValidator = (value: string) => Promise<boolean | string>;
  * Validates that plugin name matches required regex.
  */
 export function pluginNameValidator(value: string): boolean | string {
-    if (!value.match(/^[a-zA-Z0-9_\-@/]*$/)) {
-        return "Invalid plugin name. Use only alphanumerical characters, underscores and dashes.";
+    if (isEmpty(value) || (value && isEmpty(value.trim()))) {
+        return "Please enter non-empty plugin name.";
+    }
+
+    // pattern used by VS code:
+    if (!value.match(/^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/)) {
+        return "Invalid plugin name. Plugin name must be a valid package name.";
+    }
+
+    if (value.length > 214) {
+        return "Invalid plugin name. Plugin too long.";
     }
 
     return true;

--- a/tools/plugin-toolkit/src/_base/utils.ts
+++ b/tools/plugin-toolkit/src/_base/utils.ts
@@ -56,6 +56,18 @@ export function convertToPluginIdentifier(name: string): string {
 }
 
 /**
+ * Converts plugin name to directory name for the plugin. This will ensure that if the plugin name
+ * contains organization (@something/plugin) then only the `plugin` will be used.
+ *
+ * @param name
+ */
+export function convertToPluginDirectory(name: string): string {
+    const split = name.split("/");
+
+    return split.length > 1 ? split[1] : name;
+}
+
+/**
  * Converts plugin identifier to entry point file name
  */
 export function convertToPluginEntrypoint(pluginIdentifier: string): string {

--- a/tools/plugin-toolkit/src/addPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/index.ts
@@ -5,6 +5,7 @@ import { AddCmdActionConfig, getAddCmdActionConfig } from "./actionConfig";
 import fse from "fs-extra";
 import { IDashboardPlugin } from "@gooddata/sdk-backend-spi";
 import { genericErrorReporter } from "../_base/utils";
+import isEmpty from "lodash/isEmpty";
 
 function printAddConfigSummary(config: AddCmdActionConfig) {
     const {
@@ -14,6 +15,7 @@ function printAddConfigSummary(config: AddCmdActionConfig) {
         pluginUrl,
         credentials: { username },
         pluginName,
+        pluginDescription,
     } = config;
 
     logInfo("Everything looks valid. Going to add new plugin object to workspace metadata.");
@@ -26,6 +28,9 @@ function printAddConfigSummary(config: AddCmdActionConfig) {
     logInfo(`  Workspace   : ${workspace}`);
     logInfo(`  Plugin URL  : ${pluginUrl}`);
     logInfo(`  Plugin name : ${pluginName}`);
+
+    const description = isEmpty(pluginDescription) ? "(empty)" : pluginDescription;
+    logInfo(`  Plugin desc : ${description}   (see package.json)`);
 }
 
 function createPluginObject(config: AddCmdActionConfig): Promise<IDashboardPlugin> {

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,12 +1,16 @@
 // (C) 2021 GoodData Corporation
 import { ActionOptions, TargetAppLanguage } from "../_base/types";
 import { logError, logInfo, logWarn } from "../_base/terminal/loggers";
-import kebabCase from "lodash/kebabCase";
 import * as path from "path";
 import fse from "fs-extra";
 import tar from "tar";
 import { getDashboardPluginTemplateArchive } from "../dashboard-plugin-template";
-import { genericErrorReporter, readJsonSync, writeAsJsonSync } from "../_base/utils";
+import {
+    convertToPluginDirectory,
+    genericErrorReporter,
+    readJsonSync,
+    writeAsJsonSync,
+} from "../_base/utils";
 import { processTigerFiles } from "./processTigerFiles";
 import { getInitCmdActionConfig, InitCmdActionConfig } from "./actionConfig";
 import { FileReplacementSpec, replaceInFiles } from "./replaceInFiles";
@@ -148,7 +152,7 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
  */
 async function prepareProject(config: InitCmdActionConfig): Promise<string> {
     const { name, targetDir, language, backend } = config;
-    const target = targetDir ? targetDir : path.resolve(process.cwd(), kebabCase(name));
+    const target = targetDir ? targetDir : path.resolve(process.cwd(), convertToPluginDirectory(name));
 
     await unpackProject(target, language);
     modifyPackageJson(target, config);

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -214,7 +214,9 @@ export async function initCmdAction(pluginName: string | undefined, options: Act
 
         runInstall(directory, config);
 
-        logInfo(`A new project for your dashboard plugin is ready in: ${directory}`);
+        logInfo(
+            `A new project for your dashboard plugin is ready in: ${directory}. Check out the package.json and fill in author and description if possible.`,
+        );
     } catch (e) {
         genericErrorReporter(e);
 


### PR DESCRIPTION
Proper plugin name validation; plugin name == package.json name
Ensure prompting does not accept empty plugin name
Improve naming of plugin directory (use name as is, strip org if needed)
Remove <plugin-description> and <plugin-author> from package.json; keep empty instead; encourage plugin creator to add author and description
Show plugin description before adding.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
