### PR TITLE
BUGFIX: TNT-325 Combo chart display proper label properties in configuration

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/lineChart/lineConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/lineChart/lineConfiguration.ts
@@ -40,7 +40,9 @@ export function getLineConfiguration(
                 },
             },
             column: {
-                dataLabels: {},
+                dataLabels: {
+                    enabled: true,
+                },
             },
         },
         xAxis: [

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -7,7 +7,7 @@ import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
 
 import MinMaxControl from "../configurationControls//MinMaxControl";
-import ConfigurationPanelContent from "./ConfigurationPanelContent";
+import ConfigurationPanelContent, { IConfigurationPanelContentProps } from "./ConfigurationPanelContent";
 import ConfigSection from "../configurationControls/ConfigSection";
 import CheckboxControl from "../configurationControls/CheckboxControl";
 import DataLabelsControl from "../configurationControls/DataLabelsControl";
@@ -24,7 +24,9 @@ import { bucketsIsEmpty, insightBuckets } from "@gooddata/sdk-model";
 import { countItemsOnAxes } from "../pluggableVisualizations/baseChart/insightIntrospection";
 import NameSubsection from "../configurationControls/axis/NameSubsection";
 
-export default class BaseChartConfigurationPanel extends ConfigurationPanelContent {
+export default class BaseChartConfigurationPanel<
+    T extends IConfigurationPanelContentProps = IConfigurationPanelContentProps,
+> extends ConfigurationPanelContent<T> {
     protected renderCanvasSection(): React.ReactNode {
         const { gridEnabled } = this.getControlProperties();
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
@@ -28,7 +28,9 @@ export interface IConfigurationPanelContentProps {
     panelConfig?: any;
 }
 
-export default abstract class ConfigurationPanelContent extends React.PureComponent<IConfigurationPanelContentProps> {
+export default abstract class ConfigurationPanelContent<
+    T extends IConfigurationPanelContentProps = IConfigurationPanelContentProps,
+> extends React.PureComponent<T> {
     public static defaultProps: IConfigurationPanelContentProps = {
         properties: null,
         references: null,

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/LineChartBasedConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/LineChartBasedConfigurationPanel.tsx
@@ -13,12 +13,24 @@ import {
     BUBBLE_ARROW_OFFSET_Y,
 } from "../../constants/bubble";
 import BaseChartConfigurationPanel from "./BaseChartConfigurationPanel";
+import { IConfigurationPanelContentProps } from "./ConfigurationPanelContent";
 
-export default class LineChartBasedConfigurationPanel extends BaseChartConfigurationPanel {
+export interface ILineChartBasedConfigurationPanel extends IConfigurationPanelContentProps {
+    dataLabelDefaultValue?: string | boolean;
+}
+
+export default class LineChartBasedConfigurationPanel extends BaseChartConfigurationPanel<ILineChartBasedConfigurationPanel> {
     protected renderConfigurationPanel(): React.ReactNode {
         const { gridEnabled, axes } = this.getControlProperties();
 
-        const { featureFlags, properties, propertiesMeta, pushData, panelConfig } = this.props;
+        const {
+            featureFlags,
+            properties,
+            propertiesMeta,
+            pushData,
+            panelConfig,
+            dataLabelDefaultValue = false,
+        } = this.props;
         const { isDataPointsControlDisabled } = panelConfig;
 
         const controlsDisabled = this.isControlDisabled();
@@ -41,7 +53,7 @@ export default class LineChartBasedConfigurationPanel extends BaseChartConfigura
                             pushData={pushData}
                             properties={properties}
                             isDisabled={controlsDisabled}
-                            defaultValue={false}
+                            defaultValue={dataLabelDefaultValue}
                         />
 
                         {featureFlags["enableHidingOfDataPoints"] && (

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -254,6 +254,7 @@ export class PluggableComboChart extends PluggableBaseChart {
                     panelConfig={{
                         isDataPointsControlDisabled: this.isDataPointsControlDisabled(insight),
                     }}
+                    dataLabelDefaultValue="auto"
                 />,
                 document.querySelector(this.configPanelElement),
             );

--- a/libs/sdk-ui-ext/src/internal/constants/axis.ts
+++ b/libs/sdk-ui-ext/src/internal/constants/axis.ts
@@ -1,5 +1,5 @@
 // (C) 2019-2020 GoodData Corporation
-import { VisualizationTypes } from "@gooddata/sdk-ui";
+import { VisualizationTypes, ChartType } from "@gooddata/sdk-ui";
 
 export const AXIS = {
     PRIMARY: "primary",
@@ -14,7 +14,7 @@ export enum AXIS_NAME {
     SECONDARY_Y = "secondary_yaxis",
 }
 
-export const DUAL_AXES_SUPPORTED_CHARTS = [
+export const DUAL_AXES_SUPPORTED_CHARTS: ChartType[] = [
     VisualizationTypes.COLUMN,
     VisualizationTypes.BAR,
     VisualizationTypes.LINE,


### PR DESCRIPTION
<!--

Description of changes.
-Changed initial configuration properties for all line-graph based graphs to "auto",
  thus configuration no longer states that labels are hidden on graph initialization 
  while they are shown.
-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
