### PR TITLE
RELATED: RAIL-3808 Fix engine version in sdk-ui-dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -43,6 +43,7 @@
         "build-styles": "bash scripts/build.sh --styles",
         "dev": "bash scripts/build.sh --dev-watch",
         "prepack": "cp -f ../../NOTICE ./NOTICE",
+        "prepublishOnly": "npm run build",
         "test": "jest --watch",
         "test-once": "jest --maxWorkers=${JEST_MAX_WORKERS:-'45%'} --passWithNoTests",
         "test-once-with-coverage": "jest --passWithNoTests --coverage=true",


### PR DESCRIPTION
Build sdk-ui-dashboard in prepublishOnly to make sure the new package
version is used in the released package. We need to do this in this step
because it is the only time the new version is known.

JIRA: RAIL-3808

Related: #1994 

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
