### PR TITLE
RELATED: RAIL-3942 Fix redux/toolkit import

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
@@ -1,8 +1,9 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { DashboardContext } from "../../types/commonTypes";
 import { SagaIterator } from "redux-saga";
 import {
     CaseReducer,
+    CaseReducerActions,
     createEntityAdapter,
     createSelector,
     createSlice,
@@ -15,7 +16,6 @@ import {
 } from "@reduxjs/toolkit";
 import { DashboardQueryType, IDashboardQuery } from "../../queries/base";
 import { DashboardState } from "../types";
-import { CaseReducerActions } from "@reduxjs/toolkit/src/createSlice";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import memoize from "lodash/memoize";
 import { invariant } from "ts-invariant";


### PR DESCRIPTION
Turns out importing directly from src in redux toolkit breaks
create-react-app because it includes the whole package into
TypeScript compilation which then fails (redux toolkit has some
unused variables internally).

This avoids the problem and should make the build marginally faster.

JIRA: RAIL-3942

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
