### PR TITLE
RELATED: RAIL-3837, RAIL-3428 - Fixes & addition of inspect dashboard

### DIFF
--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -549,7 +549,7 @@ export const convertDashboard = (
         analyticalDashboard: {
             content: {
                 ...(convertedDateFilterConfig && { dateFilterConfig: convertedDateFilterConfig }),
-                ...(convertedPlugins && { plugins: convertedPlugins }),
+                ...(convertedPlugins && !isEmpty(convertedPlugins) && { plugins: convertedPlugins }),
                 filterContext: filterContextUri,
                 widgets: widgets ? widgets.filter(isWidget).map((widget) => refToUri(widget.ref)) : [],
                 layout: convertedLayout,

--- a/tools/dashboard-plugin-template/.env.template
+++ b/tools/dashboard-plugin-template/.env.template
@@ -12,6 +12,9 @@
 # to this backend via proxy.
 #
 # If you do not provide backend URL, the harness will connect to public server used by GD.UI Examples Gallery
+#
+# Note: If you do provide backend URL, then you must also specify custom workspace and dashboard because the default
+# workspace and the default dashboard are only available on the public server.
 BACKEND_URL=
 
 # Specify workspace that contains dashboard against which you want to develop and test the plugin.

--- a/tools/dashboard-plugin-template/README.template.md
+++ b/tools/dashboard-plugin-template/README.template.md
@@ -103,6 +103,24 @@ Building a new plugin is easy. Before you start, ensure that your `.env` and `.e
 
     _TIP_: you can use the `unlink` command to remove the link between dashboard and the plugin.
 
+## Authentication & secrets
+
+Your plugin does not have to concern itself with the authentication against GoodData backend. When the plugin runs
+in context of GoodData KPI Dashboards, it is the application that takes care of all the authentication and ensures
+that the plugin executes in an authenticated environment.
+
+The authentication credentials that are required to start the development harness included in this project are used
+only during development because the harness needs to provide authenticated environment to the plugin as well.
+
+In order to provide credentials to the development harness, you can use either the `.env.secrets` file or export the
+necessary environment variables before starting the harness.
+
+The contents of `.env.secrets` will never make their way into plugin build artifacts, they are loaded only when starting
+the development harness. Check out the webpack.config.js if you would like to double-check this.
+
+_IMPORTANT: Never include credentials and secrets in your plugin source code or other assets that your plugin requires.
+All this data will be available in the publicly hosted plugin artifacts and can also be found through the browser developer console._
+
 ## FAQ
 
 ### What's up with the directories in src? Can I rename them?
@@ -116,7 +134,7 @@ The [src/{{pluginIdentifier}}\_engine](./src/{{pluginIdentifier}}_engine) and [s
 You must not modify these directories or their contents.
 
 The [src/harness] directory contains code for plugin development harness; it is used only during plugin development and the
-code in this directory will not be part of the plugin build . You can start the harness using `{{packageManager}} start`.
+code in this directory will not be part of the plugin build. You can start the harness using `{{packageManager}} start`.
 You should have no need to modify the code in the harness. We anticipate that at times you may need to tweak Analytical Backend setup
 that is contained in the [src/harness/backend.ts](src/harness/backend.ts) - this is a safe change.
 
@@ -135,5 +153,5 @@ plugin and prevent it from loading correctly.
 
 ### How about Internet Explorer?
 
-GoodData applications [do not support Internet Explorer](https://help.gooddata.com/doc/enterprise/en/how-to-get-started-with-gooddata/system-requirements-and-supported-browsers) as of November 19th 2021. Thus, you
-do not have to test your plugin with Internet Explorer because at this point there is no guarantee that the GoodData KPI Dashboards application will even load with Internet Explorer.
+GoodData applications [do not support Internet Explorer](https://help.gooddata.com/doc/enterprise/en/how-to-get-started-with-gooddata/system-requirements-and-supported-browsers) as of November 19th 2021.
+The plugin artifacts created during the plugin build are not compatible with Internet Explorer.

--- a/tools/dashboard-plugin-template/src/harness/Root.tsx
+++ b/tools/dashboard-plugin-template/src/harness/Root.tsx
@@ -2,11 +2,21 @@
 import React from "react";
 import { BackendProvider, WorkspaceProvider } from "@gooddata/sdk-ui";
 
-import { backend } from "./backend";
+import { backend, hasCredentialsSetup } from "./backend";
 import { App } from "./App";
 import { DEFAULT_WORKSPACE } from "./constants";
 
 export const Root: React.FC = () => {
+    if (!hasCredentialsSetup()) {
+        return (
+            <div>
+                The environment is not setup with credentials to use for authentication to Analytical Backend.
+                Please see the .env.secrets file or the README.md in the root of your plugin project to learn
+                how to set up your environment.
+            </div>
+        );
+    }
+
     return (
         <BackendProvider backend={backend}>
             <WorkspaceProvider workspace={process.env.WORKSPACE ?? DEFAULT_WORKSPACE}>

--- a/tools/dashboard-plugin-template/src/harness/backend--tiger.ts
+++ b/tools/dashboard-plugin-template/src/harness/backend--tiger.ts
@@ -5,7 +5,7 @@ import tigerFactory, {
 } from "@gooddata/sdk-backend-tiger";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
-function hasCredentialsSetup(): boolean {
+export function hasCredentialsSetup(): boolean {
     return !!process.env.TIGER_API_TOKEN;
 }
 

--- a/tools/dashboard-plugin-template/src/harness/backend.ts
+++ b/tools/dashboard-plugin-template/src/harness/backend.ts
@@ -5,7 +5,7 @@ import bearFactory, {
 } from "@gooddata/sdk-backend-bear";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
-function hasCredentialsSetup(): boolean {
+export function hasCredentialsSetup(): boolean {
     return !!(process.env.GDC_USERNAME && process.env.GDC_PASSWORD);
 }
 

--- a/tools/plugin-toolkit/src/index.ts
+++ b/tools/plugin-toolkit/src/index.ts
@@ -10,6 +10,8 @@ import { unlinkPluginCmdAction } from "./unlinkPluginCmd";
 import { listCmdAction } from "./listCmds/listCmdAction";
 import { listDashboards } from "./listCmds/listDashboards";
 import { listDashboardPlugins } from "./listCmds/listDashboardPlugins";
+import { inspectCmdAction } from "./inspectCmds/inspectCmdAction";
+import { inspectDashboard } from "./inspectCmds/inspectDashboard";
 
 program
     .version(pkg.version)
@@ -56,6 +58,27 @@ const listDashboardPluginsCmd = listCmd
             commandOpts: {
                 ...listCmd.opts(),
                 ...listDashboardPluginsCmd.opts(),
+            },
+        });
+    });
+
+const inspectCmd = program
+    .command("inspect")
+    .description("Commands to inspect workspace metadata objects.")
+    .option("--workspace-id <workspace>", "Identifier of workspace whose object you want to inspect.");
+
+const inspectDashboardCmd = inspectCmd
+    .command("dashboard")
+    .argument("<identifier>", "Dashboard identifier")
+    .description("Inspect workspace dashboard")
+    .action(async (identifier: string) => {
+        acceptUntrustedSsl(program.opts());
+
+        await inspectCmdAction(identifier, inspectDashboard, {
+            programOpts: program.opts(),
+            commandOpts: {
+                ...inspectCmd.opts(),
+                ...inspectDashboardCmd.opts(),
             },
         });
     });

--- a/tools/plugin-toolkit/src/inspectCmds/actionConfig.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/actionConfig.ts
@@ -1,0 +1,52 @@
+// (C) 2021 GoodData Corporation
+import { createWorkspaceTargetConfig, WorkspaceTargetConfig } from "../_base/workspaceTargetConfig";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { ActionOptions } from "../_base/types";
+import { createBackend } from "../_base/backend";
+import ora from "ora";
+import { asyncValidOrDie, createWorkspaceValidator } from "../_base/inputHandling/validators";
+
+export type InspectCmdActionConfig = WorkspaceTargetConfig & {
+    identifier: string;
+    backendInstance: IAnalyticalBackend;
+};
+
+async function doAsyncValidations(config: InspectCmdActionConfig) {
+    const { backendInstance, workspace } = config;
+
+    const asyncValidationProgress = ora({
+        text: "Authenticating and checking workspace.",
+    });
+    try {
+        asyncValidationProgress.start();
+
+        await backendInstance.authenticate(true);
+        await asyncValidOrDie("workspace", workspace, createWorkspaceValidator(backendInstance));
+    } finally {
+        asyncValidationProgress.stop();
+    }
+}
+
+export async function getInspectCmdActionConfig(
+    identifier: string,
+    options: ActionOptions,
+): Promise<InspectCmdActionConfig> {
+    const workspaceTargetConfig = createWorkspaceTargetConfig(options);
+    const { hostname, backend, credentials } = workspaceTargetConfig;
+
+    const backendInstance = createBackend({
+        hostname,
+        backend,
+        credentials,
+    });
+
+    const config: InspectCmdActionConfig = {
+        ...workspaceTargetConfig,
+        identifier,
+        backendInstance,
+    };
+
+    await doAsyncValidations(config);
+
+    return config;
+}

--- a/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
@@ -1,0 +1,54 @@
+// (C) 2021 GoodData Corporation
+import { ActionOptions } from "../_base/types";
+import fse from "fs-extra";
+import { logError, logInfo } from "../_base/terminal/loggers";
+import { genericErrorReporter } from "../_base/utils";
+import { getInspectCmdActionConfig, InspectCmdActionConfig } from "./actionConfig";
+import { InspectObjectFn } from "./types";
+
+function printInspectConfigSummary(config: InspectCmdActionConfig) {
+    const {
+        identifier,
+        backend,
+        hostname,
+        workspace,
+        credentials: { username },
+    } = config;
+
+    logInfo("Everything looks valid. Going to inspect object.");
+    logInfo(`  Hostname    : ${hostname}   (${backend === "bear" ? "GoodData platform" : "GoodData.CN"})`);
+
+    if (backend === "bear") {
+        logInfo(`  Username    : ${username}`);
+    }
+
+    logInfo(`  Workspace   : ${workspace}`);
+    logInfo(`  Identifier  : ${identifier}`);
+}
+
+export async function inspectCmdAction(
+    identifier: string,
+    inspectObjFn: InspectObjectFn,
+    options: ActionOptions,
+): Promise<void> {
+    if (!fse.existsSync("package.json")) {
+        logError(
+            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
+        );
+
+        process.exit(1);
+        return;
+    }
+
+    try {
+        const config: InspectCmdActionConfig = await getInspectCmdActionConfig(identifier, options);
+
+        printInspectConfigSummary(config);
+
+        await inspectObjFn(config, options);
+    } catch (e) {
+        genericErrorReporter(e);
+
+        process.exit(1);
+    }
+}

--- a/tools/plugin-toolkit/src/inspectCmds/inspectDashboard.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/inspectDashboard.ts
@@ -1,0 +1,59 @@
+// (C) 2021 GoodData Corporation
+/* eslint-disable no-console */
+import { InspectCmdActionConfig } from "./actionConfig";
+import { ActionOptions } from "../_base/types";
+import { idRef } from "@gooddata/sdk-model";
+import { printObjectSummary } from "./output";
+import columnify from "columnify";
+import isEmpty from "lodash/isEmpty";
+import { areObjRefsEqual } from "@gooddata/sdk-model";
+
+export async function inspectDashboard(
+    config: InspectCmdActionConfig,
+    _options: ActionOptions,
+): Promise<void> {
+    const { backendInstance, workspace, identifier } = config;
+    const ref = idRef(identifier, "analyticalDashboard");
+    const {
+        dashboard,
+        references: { plugins },
+    } = await backendInstance
+        .workspace(workspace)
+        .dashboards()
+        .getDashboardWithReferences(ref, undefined, undefined, ["dashboardPlugin"]);
+    const { title, description, tags, updated, created } = dashboard;
+
+    printObjectSummary({
+        type: "Dashboard",
+        identifier,
+        title,
+        description,
+        tags,
+        updated,
+        created,
+    });
+
+    if (isEmpty(plugins)) {
+        console.log("Dashboard is not linked with any plugins.");
+    } else {
+        console.log("\nLinked dashboard plugins\n");
+        console.log(
+            columnify(
+                plugins.map((plugin) => {
+                    const link = dashboard.plugins?.find((link) => {
+                        return areObjRefsEqual(link.plugin, plugin.ref);
+                    });
+
+                    return {
+                        identifier: plugin.identifier,
+                        title: plugin.name,
+                        url: plugin.url,
+                        parameters: !isEmpty(link?.parameters) ? link!.parameters : "(none)",
+                        created: plugin.created,
+                        updated: plugin.updated,
+                    };
+                }),
+            ),
+        );
+    }
+}

--- a/tools/plugin-toolkit/src/inspectCmds/output.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/output.ts
@@ -1,0 +1,26 @@
+// (C) 2021 GoodData Corporation
+/* eslint-disable no-console */
+import isEmpty from "lodash/isEmpty";
+
+export type ObjectSummary = {
+    type: string;
+    identifier: string;
+    title: string;
+    description?: string;
+    tags?: string[];
+    created: string;
+    updated: string;
+};
+
+export function printObjectSummary(summary: ObjectSummary): void {
+    const { type, title, description, tags, identifier, updated, created } = summary;
+
+    console.log("--");
+    console.log(`-- ${type}: ${identifier}`);
+    console.log("--");
+    console.log(`Title       : ${title}`);
+    console.log(`Description : ${!isEmpty(description) ? description : "(none)"}`);
+    console.log(`Tags        : ${!isEmpty(tags) ? tags?.join(", ") : "(none)"}`);
+    console.log(`Created     : ${created}`);
+    console.log(`Updated     : ${updated}`);
+}

--- a/tools/plugin-toolkit/src/inspectCmds/types.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/types.ts
@@ -1,0 +1,6 @@
+// (C) 2021 GoodData Corporation
+
+import { InspectCmdActionConfig } from "./actionConfig";
+import { ActionOptions } from "../_base/types";
+
+export type InspectObjectFn = (config: InspectCmdActionConfig, options: ActionOptions) => Promise<void>;


### PR DESCRIPTION
-  Fixed dashboard converter in bear to ensure that dashboard has no `plugins` instead of empty `plugins`
-  Added basic inspect dashboard command; shows info about the dashboard & the plugins used on the dashboard

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
