### PR TITLE
RELATED: RAIL-3918 Hide Save As button for users without permission

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -7,8 +7,8 @@ import {
     IDashboardDateFilter,
     isProtectedDataError,
 } from "@gooddata/sdk-backend-spi";
-
 import { ToastMessages, useToastMessage } from "@gooddata/sdk-ui-kit";
+import compact from "lodash/compact";
 
 import {
     changeAttributeFilterSelection,
@@ -16,6 +16,7 @@ import {
     clearDateFilterSelection,
     exportDashboardToPdf,
     renameDashboard,
+    selectCanCreateAnalyticalDashboard,
     selectDashboardRef,
     selectDashboardShareInfo,
     selectDashboardTitle,
@@ -180,17 +181,19 @@ export const DashboardHeader = (): JSX.Element => {
     }, [exportDashboard, dashboardRef]);
 
     const isReadOnly = useDashboardSelector(selectIsReadOnly);
+    const canCreateDashboard = useDashboardSelector(selectCanCreateAnalyticalDashboard);
 
     const defaultMenuItems = useMemo<IMenuButtonItem[]>(() => {
         if (!dashboardRef) {
             return [];
         }
 
+        const isSaveAsVisible = canCreateDashboard;
         const isSaveAsDisabled = isEmptyLayout || !dashboardRef || isReadOnly;
         const isScheduledEmailingDisabled = isReadOnly;
 
-        return [
-            {
+        return compact([
+            isSaveAsVisible && {
                 type: "button",
                 itemId: "save_as_menu_item", // careful, also a s- class selector, do not change
                 disabled: isSaveAsDisabled,
@@ -215,7 +218,7 @@ export const DashboardHeader = (): JSX.Element => {
                 itemName: intl.formatMessage({ id: "options.menu.schedule.email" }),
                 onClick: defaultOnScheduleEmailing,
             },
-        ];
+        ]);
     }, [defaultOnScheduleEmailing, defaultOnExportToPdf, dashboardRef, isReadOnly]);
 
     const onScheduleEmailingError = useCallback(() => {


### PR DESCRIPTION
This is how gdc-dashboards behave, users without
the "canCreateAnalyticalDashboard" permission are not shown
the button at all.

JIRA: RAIL-3918

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
