### PR TITLE
RELATED: RAIL-3940 Fix pivot table auto sizing

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import {
     AgGridEvent,
     AllCommunityModules,
@@ -1073,7 +1073,8 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
             isAltKeyPressed: this.internal.isAltKeyPressed,
             isMetaOrCtrlKeyPressed: this.internal.isMetaOrCtrlKeyPressed,
 
-            clientWidth: this.containerRef?.clientWidth ?? 0,
+            // use clientWidth of the viewport container to accommodate for vertical scrollbars if needed
+            clientWidth: this.containerRef?.getElementsByClassName("ag-body-viewport")[0]?.clientWidth ?? 0,
             containerRef: this.containerRef,
             separators: this.props?.config?.separators,
 


### PR DESCRIPTION
For some reason with ag-grid 25, the current autosizing logic broke
when there were vertical scrollbars present. As a fix, we take
the clientWidth of the element that now has the scrollbars if they are
needed for a given situation (not the whole table container).

JIRA: RAIL-3940

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
