### PR TITLE
Migrate DisabledConfigurationParentItem to react-intl v5

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/DisabledConfigurationParentItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/DisabledConfigurationParentItem.tsx
@@ -1,7 +1,7 @@
 // (C) 2021 GoodData Corporation
 import React from "react";
 import { ArrowOffsets, Bubble, BubbleHoverTrigger, IAlignPoint } from "@gooddata/sdk-ui-kit";
-import { FormattedHTMLMessage } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { stringUtils } from "@gooddata/util/dist";
 import cx from "classnames";
 
@@ -45,9 +45,10 @@ export const DisabledConfigurationParentItem: React.FC<IDisabledConfigurationPar
             >
                 {hasConnectingAttributes ? (
                     <div>
-                        <FormattedHTMLMessage
+                        <FormattedMessage
                             id="attributesDropdown.filterConfiguredMessage"
                             values={{
+                                strong: (chunks: string) => <strong>{chunks}</strong>,
                                 childTitle: attributeFilterTitle,
                                 parentTitle: itemTitle,
                             }}
@@ -55,9 +56,10 @@ export const DisabledConfigurationParentItem: React.FC<IDisabledConfigurationPar
                     </div>
                 ) : (
                     <div>
-                        <FormattedHTMLMessage
+                        <FormattedMessage
                             id="attributesDropdown.noConnectionMessage"
                             values={{
+                                strong: (chunks: string) => <strong>{chunks}</strong>,
                                 childTitle: attributeFilterTitle,
                                 parentTitle: itemTitle,
                             }}


### PR DESCRIPTION
- FormattedHTMLMessage is no longer available in react-intl v5

JIRA: RAIL-3915

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
