### PR TITLE
RELATED: RAIL-3725 HeaderPredicates matching any object for attribute or measure

### DIFF
--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -471,6 +471,7 @@ export const HeaderPredicates: {
     localIdentifierMatch: typeof localIdentifierMatch;
     uriMatch: typeof uriMatch;
     objRefMatch: typeof objRefMatch;
+    objMatch: typeof objMatch;
 };
 
 // @public (undocumented)
@@ -1462,6 +1463,9 @@ export type NullableFilterOrPlaceholder = FilterOrPlaceholder | ValueOrPlacehold
 
 // @public
 export type NullableFiltersOrPlaceholders = Array<FilterOrMultiValuePlaceholder | ValueOrMultiValuePlaceholder<INullableFilter> | ValueOrMultiValuePlaceholder<IFilter | null> | ValueOrMultiValuePlaceholder<IDateFilter | null> | ValueOrMultiValuePlaceholder<IMeasureFilter | null> | ValueOrMultiValuePlaceholder<IAttributeFilter | null> | ValueOrMultiValuePlaceholder<IAbsoluteDateFilter | null> | ValueOrMultiValuePlaceholder<IRelativeDateFilter | null> | ValueOrMultiValuePlaceholder<IPositiveAttributeFilter | null> | ValueOrMultiValuePlaceholder<INegativeAttributeFilter | null> | ValueOrMultiValuePlaceholder<IMeasureValueFilter | null> | ValueOrMultiValuePlaceholder<IRankingFilter | null>>;
+
+// @public
+export function objMatch(obj: any): IHeaderPredicate;
 
 // @public
 export function objRefMatch(objRef: ObjRef): IHeaderPredicate;

--- a/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
+++ b/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
@@ -9,9 +9,14 @@ import {
 } from "./MappingHeader";
 import { IMeasureDescriptor, isMeasureDescriptor, isResultAttributeHeader } from "@gooddata/sdk-backend-spi";
 import {
+    attributeDisplayFormRef,
+    attributeLocalId,
     IMeasure,
     isArithmeticMeasure,
+    isAttribute,
     isIdentifierRef,
+    isObjRef,
+    isSimpleMeasure,
     measureArithmeticOperands,
     measureIdentifier,
     measureLocalId,
@@ -294,6 +299,39 @@ export function objRefMatch(objRef: ObjRef): IHeaderPredicate {
 }
 
 /**
+ * Creates a new predicate that returns true for any header that belongs to either attribute or measure matching
+ * the provided object.
+ *
+ * If the object is empty or is not attribute, simple measure or object reference, the function returns predicate
+ * that is always falsy.
+ *
+ * @param obj - the object to be checked
+ *
+ * @public
+ */
+export function objMatch(obj: any): IHeaderPredicate {
+    if (!obj) {
+        return alwaysFalsePredicate;
+    }
+
+    if (isAttribute(obj)) {
+        return (header, context) =>
+            localIdentifierMatch(attributeLocalId(obj))(header, context) ||
+            objRefMatch(attributeDisplayFormRef(obj))(header, context);
+    }
+
+    if (isSimpleMeasure(obj)) {
+        return localIdentifierMatch(measureLocalId(obj));
+    }
+
+    if (isObjRef(obj)) {
+        return objRefMatch(obj);
+    }
+
+    return alwaysFalsePredicate;
+}
+
+/**
  * Creates a new predicate that returns true of any arithmetic measure where measure with the provided URI
  * is used as an operand.
  *
@@ -334,4 +372,5 @@ export const HeaderPredicates = {
     localIdentifierMatch,
     uriMatch,
     objRefMatch,
+    objMatch,
 };

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -662,7 +662,7 @@ describe("attributeItemNameMatch", () => {
     });
 });
 
-describe("objRefMatch tests", () => {
+describe("objMatch tests", () => {
     it("should return false - empty input", () => {
         const predicate = headerPredicateFactory.objMatch(undefined);
         expect(predicate(attributeDescriptor, context)).toBe(false);
@@ -712,6 +712,40 @@ describe("objRefMatch tests", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/otherAttributeUri")));
 
         const predicate = headerPredicateFactory.objMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+});
+
+describe("objRefMatch tests", () => {
+    it("objRefMatch - should match predicate when attribute objRef matches - identifier match scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute("attributeIdentifier"));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
+    it("objRefMatch - should match predicate when attribute objRef matches - uri match scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/attributeUri")));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
+    it("objRefMatch - should match predicate when attribute objRef matches - identifier match negative scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute("otherAttributeIdentifier"));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("objRefMatch - should match predicate when attribute objRef matches - uri match negative scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/otherAttributeUri")));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(false);
     });

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -663,10 +663,31 @@ describe("attributeItemNameMatch", () => {
 });
 
 describe("objRefMatch tests", () => {
+    it("should return false - empty input", () => {
+        const predicate = headerPredicateFactory.objMatch(undefined);
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("should match predicate when attribute matches", () => {
+        const predicate = headerPredicateFactory.objMatch(
+            newAttribute("attributeIdentifier", (a) =>
+                a.localId(attributeDescriptor.attributeHeader.localIdentifier),
+            ),
+        );
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
+    it("should not match predicate when attribute does not match", () => {
+        const predicate = headerPredicateFactory.objMatch(newAttribute("otherAttributeIdentifier"));
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
     it("should match predicate when attribute objRef matches - identifier match scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute("attributeIdentifier"));
 
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+        const predicate = headerPredicateFactory.objMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(true);
     });
@@ -674,7 +695,7 @@ describe("objRefMatch tests", () => {
     it("should match predicate when attribute objRef matches - uri match scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/attributeUri")));
 
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+        const predicate = headerPredicateFactory.objMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(true);
     });
@@ -682,7 +703,7 @@ describe("objRefMatch tests", () => {
     it("should match predicate when attribute objRef matches - identifier match negative scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute("otherAttributeIdentifier"));
 
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+        const predicate = headerPredicateFactory.objMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(false);
     });
@@ -690,7 +711,7 @@ describe("objRefMatch tests", () => {
     it("should match predicate when attribute objRef matches - uri match negative scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/otherAttributeUri")));
 
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+        const predicate = headerPredicateFactory.objMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(false);
     });

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 
 /*
  *
@@ -208,6 +208,7 @@ export {
     localIdentifierMatch,
     uriMatch,
     objRefMatch,
+    objMatch,
 } from "./headerMatching/HeaderPredicateFactory";
 
 /*


### PR DESCRIPTION
JIRA: RAIL-3725

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
