### PR TITLE
RELATED: RAIL-3808 - Mark default insight and KPI components as public

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1557,7 +1557,7 @@ export const DefaultDashboardAttributeFilter: (props: IDashboardAttributeFilterP
 // @alpha
 export const DefaultDashboardDateFilter: (props: IDashboardDateFilterProps) => JSX.Element;
 
-// @internal (undocumented)
+// @public
 export const DefaultDashboardInsight: (props: IDashboardInsightProps) => JSX.Element;
 
 // @alpha (undocumented)
@@ -1566,7 +1566,7 @@ export const DefaultDashboardInsightMenu: (props: IDashboardInsightMenuProps) =>
 // @internal (undocumented)
 export const DefaultDashboardInsightMenuButton: (props: IDashboardInsightMenuButtonProps) => JSX.Element;
 
-// @internal (undocumented)
+// @public
 export const DefaultDashboardKpi: (props: IDashboardKpiProps) => JSX.Element;
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DefaultDashboardInsight.tsx
@@ -5,7 +5,9 @@ import { IDashboardInsightProps } from "../types";
 import { DashboardInsightWithDrillDialog } from "./DashboardInsightWithDrillDialog";
 
 /**
- * @internal
+ * Default implementation of the Dashboard Insight widget.
+ *
+ * @public
  */
 export const DefaultDashboardInsight = (props: IDashboardInsightProps): JSX.Element => {
     return <DashboardInsightWithDrillDialog {...props} />;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DefaultDashboardKpi.tsx
@@ -5,7 +5,9 @@ import { IDashboardKpiProps } from "../types";
 import { DefaultDashboardKpiWithDrills } from "./DefaultDashboardKpiWithDrills";
 
 /**
- * @internal
+ * Default implementation of the Dashboard KPI widget.
+ *
+ * @public
  */
 export const DefaultDashboardKpi = (props: IDashboardKpiProps): JSX.Element => {
     return <DefaultDashboardKpiWithDrills {...props} />;


### PR DESCRIPTION
-  This was a miss during the round of publication
-  Their props are public already

JIRA: RAIL-3808

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
