### PR TITLE
RELATED: RAIL-3850 negative attribute filter subtitle

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -39,7 +39,8 @@ import MediaQuery from "react-responsive";
 import { MediaQueries } from "../constants";
 import {
     attributeElementsToAttributeElementArray,
-    getAllTitleIntl,
+    getAllExceptTitle,
+    getAllTitle,
     getElementTotalCount,
     getFilteringTitleIntl,
     getItemsTitles,
@@ -626,25 +627,21 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         }
 
         if (isAllFiltered) {
-            return getAllTitleIntl(props.intl, true, true, true);
+            return getAllTitle(props.intl);
         }
 
         const displayForm = getObjRef(currentFilter, props.identifier);
-        if (state.uriToAttributeElementMap.size > 0 && !isNil(totalCount) && displayForm) {
-            const empty = isEmpty(state.selectedFilterOptions);
-            const equal = isEqual(originalTotalCount, state.selectedFilterOptions?.length);
-            const getAllPartIntl = getAllTitleIntl(props.intl, state.isInverted, empty, equal);
+        if (state.uriToAttributeElementMap.size > 0 && !isNil(originalTotalCount) && displayForm) {
+            const empty = getNumberOfSelectedItems() === 0 && originalTotalCount > 0;
+            const all = getNumberOfSelectedItems() === originalTotalCount;
+            const getAllPartIntl = all ? getAllTitle(props.intl) : getAllExceptTitle(props.intl);
 
-            if (!state.selectedFilterOptions?.length && state.searchString) {
+            if (empty) {
                 return getNoneTitleIntl(props.intl);
             }
 
-            if (empty) {
-                return !state.isInverted ? `${getNoneTitleIntl(props.intl)}` : `${getAllPartIntl}`;
-            }
-
-            if (equal) {
-                return state.isInverted ? "" : `${getAllPartIntl}`;
+            if (all) {
+                return getAllPartIntl;
             }
 
             return state.isInverted

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -632,7 +632,19 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
 
         const displayForm = getObjRef(currentFilter, props.identifier);
         if (state.uriToAttributeElementMap.size > 0 && !isNil(originalTotalCount) && displayForm) {
+            /**
+             * If the attribute filter is positive, `getNumberOfSelectedItems` returns current size of
+             * the `state.selectedFilterOptions` array. If the filter is negative attribute filter, it
+             * returns difference between `originalTotalCount` and current size of the selection.
+             *
+             * If the number of selected items is 0 and originalTotalCount is greater than 0, it is
+             * considered the selection is empty.
+             */
             const empty = getNumberOfSelectedItems() === 0 && originalTotalCount > 0;
+            /**
+             * All items are selected only in case the number of selected items is equal to original total
+             * count.
+             */
             const all = getNumberOfSelectedItems() === originalTotalCount;
             const getAllPartIntl = all ? getAllTitle(props.intl) : getAllExceptTitle(props.intl);
 

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -32,8 +32,16 @@ export const getAllTitleIntl = (
     equal: boolean,
 ): string => {
     if ((isInverted && empty) || (!isInverted && equal)) {
-        return intl.formatMessage({ id: "attrf.all" });
+        return getAllTitle(intl);
     }
+    return getAllExceptTitle(intl);
+};
+
+export const getAllTitle = (intl: IntlShape): string => {
+    return intl.formatMessage({ id: "attrf.all" });
+};
+
+export const getAllExceptTitle = (intl: IntlShape): string => {
     return intl.formatMessage({ id: "attrf.all_except" });
 };
 


### PR DESCRIPTION
- Modify subtitle generating function to resolve negative attribute filter properly

JIRA: RAIL-3850

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
