### PR TITLE
RELATED: RAIL-3428, RAIL-3840 plugin-related improvements

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2126,10 +2126,10 @@ export interface IDashboardCustomComponentProps {
     DashboardDateFilterComponent?: CustomDashboardDateFilterComponent;
     ErrorComponent?: ComponentType<IErrorProps>;
     FilterBarComponent?: CustomFilterBarComponent;
-    InsightComponentProvider?: InsightComponentProvider;
+    InsightComponentProvider?: OptionalInsightComponentProvider;
     InsightMenuButtonComponentProvider?: InsightMenuButtonComponentProvider;
     InsightMenuComponentProvider?: InsightMenuComponentProvider;
-    KpiComponentProvider?: KpiComponentProvider;
+    KpiComponentProvider?: OptionalKpiComponentProvider;
     LayoutComponent?: CustomDashboardLayoutComponent;
     LoadingComponent?: ComponentType<ILoadingProps>;
     MenuButtonComponent?: CustomMenuButtonComponent;
@@ -2138,7 +2138,7 @@ export interface IDashboardCustomComponentProps {
     ShareDialogComponent?: CustomShareDialogComponent;
     TitleComponent?: CustomTitleComponent;
     TopBarComponent?: CustomTopBarComponent;
-    WidgetComponentProvider?: WidgetComponentProvider;
+    WidgetComponentProvider?: OptionalWidgetComponentProvider;
 }
 
 // @alpha (undocumented)
@@ -2228,7 +2228,7 @@ export type IDashboardFilter = IAbsoluteDateFilter | IRelativeDateFilter | IPosi
 
 // @alpha (undocumented)
 export interface IDashboardInsightCustomizer {
-    withCustomDecorator(providerFactory: (next: InsightComponentProvider) => InsightComponentProvider): IDashboardInsightCustomizer;
+    withCustomDecorator(providerFactory: (next: InsightComponentProvider) => OptionalInsightComponentProvider): IDashboardInsightCustomizer;
     withCustomProvider(provider: InsightComponentProvider): IDashboardInsightCustomizer;
     withTag(tag: string, component: React_2.ComponentType): IDashboardInsightCustomizer;
 }
@@ -2303,7 +2303,7 @@ export interface IDashboardInsightProps {
 
 // @alpha (undocumented)
 export interface IDashboardKpiCustomizer {
-    withCustomDecorator(providerFactory: (next: KpiComponentProvider) => KpiComponentProvider): IDashboardKpiCustomizer;
+    withCustomDecorator(providerFactory: (next: KpiComponentProvider) => OptionalKpiComponentProvider): IDashboardKpiCustomizer;
     withCustomProvider(provider: KpiComponentProvider): IDashboardKpiCustomizer;
 }
 
@@ -2547,7 +2547,7 @@ export type InsightAttributesMeta = {
 };
 
 // @alpha (undocumented)
-export type InsightComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightComponent | undefined;
+export type InsightComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightComponent;
 
 // @alpha
 export type InsightDateDatasets = {
@@ -2931,7 +2931,7 @@ export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kp
 }>;
 
 // @alpha (undocumented)
-export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent | undefined;
+export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
 
 // @alpha (undocumented)
 export type KpiPlaceholderWidget = ICustomWidgetBase & {
@@ -3150,6 +3150,18 @@ export type OnFiredDashboardViewDrillEvent = (event: IDashboardDrillEvent) => Re
 
 // @internal (undocumented)
 export type OnWidgetDrill = (drillEvent: IDashboardDrillEvent, drillContext: DashboardDrillContext) => void;
+
+// @alpha (undocumented)
+export type OptionalInsightComponentProvider = OptionalProvider<InsightComponentProvider>;
+
+// @alpha (undocumented)
+export type OptionalKpiComponentProvider = OptionalProvider<KpiComponentProvider>;
+
+// @alpha (undocumented)
+export type OptionalProvider<T> = T extends (...args: infer TArgs) => infer TRes ? (...args: TArgs) => TRes | undefined : never;
+
+// @alpha (undocumented)
+export type OptionalWidgetComponentProvider = OptionalProvider<WidgetComponentProvider>;
 
 // @alpha (undocumented)
 export interface PermissionsState {
@@ -4549,7 +4561,7 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
 };
 
 // @alpha (undocumented)
-export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent | undefined;
+export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
 
 // @alpha
 export type WidgetFilterOperation = FilterOpEnableDateFilter | FilterOpDisableDateFilter | FilterOpReplaceAttributeIgnores | FilterOpIgnoreAttributeFilter | FilterOpUnignoreAttributeFilter | FilterOpReplaceAll;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/insightCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/insightCustomizer.tsx
@@ -1,6 +1,10 @@
 // (C) 2021 GoodData Corporation
 import { IDashboardInsightCustomizer } from "../customizer";
-import { DefaultDashboardInsightInner, InsightComponentProvider } from "../../presentation";
+import {
+    DefaultDashboardInsightInner,
+    InsightComponentProvider,
+    OptionalInsightComponentProvider,
+} from "../../presentation";
 import React from "react";
 import { InvariantError } from "ts-invariant";
 import includes from "lodash/includes";
@@ -12,8 +16,8 @@ const DefaultInsightRendererProvider: InsightComponentProvider = () => {
 };
 
 interface IInsightCustomizerState {
-    addTagProvider(tag: string, provider: InsightComponentProvider): void;
-    addCustomProvider(provider: InsightComponentProvider): void;
+    addTagProvider(tag: string, provider: OptionalInsightComponentProvider): void;
+    addCustomProvider(provider: OptionalInsightComponentProvider): void;
     getRootProvider(): InsightComponentProvider;
     switchRootProvider(provider: InsightComponentProvider): void;
 }
@@ -177,7 +181,7 @@ export class DefaultInsightCustomizer implements IDashboardInsightCustomizer {
             return this;
         }
 
-        const newProvider: InsightComponentProvider = (insight) => {
+        const newProvider: OptionalInsightComponentProvider = (insight) => {
             if (includes(insightTags(insight), tag)) {
                 return component;
             }
@@ -188,14 +192,14 @@ export class DefaultInsightCustomizer implements IDashboardInsightCustomizer {
         return this;
     };
 
-    public withCustomProvider = (provider: InsightComponentProvider): this => {
+    public withCustomProvider = (provider: OptionalInsightComponentProvider): this => {
         this.state.addCustomProvider(provider);
 
         return this;
     };
 
     public withCustomDecorator = (
-        providerFactory: (next: InsightComponentProvider) => InsightComponentProvider,
+        providerFactory: (next: InsightComponentProvider) => OptionalInsightComponentProvider,
     ): this => {
         // snapshot current root provider
         const rootSnapshot = this.state.getRootProvider();

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/kpiCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/kpiCustomizer.tsx
@@ -1,6 +1,10 @@
 // (C) 2021 GoodData Corporation
 import { IDashboardKpiCustomizer } from "../customizer";
-import { DefaultDashboardKpiInner, KpiComponentProvider } from "../../presentation";
+import {
+    DefaultDashboardKpiInner,
+    KpiComponentProvider,
+    OptionalKpiComponentProvider,
+} from "../../presentation";
 import { InvariantError } from "ts-invariant";
 import { DashboardCustomizationLogger } from "./customizationLogging";
 
@@ -9,7 +13,7 @@ const DefaultKpiRendererProvider: KpiComponentProvider = () => {
 };
 
 interface IKpiCustomizerState {
-    addCustomProvider(provider: KpiComponentProvider): void;
+    addCustomProvider(provider: OptionalKpiComponentProvider): void;
     getRootProvider(): KpiComponentProvider;
     switchRootProvider(provider: KpiComponentProvider): void;
 }
@@ -126,14 +130,14 @@ export class DefaultKpiCustomizer implements IDashboardKpiCustomizer {
         this.state = new DefaultKpiCustomizerState(defaultProvider);
     }
 
-    public withCustomProvider = (provider: KpiComponentProvider): IDashboardKpiCustomizer => {
+    public withCustomProvider = (provider: OptionalKpiComponentProvider): IDashboardKpiCustomizer => {
         this.state.addCustomProvider(provider);
 
         return this;
     };
 
     public withCustomDecorator = (
-        providerFactory: (next: KpiComponentProvider) => KpiComponentProvider,
+        providerFactory: (next: KpiComponentProvider) => OptionalKpiComponentProvider,
     ): IDashboardKpiCustomizer => {
         // snapshot current root provider
         const rootSnapshot = this.state.getRootProvider();

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/insightCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/insightCustomizer.test.tsx
@@ -2,7 +2,7 @@
 
 import { DefaultInsightCustomizer } from "../insightCustomizer";
 import React from "react";
-import { InsightComponentProvider } from "../../../presentation";
+import { InsightComponentProvider, OptionalInsightComponentProvider } from "../../../presentation";
 import { IInsight, insightTags, insightTitle } from "@gooddata/sdk-model";
 import { IInsightWidget } from "@gooddata/sdk-backend-spi";
 import { recordedInsight } from "@gooddata/sdk-backend-mockingbird";
@@ -41,7 +41,7 @@ function createTestComponent(name: string): React.FC {
 function createTestComponentProvider(
     name: string,
     predicate: (insight: IInsight, widget: IInsightWidget) => boolean,
-): InsightComponentProvider {
+): OptionalInsightComponentProvider {
     const Component = createTestComponent(name);
 
     return (insight, widget) => {
@@ -57,7 +57,7 @@ function createTestDecoratorFactory(
     name: string,
     predicate: (insight: IInsight, widget: IInsightWidget) => boolean,
 ) {
-    return (next: InsightComponentProvider): InsightComponentProvider => {
+    return (next: InsightComponentProvider): OptionalInsightComponentProvider => {
         return (insight, widget) => {
             if (!predicate(insight, widget)) {
                 return undefined;
@@ -81,7 +81,7 @@ function createTestDecoratorFactory(
 const DefaultTestComponentProvider: InsightComponentProvider = createTestComponentProvider(
     "default",
     () => true,
-);
+) as InsightComponentProvider;
 
 //
 //

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/kpiCustomizer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/kpiCustomizer.test.tsx
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 
 import React from "react";
-import { KpiComponentProvider } from "../../../presentation";
+import { KpiComponentProvider, OptionalKpiComponentProvider } from "../../../presentation";
 import { idRef, measureItem } from "@gooddata/sdk-model";
 import { IKpiWidget, ILegacyKpi } from "@gooddata/sdk-backend-spi";
 import { ReferenceLdm } from "@gooddata/reference-workspace";
@@ -47,7 +47,7 @@ function createTestComponent(name: string): React.FC {
 function createTestComponentProvider(
     name: string,
     predicate: (kpi: ILegacyKpi, widget: IKpiWidget) => boolean,
-): KpiComponentProvider {
+): OptionalKpiComponentProvider {
     const Component = createTestComponent(name);
 
     return (kpi, widget) => {
@@ -63,7 +63,7 @@ function createTestDecoratorFactory(
     name: string,
     predicate: (kpi: ILegacyKpi, widget: IKpiWidget) => boolean,
 ) {
-    return (next: KpiComponentProvider): KpiComponentProvider => {
+    return (next: KpiComponentProvider): OptionalKpiComponentProvider => {
         return (kpi, widget) => {
             if (!predicate(kpi, widget)) {
                 return undefined;
@@ -84,7 +84,10 @@ function createTestDecoratorFactory(
     };
 }
 
-const DefaultTestComponentProvider: KpiComponentProvider = createTestComponentProvider("default", () => true);
+const DefaultTestComponentProvider: KpiComponentProvider = createTestComponentProvider(
+    "default",
+    () => true,
+) as KpiComponentProvider;
 
 //
 //

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/widgetCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/widgetCustomizer.tsx
@@ -2,7 +2,7 @@
 
 import { IDashboardWidgetCustomizer } from "../customizer";
 import { DashboardCustomizationLogger } from "./customizationLogging";
-import { WidgetComponentProvider } from "../../presentation";
+import { OptionalWidgetComponentProvider } from "../../presentation";
 import React from "react";
 import { isCustomWidget } from "../../model";
 
@@ -91,7 +91,7 @@ export class DefaultWidgetCustomizer implements IDashboardWidgetCustomizer {
         return this;
     };
 
-    public getWidgetComponentProvider = (): WidgetComponentProvider => {
+    public getWidgetComponentProvider = (): OptionalWidgetComponentProvider => {
         const customWidgetMap = this.state.getCustomWidgetMap();
 
         return (widget) => {

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -1,6 +1,11 @@
 // (C) 2021 GoodData Corporation
 import React from "react";
-import { InsightComponentProvider, KpiComponentProvider } from "../presentation";
+import {
+    InsightComponentProvider,
+    KpiComponentProvider,
+    OptionalInsightComponentProvider,
+    OptionalKpiComponentProvider,
+} from "../presentation";
 import {
     DashboardDispatch,
     DashboardEventHandler,
@@ -66,9 +71,6 @@ export interface IDashboardInsightCustomizer {
      *
      *         function MyCustomDecorator() {
      *              const Decorated = next(insight, widget);
-     *              if (!Decorated) {
-     *                  return null;
-     *              }
      *
      *              return (
      *                  <div>
@@ -93,7 +95,7 @@ export interface IDashboardInsightCustomizer {
      * @param providerFactory - factory
      */
     withCustomDecorator(
-        providerFactory: (next: InsightComponentProvider) => InsightComponentProvider,
+        providerFactory: (next: InsightComponentProvider) => OptionalInsightComponentProvider,
     ): IDashboardInsightCustomizer;
 }
 
@@ -138,9 +140,6 @@ export interface IDashboardKpiCustomizer {
      *
      *         function MyCustomDecorator() {
      *              const Decorated = next(kpi, widget);
-     *              if (!Decorated) {
-     *                  return null;
-     *              }
      *
      *              return (
      *                  <div>
@@ -165,7 +164,7 @@ export interface IDashboardKpiCustomizer {
      * @param providerFactory - factory
      */
     withCustomDecorator(
-        providerFactory: (next: KpiComponentProvider) => KpiComponentProvider,
+        providerFactory: (next: KpiComponentProvider) => OptionalKpiComponentProvider,
     ): IDashboardKpiCustomizer;
 }
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -66,6 +66,9 @@ export interface IDashboardInsightCustomizer {
      *
      *         function MyCustomDecorator() {
      *              const Decorated = next(insight, widget);
+     *              if (!Decorated) {
+     *                  return null;
+     *              }
      *
      *              return (
      *                  <div>
@@ -135,6 +138,9 @@ export interface IDashboardKpiCustomizer {
      *
      *         function MyCustomDecorator() {
      *              const Decorated = next(kpi, widget);
+     *              if (!Decorated) {
+     *                  return null;
+     *              }
      *
      *              return (
      *                  <div>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -49,9 +49,19 @@ import { CustomShareDialogComponent } from "../shareDialog";
 /**
  * @alpha
  */
-export type WidgetComponentProvider = (
-    widget: ExtendedDashboardWidget,
-) => CustomDashboardWidgetComponent | undefined;
+export type OptionalProvider<T> = T extends (...args: infer TArgs) => infer TRes
+    ? (...args: TArgs) => TRes | undefined
+    : never;
+
+/**
+ * @alpha
+ */
+export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalWidgetComponentProvider = OptionalProvider<WidgetComponentProvider>;
 
 /**
  * @alpha
@@ -59,7 +69,12 @@ export type WidgetComponentProvider = (
 export type InsightComponentProvider = (
     insight: IInsight,
     widget: IInsightWidget,
-) => CustomDashboardInsightComponent | undefined;
+) => CustomDashboardInsightComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalInsightComponentProvider = OptionalProvider<InsightComponentProvider>;
 
 /**
  * @alpha
@@ -90,10 +105,12 @@ export type InsightMenuItemsProvider = (
 /**
  * @alpha
  */
-export type KpiComponentProvider = (
-    kpi: ILegacyKpi,
-    widget: IKpiWidget,
-) => CustomDashboardKpiComponent | undefined;
+export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalKpiComponentProvider = OptionalProvider<KpiComponentProvider>;
 
 /**
  * @alpha
@@ -159,7 +176,7 @@ export interface IDashboardCustomComponentProps {
      * };
      * ```
      */
-    WidgetComponentProvider?: WidgetComponentProvider;
+    WidgetComponentProvider?: OptionalWidgetComponentProvider;
 
     /**
      * Optionally specify function to obtain custom component to use for rendering an insight.
@@ -173,7 +190,7 @@ export interface IDashboardCustomComponentProps {
      * To access the necessary props in your component, use the {@link useDashboardInsightProps} hook.
      * To fall back to the default implementation, use the {@link DefaultDashboardInsight} component.
      */
-    InsightComponentProvider?: InsightComponentProvider;
+    InsightComponentProvider?: OptionalInsightComponentProvider;
 
     /**
      * Optionally specify function to obtain custom component to use for rendering an insight menu button.
@@ -217,7 +234,7 @@ export interface IDashboardCustomComponentProps {
      * To access the necessary props in your component, use the {@link useDashboardKpiProps} hook.
      * To fall back to the default implementation, use the {@link DefaultDashboardKpi} component.
      */
-    KpiComponentProvider?: KpiComponentProvider;
+    KpiComponentProvider?: OptionalKpiComponentProvider;
 
     /**
      * Optionally specify component to use for rendering the scheduled email dialog.

--- a/tools/dashboard-plugin-template/tsconfig.json
+++ b/tools/dashboard-plugin-template/tsconfig.json
@@ -3,9 +3,9 @@
     "compilerOptions": {
         "declaration": true,
         "declarationMap": true,
-        "target": "es5",
+        "target": "es2017",
         "jsx": "react",
-        "lib": ["es7", "dom"],
+        "lib": ["es2017", "dom"],
         "module": "ESNext",
         "moduleResolution": "node",
         "esModuleInterop": true,


### PR DESCRIPTION
* RAIL-3428 - Target ES2017 in dashboard plugins. This is more forward compatible with gdc-dashboards dropping IE support: the current gdc-dashboards can run ES2017 plugins and gdc-dashboards without IE support can run them too. They can't run ES5 plugins, though.
* RAIL-3840 -  improve decorator typings to prevent undefined results of the providerFactory.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
