### PR TITLE
RELATED: RAIL-3864, RAIL-3689 typings improvements

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1789,6 +1789,14 @@ export function exportInsightWidget(ref: ObjRef, config: IExportConfig, correlat
 export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayoutItem<T>;
 
 // @alpha
+export type ExtendedDashboardItemType<T> = T extends ExtendedDashboardItem<infer S> ? S : never;
+
+// @alpha
+export type ExtendedDashboardItemTypes<T extends ReadonlyArray<ExtendedDashboardItem<unknown>>> = {
+    [K in keyof T]: ExtendedDashboardItemType<T[K]>;
+}[number];
+
+// @alpha
 export type ExtendedDashboardLayoutSection = IDashboardLayoutSection<ExtendedDashboardWidget>;
 
 // @alpha
@@ -2997,7 +3005,7 @@ export function newDashboardEventPredicate<T extends DashboardEvents["type"]>(ev
 export function newDashboardItem<T = ExtendedDashboardWidget>(widget: T, sizeOrColSize: IDashboardLayoutSizeByScreenSize | number): ExtendedDashboardItem<T>;
 
 // @alpha
-export function newDashboardSection<T = ExtendedDashboardWidget>(titleOrHeader: IDashboardLayoutSectionHeader | string | undefined, ...items: ReadonlyArray<ExtendedDashboardItem<T>>): IDashboardLayoutSection<T>;
+export function newDashboardSection<T extends ReadonlyArray<ExtendedDashboardItem<unknown>>>(titleOrHeader: IDashboardLayoutSectionHeader | string | undefined, ...items: T): IDashboardLayoutSection<ExtendedDashboardItemTypes<T>>;
 
 // @alpha
 export function newDisplayFormMap(items: ReadonlyArray<IAttributeDisplayFormMetadataObject>, strictTypeCheck?: boolean): ObjRefMap<IAttributeDisplayFormMetadataObject>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2122,7 +2122,7 @@ export type IDashboardFilter = IAbsoluteDateFilter | IRelativeDateFilter | IPosi
 // @alpha (undocumented)
 export interface IDashboardInsightCustomizer {
     withCustomDecorator(providerFactory: (next: InsightComponentProvider) => OptionalInsightComponentProvider): IDashboardInsightCustomizer;
-    withCustomProvider(provider: InsightComponentProvider): IDashboardInsightCustomizer;
+    withCustomProvider(provider: OptionalInsightComponentProvider): IDashboardInsightCustomizer;
     withTag(tag: string, component: CustomDashboardInsightComponent): IDashboardInsightCustomizer;
 }
 
@@ -2197,7 +2197,7 @@ export interface IDashboardInsightProps {
 // @alpha (undocumented)
 export interface IDashboardKpiCustomizer {
     withCustomDecorator(providerFactory: (next: KpiComponentProvider) => OptionalKpiComponentProvider): IDashboardKpiCustomizer;
-    withCustomProvider(provider: KpiComponentProvider): IDashboardKpiCustomizer;
+    withCustomProvider(provider: OptionalKpiComponentProvider): IDashboardKpiCustomizer;
 }
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -42,6 +42,8 @@ export {
     StashedDashboardItemsId,
     ExtendedDashboardLayoutSection,
     RelativeIndex,
+    ExtendedDashboardItemType,
+    ExtendedDashboardItemTypes,
 } from "./types/layoutTypes";
 export {
     FilterOp,

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -128,6 +128,20 @@ export type ExtendedDashboardWidget = IWidget | ICustomWidget;
 export type ExtendedDashboardItem<T = ExtendedDashboardWidget> = IDashboardLayoutItem<T>;
 
 /**
+ * Utility type to get the widget type from a given {@link ExtendedDashboardItem} type.
+ * @alpha
+ */
+export type ExtendedDashboardItemType<T> = T extends ExtendedDashboardItem<infer S> ? S : never;
+
+/**
+ * Utility type to get the widget type from a given {@link ExtendedDashboardItem} array.
+ * @alpha
+ */
+export type ExtendedDashboardItemTypes<T extends ReadonlyArray<ExtendedDashboardItem<unknown>>> = {
+    [K in keyof T]: ExtendedDashboardItemType<T[K]>;
+}[number];
+
+/**
  * Creates a new dashboard item containing the provided custom widget.
  *
  * @param widget - custom widget to include
@@ -178,12 +192,12 @@ function getOrCreateSectionHeader(
  *
  * @alpha
  */
-export function newDashboardSection<T = ExtendedDashboardWidget>(
+export function newDashboardSection<T extends ReadonlyArray<ExtendedDashboardItem<unknown>>>(
     titleOrHeader: IDashboardLayoutSectionHeader | string | undefined,
-    ...items: ReadonlyArray<ExtendedDashboardItem<T>>
-): IDashboardLayoutSection<T> {
+    ...items: T
+): IDashboardLayoutSection<ExtendedDashboardItemTypes<T>> {
     const header = getOrCreateSectionHeader(titleOrHeader);
-    const itemsClone: Array<ExtendedDashboardItem<T>> = cloneDeep(items) as Array<ExtendedDashboardItem<T>>;
+    const itemsClone = cloneDeep(items) as any;
 
     return {
         type: "IDashboardLayoutSection",

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -53,7 +53,7 @@ export interface IDashboardInsightCustomizer {
      * @param provider - provider to register
      * @returns self, for call chaining sakes
      */
-    withCustomProvider(provider: InsightComponentProvider): IDashboardInsightCustomizer;
+    withCustomProvider(provider: OptionalInsightComponentProvider): IDashboardInsightCustomizer;
 
     /**
      * Register a factory for insight decorator providers. Decorators are a way to add customizations or embellishments on top
@@ -117,12 +117,10 @@ export interface IDashboardKpiCustomizer {
      *
      * You may register multiple providers. They will be evaluated in the order you register them.
      *
-     * @remarks see the {@link IDashboardInsightCustomizer.withTag} convenience method to register components for insights
-     *  with particular tags.
      * @param provider - provider to register
      * @returns self, for call chaining sakes
      */
-    withCustomProvider(provider: KpiComponentProvider): IDashboardKpiCustomizer;
+    withCustomProvider(provider: OptionalKpiComponentProvider): IDashboardKpiCustomizer;
 
     /**
      * Register a factory for insight decorator providers. Decorators are a way to add customizations or embellishments on top


### PR DESCRIPTION
* RAIL-3864 - allow OptionalProviders in withCustomProvider, remove non-sensical comment: it only makes sense for insights, not KPIs
* RAIL-3869 - allow heterogeneous items in newDashboardSection

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
