### PR TITLE
Handle different versions of the dashboard plugins

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/mkn-rail-3910-validation_2021-12-20-13-57.json
+++ b/common/changes/@gooddata/sdk-ui-all/mkn-rail-3910-validation_2021-12-20-13-57.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Geo Pushpin Chart is no longer supported in Internet Explorer 11.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/config/rush/browser-approved-packages.json
+++ b/common/config/rush/browser-approved-packages.json
@@ -147,10 +147,6 @@
       "allowedCategories": [ "examples", "production", "tools" ]
     },
     {
-      "name": "@gooddata/sdk-ui-charts",
-      "allowedCategories": [ "examples", "production", "tools" ]
-    },
-    {
       "name": "@gooddata/sdk-ui-dashboard",
       "allowedCategories": [ "examples", "production", "tools" ]
     },
@@ -165,6 +161,10 @@
     {
       "name": "@gooddata/sdk-ui-geo",
       "allowedCategories": [ "examples", "production" ]
+    },
+    {
+      "name": "@gooddata/sdk-ui-charts",
+      "allowedCategories": [ "examples", "production", "tools" ]
     },
     {
       "name": "@gooddata/sdk-ui-kit",
@@ -391,6 +391,10 @@
       "allowedCategories": [ "tools" ]
     },
     {
+      "name": "@types/semver",
+      "allowedCategories": [ "production" ]
+    },
+    {
       "name": "@types/spark-md5",
       "allowedCategories": [ "production" ]
     },
