### PR TITLE
RELATED: RAIL-3896 - Fix checking against plugin hosts

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/list_2021-12-06-11-43.json
+++ b/common/changes/@gooddata/sdk-ui-all/list_2021-12-06-11-43.json
@@ -2,7 +2,7 @@
     "changes": [
         {
             "packageName": "@gooddata/sdk-ui-all",
-            "comment": "Dashboard, a component for embedding dashboards created in KPI Dashboards, is added in the beta stage.",
+            "comment": "Fixed bug with dashboardPluginHosts validation",
             "type": "none"
         }
     ],

--- a/libs/sdk-backend-bear/src/backend/organization/securitySettings.ts
+++ b/libs/sdk-backend-bear/src/backend/organization/securitySettings.ts
@@ -2,6 +2,7 @@
 import { validatePluginUrlIsSane } from "@gooddata/sdk-backend-base";
 import { ISecuritySettingsService, ValidationContext } from "@gooddata/sdk-backend-spi";
 import { BearAuthenticatedCallGuard } from "../../types/auth";
+import isEmpty from "lodash/isEmpty";
 
 export interface IValidationResponse {
     validationResponse: {
@@ -50,9 +51,19 @@ export class SecuritySettingsService implements ISecuritySettingsService {
             return sdk.project.getConfigItem(workspace, "dashboardPluginHosts");
         });
 
-        const hostList = setting?.settingItem?.value ?? "";
-        const allowedHosts = hostList.split(";").map((entry) => entry.trim());
-
-        return allowedHosts.some((host) => url.startsWith(host));
+        return validateAgainstList(url, setting?.settingItem?.value);
     };
+}
+
+export function validateAgainstList(url: string, listContent: any): boolean {
+    if (!listContent || isEmpty(listContent) || typeof listContent !== "string") {
+        return false;
+    }
+
+    const allowedHosts = listContent
+        .split(";")
+        .map((entry) => entry.trim())
+        .filter((entry) => !isEmpty(entry));
+
+    return allowedHosts.some((host) => url.startsWith(host));
 }

--- a/libs/sdk-backend-bear/src/backend/organization/tests/securitySettings.test.ts
+++ b/libs/sdk-backend-bear/src/backend/organization/tests/securitySettings.test.ts
@@ -1,0 +1,57 @@
+// (C) 2021 GoodData Corporation
+
+import { validateAgainstList } from "../securitySettings";
+
+describe("validateAgainstList", () => {
+    const Scenarios: Array<[boolean, string, string, any]> = [
+        [false, "for undefined list", "https://example.com/plugin.js", undefined],
+        [false, "for null list", "https://example.com/plugin.js", null],
+        [false, "for number value as list", "https://example.com/plugin.js", 123],
+        [false, "for boolean value as list", "https://example.com/plugin.js", true],
+        [false, "for object value as list", "https://example.com/plugin.js", {}],
+        [false, "for array value as list", "https://example.com/plugin.js", []],
+        [false, "for empty string in list", "https://example.com/plugin.js", ""],
+        [false, "for list with only whitespaces value", "https://example.com/plugin.js", "   "],
+        [false, "for list with only semicolons", "https://example.com/plugin.js", ";;;"],
+        [
+            false,
+            "for list with only semicolons and whitespace",
+            "https://example.com/plugin.js",
+            "; ;\n;\t;\r",
+        ],
+        [
+            false,
+            "when prefix does not match",
+            "https://example.com/plugin.js",
+            "https://example.com/pluginSource/",
+        ],
+        [
+            false,
+            "when prefix does not match any prefix from list",
+            "https://example.com/plugin.js",
+            "https://example.com/pluginSource/",
+        ],
+        [
+            false,
+            "when prefix does not match and there are empty entries",
+            "https://example.com/plugin.js;https://sub.example.com/pluginSource",
+            "https://my.example.com/plugin.js",
+        ],
+        [
+            true,
+            "when url starts with prefix from list",
+            "https://example.com/plugin.js",
+            "https://example.com",
+        ],
+        [
+            true,
+            "when url starts with prefix from list of multiple values",
+            "https://sub.example.com/pluginSource/plugin.js",
+            "https://example.com;https://sub.example.com/pluginSource",
+        ],
+    ];
+
+    it.each(Scenarios)("should return %s %s", (expected, _desc, value, list) => {
+        expect(validateAgainstList(value, list)).toEqual(expected);
+    });
+});


### PR DESCRIPTION
JIRA: RAIL-3896

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
