### PR TITLE
Fix / optimize ServerPaging

### DIFF
--- a/libs/sdk-backend-bear/tests/integrated/__snapshots__/dateFilterConfigs.test.ts.snap
+++ b/libs/sdk-backend-bear/tests/integrated/__snapshots__/dateFilterConfigs.test.ts.snap
@@ -159,7 +159,7 @@ ServerPaging {
   "getData": [Function],
   "items": Array [],
   "limit": 10,
-  "offset": 1,
+  "offset": 40,
   "totalCount": 1,
 }
 `;

--- a/libs/sdk-backend-bear/tests/integrated/__snapshots__/elements.test.ts.snap
+++ b/libs/sdk-backend-bear/tests/integrated/__snapshots__/elements.test.ts.snap
@@ -357,7 +357,7 @@ ServerPaging {
   "getData": [Function],
   "items": Array [],
   "limit": 100,
-  "offset": 4846,
+  "offset": 5000,
   "totalCount": 4846,
 }
 `;
@@ -367,7 +367,7 @@ ServerPaging {
   "getData": [Function],
   "items": Array [],
   "limit": 100,
-  "offset": 4846,
+  "offset": 10000,
   "totalCount": 4846,
 }
 `;
@@ -377,7 +377,7 @@ ServerPaging {
   "getData": [Function],
   "items": Array [],
   "limit": 100,
-  "offset": 4846,
+  "offset": 4940,
   "totalCount": 4846,
 }
 `;

--- a/libs/sdk-backend-bear/tests/integrated/__snapshots__/insights.test.ts.snap
+++ b/libs/sdk-backend-bear/tests/integrated/__snapshots__/insights.test.ts.snap
@@ -5,7 +5,7 @@ ServerPaging {
   "getData": [Function],
   "items": Array [],
   "limit": 50,
-  "offset": 23,
+  "offset": 200,
   "totalCount": 23,
 }
 `;


### PR DESCRIPTION
- Do not fire unnecessary request on .next() call, return empty result immediately if we know that it will be empty
- Do not limit offset
- This is also fix for Cypress tests in KD

JIRA: FET-847

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
