### PR TITLE
Enable configured drills even for invalid Kpi

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -10,6 +10,7 @@ import round from "lodash/round";
 import {
     FilterContextItem,
     IAnalyticalBackend,
+    IDataView,
     IKpiWidget,
     ISeparators,
     IUserWorkspaceSettings,
@@ -178,12 +179,12 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
 
     const handleOnDrill = useCallback(
         (drillContext: IDrillEventContext): ReturnType<OnFiredDashboardViewDrillEvent> => {
-            if (!onDrill || !result) {
+            if (!onDrill) {
                 return false;
             }
 
             return onDrill({
-                dataView: result.dataView,
+                dataView: result?.dataView as IDataView, // Even invalid Kpi can be drillable
                 drillContext,
                 drillDefinitions: kpiWidget.drills,
                 widgetRef: widgetRef(kpiWidget),
@@ -221,11 +222,11 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
 
     const predicates = convertDrillableItemsToPredicates(drillableItems);
     const isDrillable =
-        kpiResult?.measureDescriptor &&
-        result &&
-        status !== "error" &&
-        (isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result) ||
-            widgetDrills.length > 0);
+        (kpiResult?.measureDescriptor &&
+            result &&
+            status !== "error" &&
+            isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result)) ||
+        widgetDrills.length > 0;
 
     const enableCompactSize = settings.enableKDWidgetCustomHeight;
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiRenderer.tsx
@@ -40,18 +40,21 @@ export const KpiRenderer: React.FC<IKpiRendererProps> = ({
     isLoading,
 }) => {
     const onPrimaryValueClick = useCallback(() => {
-        if (!isDrillable || !onDrill || !kpiResult?.measureDescriptor) {
+        if (!isDrillable || !onDrill) {
             return;
         }
+
         return onDrill({
             type: "headline", // TODO is that correct?
             element: "primaryValue",
-            value: kpiResult.measureResult?.toString(),
-            intersection: [
-                {
-                    header: kpiResult.measureDescriptor,
-                },
-            ],
+            value: kpiResult?.measureResult?.toString(),
+            intersection: kpiResult?.measureDescriptor
+                ? [
+                      {
+                          header: kpiResult.measureDescriptor,
+                      },
+                  ]
+                : [],
         });
     }, [kpiResult?.measureResult, kpiResult?.measureDescriptor, isDrillable, onDrill]);
 


### PR DESCRIPTION
- to align with KD, where even invalid Kpis can be drillable

JIRA: RAIL-3647

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
