### PR TITLE
RELATED: RAIL-3871 Fix InsightView when insight not found

### DIFF
--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -21,6 +21,7 @@ import {
     OnLoadingChanged,
     OnError,
     useCancelablePromise,
+    convertError,
 } from "@gooddata/sdk-ui";
 import { IInsightViewProps } from "./types";
 import InsightTitle from "./InsightTitle";
@@ -212,7 +213,9 @@ const InsightViewCore: React.FC<IInsightViewProps & WrappedComponentProps> = (pr
         <div className="insight-view-container">
             {resolvedTitle && <TitleComponent title={resolvedTitle} />}
             {isLoadingShown && <LoadingComponent className="insight-view-loader" />}
-            {error && !isDataLoading && <InsightError error={error} ErrorComponent={ErrorComponent} />}
+            {error && !isDataLoading && (
+                <InsightError error={convertError(error)} ErrorComponent={ErrorComponent} />
+            )}
             <div
                 className="insight-view-visualization"
                 // make the visualization div 0 height so that the loading component can take up the whole area


### PR DESCRIPTION
Make sure the errors going to the InsightError component
are of the correct type so that it properly maps the Unexpected error
to the Not found message.

 JIRA: RAIL-3871

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
