### PR TITLE
RELATED: RAIL-3867 Add option to disable theme loading

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2274,6 +2274,7 @@ export interface IDashboardStoreProviderProps {
 
 // @alpha (undocumented)
 export interface IDashboardThemingProps {
+    disableThemeLoading?: boolean;
     theme?: ITheme;
     themeModifier?: (theme: ITheme) => ITheme;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -230,11 +230,13 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
         </DashboardStoreProvider>
     );
 
-    if (props.theme || !hasThemeProvider) {
+    if (props.theme || (!hasThemeProvider && !props.disableThemeLoading)) {
         dashboardRender = (
             <ThemeProvider
                 theme={props.theme}
                 modifier={props.themeModifier ?? defaultDashboardThemeModifier}
+                backend={props.backend}
+                workspace={props.workspace}
             >
                 {dashboardRender}
             </ThemeProvider>

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -327,6 +327,17 @@ export interface IDashboardThemingProps {
     theme?: ITheme;
 
     /**
+     * When true, disables the loading of the workspace theme and creation of a ThemeProvider (if there is none
+     * already present in the parent scope). Currently – for technical reasons – the ThemeProvider changes the theme
+     * globally (i.e. the theme is NOT constrained inside of a ThemeProvider).
+     *
+     * Turn this property to true if you need to avoid the global aspect of the themes, or you do not want to use themes at all.
+     *
+     * Defaults to false.
+     */
+    disableThemeLoading?: boolean;
+
+    /**
      * If provided it is called with loaded theme to allow its modification according to the app needs.
      * This is only applied to themes loaded from the backend, it is NOT applied to themes provided using
      * the "theme" prop.


### PR DESCRIPTION
This is useful in apps that already load the Theme themselves. Also properly pass backend/workspace props to the ThemeProvider.

JIRA: RAIL-3867

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
