### PR TITLE
RELATED: RAIL-3925 Make DefaultDashboardInsightWidget more robust

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -1,8 +1,8 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useMemo } from "react";
 import cx from "classnames";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { insightVisualizationUrl } from "@gooddata/sdk-model";
+import { IInsight, insightVisualizationUrl } from "@gooddata/sdk-model";
 import { IInsightWidget, ScreenSize, widgetTitle } from "@gooddata/sdk-backend-spi";
 import { OnError, OnExportReady, OnLoadingChanged, VisType } from "@gooddata/sdk-ui";
 
@@ -28,15 +28,33 @@ interface IDefaultDashboardInsightWidgetProps {
     onError?: OnError;
 }
 
+// Sometimes this component is rendered even before insights are ready, which blows up.
+// Since the behavior is nearly impossible to replicate reliably, let's be defensive here and not render
+// anything until the insights "catch up".
+const DefaultDashboardInsightWidgetWrapper: React.FC<
+    IDefaultDashboardInsightWidgetProps & WrappedComponentProps
+> = (props) => {
+    const { widget } = props;
+    const insights = useDashboardSelector(selectInsightsMap);
+    const insight = insights.get(widget.insight);
+
+    if (!insight) {
+        // eslint-disable-next-line no-console
+        console.debug(
+            "DefaultDashboardInsightWidget rendered before the insights were ready, skipping render.",
+        );
+        return null;
+    }
+
+    return <DefaultDashboardInsightWidgetCore {...props} insight={insight} />;
+};
+
 /**
  * @internal
  */
 const DefaultDashboardInsightWidgetCore: React.FC<
-    IDefaultDashboardInsightWidgetProps & WrappedComponentProps
-> = ({ widget, screen, onError, onExportReady, onLoadingChanged, intl }) => {
-    const insights = useDashboardSelector(selectInsightsMap);
-
-    const insight = insights.get(widget.insight)!;
+    IDefaultDashboardInsightWidgetProps & WrappedComponentProps & { insight: IInsight }
+> = ({ widget, insight, screen, onError, onExportReady, onLoadingChanged, intl }) => {
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
 
     const { exportCSVEnabled, exportXLSXEnabled, onExportCSV, onExportXLSX } = useInsightExport({
@@ -72,7 +90,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
             className={cx(
                 "type-visualization",
                 "gd-dashboard-view-widget",
-                getVisTypeCssClass(widget.type, visType!),
+                getVisTypeCssClass(widget.type, visType),
             )}
             screen={screen}
         >
@@ -109,7 +127,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
                     <DashboardInsight
                         clientHeight={clientHeight}
                         clientWidth={clientWidth}
-                        insight={insight!}
+                        insight={insight}
                         widget={widget}
                         onExportReady={onExportReady}
                         onLoadingChanged={onLoadingChanged}
@@ -121,4 +139,4 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     );
 };
 
-export const DefaultDashboardInsightWidget = injectIntl(DefaultDashboardInsightWidgetCore);
+export const DefaultDashboardInsightWidget = injectIntl(DefaultDashboardInsightWidgetWrapper);


### PR DESCRIPTION
Similar to #2041 there are hard-to-reproduce situations when a code
assumes the insights are loaded even thoug for some reason they are
in fact not ready. This results in hard to reproduce issues.

As a fix, we prevent these invariants from happening and log
the occurences. This also avoids explicit not-null assertion.

Also fix two Sonar-reported code smells in the file.

JIRA: RAIL-3925

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
