### PR TITLE
Improve workspace.getDescriptor() performance

### DIFF
--- a/libs/api-client-bear/src/project.ts
+++ b/libs/api-client-bear/src/project.ts
@@ -81,6 +81,17 @@ export class ProjectModule {
     }
 
     /**
+     * Fetches project by its identifier.
+     *
+     * @method getProject
+     * @param {String} projectId - Project identifier
+     * @return {GdcUser.IProject} Project
+     */
+    public getProject(projectId: string): Promise<GdcUser.IProject> {
+        return this.xhr.getParsed(`/gdc/projects/${projectId}`);
+    }
+
+    /**
      * Fetches projects available for the user represented by the given profileId
      *
      * @method getProjects

--- a/libs/sdk-backend-bear/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/index.ts
@@ -33,7 +33,6 @@ import { BearWorkspaceUsersQuery } from "./users";
 import { BearWorkspaceDateFilterConfigsQuery } from "./dateFilterConfigs";
 import { BearWorkspaceAttributes } from "./attributes/index";
 import { BearWorkspaceFacts } from "./facts";
-import { userLoginMd5FromAuthenticatedPrincipal } from "../../utils/api";
 import { BearWorkspaceUserGroupsQuery } from "./userGroups";
 import { BearWorkspaceAccessControlService } from "./accessControl";
 
@@ -46,14 +45,10 @@ export class BearWorkspace implements IAnalyticalWorkspace {
 
     public async getDescriptor(): Promise<IWorkspaceDescriptor> {
         if (!this.descriptor) {
-            const projects = await this.authCall(async (sdk, { getPrincipal }) => {
-                const userId = await userLoginMd5FromAuthenticatedPrincipal(getPrincipal);
-                // TODO: this is wasteful; we should get single project directly
-                return sdk.project.getProjects(userId);
+            const project = await this.authCall(async (sdk) => {
+                return sdk.project.getProject(this.workspace);
             });
-            const project = projects.find(
-                (project) => project.links?.self.split("/").pop() === this.workspace,
-            );
+
             return {
                 id: this.workspace,
                 description: project?.meta.summary ?? "",

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -27,6 +27,7 @@ export interface IAnalyticalWorkspace {
 
     /**
      * Returns details about the analytical workspace.
+     * Throws error in case the workspace does not exist.
      */
     getDescriptor(): Promise<IWorkspaceDescriptor>;
 


### PR DESCRIPTION
- Do not fetch all workspaces if the descriptor is missing. Fetch the necessary workspace only.

JIRA: FET-902

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