@@ -468,14 +472,6 @@
     },
     {
       "name": "case-sensitive-paths-webpack-plugin",
-      "allowedCategories": [ "tools" ]
-    },
-    {
-      "name": "chalk",
-      "allowedCategories": [ "tools" ]
-    },
-    {
-      "name": "chokidar",
       "allowedCategories": [ "tools" ]
     },
     {
@@ -665,6 +661,14 @@
     {
       "name": "http-status-codes",
       "allowedCategories": [ "production" ]
+    },
+    {
+      "name": "chalk",
+      "allowedCategories": [ "tools" ]
+    },
+    {
+      "name": "chokidar",
+      "allowedCategories": [ "tools" ]
     },
     {
       "name": "immer",
@@ -891,16 +895,16 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "recharts",
-      "allowedCategories": [ "examples" ]
-    },
-    {
       "name": "redux-batched-actions",
       "allowedCategories": [ "production" ]
     },
     {
       "name": "redux-saga",
       "allowedCategories": [ "production" ]
+    },
+    {
+      "name": "recharts",
+      "allowedCategories": [ "examples" ]
     },
     {
       "name": "rimraf",
@@ -913,6 +917,10 @@
     {
       "name": "sass-loader",
       "allowedCategories": [ "examples", "production" ]
+    },
+    {
+      "name": "semver",
+      "allowedCategories": [ "production" ]
     },
     {
       "name": "source-map-loader",
@@ -947,11 +955,11 @@
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "stylelint-checkstyle-formatter",
+      "name": "stylelint-config-prettier",
       "allowedCategories": [ "production" ]
     },
     {
-      "name": "stylelint-config-prettier",
+      "name": "stylelint-checkstyle-formatter",
       "allowedCategories": [ "production" ]
     },
     {

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1959,8 +1959,8 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-standard: 20.0.0_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       stylelint-order: 4.1.0_stylelint@13.13.1
       stylelint-scss: 3.21.0_stylelint@13.13.1
     transitivePeerDependencies:
@@ -2089,10 +2089,10 @@ packages:
       '@heroku-cli/command': 8.5.0
       '@oclif/command': 1.8.6
       '@oclif/config': 1.18.1
-      chalk: 2.4.2
       cli-ux: 4.9.3
       debug: 4.3.3
       fs-extra: 7.0.1
+      chalk: 2.4.2
       lodash.flatten: 4.4.0
       tslib: 1.9.3
     transitivePeerDependencies:
@@ -2491,13 +2491,13 @@ packages:
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
       ansi-escapes: 4.3.2
-      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.8
-      jest-changed-files: 27.4.2
+      chalk: 4.1.2
       jest-config: 27.4.2_ts-node@10.4.0
       jest-haste-map: 27.4.2
+      jest-changed-files: 27.4.2
       jest-message-util: 27.4.2
       jest-regex-util: 27.4.0
       jest-resolve: 27.4.2
@@ -2566,11 +2566,11 @@ packages:
       '@jest/transform': 27.4.2
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
-      chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 4.0.3
       istanbul-lib-report: 3.0.0
@@ -2627,10 +2627,10 @@ packages:
       '@babel/core': 7.16.0
       '@jest/types': 27.4.2
       babel-plugin-istanbul: 6.1.1
-      chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-haste-map: 27.4.2
       jest-regex-util: 27.4.0
       jest-util: 27.4.2
@@ -3090,11 +3090,11 @@ packages:
     dependencies:
       '@oclif/color': 0.0.0
       '@oclif/command': 1.5.18
-      chalk: 2.4.2
       cli-ux: 5.6.4
       debug: 4.3.3
       fs-extra: 7.0.1
       http-call: 5.3.0
+      chalk: 2.4.2
       load-json-file: 5.3.0
       npm-run-path: 3.1.0
       semver: 5.7.1
@@ -3134,10 +3134,10 @@ packages:
       '@oclif/command': 1.5.18
       '@oclif/config': 1.13.2
       '@oclif/errors': 1.2.2
-      chalk: 2.4.2
       debug: 4.3.3
       fs-extra: 7.0.1
       http-call: 5.3.0
+      chalk: 2.4.2
       lodash.template: 4.5.0
       semver: 5.7.1
     transitivePeerDependencies:
@@ -3388,9 +3388,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@storybook/api': 6.3.0_react-dom@17.0.2+react@17.0.2
-      '@storybook/channels': 6.3.0
       '@storybook/client-logger': 6.3.0
       '@storybook/core-events': 6.3.0
+      '@storybook/channels': 6.3.0
       '@storybook/router': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/theming': 6.3.0_react-dom@17.0.2+react@17.0.2
       core-js: 3.19.2
@@ -3407,10 +3407,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@reach/router': 1.3.4_react-dom@17.0.2+react@17.0.2
-      '@storybook/channels': 6.3.0
       '@storybook/client-logger': 6.3.0
       '@storybook/core-events': 6.3.0
       '@storybook/csf': 0.0.1
+      '@storybook/channels': 6.3.0
       '@storybook/router': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.3.0_react-dom@17.0.2+react@17.0.2
@@ -3463,13 +3463,13 @@ packages:
       '@babel/preset-typescript': 7.16.0_@babel+core@7.16.0
       '@storybook/addons': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/api': 6.3.0_react-dom@17.0.2+react@17.0.2
-      '@storybook/channel-postmessage': 6.3.0
-      '@storybook/channels': 6.3.0
       '@storybook/client-api': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.3.0
       '@storybook/components': 6.3.0_5539cae010396b202b015f3568914e95
       '@storybook/core-common': 6.3.0_490e12531c2c2a61a1bc9392dbcf4fae
       '@storybook/core-events': 6.3.0
+      '@storybook/channel-postmessage': 6.3.0
+      '@storybook/channels': 6.3.0
       '@storybook/node-logger': 6.3.0
       '@storybook/router': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/semver': 7.3.2
@@ -3526,9 +3526,9 @@ packages:
   /@storybook/channel-postmessage/6.3.0:
     resolution: {integrity: sha512-q7FeNWIIrvZxycIMBscqahFLygxAa2L4eJ9oxZFF9zJpSV80bxDalMou3Uo7RvDJFrAeHCanF1Y7bnEDMus4yg==}
     dependencies:
-      '@storybook/channels': 6.3.0
       '@storybook/client-logger': 6.3.0
       '@storybook/core-events': 6.3.0
+      '@storybook/channels': 6.3.0
       core-js: 3.19.2
       global: 4.4.0
       qs: 6.10.1
@@ -3550,11 +3550,11 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@storybook/addons': 6.3.0_react-dom@17.0.2+react@17.0.2
-      '@storybook/channel-postmessage': 6.3.0
-      '@storybook/channels': 6.3.0
       '@storybook/client-logger': 6.3.0
       '@storybook/core-events': 6.3.0
       '@storybook/csf': 0.0.1
+      '@storybook/channel-postmessage': 6.3.0
+      '@storybook/channels': 6.3.0
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.16.3
       core-js: 3.19.2
@@ -3626,11 +3626,11 @@ packages:
         optional: true
     dependencies:
       '@storybook/addons': 6.3.0_react-dom@17.0.2+react@17.0.2
-      '@storybook/channel-postmessage': 6.3.0
       '@storybook/client-api': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.3.0
       '@storybook/core-events': 6.3.0
       '@storybook/csf': 0.0.1
+      '@storybook/channel-postmessage': 6.3.0
       '@storybook/ui': 6.3.0_5539cae010396b202b015f3568914e95
       airbnb-js-shims: 2.2.1
       ansi-to-html: 0.6.15
@@ -3690,7 +3690,6 @@ packages:
       babel-loader: 8.2.3_1bd60a6cd0f7024f034efd75ae733a3f
       babel-plugin-macros: 3.1.0
       babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.16.0
-      chalk: 4.1.2
       core-js: 3.19.2
       express: 4.17.1
       file-system-cache: 1.0.5
@@ -3698,6 +3697,7 @@ packages:
       fork-ts-checker-webpack-plugin: 6.5.0_9db5b9194b10a90f10e212947d7942e4
       glob: 7.2.0
       glob-base: 0.3.0
+      chalk: 4.1.2
       interpret: 2.2.0
       json5: 2.2.0
       lazy-universal-dotenv: 3.0.1
@@ -3754,7 +3754,6 @@ packages:
       '@types/webpack': 4.41.32
       better-opn: 2.1.1
       boxen: 4.2.0
-      chalk: 4.1.2
       cli-table3: 0.6.0
       commander: 6.2.1
       compression: 1.7.4
@@ -3765,6 +3764,7 @@ packages:
       file-system-cache: 1.0.5
       fs-extra: 9.1.0
       globby: 11.0.4
+      chalk: 4.1.2
       ip: 1.1.5
       node-fetch: 2.6.6
       pretty-hrtime: 1.0.3
@@ -3870,7 +3870,6 @@ packages:
       '@types/webpack': 4.41.32
       babel-loader: 8.2.3_1bd60a6cd0f7024f034efd75ae733a3f
       case-sensitive-paths-webpack-plugin: 2.4.0
-      chalk: 4.1.2
       core-js: 3.19.2
       css-loader: 3.6.0_webpack@4.46.0
       dotenv-webpack: 1.8.0_webpack@4.46.0
@@ -3880,6 +3879,7 @@ packages:
       find-up: 5.0.0
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
+      chalk: 4.1.2
       node-fetch: 2.6.6
       pnp-webpack-plugin: 1.6.4_typescript@4.0.2
       react: 17.0.2
@@ -3911,8 +3911,8 @@ packages:
     resolution: {integrity: sha512-gxvYOwDzHSYDTvnrwsyonCk88lRQ9gHrEvu3J8sM/0G/0br8g7G8+jSakKR8miE7urcwxd0uoYK+Y4KwJHkJpg==}
     dependencies:
       '@types/npmlog': 4.1.3
-      chalk: 4.1.2
       core-js: 3.19.2
+      chalk: 4.1.2
       npmlog: 4.1.2
       pretty-hrtime: 1.0.3
     dev: false
@@ -4068,10 +4068,10 @@ packages:
       '@emotion/core': 10.3.0_react@17.0.2
       '@storybook/addons': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/api': 6.3.0_react-dom@17.0.2+react@17.0.2
-      '@storybook/channels': 6.3.0
       '@storybook/client-logger': 6.3.0
       '@storybook/components': 6.3.0_5539cae010396b202b015f3568914e95
       '@storybook/core-events': 6.3.0
+      '@storybook/channels': 6.3.0
       '@storybook/router': 6.3.0_react-dom@17.0.2+react@17.0.2
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.3.0_react-dom@17.0.2+react@17.0.2
@@ -4704,6 +4704,10 @@ packages:
 
   /@types/semver/5.5.0:
     resolution: {integrity: sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==}
+    dev: false
+
+  /@types/semver/7.3.9:
+    resolution: {integrity: sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==}
     dev: false
 
   /@types/sinonjs__fake-timers/6.0.4:
@@ -5762,10 +5766,10 @@ packages:
     engines: {node: '>=8.0'}
     hasBin: true
     dependencies:
-      chromium-pickle-js: 0.2.0
       commander: 2.20.3
       cuint: 0.2.2
       glob: 7.2.0
+      chromium-pickle-js: 0.2.0
       minimatch: 3.0.4
       mkdirp: 0.5.5
       tmp-promise: 1.1.0
@@ -5919,8 +5923,8 @@ packages:
       '@types/babel__core': 7.1.16
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.4.0_@babel+core@7.16.0
-      chalk: 4.1.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6354,8 +6358,8 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 5.3.1
-      chalk: 3.0.0
       cli-boxes: 2.2.1
+      chalk: 3.0.0
       string-width: 4.2.3
       term-size: 2.2.1
       type-fest: 0.8.1
@@ -6590,10 +6594,10 @@ packages:
     resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}
     dependencies:
       bluebird: 3.7.2
-      chownr: 1.1.4
       figgy-pudding: 3.5.2
       glob: 7.2.0
       graceful-fs: 4.2.8
+      chownr: 1.1.4
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
@@ -6612,9 +6616,9 @@ packages:
     dependencies:
       '@npmcli/fs': 1.0.0
       '@npmcli/move-file': 1.1.2
-      chownr: 2.0.0
       fs-minipass: 2.1.0
       glob: 7.2.0
+      chownr: 2.0.0
       infer-owner: 1.0.4
       lru-cache: 6.0.0
       minipass: 3.1.5
@@ -6692,9 +6696,9 @@ packages:
       '@types/error-stack-parser': 1.3.18
       '@types/lodash': 4.14.177
       callsite: 1.0.0
-      chalk: 2.4.2
       error-stack-parser: 1.3.6
       highlight-es: 1.0.3
+      chalk: 2.4.2
       lodash: 4.17.21
       pinkie-promise: 2.0.1
     dev: false
@@ -6776,9 +6780,9 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
-      check-error: 1.0.2
       deep-eql: 3.0.1
       get-func-name: 2.0.0
+      check-error: 1.0.2
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: false
@@ -6886,10 +6890,10 @@ packages:
     resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
     engines: {node: '>= 6'}
     dependencies:
-      cheerio-select: 1.5.0
       dom-serializer: 1.3.2
       domhandler: 4.2.2
       htmlparser2: 6.1.0
+      cheerio-select: 1.5.0
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       tslib: 2.3.1
@@ -7110,11 +7114,11 @@ packages:
       ansi-escapes: 3.2.0
       ansi-styles: 3.2.1
       cardinal: 2.1.1
-      chalk: 2.4.2
       clean-stack: 2.2.0
       extract-stack: 1.0.0
       fs-extra: 7.0.1
       hyperlinker: 1.0.0
+      chalk: 2.4.2
       indent-string: 3.2.0
       is-wsl: 1.1.0
       lodash: 4.17.21
@@ -7138,12 +7142,12 @@ packages:
       ansi-escapes: 4.3.2
       ansi-styles: 4.3.0
       cardinal: 2.1.1
-      chalk: 4.1.2
       clean-stack: 3.0.1
       cli-progress: 3.9.1
       extract-stack: 2.0.0
       fs-extra: 8.1.0
       hyperlinker: 1.0.0
+      chalk: 4.1.2
       indent-string: 4.0.0
       is-wsl: 2.2.0
       js-yaml: 3.14.1
@@ -7374,8 +7378,8 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      schema-utils: 3.1.1
       serialize-javascript: 5.0.1
+      schema-utils: 3.1.1
       webpack: 5.64.4_webpack-cli@4.9.1
     dev: false
 
@@ -7415,8 +7419,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     dependencies:
-      chalk: 4.1.2
       date-fns: 2.27.0
+      chalk: 4.1.2
       lodash: 4.17.21
       rxjs: 6.6.7
       spawn-command: 0.0.2-1
@@ -7710,8 +7714,8 @@ packages:
       postcss-modules-scope: 2.2.0
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.2.0
-      schema-utils: 2.7.1
       semver: 6.3.0
+      schema-utils: 2.7.1
       webpack: 4.46.0
     dev: false
 
@@ -7729,8 +7733,8 @@ packages:
       postcss-modules-scope: 3.0.0_postcss@8.4.4
       postcss-modules-values: 4.0.0_postcss@8.4.4
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
     dev: false
 
   /css-loader/5.2.7_webpack@5.64.4:
@@ -7747,8 +7751,8 @@ packages:
       postcss-modules-scope: 3.0.0_postcss@8.4.4
       postcss-modules-values: 4.0.0_postcss@8.4.4
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
       webpack: 5.64.4_webpack-cli@4.9.1
     dev: false
 
@@ -7872,8 +7876,6 @@ packages:
       blob-util: 2.0.2
       bluebird: 3.7.2
       cachedir: 2.3.0
-      chalk: 4.1.2
-      check-more-types: 2.24.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.0
       commander: 5.1.0
@@ -7888,6 +7890,8 @@ packages:
       figures: 3.2.0
       fs-extra: 9.1.0
       getos: 3.2.1
+      chalk: 4.1.2
+      check-more-types: 2.24.0
       is-ci: 3.0.1
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
@@ -8258,13 +8262,13 @@ packages:
       acorn-loose: 8.2.1
       acorn-walk: 8.2.0
       ajv: 8.8.2
-      chalk: 4.1.2
       commander: 8.3.0
       enhanced-resolve: 5.8.3
       figures: 3.2.0
       get-stream: 6.0.1
       glob: 7.2.0
       handlebars: 4.7.7
+      chalk: 4.1.2
       indent-string: 4.0.0
       inquirer: 8.2.0
       json5: 2.2.0
@@ -8794,11 +8798,11 @@ packages:
     resolution: {integrity: sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==}
     dependencies:
       array.prototype.flat: 1.2.5
-      cheerio: 1.0.0-rc.10
       enzyme-shallow-equal: 1.0.4
       function.prototype.name: 1.1.5
       has: 1.0.3
       html-element-map: 1.3.1
+      cheerio: 1.0.0-rc.10
       is-boolean-object: 1.1.2
       is-callable: 1.2.4
       is-number-object: 1.0.6
@@ -8959,8 +8963,8 @@ packages:
     dependencies:
       '@types/eslint': 7.29.0
       ansi-escapes: 4.3.2
-      chalk: 4.1.2
       eslint-rule-docs: 1.1.231
+      chalk: 4.1.2
       log-symbols: 4.1.0
       plur: 4.0.0
       string-width: 4.2.3
@@ -9165,7 +9169,6 @@ packages:
       '@eslint/eslintrc': 1.0.4
       '@humanwhocodes/config-array': 0.6.0
       ajv: 6.12.6
-      chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.3
       doctrine: 3.0.0
@@ -9182,6 +9185,7 @@ packages:
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
       globals: 13.12.0
+      chalk: 4.1.2
       ignore: 4.0.6
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -9926,17 +9930,17 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.0
       '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.2
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
       eslint: 8.3.0
       fs-extra: 9.1.0
       glob: 7.2.0
+      chalk: 4.1.2
+      chokidar: 3.5.2
       memfs: 3.4.0
       minimatch: 3.0.4
-      schema-utils: 2.7.0
       semver: 7.3.5
+      schema-utils: 2.7.0
       tapable: 1.1.3
       typescript: 4.0.2
       webpack: 4.46.0
@@ -9958,17 +9962,17 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.0
       '@types/json-schema': 7.0.9
-      chalk: 4.1.2
-      chokidar: 3.5.2
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
       eslint: 8.3.0
       fs-extra: 9.1.0
       glob: 7.2.0
+      chalk: 4.1.2
+      chokidar: 3.5.2
       memfs: 3.4.0
       minimatch: 3.0.4
-      schema-utils: 2.7.0
       semver: 7.3.5
+      schema-utils: 2.7.0
       tapable: 1.1.3
       typescript: 4.0.2
       webpack: 5.64.4_webpack-cli@4.9.1
@@ -10848,10 +10852,10 @@ packages:
       ansi-escapes: 3.2.0
       ansi-styles: 3.2.1
       cardinal: 2.1.1
-      chalk: 2.4.2
       co: 4.6.0
       got: 8.3.2
       heroku-client: 3.1.0
+      chalk: 2.4.2
       lodash: 4.17.21
       netrc-parser: 3.1.6
       opn: 3.0.3
@@ -11471,11 +11475,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       ansi-escapes: 3.2.0
-      chalk: 2.4.2
       cli-cursor: 2.1.0
       cli-width: 2.2.1
       external-editor: 3.1.0
       figures: 2.0.0
+      chalk: 2.4.2
       lodash: 4.17.21
       mute-stream: 0.0.7
       run-async: 2.4.1
@@ -11490,11 +11494,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
+      chalk: 4.1.2
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
@@ -11509,11 +11513,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
-      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
+      chalk: 4.1.2
       lodash: 4.17.21
       mute-stream: 0.0.8
       ora: 5.4.1
@@ -12277,10 +12281,10 @@ packages:
       '@jest/test-result': 27.4.2
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
-      chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
       expect: 27.4.2
+      chalk: 4.1.2
       is-generator-fn: 2.1.0
       jest-each: 27.4.2
       jest-matcher-utils: 27.4.2
@@ -12309,9 +12313,9 @@ packages:
       '@jest/core': 27.4.2_ts-node@10.4.0
       '@jest/test-result': 27.4.2
       '@jest/types': 27.4.2
-      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       import-local: 3.0.3
       jest-config: 27.4.2_ts-node@10.4.0
       jest-util: 27.4.2
@@ -12339,11 +12343,11 @@ packages:
       '@jest/test-sequencer': 27.4.2
       '@jest/types': 27.4.2
       babel-jest: 27.4.2_@babel+core@7.16.0
-      chalk: 4.1.2
       ci-info: 3.3.0
       deepmerge: 4.2.2
       glob: 7.2.0
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-circus: 27.4.2
       jest-environment-jsdom: 27.4.2
       jest-environment-node: 27.4.2
@@ -12369,8 +12373,8 @@ packages:
     resolution: {integrity: sha512-ujc9ToyUZDh9KcqvQDkk/gkbf6zSaeEg9AiBxtttXW59H/AcqEYp1ciXAtJp+jXWva5nAf/ePtSsgWwE5mqp4Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      chalk: 4.1.2
       diff-sequences: 27.4.0
+      chalk: 4.1.2
       jest-get-type: 27.4.0
       pretty-format: 27.4.2
     dev: false
@@ -12496,9 +12500,9 @@ packages:
       '@jest/test-result': 27.4.2
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
-      chalk: 4.1.2
       co: 4.6.0
       expect: 27.4.2
+      chalk: 4.1.2
       is-generator-fn: 2.1.0
       jest-each: 27.4.2
       jest-matcher-utils: 27.4.2
@@ -12546,8 +12550,8 @@ packages:
       '@babel/code-frame': 7.16.0
       '@jest/types': 27.4.2
       '@types/stack-utils': 2.0.1
-      chalk: 4.1.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       micromatch: 4.0.4
       pretty-format: 27.4.2
       slash: 3.0.0
@@ -12595,8 +12599,8 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.4.2
-      chalk: 4.1.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-haste-map: 27.4.2
       jest-pnp-resolver: 1.2.2_jest-resolve@27.4.2
       jest-util: 27.4.2
@@ -12616,10 +12620,10 @@ packages:
       '@jest/transform': 27.4.2
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
-      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-docblock: 27.4.0
       jest-environment-jsdom: 27.4.2
       jest-environment-node: 27.4.2
@@ -12651,13 +12655,13 @@ packages:
       '@jest/transform': 27.4.2
       '@jest/types': 27.4.2
       '@types/yargs': 16.0.4
-      chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
       exit: 0.1.2
       glob: 7.2.0
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-haste-map: 27.4.2
       jest-message-util: 27.4.2
       jest-mock: 27.4.2
@@ -12696,9 +12700,9 @@ packages:
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.4.2
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.16.0
-      chalk: 4.1.2
       expect: 27.4.2
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       jest-diff: 27.4.2
       jest-get-type: 27.4.0
       jest-haste-map: 27.4.2
@@ -12719,9 +12723,9 @@ packages:
     dependencies:
       '@jest/types': 27.4.2
       '@types/node': 16.11.11
-      chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.8
+      chalk: 4.1.2
       picomatch: 2.3.0
     dev: false
 
@@ -14346,11 +14350,11 @@ packages:
     requiresBuild: true
     dependencies:
       async-foreach: 0.1.3
-      chalk: 1.1.3
       cross-spawn: 7.0.3
       gaze: 1.1.3
       get-stdin: 4.0.1
       glob: 7.2.0
+      chalk: 1.1.3
       lodash: 4.17.21
       meow: 9.0.0
       nan: 2.15.0
@@ -14442,8 +14446,8 @@ packages:
     hasBin: true
     dependencies:
       ansi-styles: 3.2.1
-      chalk: 2.4.2
       cross-spawn: 6.0.5
+      chalk: 2.4.2
       memorystream: 0.3.1
       minimatch: 3.0.4
       pidtree: 0.3.1
@@ -14716,9 +14720,9 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       bl: 4.1.0
-      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
+      chalk: 4.1.2
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -15354,8 +15358,8 @@ packages:
       klona: 2.0.5
       loader-utils: 2.0.2
       postcss: 7.0.39
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
       webpack: 4.46.0
     dev: false
 
@@ -15611,9 +15615,9 @@ packages:
     peerDependencies:
       prettier: '>=2.0.0'
     dependencies:
-      chalk: 3.0.0
       execa: 4.1.0
       find-up: 4.1.0
+      chalk: 3.0.0
       ignore: 5.1.9
       mri: 1.2.0
       multimatch: 4.0.0
@@ -16017,7 +16021,6 @@ packages:
       '@babel/code-frame': 7.10.4
       address: 1.1.2
       browserslist: 4.14.2
-      chalk: 2.4.2
       cross-spawn: 7.0.3
       detect-port-alt: 1.1.6
       escape-string-regexp: 2.0.0
@@ -16027,6 +16030,7 @@ packages:
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
+      chalk: 2.4.2
       immer: 8.0.1
       is-root: 2.1.0
       loader-utils: 2.0.0
@@ -16624,8 +16628,8 @@ packages:
       react-is: 16.13.1
       react-resize-detector: 6.7.6_react-dom@17.0.2+react@17.0.2
       react-smooth: 2.0.0_react-dom@17.0.2+react@17.0.2
-      recharts-scale: 0.4.5
       reduce-css-calc: 2.1.8
+      recharts-scale: 0.4.5
     transitivePeerDependencies:
       - prop-types
     dev: false
@@ -17261,8 +17265,8 @@ packages:
       klona: 2.0.5
       loader-utils: 2.0.2
       neo-async: 2.6.2
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
     dev: false
 
   /sass-loader/10.2.0_341eb52569068637b7d77d447d0b9b8d:
@@ -17286,8 +17290,8 @@ packages:
       neo-async: 2.6.2
       node-sass: 6.0.1
       sass: 1.44.0
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
       webpack: 5.64.4_webpack-cli@4.9.1
     dev: false
 
@@ -17311,8 +17315,8 @@ packages:
       loader-utils: 2.0.2
       neo-async: 2.6.2
       sass: 1.44.0
-      schema-utils: 3.1.1
       semver: 7.3.5
+      schema-utils: 3.1.1
       webpack: 5.64.4_webpack-cli@4.9.1
     dev: false
 
@@ -18412,7 +18416,6 @@ packages:
       '@stylelint/postcss-markdown': 0.36.2_4f7b71a942b8b7a555b8adf78f88122b
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
-      chalk: 4.1.2
       cosmiconfig: 7.0.1
       debug: 4.3.3
       execall: 2.0.0
@@ -18424,6 +18427,7 @@ packages:
       globby: 11.0.4
       globjoin: 0.1.4
       html-tags: 3.1.0
+      chalk: 4.1.2
       ignore: 5.1.9
       import-lazy: 4.0.0
       imurmurhash: 0.1.4
@@ -18623,8 +18627,8 @@ packages:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
     dependencies:
-      chownr: 2.0.0
       fs-minipass: 2.1.0
+      chownr: 2.0.0
       minipass: 3.1.5
       minizlib: 2.1.2
       mkdirp: 1.0.4
@@ -18693,8 +18697,8 @@ packages:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
-      schema-utils: 1.0.0
       serialize-javascript: 4.0.0
+      schema-utils: 1.0.0
       source-map: 0.6.1
       terser: 4.8.0
       webpack: 4.46.0
@@ -18712,8 +18716,8 @@ packages:
       find-cache-dir: 3.3.2
       jest-worker: 26.6.2
       p-limit: 3.1.0
-      schema-utils: 3.1.1
       serialize-javascript: 5.0.1
+      schema-utils: 3.1.1
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 4.46.0
@@ -18739,8 +18743,8 @@ packages:
         optional: true
     dependencies:
       jest-worker: 27.4.2
-      schema-utils: 3.1.1
       serialize-javascript: 6.0.0
+      schema-utils: 3.1.1
       source-map: 0.6.1
       terser: 5.10.0_acorn@8.6.0
       webpack: 5.64.4_webpack-cli@4.9.1
@@ -18927,9 +18931,6 @@ packages:
       bowser: 2.11.0
       callsite: 1.0.0
       callsite-record: 4.1.3
-      chai: 4.3.4
-      chalk: 2.4.2
-      chrome-remote-interface: 0.30.1
       coffeescript: 2.6.1
       commander: 8.3.0
       debug: 4.3.3
@@ -18946,6 +18947,9 @@ packages:
       graceful-fs: 4.2.8
       graphlib: 2.1.8
       humanize-duration: 3.27.0
+      chai: 4.3.4
+      chalk: 2.4.2
+      chrome-remote-interface: 0.30.1
       import-lazy: 3.1.0
       indent-string: 1.2.2
       is-ci: 1.2.1
@@ -19349,8 +19353,8 @@ packages:
       typescript: '*'
       webpack: '*'
     dependencies:
-      chalk: 4.1.2
       enhanced-resolve: 4.5.0
+      chalk: 4.1.2
       loader-utils: 2.0.2
       micromatch: 4.0.4
       semver: 7.3.5
@@ -19364,8 +19368,8 @@ packages:
       typescript: '*'
       webpack: '*'
     dependencies:
-      chalk: 4.1.2
       enhanced-resolve: 4.5.0
+      chalk: 4.1.2
       loader-utils: 2.0.2
       micromatch: 4.0.4
       semver: 7.3.5
@@ -19425,8 +19429,8 @@ packages:
   /tsconfig-paths-webpack-plugin/3.5.2:
     resolution: {integrity: sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==}
     dependencies:
-      chalk: 4.1.2
       enhanced-resolve: 5.8.3
+      chalk: 4.1.2
       tsconfig-paths: 3.12.0
     dev: false
 
@@ -19805,9 +19809,9 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       boxen: 4.2.0
-      chalk: 3.0.0
       configstore: 5.0.1
       has-yarn: 2.1.0
+      chalk: 3.0.0
       import-lazy: 2.1.0
       is-ci: 2.0.0
       is-installed-globally: 0.3.2
@@ -20208,9 +20212,9 @@ packages:
     dependencies:
       acorn: 8.6.0
       acorn-walk: 8.2.0
-      chalk: 4.1.2
       commander: 7.2.0
       gzip-size: 6.0.0
+      chalk: 4.1.2
       lodash: 4.17.21
       opener: 1.5.2
       sirv: 1.0.18
@@ -20369,7 +20373,6 @@ packages:
     dependencies:
       ansi-html-community: 0.0.8
       bonjour: 3.5.0
-      chokidar: 2.1.8
       compression: 1.7.4
       connect-history-api-fallback: 1.6.0
       debug: 4.3.3_supports-color@6.1.0
@@ -20377,6 +20380,7 @@ packages:
       express: 4.17.1
       html-entities: 1.4.0
       http-proxy-middleware: 0.19.1_debug@4.3.3
+      chokidar: 2.1.8
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.5
@@ -20386,10 +20390,10 @@ packages:
       opn: 5.5.0
       p-retry: 3.0.1
       portfinder: 1.0.28
-      schema-utils: 1.0.0
       selfsigned: 1.10.11
       semver: 6.3.0
       serve-index: 1.9.1
+      schema-utils: 1.0.0
       sockjs: 0.3.21
       sockjs-client: 1.5.2
       spdy: 4.0.2_supports-color@6.1.0
@@ -20476,9 +20480,9 @@ packages:
       acorn: 6.4.2
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
-      chrome-trace-event: 1.0.3
       enhanced-resolve: 4.5.0
       eslint-scope: 4.0.3
+      chrome-trace-event: 1.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 2.4.0
       loader-utils: 1.4.0
@@ -20512,13 +20516,13 @@ packages:
       acorn: 8.6.0
       acorn-import-assertions: 1.8.0_acorn@8.6.0
       browserslist: 4.18.1
-      chrome-trace-event: 1.0.3
       enhanced-resolve: 5.8.3
       es-module-lexer: 0.9.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.8
+      chrome-trace-event: 1.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 4.2.0
       mime-types: 2.1.34
@@ -20924,7 +20928,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-zCmUqWp7FGqKTAqR8nJnWKVRaUGZxA1C0tTOa2Pv/KwP3FD4zitec6gJyT+uVcpgnTK8Uw/QfqjgQEmdr+WrJA==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-H/w24PoB2DIj5EYLipjJDMxNnxlz+zVCkOxjkR0A0rCvWOL3qyt4qJqsb5+0pANOmQQQnK+YHrLTh3+teTVG5Q==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -20989,7 +20993,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-olMHjj4u45XlZPLwbDFsuQRhWt419H44pgsrdAqrTz4WoA+FogkVmGQy6GAqxNxjsUc//OM7XSSXPGVPFQHmZw==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-LGfAJBw90TdnyC1Ntyn+sj8zk2rsllQsRo0i6rwA1CS+GIdff2Zy+kujPAM1I/CkynEZ/yNMVs4qEQh3vY14VA==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21095,7 +21099,6 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       blessed: 0.1.81
-      chokidar: 3.5.2
       commander: 8.3.0
       cross-spawn: 7.0.3
       dependency-cruiser: 10.8.0
@@ -21107,6 +21110,7 @@ packages:
       eslint-plugin-prettier: 4.0.0_eslint@8.3.0+prettier@2.5.0
       eslint-plugin-sonarjs: 0.11.0_eslint@8.3.0
       find-up: 5.0.0
+      chokidar: 3.5.2
       jest: 27.4.2_ts-node@10.4.0
       jest-junit: 3.7.0
       json5: 2.2.0
@@ -21130,7 +21134,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-Zxe24hDkoV92ZqBiaxCJyMuwlrmSNYOyFCOngsaUpEymC7B1qwCLKcOS/axTlj1r3mwT6y8A4IWQ6ey0tYYiCw==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-VOq2dnj6mf318OsdLYftmjfV9FzCn+pWc2Xk/dW2s8tpHZ2LPuaZsMrxUh1h4/Sugkx+ZHPWpmrltqHXwpoLAQ==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21144,7 +21148,6 @@ packages:
       '@types/prettier': 1.18.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
-      chalk: 4.1.2
       commander: 8.3.0
       dependency-cruiser: 10.8.0
       dotenv: 10.0.0
@@ -21155,6 +21158,7 @@ packages:
       eslint-plugin-no-only-tests: 2.6.0
       eslint-plugin-prettier: 4.0.0_eslint@8.3.0+prettier@2.5.0
       eslint-plugin-sonarjs: 0.11.0_eslint@8.3.0
+      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.4.2_ts-node@10.4.0
       jest-junit: 3.7.0
@@ -21182,7 +21186,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-V2y43q+6P7C0r9hEwfAXLNC6T9wUgYHMieb2XTJtVg2HTp30OKI1Or8SVxnh8yugUdcjihibDmi3ppCYdUdBMA==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-/JlPbGwdhBBgwR1ieSmkC2awEoF1ySd4hoqwG6VzpwkffynFQojEQFF30Dc4WmLPPIspU6tQCCobdJz8/J69PQ==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21259,7 +21263,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-7CpNEcB3erUcbF+HGXfDQs/r+TSQo48TeCe/0hLjzkzegcI5yJJYM28g45ui8iQOZ7QRycJ3qyIy3buEZs6dFQ==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-VqWCWx4YI92kYodORSB2emJoAIamfH/iRE7IKDzIFkSwQI+k/THRxcWA6yAZ5GLFsxQaOlVItxtW2Gn2rdzwsQ==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21299,7 +21303,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-H0gUklc4qDGFYt74WMWCqrmOFPH/tdwQatv6rYEPTKRaoWyhLSgP0gdwYiueoWcQNDTpBhvB5VXP02mNuutrGQ==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-8DwHC0b132fPnGKT0WFxQnBDvXhBe/mkt1tuylWBtmvYoUjlgomn0FR87HKjkFkjv6lU5j5Erx95r8iB8MmJDQ==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21338,7 +21342,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-uXpMQyPx+YkjxiMh2nvptL5oQkvK0NFgHbNoDyLNZGOwjPgyiEwagxS2s3lyz3F4zHNJIKkq6HFFTcUS+LWNJQ==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-oiH//LyBlx0cKcO9gx8x8z0cUuzZX+KvaBYtEcTEonasRqOqVrAM0csomCkQI8Zaj0zbWpsL73CMFjHJs4gCXA==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21352,7 +21356,6 @@ packages:
       '@types/rimraf': 2.0.5
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
-      chalk: 4.1.2
       commander: 8.3.0
       dependency-cruiser: 10.8.0
       eslint: 8.3.0
@@ -21362,6 +21365,7 @@ packages:
       eslint-plugin-no-only-tests: 2.6.0
       eslint-plugin-prettier: 4.0.0_eslint@8.3.0+prettier@2.5.0
       eslint-plugin-sonarjs: 0.11.0_eslint@8.3.0
+      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.4.2_ts-node@10.4.0
       jest-junit: 3.7.0
@@ -21390,7 +21394,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-42uSl59vAZl/uxudsS9RWdDY+xSmNRwopq4JYcW68FO+ReyN+2ErhBF1INHyTu2JOTsc3hGevPE6VqLtbjSucA==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-2ry5iaHf7jGpxQsFbG7KONHpPBfzLBfo79fn3rG6HVVKaOq/YZe8ewTTFhZECqc59/qn5FvZvgplioHbGUXfnA==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21474,7 +21478,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-/a9kx/mun0hkv03jjjfvj2t+uFQDeObbvXjGROFW/Mer265nB8RYWIQl9P1gTncJaQa3ojlgXeo4aB+onVgrkw==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-sYvfi/yQtlNZuvjqKmFw4vGl/bOjqINZLePJKmkh3fdMfUaO8a+uo8WVXjUdLLwdoiSMw3+5swXKyw7e/yaNgg==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -21494,7 +21498,6 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       axios: 0.21.4
-      chalk: 4.1.2
       columnify: 1.5.4
       commander: 8.3.0
       concurrently: 6.4.0
@@ -21510,6 +21513,7 @@ packages:
       eslint-plugin-sonarjs: 0.11.0_eslint@8.3.0
       fast-glob: 3.2.7
       fs-extra: 10.0.0
+      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.4.2_ts-node@10.4.0
       jest-junit: 3.7.0
@@ -21536,7 +21540,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-tzfH2CJ1jrNFqLMYDQ2Lmx/9WFGgICK3Uh5KvpVRYB34o45yZ44NaAR5VCb1rHsNDccjqu4xbS+r4nBF+xMrow==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-PlvJD895L9dBx+eLaFjTIaEnF/0qqVrggk2Vrxf0HWHe0Q4SSNTnNFWY5JYM0BF1IHrRaGAAmPmkp9XsN4CEEg==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -21574,7 +21578,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-k8w6zb1K0qyFZeu/V9NgespJIqZUARLtcIcZSoL5vdb3f/3eW9zI8ahV6nym0anA8OV7K8K0FYarVl7B2ifk1w==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-h0LDAV1GsxqsujZnkSwAri8TgDy2PmPyqxw4yeCfcouZHMhHAEhdP/JAgNVx/ylCbahZVyG77hj4TN7vWAFf+A==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -21613,7 +21617,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-t7Y1rxH8zHghT9wR99HQMKi/WQ0cw45C5iN3upp3MLwwoThAL2c1KbRrk6DcKkUH8UNeIgd+9amqQ+T/W+DLOw==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-WyJYjbpqu/JgvXLmiORmIImzJ+MT7K54cVp9o/BBM10vFcuUBsuC49tT6fXiLBA6R1fK4OvyE6xsFwpEREQxUg==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -21664,7 +21668,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-ojStvMbHlCYKdqe0MJEipe4a1EiEL+Ky3FKdzwHggUem0nmu9pspzYPQIBxTZUiR/Cm7+3bxB0v4afjleV337w==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-qTfvg9Aj8UFysYgCRwv5jwSZTB3GB8ZiM2gNvOYBjIpmDY8W4DB0OC/YZy7Uhip9DNV8Z0dLXknEOpURc4W4RQ==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -21715,7 +21719,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-2Jo5/MbJbuipPL0RNTIvSTgNogGoqi9+1Ms5EMj7tbN4WhI9gHGFcMT6QPcG1KP39ajoR5AbuEwKSaKnMHJp+w==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-8XmIZRhpL6h9vuNUy8u13zNeFofH3xTVPy/ZlLSQ0IlnRemxXIIMnAXJRtTIp4kSRe5ygXChkpx537IvOg/QvA==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -21759,7 +21763,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-O/NC5wjpBtEjoPbgDAV+WGgybwiOBzQl1FN2xr0DwG9UKJUhfpWlI6dbeuMp9dlgfi3t/XR9WEn2HsF8/hqelw==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-JaFCjGjC/WUFXmziTjt6i0AXmJg/FgGRXxBt+SM1Y894bhUE6sL0uZmeYPQ2rl/26/6OtruYkuIt1lsvCnLFpw==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -21803,7 +21807,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-US1xXmLBy+T3YNGhodIf4Z3sGMOV7EcmgPTVB6SmqfX10YUQjeHgFi72JmxSG4B9XXAuSDg5PI9k/yXTe9I2CQ==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-SkXx7tc02h9qHw01l71l7lQ+N8ogDKYgv95z/nF+yFqAOitsWKepz7gX2QkQMGWgELKPUCT67aqzotiDByELww==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -21854,7 +21858,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-4+gd1gjbqrXRmkaxjMNnFS+ENhWpyXkk2c1aD3NeQWFmWCKLOY8BWf6WDAzZxkfdDL5MsGgX0WF4434+pc+oSQ==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-ncRnD7anQm7vyP+sT6yH4RPKzUbw/NWES3UgPHUiCT7SagzF0QoRNWBOLMefCSc94+5r3gjLxblaOq9SXv5x4A==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -21896,7 +21900,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-T70W222am/sVlz//uQw4gpxNYP/CuW0K9WAm04rc90a2At/w1SYe0OgjOwYuPXkrOyEjXJMNQmXP0YTNzzmlng==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-FzkkN6w2ni03sYinu8JhuUiBf4tf16s++d0UzKWBWi5p5IUYP/cS6v6kljJCmw337gn8b/GODuHDbudrcaQPvA==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22154,7 +22158,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-3RfTUvrojHqkSVpdxoNkRzDzvc4qTrNer5PcroUKxGzVLqyp5cMRJj+u3wIWfmo/Bib2Icgc1sVjukK05CHqBw==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-CBg3RRjvx1rXRi85SF0aamQo1SUt+TyA4HEsM90fC0FhTjrQUq8pC+lCLGnzPvmX4bJ8bCKrcCtryar13xSorg==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22193,7 +22197,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-vQHBkZGkQGNYEcVaqJ8ggCT6RVFBMHqohS/rykWS3hWvrdFqWIbBBXK8gRUWyPIhjchXZUw/8yQn4kmcHQqaoA==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-NMOfFkwPE1g+EBUtcPQUiEvTgZTAVNWI5wO6+/KW8h7/HapI7zluu0+G8ICNhUNJ9Qtlk4MISaaL3edNGaOhOg==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22248,8 +22252,8 @@ packages:
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       svg-classlist-polyfill: 1.0.6
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
@@ -22269,7 +22273,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-xvFSTyEILF9t3K/j56qPK6KF7rtuniMiIvvVP9u9SC833X/VJxoYSHFOkUchmX56oVKT6BhBpVQfZWD/bQKQZQ==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-ANrQTQDVnNVQj3s3gvh/L/bmzIUG0A3cJWIy0inkmIOq736AbD+1RFo8Ggqt9T16qzXMaMJJD9DeKYIwjqfWKQ==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22354,7 +22358,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-9epQtFuBMa90OhVVy7zrPggV3httY+22sI4PvVLHk8q7SsDJ7p+2vzorjLfxJe6wFEGjGt7AM44FTBWLbNrOqg==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-4Gya07km/D16XBMExbRTnvYGA600/FajJ+wBhea/Ot4ZGkk+O8s2wVctFPeCZHPD33aXUYZGc3d2DA1dm/kOPQ==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22416,8 +22420,8 @@ packages:
       react-transition-group: 4.4.2_react-dom@17.0.2+react@17.0.2
       react-truncate: 2.4.0_react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       svgo: 2.8.0
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
@@ -22438,7 +22442,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-c3gM4kAtEY8EYJJslsLewSK91spfKZPRHkBUew7zvkqI9c1yk/e3mNzoPcQGNWeTjPUYKCMXR59n9ylEipkFtw==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-L4l+sg7ic6KA11lcGQOya5BAhqCjXBWycdoMKDvPkir+6WbIHGZ+/uJchlNG5v8wTTXOQG2gzqM0MQLP3Dx2cg==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -22497,8 +22501,8 @@ packages:
       react-responsive: 8.2.0_react@17.0.2
       react-window: 1.8.6_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tslib: 2.3.1
@@ -22516,7 +22520,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-hEhI4u+yGLeWjHnMNKhJvSSuYUSWqJKbO77RPo4kw4jnmVsy6s+7MYK/lbw8KzY+0b3iWHlLerQPjNaR03pNzA==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-M3sBHXvcMRnq3ZPq25uaoGxvnK1A0Tx9b9YvLluHMyu2QYJr52f83qwTZr4ecuR5IgwYvnnu4UFIeUu/C5OKlw==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -22566,8 +22570,8 @@ packages:
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tslib: 2.3.1
@@ -22586,7 +22590,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-PR8iBZxwyhuLWxmtCrqSQYRjjl4AH15ZkdYZ0b0hOYVSqZZq0YlReUDsfFZDMzCwO7wP4gZeqzpTrJCLdKgE5w==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-3if8M69p5a1nq7qxVgxkCDG/01KKS2RyAD1QZipx3kCAxt3I8VnA6ziI/tFnyCD/WS80F/n+x9v6Gxnze3YvGg==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -22660,8 +22664,8 @@ packages:
       react-textarea-autosize: 8.3.3_cfedea9b3ed0faf0dded75c187406c5e
       react-transition-group: 4.4.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       svgo: 2.8.0
       tinycolor2: 1.4.2
       ts-invariant: 0.7.5
@@ -22682,7 +22686,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-Ch5zqksHGjwL94AHIi7aO9GI99xkrpLVZC0dbUBstDiWlfYyhaeKuVnAF/UMyDlc4UG4tuPevMGP7qFGXM5kfw==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-faUndzladYNP6ilzkRPw595td9ZJ3vLwCKsdhWqLjzItMDnWcGDpVMEjrPDUTZOzK/U0MAMhgpv7zqYP7COBBQ==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -22696,6 +22700,7 @@ packages:
       '@types/raf': 3.4.0
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
+      '@types/semver': 7.3.9
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22722,6 +22727,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
+      semver: 7.3.5
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tslib: 2.3.1
@@ -22739,7 +22745,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-zwBHwbNHZv9ZU4tCyP5+8FEtY/awM4D5rwhvZhYt1hNoyOax9o9yFwxcjoHT5qkYSTGhAx/KAV6B5arxR3ID8Q==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-HjubLHaK3Ww//BBqPM3+DgItUIbTP3lLZwr/JnQjqGbflGccTUqN7N3lDrNSqJjfv93jaWItsc0f4GrWjr5c9g==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -22791,8 +22797,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tslib: 2.3.1
@@ -22812,7 +22818,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-oP8R34vEan2RMo3+11+ni1MOjLumHa6d/ylu5Ri+8fNmqZzKHKRea69bQNlB6tGIHDlVUnRWySXoh58JSBWOyg==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-rkYd8VA8B+j5mKbimTA6UtJL6jrEEhP9SPkz+LJeOvxaRzid7gozOqCDL7DRV5pMXAWjI8CymX98TYarZKk4IQ==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -22912,7 +22918,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-/a0iwccMhS3X2dfWYyqx7kUcu87UhOZ8KTDfx9SrLlKlKa38Ytj1Gx7Yae17qu+MgESg6pj7M73Xg5G0wVQsZQ==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-VE7slypCr2vT6J4Hajv3bsQwakjENPgv/UZxsj0gcL72WZ1o4pnT+DsvpMhESjjDZGe7gLh5jFP3XksMkbKfaA==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -22974,8 +22980,8 @@ packages:
       spark-md5: 3.0.2
       style-loader: 1.3.0
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       testcafe: 1.17.1
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_0c1d779e00072c44d0a6a9615a4f0a08
@@ -23012,7 +23018,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-UztDmo2zcnwu6eOmCGqZEIUKIq5J5g24K3bffeXmQIL8ICAig5d/hti8Koe04/vgiEHhrHPTcQuECnTa7TTXlQ==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-AFMh4ap74YupdEFqVGA7s78kf4dFG4SAeeOhJbebJjtTsxKzB3KNkBcpu5HK/jzwPEKb1IdCiq/Y0kmFuVVD+w==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23070,7 +23076,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-qLcrHQ/BCgY0ONO9pQNwUGCWKwEyIDFkiao5VM0HnndMpn29oNkBsWHaNq9TKE5vkpw0tacBkKqD6Gn4di2eKg==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-Hn1LWAbfM7cLPppNfWl7OvThX0WNfbGcTMn7Y21wnCIE9wkBu7K6U2w/GV/9k2wnkwq0fkpZZesDU5ng5Mxrig==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23116,8 +23122,8 @@ packages:
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tslib: 2.3.1
       typescript: 4.0.2
@@ -23134,7 +23140,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-lx1y5qJhkpNttVdTLBlN7alndlmIE8hKgeNN6sxZeWb2Qih3UxQQV3Oeq46H1/obO/9Lh8e7QDF8YAq8VGdZbw==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-owVPU4sYIbeBwulk5yf3S5do/ZMR7gE/u14VVej4fchd+yZJ+XTsmXMJZuNvdsGjVq9go8YwItOxfT7cZ1BcMw==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0
@@ -23188,8 +23194,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.23.0_react@17.0.2+typescript@4.0.2
       stylelint: 13.13.1
-      stylelint-checkstyle-formatter: 0.1.2
       stylelint-config-prettier: 8.0.2_stylelint@13.13.1
+      stylelint-checkstyle-formatter: 0.1.2
       ts-invariant: 0.7.5
       ts-jest: 27.0.7_2775690c852eaeee158508de6867e4cb
       tsd: 0.15.1

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1304,8 +1304,8 @@ export type DashboardPluginDescriptor = {
     readonly shortDescription?: string;
     readonly longDescription?: string;
     readonly debugName?: string;
-    readonly minEngineVersion: "bundled";
-    readonly maxEngineVersion?: "bundled";
+    readonly minEngineVersion: string;
+    readonly maxEngineVersion?: string;
 };
 
 // @public
@@ -1315,9 +1315,9 @@ export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
     // (undocumented)
     abstract readonly displayName: string;
     // (undocumented)
-    readonly maxEngineVersion = "bundled";
+    readonly maxEngineVersion?: string;
     // (undocumented)
-    readonly minEngineVersion = "bundled";
+    readonly minEngineVersion: string;
     // (undocumented)
     readonly _pluginVersion = "1.0";
     // (undocumented)

--- a/libs/sdk-ui-dashboard/src/plugins/plugin.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/plugin.ts
@@ -43,13 +43,19 @@ export type DashboardPluginDescriptor = {
 
     /**
      * Minimum version of dashboard engine that this plugin supports.
+     *
+     * Value can be "bundled" - then the minimum required version of the engine equals to the bundled one.
+     * Another option is to specify exact minimum version of the SDK - e.g. "8.7.0".
      */
-    readonly minEngineVersion: "bundled";
+    readonly minEngineVersion: string;
 
     /**
      * Greatest version of the dashboard engine that this plugin supports.
+     *
+     * Value can be "bundled" - then the maximum possible version of the engine equals to the bundled one.
+     * Another option is to specify exact maximum version of the SDK - e.g. "8.8.0".
      */
-    readonly maxEngineVersion?: "bundled";
+    readonly maxEngineVersion?: string;
 };
 
 /**
@@ -126,8 +132,8 @@ export interface IDashboardPluginContract_V1 extends DashboardPluginDescriptor {
  */
 export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
     public readonly _pluginVersion = "1.0";
-    public readonly minEngineVersion = "bundled";
-    public readonly maxEngineVersion = "bundled";
+    public readonly minEngineVersion: string = "bundled";
+    public readonly maxEngineVersion?: string = "bundled";
     public abstract readonly author: string;
     public abstract readonly displayName: string;
     public abstract readonly version: string;

--- a/libs/sdk-ui-geo/README.md
+++ b/libs/sdk-ui-geo/README.md
@@ -4,6 +4,10 @@ This package provides the components that you can use to visualize location-base
 
 Currently, only the GeoPushpinChart component is available. Use this component to visualize data bound to a single location (not an area).
 
+#### Internet Explorer
+
+With GoodData.UI SDK version >=8.8, Geo Pushpin Chart is no longer supported in Internet Explorer 11.
+
 ## License
 
 (C) 2017-2021 GoodData Corporation

--- a/libs/sdk-ui-loaders/package.json
+++ b/libs/sdk-ui-loaders/package.json
@@ -59,6 +59,7 @@
         "@gooddata/sdk-ui": "^8.8.0-alpha.36",
         "lodash": "^4.17.19",
         "react-intl": "^5.23.0",
+        "semver": "^7.3.5",
         "ts-invariant": "^0.7.3",
         "tslib": "^2.0.0"
     },
@@ -78,6 +79,7 @@
         "@types/raf": "^3.4.0",
         "@types/react-dom": "^17.0.11",
         "@types/react": "^17.0.34",
+        "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/determineDashboardEngine.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/determineDashboardEngine.ts
@@ -1,0 +1,44 @@
+// (C) 2021 GoodData Corporation
+// import semver from 'semver';
+import { IDashboardEngine, IDashboardPluginContract_V1 } from "@gooddata/sdk-ui-dashboard";
+import semverCompareBuild from "semver/functions/compare-build";
+import semverSatisfies from "semver/functions/satisfies";
+
+/**
+ * Determine dashboard engine to use with the plugins.
+ * Currently it selects the engine with the greatest version.
+ *
+ * @internal
+ */
+export function determineDashboardEngine(engines: IDashboardEngine[]): IDashboardEngine {
+    const sortedByVersion = [...engines].sort((engineA, engineB) =>
+        semverCompareBuild(engineB.version, engineA.version),
+    );
+    const [engineWithGreatestVersion] = sortedByVersion;
+    return engineWithGreatestVersion;
+}
+
+/**
+ * Checks if the dashboard plugin match version of the dashboard engine.
+ *
+ * @internal
+ */
+export function isPluginCompatibleWithDashboardEngine(
+    engine: IDashboardEngine,
+    plugin: IDashboardPluginContract_V1,
+): boolean {
+    const { minEngineVersion, maxEngineVersion, debugName, displayName, version } = plugin;
+    const requiredVersion = `>=${minEngineVersion}${maxEngineVersion ? " <=" + maxEngineVersion : ""}`;
+    const matchesEngineVersion = semverSatisfies(engine.version, requiredVersion);
+    if (!matchesEngineVersion) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `The dashboard plugin ${
+                debugName ?? displayName
+            } ${version} requires engine with version ${requiredVersion}, but the loaded dashboard engine has version ${
+                engine.version
+            }.`,
+        );
+    }
+    return matchesEngineVersion;
+}

