### PR TITLE
RELATED: RAIL-3636, RAIL-3826, RAIL-3834 Fix drillToDashboardHandler

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -28,6 +28,7 @@ import { IAccessControlAware } from '@gooddata/sdk-backend-spi';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttributeDisplayFormMetadataObject } from '@gooddata/sdk-backend-spi';
 import { IAttributeElements } from '@gooddata/sdk-model';
+import { IAttributeFilter } from '@gooddata/sdk-model';
 import { IAttributeMetadataObject } from '@gooddata/sdk-backend-spi';
 import { IAuditableUsers } from '@gooddata/sdk-model';
 import { IAvailableDrillTargets } from '@gooddata/sdk-ui';
@@ -51,6 +52,7 @@ import { IDashboardLayoutSectionHeader } from '@gooddata/sdk-backend-spi';
 import { IDashboardObjectIdentity } from '@gooddata/sdk-backend-spi';
 import { IDashboardWidget } from '@gooddata/sdk-backend-spi';
 import { IDataView } from '@gooddata/sdk-backend-spi';
+import { IDateFilter } from '@gooddata/sdk-model';
 import { IDateFilterConfig } from '@gooddata/sdk-backend-spi';
 import { IDateFilterOptionsByType } from '@gooddata/sdk-ui-filters';
 import { Identifier } from '@gooddata/sdk-model';
@@ -1924,6 +1926,12 @@ export const FilterBar: () => JSX.Element;
 
 // @internal (undocumented)
 export const FilterBarPropsProvider: React_2.FC<IFilterBarProps>;
+
+// @internal
+export function filterContextAttributeFilterToAttributeFilter(filter: IDashboardAttributeFilter): IAttributeFilter;
+
+// @internal
+export function filterContextDateFilterToDateFilter(filter: IDashboardDateFilter, widget: IWidgetDefinition): IDateFilter;
 
 // @internal
 export function filterContextItemsToFiltersForWidget(filterContextItems: FilterContextItem[], widget: IWidgetDefinition): IDashboardFilter[];

--- a/libs/sdk-ui-dashboard/src/converters/filterConverters.ts
+++ b/libs/sdk-ui-dashboard/src/converters/filterConverters.ts
@@ -2,6 +2,7 @@
 import {
     FilterContextItem,
     IDashboardAttributeFilter,
+    IDashboardDateFilter,
     IFilterContext,
     IFilterContextDefinition,
     isDashboardAttributeFilter,
@@ -14,6 +15,7 @@ import {
     newRelativeDateFilter,
     newAbsoluteDateFilter,
     IAttributeFilter,
+    IDateFilter,
 } from "@gooddata/sdk-model";
 import isString from "lodash/isString";
 import { IDashboardFilter } from "../types";
@@ -37,7 +39,7 @@ export function filterContextToFiltersForWidget(
 }
 
 /**
- * Converts {@link IDashboardAttributeFilter} to {@link @gooddata/sdk-model#IAttributeFilter} instance.
+ * Converts {@link @gooddata/sdk-backend-spi#IDashboardAttributeFilter} to {@link @gooddata/sdk-model#IAttributeFilter} instance.
  *
  * @param filter - filter context attribute filter to convert
  * @internal
@@ -59,6 +61,33 @@ export function filterContextAttributeFilterToAttributeFilter(
 }
 
 /**
+ * Converts {@link @gooddata/sdk-backend-spi#IDashboardDateFilter} to {@link @gooddata/sdk-model#IAttributeFilter} instance.
+ *
+ * @param filter - filter context attribute filter to convert
+ * @param widget - widget to use to get dateDataSet for date filters
+ * @internal
+ */
+export function filterContextDateFilterToDateFilter(
+    filter: IDashboardDateFilter,
+    widget: IWidgetDefinition,
+): IDateFilter {
+    if (filter.dateFilter.type === "relative") {
+        return newRelativeDateFilter(
+            widget.dateDataSet!,
+            filter.dateFilter.granularity,
+            numberOrStringToNumber(filter.dateFilter.from!),
+            numberOrStringToNumber(filter.dateFilter.to!),
+        );
+    } else {
+        return newAbsoluteDateFilter(
+            widget.dateDataSet!,
+            filter.dateFilter.from!.toString(),
+            filter.dateFilter.to!.toString(),
+        );
+    }
+}
+
+/**
  * Gets {@link IDashboardFilter} items for filters specified as {@link @gooddata/sdk-backend-spi#FilterContextItem} instances.
  *
  * @param filterContextItems - filter context items to get filters for
@@ -73,20 +102,7 @@ export function filterContextItemsToFiltersForWidget(
         if (isDashboardAttributeFilter(filter)) {
             return filterContextAttributeFilterToAttributeFilter(filter);
         } else {
-            if (filter.dateFilter.type === "relative") {
-                return newRelativeDateFilter(
-                    widget.dateDataSet!,
-                    filter.dateFilter.granularity,
-                    numberOrStringToNumber(filter.dateFilter.from!),
-                    numberOrStringToNumber(filter.dateFilter.to!),
-                );
-            } else {
-                return newAbsoluteDateFilter(
-                    widget.dateDataSet!,
-                    filter.dateFilter.from!.toString(),
-                    filter.dateFilter.to!.toString(),
-                );
-            }
+            return filterContextDateFilterToDateFilter(filter, widget);
         }
     });
 }

--- a/libs/sdk-ui-dashboard/src/converters/index.ts
+++ b/libs/sdk-ui-dashboard/src/converters/index.ts
@@ -1,2 +1,7 @@
 // (C) 2021 GoodData Corporation
-export { filterContextItemsToFiltersForWidget, filterContextToFiltersForWidget } from "./filterConverters";
+export {
+    filterContextItemsToFiltersForWidget,
+    filterContextToFiltersForWidget,
+    filterContextDateFilterToDateFilter,
+    filterContextAttributeFilterToAttributeFilter,
+} from "./filterConverters";


### PR DESCRIPTION
Adapt the logic from gdc-dashboards, mainly the date filter disabled
logic that should prevent the date filter from being used in certain
cases. Also added some comments to clarify the code.

Partially reverts c8ee469db8b118e305b654a24e00f9346e5fdf23

JIRA: RAIL-3636, RAIL-3826, RAIL-3834

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
