### PR TITLE
RELATED: RAIL-3865 - Remove empty sections from layout before saving

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -17,6 +17,7 @@ import { newMapForObjectWithIdentity } from "../../../_staging/metadata/objRefMa
 import { selectFilterContextFilters } from "../filterContext/filterContextSelectors";
 import { filterContextItemsToFiltersForWidget } from "../../../converters";
 import { createMemoizedSelector } from "../_infra/selectors";
+import isEmpty from "lodash/isEmpty";
 
 const selectSelf = createSelector(
     (state: DashboardState) => state,
@@ -72,17 +73,23 @@ function isItemWithBaseWidget(
  * handlers will not wipe the custom widgets from the state during the save - so at this point the custom
  * widgets are treated as client-side extensions.
  *
+ * Note: this selector also intentionally removes empty sections; dashboard cannot cope with them and
+ * they may readily appear if user adds section full of custom widgets and then does saveAs; such sections
+ * would end up empty.
+ *
  * @internal
  */
 export const selectBasicLayout = createSelector(selectLayout, (layout) => {
     const dashboardLayout: IDashboardLayout<IWidget> = {
         ...layout,
-        sections: layout.sections.map((section) => {
-            return {
-                ...section,
-                items: section.items.filter(isItemWithBaseWidget),
-            };
-        }),
+        sections: layout.sections
+            .map((section) => {
+                return {
+                    ...section,
+                    items: section.items.filter(isItemWithBaseWidget),
+                };
+            })
+            .filter((section) => !isEmpty(section.items)),
     };
 
     return dashboardLayout;


### PR DESCRIPTION
-  Surgical change in selectBasicLayout - this selector is used internally now, only during save
-  The selector already removed all custom widgets (because not all backends know how to persist them)
-  It did not, however remove empty sections in case such sections were created purely out of custom widgets
-  Saving dashboard with empty sections leads to problems / unhandled corner cases

RELATED: RAIL-3865

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
