### PR TITLE
Do not share react-intl with the plugin

### DIFF
--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -208,9 +208,6 @@ module.exports = (_env, argv) => {
                             requiredVersion: deps["react-dom"],
                         },
                         // add all the packages that absolutely need to be shared and singletons because of contexts
-                        "react-intl": {
-                            singleton: true,
-                        },
                         ...gooddataSharePackagesEntries,
                     },
                 }),


### PR DESCRIPTION
- avoid sharing react-intl with the dashboard plugin
- if the dashboard plugin is built with react-intl v3 and SDK contains react-intl v5, current setup can lead to runtime errors (eg FormattedHTMLMessage element does not exist in v5)

JIRA: RAIL-3915

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
