### PR TITLE
RELATED: RAIL-3841 Call onPluginLoaded on external plugins

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/adaptiveComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/adaptiveComponentLoaders.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 import { IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
-import { DashboardContext, IDashboardEngine, IDashboardPluginContract_V1 } from "@gooddata/sdk-ui-dashboard";
+import { DashboardContext, IDashboardEngine } from "@gooddata/sdk-ui-dashboard";
 import isEmpty from "lodash/isEmpty";
 import {
     noopDashboardBeforeLoad,
@@ -12,7 +12,7 @@ import {
     dynamicDashboardEngineLoader,
     dynamicDashboardPluginLoader,
 } from "./dynamicComponentLoaders";
-import { ModuleFederationIntegration } from "../types";
+import { LoadedPlugin, ModuleFederationIntegration } from "../types";
 
 /**
  * Adaptive loader will check if there are any plugins linked with the dashboard. If so, it will use the
@@ -43,7 +43,7 @@ export const adaptiveDashboardEngineLoaderFactory =
  */
 export const adaptiveDashboardPluginLoaderFactory =
     (moduleFederationIntegration: ModuleFederationIntegration) =>
-    (ctx: DashboardContext, dashboard: IDashboardWithReferences): Promise<IDashboardPluginContract_V1[]> => {
+    (ctx: DashboardContext, dashboard: IDashboardWithReferences): Promise<LoadedPlugin[]> => {
         if (!isEmpty(dashboard.references.plugins)) {
             return dynamicDashboardPluginLoader(ctx, dashboard, moduleFederationIntegration);
         }

--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/staticComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/staticComponentLoaders.ts
@@ -1,12 +1,8 @@
 // (C) 2021 GoodData Corporation
 
 import { IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
-import {
-    DashboardContext,
-    IDashboardEngine,
-    IDashboardPluginContract_V1,
-    newDashboardEngine,
-} from "@gooddata/sdk-ui-dashboard";
+import { DashboardContext, IDashboardEngine, newDashboardEngine } from "@gooddata/sdk-ui-dashboard";
+import { LoadedPlugin } from "../types";
 
 /**
  * This loader expects that a dashboard engine is build-time linked into the application and will create
@@ -34,7 +30,7 @@ export function staticDashboardEngineLoader(_dashboard: IDashboardWithReferences
 export function noopDashboardPluginLoader(
     _ctx: DashboardContext,
     _dashboard: IDashboardWithReferences,
-): Promise<IDashboardPluginContract_V1[]> {
+): Promise<LoadedPlugin[]> {
     return Promise.resolve([]);
 }
 

--- a/libs/sdk-ui-loaders/src/dashboard/types.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/types.ts
@@ -1,5 +1,5 @@
 // (C) 2021 GoodData Corporation
-import { IDashboardBaseProps } from "@gooddata/sdk-ui-dashboard";
+import { IDashboardBaseProps, IDashboardPluginContract_V1 } from "@gooddata/sdk-ui-dashboard";
 import { IClientWorkspaceIdentifiers } from "@gooddata/sdk-ui";
 import { IEmbeddedPlugin } from "./loader";
 import { ObjRef } from "@gooddata/sdk-model";
@@ -136,4 +136,13 @@ export type AdaptiveLoadOptions = {
 export type ModuleFederationIntegration = {
     __webpack_init_sharing__: (scope: string) => Promise<void>;
     __webpack_share_scopes__: any;
+};
+
+/**
+ * Dashboard plugin and its parameters.
+ * @alpha
+ */
+export type LoadedPlugin = {
+    plugin: IDashboardPluginContract_V1;
+    parameters: string | undefined;
 };


### PR DESCRIPTION
If the onPluginLoaded call fails, the plugin is ignored.

JIRA: RAIL-3841

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
