### PR TITLE
RELATED: RAIL-3808 Fix apidocs build on Node 16

### DIFF
--- a/common/scripts/build-docs.js
+++ b/common/scripts/build-docs.js
@@ -1,15 +1,8 @@
 #!/usr/bin/env node
-const fs = require("fs");
+const { mkdir, readdir, readFile, rm, unlink, writeFile } = require("fs/promises");
 const path = require("path");
 const util = require("util");
 const child_process = require("child_process");
-
-const rmdir = util.promisify(fs.rmdir);
-const mkdir = util.promisify(fs.mkdir);
-const readdir = util.promisify(fs.readdir);
-const readFile = util.promisify(fs.readFile);
-const writeFile = util.promisify(fs.writeFile);
-const unlink = util.promisify(fs.unlink);
 
 const exec = util.promisify(child_process.exec);
 
@@ -134,11 +127,11 @@ async function buildVersion(versionName, dev, onSuccess) {
     }
 
     // clean the version folder and init it with a template
-    await rmdir(apiDocDirVersioned, { recursive: true });
+    await rm(apiDocDirVersioned, { recursive: true, force: true });
     // native node does not have recursive copy...
     await exec(`cp -rf '${path.resolve(apiDocDir, "_template")}' '${apiDocDirVersioned}'`);
 
-    await rmdir(apiDocDirDocs, { recursive: true });
+    await rm(apiDocDirDocs, { recursive: true, force: true });
     await mkdir(apiDocInputDir, { recursive: true });
 
     await writeJson(versionFile, { version: versionName });


### PR DESCRIPTION
* use the rm function instead of deprecated rmdir
* add the force parameter to not fail when the directory does not exist
* use native promise versions of the fs functions

JIRA: RAIL-3808

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
