### PR TITLE
Add example hook to get data for particular insight widget

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21275,7 +21275,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@8.10.2:
-    resolution: {integrity: sha512-tnhtsGZiELUAIn5rMC6arJmdp8j0hoqiG9U0wRS0ri9f98UXpS6l65MQjmdFZThA7qL/iMEXqT0XEmamGyH5kQ==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-E6Wleru+vgD/vK1JOFJO1yitfa7ZZzIvQDIfe9IPnf7T5q8JpW828TShImCz4uz/6ke05krWUOkRsAZlhBi4kw==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21287,6 +21287,7 @@ packages:
       '@types/enzyme': 3.10.8
       '@types/enzyme-adapter-react-16': 1.0.6
       '@types/jest': 26.0.23
+      '@types/json-stable-stringify': 1.0.32
       '@types/lodash': 4.14.170
       '@types/raf': 3.4.0
       '@types/react': 16.14.8
@@ -21315,6 +21316,7 @@ packages:
       jest: 26.6.3_ts-node@8.10.2
       jest-enzyme: 7.1.2_847a09de400b6a6d5a9c863e7946818d
       jest-junit: 3.7.0
+      json-stable-stringify: 1.0.1
       lodash: 4.17.21
       prettier: 2.3.1
       process: 0.11.10

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3694,7 +3694,7 @@ error?: string | undefined;
 } | undefined>;
 
 // @alpha
-export const selectInsightByRef: ((ref: ObjRef) => OutputSelector<DashboardState, IInsight | undefined, (res: ObjRefMap<IInsight>) => IInsight | undefined>) & MemoizedFunction;
+export const selectInsightByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IInsight | undefined, (res: ObjRefMap<IInsight>) => IInsight | undefined>;
 
 // @alpha
 export const selectInsightRefs: OutputSelector<DashboardState, ObjRef[], (res: IInsight[]) => ObjRef[]>;

--- a/libs/sdk-ui-dashboard/src/model/store/insights/insightsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/insights/insightsSelectors.ts
@@ -2,10 +2,10 @@
 import { insightsAdapter } from "./insightsEntityAdapter";
 import { DashboardState } from "../types";
 import { createSelector } from "@reduxjs/toolkit";
-import { insightRef, ObjRef, serializeObjRef } from "@gooddata/sdk-model";
-import memoize from "lodash/memoize";
+import { insightRef, ObjRef } from "@gooddata/sdk-model";
 import { newInsightMap } from "../../../_staging/metadata/objRefMap";
 import { selectBackendCapabilities } from "../backendCapabilities/backendCapabilitiesSelectors";
+import { createMemoizedSelector } from "../_infra/selectors";
 
 const entitySelectors = insightsAdapter.getSelectors((state: DashboardState) => state.insights);
 
@@ -50,8 +50,8 @@ export const selectInsightsMap = createSelector(
  *
  * @alpha
  */
-export const selectInsightByRef = memoize((ref: ObjRef) => {
+export const selectInsightByRef = createMemoizedSelector((ref: ObjRef | undefined) => {
     return createSelector(selectInsightsMap, (insights) => {
-        return insights.get(ref);
+        return ref && insights.get(ref);
     });
-}, serializeObjRef);
+});

--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -50,6 +50,7 @@
     },
     "dependencies": {
         "@gooddata/sdk-ui-dashboard": "^8.7.0-beta.7",
+        "json-stable-stringify": "^1.0.1",
         "lodash": "^4.17.19",
         "tslib": "^2.0.0"
     },
@@ -82,6 +83,7 @@
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/enzyme": "^3.10.3",
         "@types/jest": "^26.0.12",
+        "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.158",
         "@types/raf": "^3.4.0",
         "@types/react-dom": "^16.9.3",

--- a/tools/dashboard-plugin-template/src/plugin/utils/useInsightWidgetDataView.ts
+++ b/tools/dashboard-plugin-template/src/plugin/utils/useInsightWidgetDataView.ts
@@ -1,0 +1,67 @@
+// (C) 2020-2021 GoodData Corporation
+import { useMemo } from "react";
+import stringify from "json-stable-stringify";
+import { IInsightWidget } from "@gooddata/sdk-backend-spi";
+import { insightSetFilters } from "@gooddata/sdk-model";
+import {
+    GoodDataSdkError,
+    useBackendStrict,
+    useWorkspaceStrict,
+    UseCancelablePromiseState,
+    useCancelablePromise,
+    DataViewFacade,
+    useExecutionDataView,
+} from "@gooddata/sdk-ui";
+import { useWidgetFilters, selectInsightByRef, useDashboardSelector } from "@gooddata/sdk-ui-dashboard";
+
+interface IUseInsightWidgetDataView {
+    /**
+     * Insight widget to get data view for.
+     *
+     * Note: When the insight widget is not provided, hook is locked in a "pending" state.
+     */
+    insightWidget?: IInsightWidget;
+}
+
+/**
+ * Hook that presents bare minimum code to get data view for particular insight widget,
+ * with respect to current dashboard filters.
+ *
+ * @param config - configuration of the hook
+ */
+export function useInsightWidgetDataView(
+    config: IUseInsightWidgetDataView,
+): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
+    const { insightWidget } = config;
+    const backend = useBackendStrict();
+    const workspace = useWorkspaceStrict();
+    const insight = useDashboardSelector(selectInsightByRef(insightWidget?.insight));
+    const widgetFiltersPromise = useWidgetFilters(insightWidget);
+
+    const insightWithAddedFilters = useMemo(
+        () => insightSetFilters(insight!, widgetFiltersPromise.result),
+        [
+            insight,
+            /**
+             * We use stringified value to avoid setting equal filters. This prevents cascading cache invalidation
+             * and expensive re-renders down the line. The stringification is worth it as the filters are usually
+             * pretty small thus saving more time than it is taking.
+             */
+            stringify(widgetFiltersPromise.result),
+        ],
+    );
+
+    const insightWidgetExecutionPromise = useCancelablePromise(
+        {
+            promise:
+                insightWithAddedFilters && insightWidget
+                    ? async () => {
+                          return backend.workspace(workspace).execution().forInsight(insightWithAddedFilters);
+                      }
+                    : null,
+        },
+        [backend, workspace, insightWithAddedFilters, insightWidget],
+    );
+
+    return useExecutionDataView({ execution: insightWidgetExecutionPromise.result });
+}


### PR DESCRIPTION
- add example hook to the plugin template, so users can see how to get data view for particular insight widget

JIRA: RAIL-3872

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
