### PR TITLE
RELATED: RAIL-3725 objRefMatch fallback if measure has no localId

### DIFF
--- a/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
+++ b/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
@@ -19,6 +19,7 @@ import {
     isSimpleMeasure,
     measureArithmeticOperands,
     measureIdentifier,
+    measureItem,
     measureLocalId,
     measureMasterIdentifier,
     measureUri,
@@ -321,7 +322,9 @@ export function objMatch(obj: any): IHeaderPredicate {
     }
 
     if (isSimpleMeasure(obj)) {
-        return localIdentifierMatch(measureLocalId(obj));
+        return (header, context) =>
+            localIdentifierMatch(measureLocalId(obj))(header, context) ||
+            objRefMatch(measureItem(obj))(header, context);
     }
 
     if (isObjRef(obj)) {

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -7,7 +7,7 @@ import {
     attributeHeaderItem,
     attributeDescriptor,
 } from "./HeaderPredicateFactory.fixtures";
-import { attributeDisplayFormRef, newAttribute, uriRef } from "@gooddata/sdk-model";
+import { attributeDisplayFormRef, measureItem, newAttribute, newMeasure, uriRef } from "@gooddata/sdk-model";
 
 describe("uriMatch", () => {
     describe("measure headers", () => {
@@ -714,6 +714,48 @@ describe("objMatch tests", () => {
         const predicate = headerPredicateFactory.objMatch(attributeObjRef);
 
         expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("should match predicate when measure localIdentifier matches", () => {
+        const measureObjRef = measureItem(
+            newMeasure(uriRef(measureDescriptors.uriBasedMeasure.measureHeaderItem.uri!), (m) =>
+                m.localId(measureDescriptors.identifierBasedRatioMeasure.measureHeaderItem.localIdentifier),
+            ),
+        );
+
+        const predicate = headerPredicateFactory.objMatch(measureObjRef);
+
+        expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(true);
+    });
+
+    it("should match predicate when measure objRef matches", () => {
+        const measureObjRef = measureItem(
+            newMeasure(measureDescriptors.identifierBasedMeasure.measureHeaderItem.identifier!),
+        );
+
+        const predicate = headerPredicateFactory.objMatch(measureObjRef);
+
+        expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
+    });
+
+    it("should match predicate when localIdentifier does not match but measure objRef does", () => {
+        const measureObjRef = measureItem(
+            newMeasure(measureDescriptors.identifierBasedMeasure.measureHeaderItem.identifier!, (m) =>
+                m.localId("someOtherLocalIdentifier"),
+            ),
+        );
+
+        const predicate = headerPredicateFactory.objMatch(measureObjRef);
+
+        expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
+    });
+
+    it("should not match predicate when measure objRef does not match", () => {
+        const measureObjRef = measureItem(newMeasure("otherIdentifier"));
+
+        const predicate = headerPredicateFactory.objMatch(measureObjRef);
+
+        expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(false);
     });
 });
 


### PR DESCRIPTION
- objRefMatch fallback if measure has no localIdentifier 

JIRA: RAIL-3725

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
