### PR TITLE
Fix appearance of the kpi loading dots

### DIFF
--- a/libs/sdk-ui-kit/styles/scss/loadingDots.scss
+++ b/libs/sdk-ui-kit/styles/scss/loadingDots.scss
@@ -9,6 +9,7 @@ $loading-dot-delay: 0.16;
     overflow: hidden;
 
     &-centered {
+        min-width: 36px;
         position: absolute;
         top: 50%;
         left: 50%;


### PR DESCRIPTION
- ensure that they are rendered horizontally (for parent element with zero width, they are rendered vertically)

JIRA: RAIL-3862

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
