### PR TITLE
RELATED: RAIL-3428 Small plugin toolkit tweaks

### DIFF
--- a/tools/dashboard-plugin-template/README.template.md
+++ b/tools/dashboard-plugin-template/README.template.md
@@ -38,7 +38,7 @@ Building a new plugin is easy. Before you start, ensure that your `.env` and `.e
 
 1.  Start the development server: `{{packageManager}} start`
 
-    To verify everything works correctly, navigate to `https://localhost:3001`. You should see your existing
+    To verify everything works correctly, navigate to `{{protocol}}//localhost:3001`. You should see your existing
     dashboard with a new empty section added at the end. The section will be titled 'Added from a plugin'.
 
     Note: you can use `PORT` env variable to specify different port number.
@@ -52,7 +52,7 @@ Building a new plugin is easy. Before you start, ensure that your `.env` and `.e
     Note: we recommend to write your plugin in TypeScript and to use a modern IDE. This way you can conveniently
     explore the plugin customization APIs from the comfort of your development environment.
 
-3.  Build the plugin: `{{packageManager}} build-plugin`
+3.  Build the plugin: `{{packageManager}} run build-plugin`
 
     This will build plugin artifacts under `dist/dashboardPlugin`.
 

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -4,6 +4,7 @@ import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/logger
 import * as path from "path";
 import fse from "fs-extra";
 import tar from "tar";
+import url from "url";
 import { getDashboardPluginTemplateArchive } from "../dashboard-plugin-template";
 import {
     convertToPluginDirectory,
@@ -79,6 +80,7 @@ function renamePluginDirectories(target: string, config: InitCmdActionConfig) {
 function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): Promise<void> {
     const { backend, hostname, workspace, dashboard, pluginIdentifier, language, packageManager } = config;
     const isTiger = backend === "tiger";
+    const { protocol } = url.parse(hostname);
     const replacements: FileReplacementSpec = {
         "webpack.config.js": [
             {
@@ -113,6 +115,10 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
             {
                 regex: /{{language}}/g,
                 value: language,
+            },
+            {
+                regex: /{{protocol}}/g,
+                value: protocol ?? "https:",
             },
         ],
         src: {


### PR DESCRIPTION
* add missing `run` in one of the commands
* use the same protocol as the backend for the app

JIRA: RAIL-3428

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
