### PR TITLE
Hides Share button for users without full access

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/DefaultShareButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareButton/DefaultShareButton.tsx
@@ -12,6 +12,8 @@ import {
     selectCanManageWorkspace,
     selectDashboardLockStatus,
     selectIsReadOnly,
+    selectDashboardRef,
+    selectListedDashboardsMap,
 } from "../../../model";
 
 import { HiddenShareButton } from "./HiddenShareButton";
@@ -26,11 +28,15 @@ const DefaultShareButtonCore: React.FC<IShareButtonProps & WrappedComponentProps
     const isLocked = useDashboardSelector(selectDashboardLockStatus);
     const isAdmin = useDashboardSelector(selectCanManageWorkspace);
     const isReadOnly = useDashboardSelector(selectIsReadOnly);
+    const currentDashboardRef = useDashboardSelector(selectDashboardRef);
+    const dashboardsList = useDashboardSelector(selectListedDashboardsMap);
+    const currentDashboardIsNormallyVisible = currentDashboardRef && dashboardsList.has(currentDashboardRef);
 
     if (
         settings.enableAnalyticalDashboardPermissions &&
         capabilities.supportsAccessControl &&
         hasPermission &&
+        currentDashboardIsNormallyVisible &&
         (!isLocked || isAdmin) &&
         !isReadOnly
     ) {


### PR DESCRIPTION
JIRA: TNT-320
If user can access dashboard only via link, but cant see it in the dashboards navigation than he cant change the sharing

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
