### PR TITLE
RELATED: RAIL-3929 Make the ag-grid internals access robust

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/base/agApiWrapper.ts
+++ b/libs/sdk-ui-pivot/src/impl/base/agApiWrapper.ts
@@ -9,7 +9,7 @@ function getCellElement(gridApi: GridApi, attributeId: string, rowIndex: number)
     const rowRenderer = (gridApi as any).rowRenderer;
     const rowCon = rowRenderer.rowConsByRowIndex[rowIndex];
 
-    return rowCon ? rowCon.centerRowComp.cellComps[attributeId].eGui : null;
+    return rowCon?.centerRowComp?.cellComps?.[attributeId]?.eGui ?? null;
 }
 
 function addCellClass(gridApi: GridApi, attributeId: string, rowIndex: number, className: string): void {
@@ -41,8 +41,8 @@ function getPinnedTopRowElement(gridApi: GridApi): HTMLElement | null {
         return null;
     }
 
-    const rootElement: HTMLElement = (gridApi as any).gridBodyComp.eGui;
-    const rowElement = rootElement.querySelector(`[row-id=${pinnedTopRow.id}]`);
+    const rootElement: HTMLElement | undefined = (gridApi as any).gridBodyComp?.eGui;
+    const rowElement = rootElement?.querySelector(`[row-id=${pinnedTopRow.id}]`);
 
     return rowElement?.parentElement?.parentElement ?? null;
 }

--- a/libs/sdk-ui-tests/stories/visual-regression/visualizations/insightStories.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/visualizations/insightStories.tsx
@@ -27,7 +27,7 @@ import {
     createElementCountResolver,
     ScreenshotReadyWrapper,
 } from "../../_infra/ScreenshotReadyWrapper";
-import { withScreenshot } from "../../_infra/backstopWrapper";
+import { ShortPostInteractionTimeout, withScreenshot } from "../../_infra/backstopWrapper";
 import { ConfigurationPanelWrapper } from "../../_infra/ConfigurationPanelWrapper";
 import { StorybookBackend } from "../../_infra/backend";
 import { ExamplesRecordings } from "@gooddata/live-examples-workspace";
@@ -165,7 +165,10 @@ function plugVizStory(insight: IInsight, testScenario: IScenario<any>) {
         withScreenshot(child, {
             clickSelector: `.${ConfigurationPanelWrapper.DefaultExpandAllClassName}`,
             readySelector: `.${ScreenshotReadyWrapper.OnReadyClassName}`,
-            postInteractionWait: 200,
+            // give tables some more time to finish rendering
+            postInteractionWait: insightVisualizationUrl(insight).includes("table")
+                ? ShortPostInteractionTimeout
+                : 200,
         });
 
     const wrapper = (child: any) => screenshotWrapper(wrapWithTheme(child, testScenario.tags)); // since themes are global anyway, wrap only once


### PR DESCRIPTION
Since we do not have typings for the internals, assume anything
along the "happy path" can be nullish just to be safe.

JIRA: RAIL-3929

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
