### PR TITLE
RELATED: NAS-2452 Propose new queryTotalCount method

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
@@ -113,6 +113,13 @@ class BearWorkspaceElementsQuery implements IElementsQuery {
         return this.queryWorker(this.offset, this.limit, this.options);
     }
 
+    public async queryTotalCount(): Promise<number> {
+        // on bear, there is currently no special API for this
+        // so just use the "full-blown" API and unwrap the totalCount value
+        const queryResult = await this.query();
+        return queryResult.totalCount;
+    }
+
     private async getObjectId(): Promise<string> {
         if (!this.objectId) {
             const uri = await objRefToUri(this.displayFormRef, this.workspace, this.authCall);

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/elements.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/elements.ts
@@ -73,6 +73,11 @@ class RecordedElements implements IElementsQuery {
         return Promise.resolve(new InMemoryPaging<IAttributeElement>(elements, this.limit, this.offset));
     }
 
+    public async queryTotalCount(): Promise<number> {
+        const result = await this.query();
+        return result.totalCount;
+    }
+
     public withLimit(limit: number): IElementsQuery {
         if (limit <= 0) {
             throw new Error("Limit must be positive number");

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -771,6 +771,7 @@ export interface IDrillToLegacyDashboard extends IDrill {
 // @public
 export interface IElementsQuery {
     query(): Promise<IElementsQueryResult>;
+    queryTotalCount(): Promise<number>;
     withAttributeFilters(filters: IElementsQueryAttributeFilter[]): IElementsQuery;
     withDateFilters(filters: IRelativeDateFilter[]): IElementsQuery;
     withLimit(limit: number): IElementsQuery;

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -148,6 +148,17 @@ export interface IElementsQuery {
     query(): Promise<IElementsQueryResult>;
 
     /**
+     * Starts the query that will return the total count of elements valid for the provided options.
+     *
+     * @remarks
+     * This can be useful when we are only interested in the number of elements, not the elements themselves.
+     * The backend implementation can also use more efficient logic for this, potentially improving performance.
+     *
+     * @returns promise of total count of elements valid for the provided options
+     */
+    queryTotalCount(): Promise<number>;
+
+    /**
      * Sets the date filters that will limit the available elements
      *
      * @param filters - date filters limiting the elements

--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
@@ -81,6 +81,12 @@ class TigerWorkspaceElementsQuery implements IElementsQuery {
         return this.queryWorker(this.offset, this.limit, this.options);
     }
 
+    public async queryTotalCount(): Promise<number> {
+        // TODO use special "count-only" API when that is ready
+        const result = await this.queryWorker(this.offset, this.limit, this.options);
+        return result.totalCount;
+    }
+
     private async queryWorker(
         offset: number,
         limit: number,

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -107,9 +107,7 @@ export const getElementTotalCount = async (
         elementsLoader = elementsLoader.withAttributeFilters(parentFilters);
     }
 
-    const elements = await elementsLoader.query();
-
-    return elements.totalCount;
+    return elementsLoader.queryTotalCount();
 };
 
 /**


### PR DESCRIPTION
This can help certain backends get the element counts more
efficiently (avoiding sorting of the results for example).

JIRA: NAS-2452

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
