### PR TITLE
RELATED: RAIL-3728 Enable using MD for drill definitions

### DIFF
--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -470,6 +470,7 @@ export const HeaderPredicates: {
     identifierMatch: typeof identifierMatch;
     localIdentifierMatch: typeof localIdentifierMatch;
     uriMatch: typeof uriMatch;
+    objRefMatch: typeof objRefMatch;
 };
 
 // @public (undocumented)
@@ -1461,6 +1462,9 @@ export type NullableFilterOrPlaceholder = FilterOrPlaceholder | ValueOrPlacehold
 
 // @public
 export type NullableFiltersOrPlaceholders = Array<FilterOrMultiValuePlaceholder | ValueOrMultiValuePlaceholder<INullableFilter> | ValueOrMultiValuePlaceholder<IFilter | null> | ValueOrMultiValuePlaceholder<IDateFilter | null> | ValueOrMultiValuePlaceholder<IMeasureFilter | null> | ValueOrMultiValuePlaceholder<IAttributeFilter | null> | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter | null> | ValueOrMultiValuePlaceholder<IRelativeDateFilter | null> | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter | null> | ValueOrMultiValuePlaceholder<INegativeAttributeFilter | null> | ValueOrMultiValuePlaceholder<IMeasureValueFilter | null> | ValueOrMultiValuePlaceholder<IRankingFilter | null>>;
+
+// @public
+export function objRefMatch(objRef: ObjRef): IHeaderPredicate;
 
 // @public (undocumented)
 export type OnError = (error: GoodDataSdkError) => void;

--- a/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
+++ b/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
@@ -11,11 +11,13 @@ import { IMeasureDescriptor, isMeasureDescriptor, isResultAttributeHeader } from
 import {
     IMeasure,
     isArithmeticMeasure,
+    isIdentifierRef,
     measureArithmeticOperands,
     measureIdentifier,
     measureLocalId,
     measureMasterIdentifier,
     measureUri,
+    ObjRef,
 } from "@gooddata/sdk-model";
 import { DataViewFacade } from "../results/facade";
 
@@ -280,6 +282,18 @@ export function localIdentifierMatch(localIdOrMeasure: string | IMeasure): IHead
 }
 
 /**
+ * Creates a new predicate that returns true for any header that belongs to either attribute or measure with the
+ * provided object reference.
+ *
+ * @public
+ */
+export function objRefMatch(objRef: ObjRef): IHeaderPredicate {
+    return isIdentifierRef(objRef)
+        ? HeaderPredicates.identifierMatch(objRef.identifier)
+        : HeaderPredicates.uriMatch(objRef.uri);
+}
+
+/**
  * Creates a new predicate that returns true of any arithmetic measure where measure with the provided URI
  * is used as an operand.
  *
@@ -319,4 +333,5 @@ export const HeaderPredicates = {
     identifierMatch,
     localIdentifierMatch,
     uriMatch,
+    objRefMatch,
 };

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { IHeaderPredicate } from "../HeaderPredicate";
 import * as headerPredicateFactory from "../HeaderPredicateFactory";
 import {
@@ -7,6 +7,7 @@ import {
     attributeHeaderItem,
     attributeDescriptor,
 } from "./HeaderPredicateFactory.fixtures";
+import { attributeDisplayFormRef, newAttribute, uriRef } from "@gooddata/sdk-model";
 
 describe("uriMatch", () => {
     describe("measure headers", () => {
@@ -658,5 +659,39 @@ describe("attributeItemNameMatch", () => {
         const predicate = headerPredicateFactory.attributeItemNameMatch("attributeItemName");
 
         expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
+    });
+});
+
+describe("objRefMatch tests", () => {
+    it("should match predicate when attribute objRef matches - identifier match scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute("attributeIdentifier"));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
+    it("should match predicate when attribute objRef matches - uri match scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/attributeUri")));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
+    it("should match predicate when attribute objRef matches - identifier match negative scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute("otherAttributeIdentifier"));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("should match predicate when attribute objRef matches - uri match negative scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/otherAttributeUri")));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
     });
 });

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -207,6 +207,7 @@ export {
     identifierMatch,
     localIdentifierMatch,
     uriMatch,
+    objRefMatch,
 } from "./headerMatching/HeaderPredicateFactory";
 
 /*


### PR DESCRIPTION
- enable posibility to use generated catalog export file for drillableItems definitions through objRefMatch function. This removes the need to search for identifier in generated file or graypages.

JIRA: RAIL-3725

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
