### PR TITLE
RELATED: RAIL-3428 - Rename refactor in plugin SPI

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2150,10 +2150,10 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
 
 // @alpha (undocumented)
 export interface IDashboardCustomizer {
-    insightRendering(): IDashboardInsightCustomizer;
-    kpiRendering(): IDashboardKpiCustomizer;
+    customWidgets(): IDashboardWidgetCustomizer;
+    insightWidgets(): IDashboardInsightCustomizer;
+    kpiWidgets(): IDashboardKpiCustomizer;
     layout(): IDashboardLayoutCustomizer;
-    widgets(): IDashboardWidgetCustomizer;
 }
 
 // @alpha

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
@@ -32,15 +32,15 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
         this.layoutCustomizer.sealCustomizer();
     };
 
-    public insightRendering = (): IDashboardInsightCustomizer => {
+    public insightWidgets = (): IDashboardInsightCustomizer => {
         return this.insightCustomizer;
     };
 
-    public kpiRendering = (): IDashboardKpiCustomizer => {
+    public kpiWidgets = (): IDashboardKpiCustomizer => {
         return this.kpiCustomizer;
     };
 
-    public widgets = (): IDashboardWidgetCustomizer => {
+    public customWidgets = (): IDashboardWidgetCustomizer => {
         return this.widgetCustomizer;
     };
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -246,19 +246,19 @@ export interface IDashboardLayoutCustomizer {
  */
 export interface IDashboardCustomizer {
     /**
-     * Customize how rendering of insights is done.
+     * Customize how rendering of insight widgets is done.
      */
-    insightRendering(): IDashboardInsightCustomizer;
+    insightWidgets(): IDashboardInsightCustomizer;
 
     /**
-     * Customize how rendering of KPIs is done.
+     * Customize how rendering of KPI widgets is done.
      */
-    kpiRendering(): IDashboardKpiCustomizer;
+    kpiWidgets(): IDashboardKpiCustomizer;
 
     /**
      * Register custom widget types.
      */
-    widgets(): IDashboardWidgetCustomizer;
+    customWidgets(): IDashboardWidgetCustomizer;
 
     /**
      * Customize dashboard layout - this allows the plugin step in during initialization and modify

--- a/libs/sdk-ui-dashboard/src/plugins/exampleDashboardPlugin.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/exampleDashboardPlugin.tsx
@@ -133,7 +133,7 @@ export class PluginAddsCustomInsightRendering extends DashboardPluginV1 {
         customize: IDashboardCustomizer,
         _handlers: IDashboardEventHandling,
     ): void {
-        customize.insightRendering().withTag("some-tag", CustomInsightRenderer);
+        customize.insightWidgets().withTag("some-tag", CustomInsightRenderer);
     }
 }
 
@@ -165,7 +165,7 @@ export class PluginAddsParameterizedInsightRendering extends DashboardPluginV1 {
         _handlers: IDashboardEventHandling,
     ): void {
         this.customizeByTag.forEach((tag) => {
-            customize.insightRendering().withTag(tag, CustomInsightRenderer);
+            customize.insightWidgets().withTag(tag, CustomInsightRenderer);
         });
     }
 }
@@ -218,10 +218,10 @@ export class PluginAddsCustomInsightDecorator extends DashboardPluginV1 {
         _handlers: IDashboardEventHandling,
     ): void {
         // register custom renderer for insights with some tags
-        customize.insightRendering().withTag("some-tag", CustomInsightRenderer);
+        customize.insightWidgets().withTag("some-tag", CustomInsightRenderer);
         // register decorator that will be used during any insight rendering - regardless if using custom renderer or
         // the default renderer
-        customize.insightRendering().withCustomDecorator(customDecoratorFactory);
+        customize.insightWidgets().withCustomDecorator(customDecoratorFactory);
     }
 }
 
@@ -269,7 +269,7 @@ export class PluginAddsCustomWidget extends DashboardPluginV1 {
         handlers: IDashboardEventHandling,
     ): void {
         // register custom widget type to use the TestWidgetComponent
-        customize.widgets().addCustomWidget("test", TestWidget);
+        customize.customWidgets().addCustomWidget("test", TestWidget);
 
         // add a new section at the end of the layout
         customize.layout().customizeFluidLayout((_layout, customizer) => {


### PR DESCRIPTION
-  insightRendering -> insightWidgets()
-  kpiRendering -> kpiWidgets()
-  widgets -> customWidgets()

This will grow better into the future where we may want to add additional customizations on how the insight or KPI widgets & their different sub-components get rendered (e.g. we may want to enhance insightWidgets() with funs to add custom content into button bar, customize how title is rendered. customize before/after/left/right components)

RELATED: RAIL-3428


---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
