### PR TITLE
RELATED: FET-529 Upgrade react-window 1.8.5 -> 1.8.6

### DIFF
--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -75,7 +75,7 @@
         "react-day-picker": "^7.4.10",
         "react-intl": "^5.23.0",
         "react-responsive": "^8.0.1",
-        "react-window": "^1.8.5",
+        "react-window": "^1.8.6",
         "tslib": "^2.0.0",
         "date-fns": "^2.22.1",
         "ts-invariant": "^0.7.3"


### PR DESCRIPTION
This is the first React-17-compatible version.
The pnpm.lock was already using the new version, that is why there are no updates in it.

JIRA: FET-529

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