--- a/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
+++ b/tools/dashboard-plugin-template/src/plugin/Plugin.tsx
@@ -10,7 +10,8 @@ import {
     newCustomWidget,
 } from "@gooddata/sdk-ui-dashboard";
 
-import packageJson from "../../package.json";
+import entryPoint from "../plugin_entry";
+
 import React from "react";
 
 /*
@@ -22,9 +23,11 @@ function MyCustomWidget(_props: IDashboardWidgetProps): JSX.Element {
 }
 
 export class Plugin extends DashboardPluginV1 {
-    public readonly author = packageJson.author;
-    public readonly displayName = packageJson.name;
-    public readonly version = packageJson.version;
+    public readonly author = entryPoint.author;
+    public readonly displayName = entryPoint.displayName;
+    public readonly version = entryPoint.version;
+    public readonly minEngineVersion = entryPoint.minEngineVersion;
+    public readonly maxEngineVersion = entryPoint.maxEngineVersion;
 
     public onPluginLoaded(_ctx: DashboardContext, _parameters?: string): Promise<void> | void {
         /*

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -136,6 +136,14 @@ function performReplacementsInFiles(dir: string, config: InitCmdActionConfig): P
                     },
                 ],
             },
+            [pluginIdentifier]: {
+                [`Plugin.${language}x`]: [
+                    {
+                        regex: /"\.\.\/plugin_entry"/g,
+                        value: `"../${pluginIdentifier}_entry"`,
+                    },
+                ],
+            },
         },
     };
 


### PR DESCRIPTION
Handle different versions of the dashboard plugins

When the dashboard is linked with multiple plugins:
- Load the engine with the greatest version
- If some of the plugins do not match the engine version, do not initialize any at all

JIRA: RAIL-3910

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
