### PR TITLE
RELATED: FET-914 Prevent caniuse-lite warnings on CI

### DIFF
--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -12,7 +12,6 @@ echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 #
 export CI=true
 
-
 echo "-----------------------------------------------------------------------"
 echo "--- starting: rush-$*"
 echo "-----------------------------------------------------------------------"
@@ -34,6 +33,7 @@ docker run \
   --env HOME="/workspace" \
   --env EXAMPLES_BUILD_TYPE \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
+  --env BROWSERSLIST_IGNORE_OLD_DATA \
   --rm \
   ${net_param} \
   --volume ${ROOT_DIR}:/workspace:Z \

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -35,6 +35,7 @@ docker run \
   --env WIREMOCK_NET \
   --env EXAMPLES_BUILD_TYPE \
   --env EXAMPLE_MAPBOX_ACCESS_TOKEN \
+  --env BROWSERSLIST_IGNORE_OLD_DATA \
   --env HOME="/workspace" \
   --rm \
   ${net_param} \


### PR DESCRIPTION
These warnings could bomb the whole build because rush treats
warnings as errors on CI.

As these warnings are not as important, it is safe to ignore them
in CI context in favor of stable, deterministic builds.

JIRA: FET-914

Tested in #1976 against release branch that had this issue.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
