### PR TITLE
RELATED: RAIL-3905 Unify the types related to component providers

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -206,7 +206,7 @@ export function anyDashboardEventHandler(handler: DashboardEventHandler["handler
 export function anyEventHandler(handler: DashboardEventHandler["handler"]): DashboardEventHandler;
 
 // @alpha (undocumented)
-export type AttributeFilterComponentProvider = (filter: IDashboardAttributeFilter) => CustomDashboardAttributeFilterComponent | undefined;
+export type AttributeFilterComponentProvider = (filter: IDashboardAttributeFilter) => CustomDashboardAttributeFilterComponent;
 
 // @alpha (undocumented)
 export interface AttributeFilterSelection {
@@ -2026,7 +2026,7 @@ export interface IDashboardCustomComponentProps {
     // @alpha
     ButtonBarComponent?: CustomButtonBarComponent;
     // @alpha
-    DashboardAttributeFilterComponentProvider?: AttributeFilterComponentProvider;
+    DashboardAttributeFilterComponentProvider?: OptionalAttributeFilterComponentProvider;
     // @alpha
     DashboardDateFilterComponent?: CustomDashboardDateFilterComponent;
     // @alpha
@@ -2035,9 +2035,9 @@ export interface IDashboardCustomComponentProps {
     FilterBarComponent?: CustomFilterBarComponent;
     InsightComponentProvider?: OptionalInsightComponentProvider;
     // @alpha
-    InsightMenuButtonComponentProvider?: InsightMenuButtonComponentProvider;
+    InsightMenuButtonComponentProvider?: OptionalInsightMenuButtonComponentProvider;
     // @alpha
-    InsightMenuComponentProvider?: InsightMenuComponentProvider;
+    InsightMenuComponentProvider?: OptionalInsightMenuComponentProvider;
     KpiComponentProvider?: OptionalKpiComponentProvider;
     // @alpha
     LayoutComponent?: CustomDashboardLayoutComponent;
@@ -2558,10 +2558,10 @@ export type InsightDateDatasets = {
 };
 
 // @alpha (undocumented)
-export type InsightMenuButtonComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightMenuButtonComponent | undefined;
+export type InsightMenuButtonComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightMenuButtonComponent;
 
 // @alpha (undocumented)
-export type InsightMenuComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightMenuComponent | undefined;
+export type InsightMenuComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightMenuComponent;
 
 // @alpha (undocumented)
 export type InsightMenuItemsProvider = (insight: IInsight, widget: IInsightWidget, defaultItems: IInsightMenuItem[], closeMenu: () => void) => IInsightMenuItem[];
@@ -3169,8 +3169,17 @@ export type OnFiredDashboardViewDrillEvent = (event: IDashboardDrillEvent) => Re
 // @alpha (undocumented)
 export type OnWidgetDrill = (drillEvent: IDashboardDrillEvent, drillContext: DashboardDrillContext) => void;
 
+// @alpha (undocumented)
+export type OptionalAttributeFilterComponentProvider = OptionalProvider<AttributeFilterComponentProvider>;
+
 // @public (undocumented)
 export type OptionalInsightComponentProvider = OptionalProvider<InsightComponentProvider>;
+
+// @alpha (undocumented)
+export type OptionalInsightMenuButtonComponentProvider = OptionalProvider<InsightMenuButtonComponentProvider>;
+
+// @alpha (undocumented)
+export type OptionalInsightMenuComponentProvider = OptionalProvider<InsightMenuComponentProvider>;
 
 // @public (undocumented)
 export type OptionalKpiComponentProvider = OptionalProvider<KpiComponentProvider>;

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -1,16 +1,8 @@
 // (C) 2021 GoodData Corporation
 import React, { ComponentType } from "react";
-import {
-    IAnalyticalBackend,
-    IDashboard,
-    IDashboardAttributeFilter,
-    IInsightWidget,
-    IKpiWidget,
-    ILegacyKpi,
-    ITheme,
-    IWorkspacePermissions,
-} from "@gooddata/sdk-backend-spi";
-import { IInsight, ObjRef } from "@gooddata/sdk-model";
+import { ReactReduxContextValue } from "react-redux";
+import { IAnalyticalBackend, IDashboard, ITheme, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
+import { ObjRef } from "@gooddata/sdk-model";
 import { IErrorProps, ILoadingProps } from "@gooddata/sdk-ui";
 
 import {
@@ -19,13 +11,8 @@ import {
     DashboardEventHandler,
     DashboardModelCustomizationFns,
     DashboardState,
-    ExtendedDashboardWidget,
 } from "../../model";
-import {
-    CustomDashboardAttributeFilterComponent,
-    CustomDashboardDateFilterComponent,
-    CustomFilterBarComponent,
-} from "../filterBar";
+import { CustomDashboardDateFilterComponent, CustomFilterBarComponent } from "../filterBar";
 import { CustomDashboardLayoutComponent } from "../layout";
 import { CustomScheduledEmailDialogComponent } from "../scheduledEmail";
 import {
@@ -35,90 +22,17 @@ import {
     CustomTopBarComponent,
     IMenuButtonConfiguration,
 } from "../topBar";
-import {
-    CustomDashboardInsightComponent,
-    CustomDashboardInsightMenuButtonComponent,
-    CustomDashboardInsightMenuComponent,
-    CustomDashboardKpiComponent,
-    CustomDashboardWidgetComponent,
-    IInsightMenuItem,
-} from "../widget";
 import { CustomSaveAsDialogComponent } from "../saveAs";
 import { CustomShareDialogComponent } from "../shareDialog";
-import { ReactReduxContextValue } from "react-redux";
-
-/**
- * @public
- */
-export type OptionalProvider<T> = T extends (...args: infer TArgs) => infer TRes
-    ? (...args: TArgs) => TRes | undefined
-    : never;
-
-/**
- * @public
- */
-export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
-
-/**
- * @public
- */
-export type OptionalWidgetComponentProvider = OptionalProvider<WidgetComponentProvider>;
-
-/**
- * @public
- */
-export type InsightComponentProvider = (
-    insight: IInsight,
-    widget: IInsightWidget,
-) => CustomDashboardInsightComponent;
-
-/**
- * @public
- */
-export type OptionalInsightComponentProvider = OptionalProvider<InsightComponentProvider>;
-
-/**
- * @alpha
- */
-export type InsightMenuButtonComponentProvider = (
-    insight: IInsight,
-    widget: IInsightWidget,
-) => CustomDashboardInsightMenuButtonComponent | undefined;
-
-/**
- * @alpha
- */
-export type InsightMenuComponentProvider = (
-    insight: IInsight,
-    widget: IInsightWidget,
-) => CustomDashboardInsightMenuComponent | undefined;
-
-/**
- * @alpha
- */
-export type InsightMenuItemsProvider = (
-    insight: IInsight,
-    widget: IInsightWidget,
-    defaultItems: IInsightMenuItem[],
-    closeMenu: () => void,
-) => IInsightMenuItem[];
-
-/**
- * @public
- */
-export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
-
-/**
- * @public
- */
-export type OptionalKpiComponentProvider = OptionalProvider<KpiComponentProvider>;
-
-/**
- * @alpha
- */
-export type AttributeFilterComponentProvider = (
-    filter: IDashboardAttributeFilter,
-) => CustomDashboardAttributeFilterComponent | undefined;
+import {
+    InsightMenuItemsProvider,
+    OptionalAttributeFilterComponentProvider,
+    OptionalInsightComponentProvider,
+    OptionalInsightMenuButtonComponentProvider,
+    OptionalInsightMenuComponentProvider,
+    OptionalKpiComponentProvider,
+    OptionalWidgetComponentProvider,
+} from "../dashboardContexts";
 
 /**
  * These props allow you to specify custom components or custom component providers that the Dashboard
@@ -205,7 +119,7 @@ export interface IDashboardCustomComponentProps {
      *
      * @alpha
      */
-    InsightMenuButtonComponentProvider?: InsightMenuButtonComponentProvider;
+    InsightMenuButtonComponentProvider?: OptionalInsightMenuButtonComponentProvider;
 
     /**
      * Optionally specify function to obtain custom component to use for rendering an insight menu.
@@ -218,7 +132,7 @@ export interface IDashboardCustomComponentProps {
      *
      * @alpha
      */
-    InsightMenuComponentProvider?: InsightMenuComponentProvider;
+    InsightMenuComponentProvider?: OptionalInsightMenuComponentProvider;
 
     /**
      * Optionally specify function to obtain custom component to use for rendering a KPI.
@@ -303,7 +217,7 @@ export interface IDashboardCustomComponentProps {
      *
      * @alpha
      */
-    DashboardAttributeFilterComponentProvider?: AttributeFilterComponentProvider;
+    DashboardAttributeFilterComponentProvider?: OptionalAttributeFilterComponentProvider;
 
     /**
      * Optionally specify component to use for rendering the date filters.

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardComponentsContext.tsx
@@ -1,15 +1,8 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import React, { createContext, useContext } from "react";
 import { IErrorProps, ILoadingProps, UnexpectedSdkError } from "@gooddata/sdk-ui";
 
 import { CustomDashboardLayoutComponent } from "../layout/types";
-import {
-    CustomDashboardInsightComponent,
-    CustomDashboardInsightMenuButtonComponent,
-    CustomDashboardInsightMenuComponent,
-    CustomDashboardKpiComponent,
-    CustomDashboardWidgetComponent,
-} from "../widget/types";
 import {
     CustomButtonBarComponent,
     CustomMenuButtonComponent,
@@ -17,16 +10,17 @@ import {
     CustomTopBarComponent,
 } from "../topBar/types";
 import { CustomScheduledEmailDialogComponent } from "../scheduledEmail/types";
-import {
-    CustomDashboardAttributeFilterComponent,
-    CustomDashboardDateFilterComponent,
-    CustomFilterBarComponent,
-} from "../filterBar/types";
-import { IDashboardAttributeFilter, IInsightWidget, IKpiWidget, ILegacyKpi } from "@gooddata/sdk-backend-spi";
+import { CustomDashboardDateFilterComponent, CustomFilterBarComponent } from "../filterBar/types";
 import { CustomSaveAsDialogComponent } from "../saveAs/types";
-import { IInsight } from "@gooddata/sdk-model";
-import { ExtendedDashboardWidget } from "../../model";
 import { CustomShareDialogComponent } from "../shareDialog/types";
+import {
+    AttributeFilterComponentProvider,
+    InsightComponentProvider,
+    InsightMenuButtonComponentProvider,
+    InsightMenuComponentProvider,
+    KpiComponentProvider,
+    WidgetComponentProvider,
+} from "./types";
 
 /**
  * @internal
@@ -35,17 +29,11 @@ interface IDashboardComponentsContext {
     ErrorComponent: React.ComponentType<IErrorProps>;
     LoadingComponent: React.ComponentType<ILoadingProps>;
     LayoutComponent: CustomDashboardLayoutComponent;
-    WidgetComponentProvider: (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
-    InsightComponentProvider: (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightComponent;
-    InsightMenuButtonComponentProvider: (
-        insight: IInsight,
-        widget: IInsightWidget,
-    ) => CustomDashboardInsightMenuButtonComponent;
-    InsightMenuComponentProvider: (
-        insight: IInsight,
-        widget: IInsightWidget,
-    ) => CustomDashboardInsightMenuComponent;
-    KpiComponentProvider: (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
+    WidgetComponentProvider: WidgetComponentProvider;
+    InsightComponentProvider: InsightComponentProvider;
+    InsightMenuButtonComponentProvider: InsightMenuButtonComponentProvider;
+    InsightMenuComponentProvider: InsightMenuComponentProvider;
+    KpiComponentProvider: KpiComponentProvider;
     ButtonBarComponent: CustomButtonBarComponent;
     MenuButtonComponent: CustomMenuButtonComponent;
     TitleComponent: CustomTitleComponent;
@@ -53,9 +41,7 @@ interface IDashboardComponentsContext {
     ScheduledEmailDialogComponent: CustomScheduledEmailDialogComponent;
     ShareDialogComponent: CustomShareDialogComponent;
     SaveAsDialogComponent: CustomSaveAsDialogComponent;
-    DashboardAttributeFilterComponentProvider: (
-        filter: IDashboardAttributeFilter,
-    ) => CustomDashboardAttributeFilterComponent;
+    DashboardAttributeFilterComponentProvider: AttributeFilterComponentProvider;
     DashboardDateFilterComponent: CustomDashboardDateFilterComponent;
     FilterBarComponent: CustomFilterBarComponent;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/index.ts
@@ -6,3 +6,4 @@ export {
 } from "./DashboardCustomizationsContext";
 export { DashboardConfigProvider, useDashboardConfigContext } from "./DashboardConfigContext";
 export { ExportDialogContextProvider, useExportDialogContext } from "./ExportDialogContext";
+export * from "./types";

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/types.ts
@@ -1,0 +1,101 @@
+// (C) 2021 GoodData Corporation
+import {
+    CustomDashboardInsightComponent,
+    CustomDashboardInsightMenuButtonComponent,
+    CustomDashboardInsightMenuComponent,
+    CustomDashboardKpiComponent,
+    CustomDashboardWidgetComponent,
+    IInsightMenuItem,
+} from "../widget/types";
+import { ExtendedDashboardWidget } from "../../model";
+import { IInsight } from "@gooddata/sdk-model";
+import { IDashboardAttributeFilter, IInsightWidget, IKpiWidget, ILegacyKpi } from "@gooddata/sdk-backend-spi";
+import { CustomDashboardAttributeFilterComponent } from "../filterBar/types";
+
+/**
+ * @public
+ */
+export type OptionalProvider<T> = T extends (...args: infer TArgs) => infer TRes
+    ? (...args: TArgs) => TRes | undefined
+    : never;
+
+/**
+ * @public
+ */
+export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
+
+/**
+ * @public
+ */
+export type OptionalWidgetComponentProvider = OptionalProvider<WidgetComponentProvider>;
+
+/**
+ * @public
+ */
+export type InsightComponentProvider = (
+    insight: IInsight,
+    widget: IInsightWidget,
+) => CustomDashboardInsightComponent;
+
+/**
+ * @public
+ */
+export type OptionalInsightComponentProvider = OptionalProvider<InsightComponentProvider>;
+
+/**
+ * @alpha
+ */
+export type InsightMenuButtonComponentProvider = (
+    insight: IInsight,
+    widget: IInsightWidget,
+) => CustomDashboardInsightMenuButtonComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalInsightMenuButtonComponentProvider = OptionalProvider<InsightMenuButtonComponentProvider>;
+
+/**
+ * @alpha
+ */
+export type InsightMenuComponentProvider = (
+    insight: IInsight,
+    widget: IInsightWidget,
+) => CustomDashboardInsightMenuComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalInsightMenuComponentProvider = OptionalProvider<InsightMenuComponentProvider>;
+
+/**
+ * @alpha
+ */
+export type InsightMenuItemsProvider = (
+    insight: IInsight,
+    widget: IInsightWidget,
+    defaultItems: IInsightMenuItem[],
+    closeMenu: () => void,
+) => IInsightMenuItem[];
+
+/**
+ * @public
+ */
+export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
+
+/**
+ * @public
+ */
+export type OptionalKpiComponentProvider = OptionalProvider<KpiComponentProvider>;
+
+/**
+ * @alpha
+ */
+export type AttributeFilterComponentProvider = (
+    filter: IDashboardAttributeFilter,
+) => CustomDashboardAttributeFilterComponent;
+
+/**
+ * @alpha
+ */
+export type OptionalAttributeFilterComponentProvider = OptionalProvider<AttributeFilterComponentProvider>;

--- a/libs/sdk-ui-dashboard/src/presentation/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/index.ts
@@ -1,5 +1,7 @@
 // (C) 2021 GoodData Corporation
 export * from "./dashboard";
+// only export the types for this, not the actual code
+export * from "./dashboardContexts/types";
 export * from "./drill";
 export * from "./filterBar";
 export * from "./layout";

--- a/libs/sdk-ui-dashboard/src/presentation/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/types.ts
@@ -1,5 +1,6 @@
 // (C) 2021 GoodData Corporation
 export * from "./dashboard/types";
+export * from "./dashboardContexts/types";
 export * from "./drill/types";
 export * from "./filterBar/types";
 export * from "./layout/types";


### PR DESCRIPTION
* Use the same pairing Provider – OptionalProvider everywhere
* Use the Provider types in the DashboardComponentsContext
* Move the types around to prevent cyclic dependencies

JIRA: RAIL-3905

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
