### PR TITLE
RELATED: RAIL-3854 - Fix plugin template webpack config

### DIFF
--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -126,11 +126,11 @@ module.exports = (_env, argv) => {
             new CaseSensitivePathsPlugin(),
             // provide bogus process.env keys that lru-cache, pseudomap and util packages use unsafely for no reason...
             new EnvironmentPlugin({
-                npm_package_name: false,
-                npm_lifecycle_script: false,
-                _nodeLRUCacheForceNoSymbol: false,
-                TEST_PSEUDOMAP: false,
-                NODE_DEBUG: !isProduction,
+                npm_package_name: "",
+                npm_lifecycle_script: "",
+                _nodeLRUCacheForceNoSymbol: "",
+                TEST_PSEUDOMAP: "",
+                NODE_DEBUG: "",
             }),
         ],
     };
@@ -185,8 +185,7 @@ module.exports = (_env, argv) => {
                         /**
                          * this is the entry to the plugin itself
                          */
-                        [`./${MODULE_FEDERATION_NAME}_PLUGIN`]: `./src/${MODULE_FEDERATION_NAME}
-                        `,
+                        [`./${MODULE_FEDERATION_NAME}_PLUGIN`]: `./src/${MODULE_FEDERATION_NAME}`,
                         /**
                          * this is the entry to the engine
                          */


### PR DESCRIPTION
-  Bad stubs for lru cache caused this

RELATED: RAIL-3854

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
