### PR TITLE
RELATED: RAIL-3945 improve default embedding experience

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2064,6 +2064,7 @@ export interface IDashboardCustomComponentProps {
 // @public
 export interface IDashboardCustomizationProps extends IDashboardCustomComponentProps {
     customizationFns?: DashboardModelCustomizationFns;
+    enableSaveAsNewButton?: boolean;
     // @alpha
     insightMenuItemsProvider?: InsightMenuItemsProvider;
     // @alpha

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1612,7 +1612,7 @@ export const DefaultShareDialog: (props: IShareDialogProps) => JSX.Element | nul
 export const DefaultShareStatus: React_2.FC<IShareStatusProps>;
 
 // @alpha (undocumented)
-export const DefaultTitle: (props: ITitleProps) => JSX.Element | null;
+export const DefaultTitle: CustomTitleComponent;
 
 // @alpha (undocumented)
 export const DefaultTopBar: (props: ITopBarProps) => JSX.Element;
@@ -1766,6 +1766,9 @@ export function drillToLegacyDashboard(drillDefinition: IDrillToLegacyDashboard,
 
 // @alpha
 export function eagerRemoveSectionItem(sectionIndex: number, itemIndex: number, stashIdentifier?: StashedDashboardItemsId, correlationId?: string): RemoveSectionItem;
+
+// @alpha (undocumented)
+export const EditableTitle: CustomTitleComponent;
 
 // @alpha
 export function enableInsightWidgetDateFilter(ref: ObjRef, dateDataset: ObjRef, correlationId?: string): ChangeInsightWidgetFilterSettings;

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
@@ -1,8 +1,9 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { DashboardContext } from "../../types/commonTypes";
 import { SagaIterator } from "redux-saga";
 import {
     CaseReducer,
+    CaseReducerActions,
     createEntityAdapter,
     createSelector,
     createSlice,
@@ -15,7 +16,6 @@ import {
 } from "@reduxjs/toolkit";
 import { DashboardQueryType, IDashboardQuery } from "../../queries/base";
 import { DashboardState } from "../types";
-import { CaseReducerActions } from "@reduxjs/toolkit/src/createSlice";
 import { call, put, SagaReturnType, select } from "redux-saga/effects";
 import memoize from "lodash/memoize";
 import { invariant } from "ts-invariant";

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useCallback, useMemo } from "react";
 import { IDashboardAttributeFilter, IInsightWidget, IKpiWidget, ILegacyKpi } from "@gooddata/sdk-backend-spi";
 import { ToastMessageContextProvider } from "@gooddata/sdk-ui-kit";
@@ -209,6 +209,7 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
                         <ExportDialogContextProvider>
                             <DashboardCustomizationsProvider
                                 insightMenuItemsProvider={props.insightMenuItemsProvider}
+                                enableSaveAsNewButton={props.enableSaveAsNewButton}
                             >
                                 <DashboardComponentsProvider
                                     ErrorComponent={props.ErrorComponent ?? DefaultError}

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useCallback, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 import {
@@ -40,6 +40,7 @@ import { ScheduledEmailDialog } from "../../scheduledEmail";
 import { SaveAsDialog } from "../../saveAs";
 import { DefaultFilterBar, FilterBar } from "../../filterBar";
 import { ShareDialogDashboardHeader } from "./ShareDialogDashboardHeader";
+import { useDashboardCustomizationsContext } from "../../dashboardContexts";
 
 const useFilterBar = (): {
     filters: FilterContextItem[];
@@ -110,6 +111,7 @@ export const DashboardHeader = (): JSX.Element => {
     const { filters, onAttributeFilterChanged, onDateFilterChanged } = useFilterBar();
     const { title, onTitleChanged, onShareButtonClick, shareInfo } = useTopBar();
     const { addSuccess, addError, addProgress, removeMessage } = useToastMessage();
+    const { enableSaveAsNewButton } = useDashboardCustomizationsContext();
 
     const dispatch = useDashboardDispatch();
     const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
@@ -190,7 +192,8 @@ export const DashboardHeader = (): JSX.Element => {
             return [];
         }
 
-        const isSaveAsVisible = canCreateDashboard;
+        // TODO RAIL-3945 remove the `|| true` once gdc-dashboards is ready for the new prop
+        const isSaveAsVisible = canCreateDashboard && (enableSaveAsNewButton || true);
         const isSaveAsDisabled = isEmptyLayout || !dashboardRef || isReadOnly;
         const isScheduledEmailingDisabled = isReadOnly;
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { ComponentType } from "react";
 import { ReactReduxContextValue } from "react-redux";
 import { IAnalyticalBackend, IDashboard, ITheme, IWorkspacePermissions } from "@gooddata/sdk-backend-spi";
@@ -193,6 +193,10 @@ export interface IDashboardCustomComponentProps {
 
     /**
      * Optionally specify component to use for rendering the title.
+     *
+     * @remarks
+     * Defaults to {@link DefaultTitle}. For an editable title, you can use {@link EditableTitle} instead.
+     * To hide the dashboard title altogether, you can use {@link HiddenTitle}.
      *
      * @alpha
      */

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -274,6 +274,14 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
      * @public
      */
     customizationFns?: DashboardModelCustomizationFns;
+
+    /**
+     * Optionally enable the button to save dashboard as copy (for users with the appropriate permissions).
+     *
+     * @remarks
+     * Defaults to false, meaning the Save as new button is not shown.
+     */
+    enableSaveAsNewButton?: boolean;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardCustomizationsContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboardContexts/DashboardCustomizationsContext.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React, { createContext, useContext } from "react";
 import { IInsightWidget } from "@gooddata/sdk-backend-spi";
 import { IInsight } from "@gooddata/sdk-model";
@@ -15,6 +15,7 @@ interface IDashboardCustomizationsContext {
         defaultItems: IInsightMenuItem[],
         closeMenu: () => void,
     ) => IInsightMenuItem[];
+    enableSaveAsNewButton?: boolean;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/DefaultTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/DefaultTitle.tsx
@@ -1,37 +1,18 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
-import { EditableLabel } from "@gooddata/sdk-ui-kit";
-import { ITitleProps } from "./types";
 
-const EditableTitle: React.FC<{
-    title: string;
-    onTitleChanged: (title: string) => void;
-}> = (props) => {
-    const { title, onTitleChanged } = props;
-    return (
-        <EditableLabel
-            value={title}
-            onSubmit={onTitleChanged}
-            className={"s-gd-dashboard-title dash-title editable"}
-        >
-            {title}
-        </EditableLabel>
-    );
-};
+import { TitleWrapper } from "./TitleWrapper";
+import { CustomTitleComponent } from "./types";
 
 /**
  * @alpha
  */
-export const DefaultTitle = (props: ITitleProps): JSX.Element | null => {
-    const { title, onTitleChanged } = props;
+export const DefaultTitle: CustomTitleComponent = (props) => {
+    const { title } = props;
 
     return (
-        <div className="dash-title-wrapper">
-            {onTitleChanged ? (
-                <EditableTitle title={title} onTitleChanged={onTitleChanged} />
-            ) : (
-                <div className={"s-gd-dashboard-title dash-title static"}>{title}</div>
-            )}
-        </div>
+        <TitleWrapper>
+            <div className={"s-gd-dashboard-title dash-title static"}>{title}</div>
+        </TitleWrapper>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/EditableTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/EditableTitle.tsx
@@ -1,0 +1,24 @@
+// (C) 2021-2022 GoodData Corporation
+import React from "react";
+import { EditableLabel } from "@gooddata/sdk-ui-kit";
+
+import { TitleWrapper } from "./TitleWrapper";
+import { CustomTitleComponent } from "./types";
+
+/**
+ * @alpha
+ */
+export const EditableTitle: CustomTitleComponent = (props) => {
+    const { title, onTitleChanged } = props;
+    return (
+        <TitleWrapper>
+            <EditableLabel
+                value={title}
+                onSubmit={onTitleChanged!}
+                className="s-gd-dashboard-title dash-title editable"
+            >
+                {title}
+            </EditableLabel>
+        </TitleWrapper>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/TitleWrapper.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/TitleWrapper.tsx
@@ -1,0 +1,9 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+
+/**
+ * @internal
+ */
+export const TitleWrapper: React.FC = ({ children }) => {
+    return <div className="dash-title-wrapper">{children}</div>;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/index.tsx
@@ -1,5 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export { DefaultTitle } from "./DefaultTitle";
+export { EditableTitle } from "./EditableTitle";
 export { HiddenTitle } from "./HiddenTitle";
 export { Title } from "./Title";
 export * from "./types";


### PR DESCRIPTION
* make the default title not editable
* make the Save as new button opt-in

Currently we ignore the enableSaveAsNewButton value in order to first make gdc-dashboards aware of the new prop and then we will actually use the prop in a follow up PR.

JIRA: RAIL-3945

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
