### PR TITLE
RELATED: RAIL-3914 Add missing spans in certain localized parts

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/DataTooLargeError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/DataTooLargeError.tsx
@@ -16,10 +16,10 @@ export const DataTooLargeError: React.FC<IDataTooLargeErrorProps> = ({ fullConte
             {fullContent ? (
                 <div className="info-label-icon gd-icon-rain">
                     <Typography tagName="h2">
-                        <FormattedMessage id="visualization.dataTooLarge.headline" />
+                        <FormattedMessage id="visualization.dataTooLarge.headline" tagName="span" />
                     </Typography>
                     <Typography tagName="p">
-                        <FormattedMessage id="visualization.dataTooLarge.text" />
+                        <FormattedMessage id="visualization.dataTooLarge.text" tagName="span" />
                     </Typography>
                 </div>
             ) : (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ExecuteProtectedError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/ExecuteProtectedError.tsx
@@ -16,10 +16,13 @@ export const ExecuteProtectedError: React.FC<IExecuteProtectedErrorProps> = ({ f
             {fullContent ? (
                 <div className="info-label-icon gd-icon-warning">
                     <Typography tagName="h2">
-                        <FormattedMessage id="visualization.execute_protected_report.headline" />
+                        <FormattedMessage
+                            id="visualization.execute_protected_report.headline"
+                            tagName="span"
+                        />
                     </Typography>
                     <Typography tagName="h2">
-                        <FormattedMessage id="visualization.execute_protected_report.text" />
+                        <FormattedMessage id="visualization.execute_protected_report.text" tagName="span" />
                     </Typography>
                 </div>
             ) : (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/NoDataError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/NoDataError.tsx
@@ -17,14 +17,14 @@ export const NoDataError: React.FC<INoDataErrorProps> = ({ fullContent }) => {
                     <>
                         <div className="info-label-icon-empty" />
                         <Typography tagName="p">
-                            <FormattedMessage id="visualization.empty.headline" />
+                            <FormattedMessage id="visualization.empty.headline" tagName="span" />
                         </Typography>
                     </>
                 ) : (
                     <BubbleHoverTrigger>
                         <div className="info-label-icon-empty" />
                         <Bubble alignPoints={bubbleAlignPoints}>
-                            <FormattedMessage id="visualization.empty.headline" />
+                            <FormattedMessage id="visualization.empty.headline" tagName="span" />
                         </Bubble>
                     </BubbleHoverTrigger>
                 )}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/OtherError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/CustomError/OtherError.tsx
@@ -16,10 +16,10 @@ export const OtherError: React.FC<IErrorProps> = ({ fullContent }) => {
             {fullContent ? (
                 <div className="info-label-icon gd-icon-warning">
                     <Typography tagName="h2">
-                        <FormattedMessage id="visualization.error.headline" />
+                        <FormattedMessage id="visualization.error.headline" tagName="span" />
                     </Typography>
                     <Typography tagName="p">
-                        <FormattedMessage id="visualization.error.text" />
+                        <FormattedMessage id="visualization.error.text" tagName="span" />
                     </Typography>
                 </div>
             ) : (

--- a/libs/sdk-ui-filters/src/RankingFilter/Preview.tsx
+++ b/libs/sdk-ui-filters/src/RankingFilter/Preview.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2021 GoodData Corporation
 import React from "react";
 import { RankingFilterOperator } from "@gooddata/sdk-model";
 import { FormattedMessage } from "react-intl";
@@ -31,6 +31,7 @@ export const Preview: React.FC<IPreviewProps> = ({ operator, value, measure, att
     <div className="gd-rf-preview s-rf-preview">
         <FormattedMessage
             id={getPreviewTemplate(operator, attribute)}
+            tagName="span"
             values={{
                 measure: measure.title,
                 attribute: attribute?.title,


### PR DESCRIPTION
To make the Graphene tests upstream stable add back recently removed span elements in:

* Preview in RankingFilter
* Widget errors in Dashboard component

JIRA: RAIL-3914

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
