### PR TITLE
RELATED: RAIL-3847 - customizer API tweaks & template enhancement

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -50,6 +50,7 @@ import { IDashboardLayout } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutItem } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutSection } from '@gooddata/sdk-backend-spi';
 import { IDashboardLayoutSectionHeader } from '@gooddata/sdk-backend-spi';
+import { IDashboardLayoutSizeByScreenSize } from '@gooddata/sdk-backend-spi';
 import { IDashboardObjectIdentity } from '@gooddata/sdk-backend-spi';
 import { IDashboardWidget } from '@gooddata/sdk-backend-spi';
 import { IDataView } from '@gooddata/sdk-backend-spi';
@@ -2990,6 +2991,12 @@ export function newDashboardEngine(): IDashboardEngine;
 export function newDashboardEventPredicate<T extends DashboardEvents["type"]>(eventType: T, pred?: (event: DashboardEvents & {
     type: T;
 }) => boolean): (event: Action) => boolean;
+
+// @alpha
+export function newDashboardItem<T = ExtendedDashboardWidget>(widget: T, sizeOrColSize: IDashboardLayoutSizeByScreenSize | number): ExtendedDashboardItem<T>;
+
+// @alpha
+export function newDashboardSection<T = ExtendedDashboardWidget>(titleOrHeader: IDashboardLayoutSectionHeader | string | undefined, ...items: ReadonlyArray<ExtendedDashboardItem<T>>): IDashboardLayoutSection<T>;
 
 // @alpha
 export function newDisplayFormMap(items: ReadonlyArray<IAttributeDisplayFormMetadataObject>, strictTypeCheck?: boolean): ObjRefMap<IAttributeDisplayFormMetadataObject>;

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -31,6 +31,8 @@ export {
     ICustomWidgetDefinition,
     ICustomWidgetBase,
     newCustomWidget,
+    newDashboardItem,
+    newDashboardSection,
     isCustomWidgetDefinition,
     isCustomWidget,
     ExtendedDashboardItem,

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -4,12 +4,15 @@ import {
     IBaseWidget,
     IDashboardLayoutItem,
     IDashboardLayoutSection,
+    IDashboardLayoutSectionHeader,
+    IDashboardLayoutSizeByScreenSize,
     IDashboardObjectIdentity,
     isWidget,
     IWidget,
     IWidgetDefinition,
 } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
+import cloneDeep from "lodash/cloneDeep";
 import isEmpty from "lodash/isEmpty";
 
 /**
@@ -44,7 +47,8 @@ export interface ICustomWidgetDefinition extends ICustomWidgetBase, Partial<IDas
  * @param identifier - identifier for custom widget; once added onto a dashboard, widget will be referencable using this identifier
  * @param customType - custom widget type
  * @param extras - optionally provide extra data to include on the custom widget; the content of this argument can be an
- *  arbitrary plain object
+ *  arbitrary plain object. note: the factory will make a copy of all the extra data. at this moment it is not possible
+ *  to modify the data once the widget is added onto a dashboard.
  * @alpha
  */
 export function newCustomWidget<TExtra = void>(
@@ -52,13 +56,15 @@ export function newCustomWidget<TExtra = void>(
     customType: string,
     extras?: TExtra,
 ): TExtra & ICustomWidget {
+    const extrasCopy = extras ? cloneDeep(extras) : {};
+
     return {
         type: "customWidget",
         customType,
         identifier,
         uri: `_custom_widget_uri/${identifier}`,
         ref: idRef(identifier),
-        ...extras,
+        ...extrasCopy,
     } as TExtra & ICustomWidget;
 }
 
@@ -120,6 +126,71 @@ export type ExtendedDashboardWidget = IWidget | ICustomWidget;
  * @alpha
  */
 export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayoutItem<T>;
+
+/**
+ * Creates a new dashboard item containing the provided custom widget.
+ *
+ * @param widget - custom widget to include
+ * @param sizeOrColSize - item size specification; for convenience you can specify the size as number which will be
+ *  interpreted as number of columns in a 12-col grid that the item should use when rendered on an XL screen.
+ * @alpha
+ */
+export function newDashboardItem<T = ExtendedDashboardWidget>(
+    widget: T,
+    sizeOrColSize: IDashboardLayoutSizeByScreenSize | number,
+): ExtendedDashboardItem<T> {
+    const size: IDashboardLayoutSizeByScreenSize =
+        typeof sizeOrColSize === "number" ? { xl: { gridWidth: sizeOrColSize } } : sizeOrColSize;
+
+    return {
+        type: "IDashboardLayoutItem",
+        size,
+        widget: cloneDeep(widget),
+    };
+}
+
+function getOrCreateSectionHeader(
+    titleOrHeader: IDashboardLayoutSectionHeader | string | undefined,
+): IDashboardLayoutSectionHeader | undefined {
+    if (!titleOrHeader) {
+        return undefined;
+    }
+
+    if (typeof titleOrHeader === "string") {
+        if (isEmpty(titleOrHeader)) {
+            return undefined;
+        }
+
+        return {
+            title: titleOrHeader,
+        };
+    }
+
+    return titleOrHeader;
+}
+
+/**
+ * Creates a new dashboard section.
+ *
+ * @param titleOrHeader - header to use for this section (if any); for convenience, you may provide just string containing the title instead
+ * of specifying full header. if you specify empty string for title, then there will be no header.
+ * @param items - dashboard items to include in the section; note: a deep copy of each item will be used on the new section
+ *
+ * @alpha
+ */
+export function newDashboardSection<T = ExtendedDashboardWidget>(
+    titleOrHeader: IDashboardLayoutSectionHeader | string | undefined,
+    ...items: ReadonlyArray<ExtendedDashboardItem<T>>
+): IDashboardLayoutSection<T> {
+    const header = getOrCreateSectionHeader(titleOrHeader);
+    const itemsClone: Array<ExtendedDashboardItem<T>> = cloneDeep(items) as Array<ExtendedDashboardItem<T>>;
+
+    return {
+        type: "IDashboardLayoutSection",
+        items: itemsClone,
+        header,
+    };
+}
 
 /**
  * Identifier of a stashed dashboard items. When removing one or more item, the caller may decide to 'stash' these items

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/fluidLayoutCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/fluidLayoutCustomizer.ts
@@ -3,6 +3,9 @@ import { IDashboardLayout, IDashboardLayoutItem, IDashboardLayoutSection } from 
 import { IFluidLayoutCustomizer } from "../customizer";
 import { ExtendedDashboardWidget, ICustomWidget } from "../../model";
 import { DashboardLayoutBuilder } from "../../_staging/dashboard/fluidLayout";
+import isEmpty from "lodash/isEmpty";
+import { DashboardCustomizationLogger } from "./customizationLogging";
+import cloneDeep from "lodash/cloneDeep";
 
 type AddItemOp = {
     sectionIdx: number;
@@ -19,17 +22,26 @@ export class FluidLayoutCustomizer implements IFluidLayoutCustomizer {
     private readonly addItemOps: AddItemOp[] = [];
     private readonly addSectionOps: AddSectionOp[] = [];
 
-    constructor() {}
+    constructor(private readonly logger: DashboardCustomizationLogger) {}
 
     public addItem = (
         sectionIdx: number,
         itemIdx: number,
         item: IDashboardLayoutItem<ICustomWidget>,
     ): IFluidLayoutCustomizer => {
+        if (!item.widget) {
+            this.logger.warn(
+                `Item to add to section ${sectionIdx} at index ${itemIdx} does not contain any widget. The item will not be added at all.`,
+                item,
+            );
+
+            return this;
+        }
+
         this.addItemOps.push({
             sectionIdx,
             itemIdx,
-            item,
+            item: cloneDeep(item),
         });
 
         return this;
@@ -39,9 +51,29 @@ export class FluidLayoutCustomizer implements IFluidLayoutCustomizer {
         sectionIdx: number,
         section: IDashboardLayoutSection<ICustomWidget>,
     ): IFluidLayoutCustomizer => {
+        if (isEmpty(section.items)) {
+            this.logger.warn(
+                `Section to add at index ${sectionIdx} contains no items. The section will not be added at all.`,
+                section,
+            );
+
+            return this;
+        }
+
+        const itemsWithoutWidget = section.items.filter((item) => item.widget === undefined);
+
+        if (!isEmpty(itemsWithoutWidget)) {
+            this.logger.warn(
+                `Section to add at index ${sectionIdx} contains items that do not specify any widgets. The section will not be added at all.`,
+                section,
+            );
+
+            return this;
+        }
+
         this.addSectionOps.push({
             sectionIdx,
-            section,
+            section: cloneDeep(section),
         });
         return this;
     };

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
@@ -52,7 +52,7 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
 
             const newLayout = snapshot.reduce((currentLayout, fn) => {
                 // Create a new fluid layout customizer just for this round of processing
-                const customizer = new FluidLayoutCustomizer();
+                const customizer = new FluidLayoutCustomizer(this.logger);
 
                 try {
                     // call out to the plugin-provided function with the current value of the layout & the

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -194,16 +194,22 @@ export interface IDashboardWidgetCustomizer {
  */
 export interface IFluidLayoutCustomizer {
     /**
-     * Adds a new section with one or more custom widgets onto the fluid layout.
+     * Adds a new section with one or more custom widgets onto the fluid layout. The section to add must not
+     * be empty - it must contain at least one item. Attempts to add empty sections will be ignored and
+     * warnings will be reported.
      *
      * @param sectionIdx - index to add the new section at
-     * @param section - section to add
+     * @param section - section to add; note: customizer will make a deep copy of the item before adding it
+     *  onto a dashboard. At this moment, the newly added items are read-only.
      */
     addSection(sectionIdx: number, section: IDashboardLayoutSection<ICustomWidget>): IFluidLayoutCustomizer;
 
     /**
      * Adds a new item containing a custom widget onto the dashboard. New item will be added to
-     * an existing section at index `sectionIdx` and within that section will be placed at `itemIdx`.
+     * an existing section at index `sectionIdx` and within that section will be placed at `itemIdx`. The item
+     * to add must contain a custom widget data. Attempts to add item that does not contain any widget data
+     * will be ignored and warnings will be reported. Keep in mind that this can lead to further errors or
+     * problems down the line if you are adding more items at specific indexes into the same section.
      *
      * Note: new items will be added into existing sections before new sections will be added using the
      * {@link IFluidLayoutCustomizer.addSection} method. Therefore,
@@ -211,7 +217,8 @@ export interface IFluidLayoutCustomizer {
      * @param sectionIdx - index of section where to add the new item
      * @param itemIdx - index within the section where to add new item; you may specify -1 to add the
      *  item at the end of the section
-     * @param item - item containing custom widget
+     * @param item - item containing custom widget; note: customizer will make a deep copy of the item before adding it
+     *  onto a dashboard. At this moment, the newly added items are read-only.
      */
     addItem(
         sectionIdx: number,

--- a/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
+++ b/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
@@ -4,11 +4,22 @@ import {
     DashboardPluginV1,
     IDashboardCustomizer,
     IDashboardEventHandling,
+    IDashboardWidgetProps,
+    newDashboardSection,
+    newDashboardItem,
+    newCustomWidget,
 } from "@gooddata/sdk-ui-dashboard";
 
 import packageJson from "../../package.json";
+import React from "react";
 
-// Implement your plugin here, you can import other files etc. Just keep the component name and make sure it stays exported.
+/*
+ * Component to render 'myCustomWidget'. If you create custom widget instance and also pass extra data,
+ * then that data will be available in
+ */
+function MyCustomWidget(_props: IDashboardWidgetProps): JSX.Element {
+    return <div>Hello from custom widget</div>;
+}
 
 export class Plugin extends DashboardPluginV1 {
     public readonly author = packageJson.author;
@@ -32,14 +43,22 @@ export class Plugin extends DashboardPluginV1 {
         customize: IDashboardCustomizer,
         handlers: IDashboardEventHandling,
     ): void {
+        customize.customWidgets().addCustomWidget("myCustomWidget", MyCustomWidget);
         customize.layout().customizeFluidLayout((_layout, customizer) => {
-            customizer.addSection(-1, {
-                items: [],
-                type: "IDashboardLayoutSection",
-                header: {
-                    title: "Added from a plugin",
-                },
-            });
+            customizer.addSection(
+                0,
+                newDashboardSection(
+                    "Section Added By Plugin",
+                    newDashboardItem(newCustomWidget("myWidget1", "myCustomWidget"), {
+                        xl: {
+                            // all 12 columns of the grid will be 'allocated' for this this new item
+                            gridWidth: 12,
+                            // minimum height since the custom widget now has just some one-liner text
+                            gridHeight: 1,
+                        },
+                    }),
+                ),
+            );
         });
         handlers.addEventHandler("GDC.DASH/EVT.INITIALIZED", (evt) => {
             // eslint-disable-next-line no-console

--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -111,7 +111,7 @@ module.exports = (_env, argv) => {
                     use: ["style-loader", "css-loader"],
                 },
                 {
-                    test: /\.(eot|woff|ttf|svg)/,
+                    test: /\.(eot|woff|ttf|svg|jpg|jpeg|gif)/,
                     type: "asset/resource",
                 },
                 !isProduction && {


### PR DESCRIPTION
-  Add section & item factories 
-  Prohibit empty sections/items during customization; 
-  Update template to contain a better example for custom widget & its placement

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
