### PR TITLE
RELATED: RAIL-3853 - Fix messaging when new plugin successfully created

### DIFF
--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 import { ActionOptions, TargetAppLanguage } from "../_base/types";
-import { logError, logInfo, logWarn } from "../_base/terminal/loggers";
+import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import * as path from "path";
 import fse from "fs-extra";
 import tar from "tar";
@@ -220,12 +220,12 @@ export async function initCmdAction(pluginName: string | undefined, options: Act
             return;
         }
 
-        const directory = await prepareProject(target, config);
+        await prepareProject(target, config);
 
         runInstall(target, config);
 
-        logInfo(
-            `A new project for your dashboard plugin is ready in: ${directory}. Check out the package.json and fill in author and description if possible.`,
+        logSuccess(
+            `A new project for your dashboard plugin is ready in: ${target}. Check out the package.json and fill in author and description if possible.`,
         );
     } catch (e) {
         genericErrorReporter(e);


### PR DESCRIPTION
-  Dir was not shown
-  Should log as success

RELATED: RAIL-3853

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
