### PR TITLE
RELATED: RAIL-3849 Parent-child filtering for all descendants

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -24,6 +24,7 @@ import {
     isAttributeElementsByValue,
     ObjRef,
 } from "@gooddata/sdk-model";
+import isEmpty from "lodash/isEmpty";
 
 export const getAllTitleIntl = (
     intl: IntlShape,
@@ -81,6 +82,22 @@ export const updateSelectedOptionsWithData = (
     selection: Array<Partial<IAttributeElement>>,
     items: AttributeListItem[],
 ): Array<IAttributeElement> => {
+    /**
+     * For original AttributeFilter we need to handle empty `items` property as a indicator, that items
+     * should not be changed and should be extended by the missing `uri` or `title` property (if needed)
+     * so it can be used in AttributeFilterDropdown.
+     *
+     * This won't affect `AttributeFilterButton` component in any case.
+     */
+    if (isEmpty(items)) {
+        return selection.map((item) => {
+            return {
+                title: item.title ?? "",
+                uri: item.uri ?? "",
+            };
+        });
+    }
+
     const nonEmptyItems = items.filter(isNonEmptyListItem);
 
     return selection.map((selectedItem) => {

--- a/libs/sdk-ui-filters/styles/scss/attributeFilter.scss
+++ b/libs/sdk-ui-filters/styles/scss/attributeFilter.scss
@@ -371,6 +371,18 @@ $gd-dashboards-filterBar-filterButton-backgroundColor: var(
     }
 }
 
+.gd-attribute-filter-button-is-filtering {
+    &.attribute-filter-button:not(.is-active) {
+        background: $gd-palette-primary-dimmed;
+        border-radius: 3px;
+
+        &.attribute-filter-button::before,
+        &.attribute-filter-button::after {
+            display: none;
+        }
+    }
+}
+
 /* hide IE10+ eraser */
 ::-ms-clear {
     display: none;


### PR DESCRIPTION
- Add support to remove selection for all descending attribute filters of the changed parent

JIRA: RAIL-3849

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
