### PR TITLE
Change indicators visibility logic

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/lockedStatus/DefaultLockedStatus.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/lockedStatus/DefaultLockedStatus.tsx
@@ -12,7 +12,7 @@ import { LockedStatusIndicator } from "./LockedStatusIndicator";
 export const DefaultLockedStatus: React.FC<ILockedStatusProps> = (props): JSX.Element | null => {
     const settings = useDashboardSelector(selectSettings);
     const canManageAnalyticalDashboard = useDashboardSelector(selectCanManageAnalyticalDashboard);
-    if (!settings.enableAnalyticalDashboardPermissions || !canManageAnalyticalDashboard) {
+    if (!settings.enableNewAnalyticalDashboardsNavigation || !canManageAnalyticalDashboard) {
         return null;
     }
     return <LockedStatusIndicator {...props} />;

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/shareStatus/DefaultShareStatus.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/shareStatus/DefaultShareStatus.tsx
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 import React from "react";
 import { IShareStatusProps } from "./types";
-import { selectSettings, useDashboardSelector } from "../../../../model";
+import { selectBackendCapabilities, selectSettings, useDashboardSelector } from "../../../../model";
 import { ShareStatusIndicator } from "./ShareStatusIndicator";
 
 /**
@@ -9,7 +9,8 @@ import { ShareStatusIndicator } from "./ShareStatusIndicator";
  */
 export const DefaultShareStatus: React.FC<IShareStatusProps> = (props): JSX.Element | null => {
     const settings = useDashboardSelector(selectSettings);
-    if (!settings.enableAnalyticalDashboardPermissions) {
+    const capabilities = useDashboardSelector(selectBackendCapabilities);
+    if (!settings.enableAnalyticalDashboardPermissions || !capabilities.supportsAccessControl) {
         return null;
     }
     return <ShareStatusIndicator {...props} />;


### PR DESCRIPTION
JIRA: TNT-374
Share status indicator visible only when backend supports access management
Lock status only when new navigation is enabled

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
