### PR TITLE
RELATED: RAIL-3428 - Fix link command when backend is tiger

### DIFF
--- a/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
@@ -62,7 +62,7 @@ function createDuplicatePluginLinkValidator(
             const { identifier: otherIdentifier, name } = otherPluginWithSameEp;
 
             return (
-                `Dashboard ${dashboard.identifier} is already linked with another plugin (${otherIdentifier} - ${name})` +
+                `Dashboard ${dashboard.identifier} is already linked with another plugin (${otherIdentifier} - ${name}) ` +
                 "that has same entry point as the plugin that you want to link now. This is likely another version of " +
                 "the same plugin. Adding two versions of the same plugin is not supported. Note: " +
                 "renaming the entry point files will not help as you will then encounter load-time errors."

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -48,7 +48,7 @@ async function updateDashboardWithPluginLink(config: LinkCmdActionConfig) {
 
     plugins.push({
         type: "IDashboardPluginLink",
-        plugin: idRef(validIdentifier),
+        plugin: idRef(validIdentifier, "dashboardPlugin"),
         parameters,
     });
 


### PR DESCRIPTION
-  the idRef for link did not include 'dashboardPlugin'
-  conversion before sending data to backend failed

RELATED: RAIL-3428

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
