### PR TITLE
RELATED: RAIL-3945 Rename and move enableSaveAsNewButton

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -699,6 +699,7 @@ export type DashboardConfig = {
     isExport?: boolean;
     disableDefaultDrills?: boolean;
     enableFilterValuesResolutionInDrillEvents?: boolean;
+    showSaveAsNewButton?: boolean;
 };
 
 // @public (undocumented)
@@ -2064,6 +2065,7 @@ export interface IDashboardCustomComponentProps {
 // @public
 export interface IDashboardCustomizationProps extends IDashboardCustomComponentProps {
     customizationFns?: DashboardModelCustomizationFns;
+    // @deprecated
     enableSaveAsNewButton?: boolean;
     // @alpha
     insightMenuItemsProvider?: InsightMenuItemsProvider;
@@ -3861,6 +3863,9 @@ export const selectSeparators: OutputSelector<DashboardState, ISeparators, (res:
 
 // @public
 export const selectSettings: OutputSelector<DashboardState, ISettings, (res: ResolvedDashboardConfig) => ISettings>;
+
+// @public
+export const selectShowSaveAsNewButton: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @internal
 export const selectStash: OutputSelector<DashboardState, Record<string, ExtendedDashboardItem<ExtendedDashboardWidget>[]>, (res: LayoutState) => Record<string, ExtendedDashboardItem<ExtendedDashboardWidget>[]>>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { all, call } from "redux-saga/effects";
 import {
@@ -165,6 +165,7 @@ export function* resolveDashboardConfig(
         isExport: config.isExport ?? false,
         disableDefaultDrills: config.disableDefaultDrills ?? false,
         enableFilterValuesResolutionInDrillEvents: config.enableFilterValuesResolutionInDrillEvents ?? false,
+        showSaveAsNewButton: config.showSaveAsNewButton ?? false,
     };
 
     return resolvedConfig;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -189,6 +189,7 @@ Object {
     "thousand": ",",
   },
   "settings": Object {},
+  "showSaveAsNewButton": false,
 }
 `;
 

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { DashboardState } from "../types";
 import invariant from "ts-invariant";
@@ -135,6 +135,15 @@ export const selectDisableDefaultDrills = createSelector(selectConfig, (state) =
  */
 export const selectEnableFilterValuesResolutionInDrillEvents = createSelector(selectConfig, (state) => {
     return state.enableFilterValuesResolutionInDrillEvents ?? false;
+});
+
+/**
+ * Returns whether Save as new button should be available.
+ *
+ * @public
+ */
+export const selectShowSaveAsNewButton = createSelector(selectConfig, (state) => {
+    return state.showSaveAsNewButton ?? false;
 });
 
 //

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export { DashboardDispatch, DashboardState, DashboardSelector, DashboardSelectorEvaluator } from "./types";
 
 export { selectDashboardLoading } from "./loading/loadingSelectors";
@@ -35,6 +35,7 @@ export {
     selectEnableKPIDashboardDrillToURL,
     selectEnableKPIDashboardImplicitDrillDown,
     selectHideKpiDrillInEmbedded,
+    selectShowSaveAsNewButton,
 } from "./config/configSelectors";
 export { PermissionsState } from "./permissions/permissionsState";
 export {

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     IAnalyticalBackend,
     IDashboard,
@@ -120,6 +120,13 @@ export type DashboardConfig = {
      * Defaults to false.
      */
     enableFilterValuesResolutionInDrillEvents?: boolean;
+
+    /**
+     * If set to true, the default menu button will include the Save as new button.
+     *
+     * Defaults to false, meaning the Save as new button is not shown.
+     */
+    showSaveAsNewButton?: boolean;
 };
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -26,6 +26,7 @@ import {
     selectIsSaveAsDialogOpen,
     selectIsScheduleEmailDialogOpen,
     selectPersistedDashboard,
+    selectShowSaveAsNewButton,
     uiActions,
     useDashboardCommandProcessing,
     useDashboardDispatch,
@@ -111,7 +112,7 @@ export const DashboardHeader = (): JSX.Element => {
     const { filters, onAttributeFilterChanged, onDateFilterChanged } = useFilterBar();
     const { title, onTitleChanged, onShareButtonClick, shareInfo } = useTopBar();
     const { addSuccess, addError, addProgress, removeMessage } = useToastMessage();
-    const { enableSaveAsNewButton } = useDashboardCustomizationsContext();
+    const { enableSaveAsNewButton: enableSaveAsNewButtonDeprecated } = useDashboardCustomizationsContext();
 
     const dispatch = useDashboardDispatch();
     const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
@@ -121,6 +122,7 @@ export const DashboardHeader = (): JSX.Element => {
     const openSaveAsDialog = () => dispatch(uiActions.openSaveAsDialog());
     const closeSaveAsDialog = () => dispatch(uiActions.closeSaveAsDialog());
     const persistedDashboard = useDashboardSelector(selectPersistedDashboard);
+    const showSaveAsNewButton = useDashboardSelector(selectShowSaveAsNewButton);
 
     const lastExportMessageId = useRef("");
     const { run: exportDashboard } = useDashboardCommandProcessing({
@@ -192,7 +194,9 @@ export const DashboardHeader = (): JSX.Element => {
             return [];
         }
 
-        const isSaveAsVisible = canCreateDashboard && enableSaveAsNewButton;
+        // TODO RAIL-3945 remove the deprecated version one gdc-dashboards are ready for this
+        const isSaveAsVisible =
+            canCreateDashboard && (showSaveAsNewButton || enableSaveAsNewButtonDeprecated);
         const isSaveAsDisabled = isEmptyLayout || !dashboardRef || isReadOnly;
         const isScheduledEmailingDisabled = isReadOnly;
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -280,6 +280,8 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
      *
      * @remarks
      * Defaults to false, meaning the Save as new button is not shown.
+     *
+     * @deprecated Use {@link DashboardConfig.showSaveAsNewButton} instead.
      */
     enableSaveAsNewButton?: boolean;
 }


### PR DESCRIPTION
* Move the enableSaveAsNewButton to the config part
* Rename it to more fitting showSaveAsNewButton

Done defensively with deprecation to allow us to adapt gdc-dashboards,
and then remove the old version.

JIRA: RAIL-3945

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
