### PR TITLE
RELATED:  RAIL-3945 Generalize the menu button item visibility setting

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -699,6 +699,7 @@ export type DashboardConfig = {
     isExport?: boolean;
     disableDefaultDrills?: boolean;
     enableFilterValuesResolutionInDrillEvents?: boolean;
+    menuButtonItemsVisibility?: IMenuButtonItemsVisibility;
 };
 
 // @public (undocumented)
@@ -2064,6 +2065,7 @@ export interface IDashboardCustomComponentProps {
 // @public
 export interface IDashboardCustomizationProps extends IDashboardCustomComponentProps {
     customizationFns?: DashboardModelCustomizationFns;
+    // @deprecated
     enableSaveAsNewButton?: boolean;
     // @alpha
     insightMenuItemsProvider?: InsightMenuItemsProvider;
@@ -2495,6 +2497,8 @@ export interface IMenuButtonItemButton {
     tooltip?: string;
     // (undocumented)
     type: "button";
+    // (undocumented)
+    visible?: boolean;
 }
 
 // @alpha (undocumented)
@@ -2513,6 +2517,13 @@ export interface IMenuButtonItemSeparator {
     itemId: string;
     // (undocumented)
     type: "separator";
+}
+
+// @alpha (undocumented)
+export interface IMenuButtonItemsVisibility {
+    pdfExportButton?: boolean;
+    saveAsNewButton?: boolean;
+    scheduleEmailButton?: boolean;
 }
 
 // @alpha (undocumented)
@@ -3844,6 +3855,9 @@ export const selectLocale: OutputSelector<DashboardState, ILocale, (res: Resolve
 // @internal
 export const selectMapboxToken: OutputSelector<DashboardState, string | undefined, (res: ResolvedDashboardConfig) => string | undefined>;
 
+// @alpha (undocumented)
+export const selectMenuButtonItemsVisibility: OutputSelector<DashboardState, IMenuButtonItemsVisibility, (res: UiState) => IMenuButtonItemsVisibility>;
+
 // @public
 export const selectObjectAvailabilityConfig: OutputSelector<DashboardState, ObjectAvailabilityConfig, (res: ResolvedDashboardConfig) => ObjectAvailabilityConfig>;
 
@@ -3969,6 +3983,10 @@ type: string;
 }>;
 openShareDialog: CaseReducer<UiState, AnyAction>;
 closeShareDialog: CaseReducer<UiState, AnyAction>;
+setMenuButtonItemsVisibility: CaseReducer<UiState, {
+payload: IMenuButtonItemsVisibility;
+type: string;
+}>;
 }>;
 
 // @alpha (undocumented)
@@ -3989,6 +4007,9 @@ export type UiState = {
     kpiAlerts: {
         openedWidgetRef: ObjRef | undefined;
         highlightedWidgetRef: ObjRef | undefined;
+    };
+    menuButton: {
+        itemsVisibility: IMenuButtonItemsVisibility;
     };
 };
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { all, call, put, SagaReturnType } from "redux-saga/effects";
 import { InitializeDashboard } from "../../../commands/dashboard";
@@ -21,6 +21,7 @@ import { alertsActions } from "../../../store/alerts";
 import { BatchAction, batchActions } from "redux-batched-actions";
 import { loadUser } from "./loadUser";
 import { userActions } from "../../../store/user";
+import { uiActions } from "../../../store/ui";
 import { loadDashboardList } from "./loadDashboardList";
 import { listedDashboardsActions } from "../../../store/listedDashboards";
 import { backendCapabilitiesActions } from "../../../store/backendCapabilities";
@@ -149,6 +150,7 @@ function* loadExistingDashboard(
             }),
             listedDashboardsActions.setListedDashboards(listedDashboards),
             accessibleDashboardsActions.setAccessibleDashboards(accessibleDashboards),
+            uiActions.setMenuButtonItemsVisibility(config.menuButtonItemsVisibility),
         ],
         "@@GDC.DASH/BATCH.INIT.EXISTING",
     );
@@ -203,6 +205,7 @@ function* initializeNewDashboard(
                 effectiveDateFilterConfig: config.dateFilterConfig,
                 isUsingDashboardOverrides: false,
             }),
+            uiActions.setMenuButtonItemsVisibility(config.menuButtonItemsVisibility),
         ],
         "@@GDC.DASH/BATCH.INIT.NEW",
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { all, call } from "redux-saga/effects";
 import {
@@ -123,7 +123,7 @@ export function* resolveDashboardConfig(
 
     if (isResolvedConfig(config)) {
         /*
-         * Config coming in props is fully specified. There is nothing to do. Bail out imediately.
+         * Config coming in props is fully specified. There is nothing to do. Bail out immediately.
          */
         return config;
     }
@@ -165,6 +165,7 @@ export function* resolveDashboardConfig(
         isExport: config.isExport ?? false,
         disableDefaultDrills: config.disableDefaultDrills ?? false,
         enableFilterValuesResolutionInDrillEvents: config.enableFilterValuesResolutionInDrillEvents ?? false,
+        menuButtonItemsVisibility: config.menuButtonItemsVisibility ?? {},
     };
 
     return resolvedConfig;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/tests/__snapshots__/handler.test.ts.snap
@@ -183,6 +183,7 @@ Object {
   "isReadOnly": false,
   "locale": "en-US",
   "mapboxToken": undefined,
+  "menuButtonItemsVisibility": Object {},
   "objectAvailability": Object {},
   "separators": Object {
     "decimal": ".",

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export { DashboardDispatch, DashboardState, DashboardSelector, DashboardSelectorEvaluator } from "./types";
 
 export { selectDashboardLoading } from "./loading/loadingSelectors";
@@ -163,6 +163,7 @@ export {
     selectFilterBarHeight,
     selectIsKpiAlertOpenedByWidgetRef,
     selectIsKpiAlertHighlightedByWidgetRef,
+    selectMenuButtonItemsVisibility,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -1,7 +1,8 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { Action, AnyAction, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
 import { ObjRef } from "@gooddata/sdk-model";
 import { UiState } from "./uiState";
+import { IMenuButtonItemsVisibility } from "../../../types";
 
 type UiReducer<A extends Action = AnyAction> = CaseReducer<UiState, A>;
 
@@ -49,6 +50,13 @@ const highlightKpiAlert: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
     state.kpiAlerts.highlightedWidgetRef = action.payload;
 };
 
+const setMenuButtonItemsVisibility: UiReducer<PayloadAction<IMenuButtonItemsVisibility>> = (
+    state,
+    action,
+) => {
+    state.menuButton.itemsVisibility = action.payload;
+};
+
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
@@ -61,4 +69,5 @@ export const uiReducers = {
     highlightKpiAlert,
     openShareDialog,
     closeShareDialog,
+    setMenuButtonItemsVisibility,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { createSelector } from "@reduxjs/toolkit";
 import { ObjRef } from "@gooddata/sdk-model";
@@ -98,4 +98,12 @@ export const selectIsKpiAlertHighlightedByWidgetRef = createMemoizedSelector(
             },
         );
     },
+);
+
+/**
+ * @alpha
+ */
+export const selectMenuButtonItemsVisibility = createSelector(
+    selectSelf,
+    (state) => state.menuButton.itemsVisibility,
 );

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -1,5 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
+
+import { IMenuButtonItemsVisibility } from "../../../types";
 
 /**
  * @alpha
@@ -22,6 +24,9 @@ export type UiState = {
         openedWidgetRef: ObjRef | undefined;
         highlightedWidgetRef: ObjRef | undefined;
     };
+    menuButton: {
+        itemsVisibility: IMenuButtonItemsVisibility;
+    };
 };
 
 export const uiInitialState: UiState = {
@@ -41,5 +46,8 @@ export const uiInitialState: UiState = {
     kpiAlerts: {
         highlightedWidgetRef: undefined,
         openedWidgetRef: undefined,
+    },
+    menuButton: {
+        itemsVisibility: {},
     },
 };

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     IAnalyticalBackend,
     IDashboard,
@@ -10,7 +10,7 @@ import { IColorPalette, ObjRef } from "@gooddata/sdk-model";
 import { ILocale } from "@gooddata/sdk-ui";
 import keys from "lodash/keys";
 import includes from "lodash/includes";
-import { IDashboardFilter } from "../../types";
+import { IDashboardFilter, IMenuButtonItemsVisibility } from "../../types";
 import { ExtendedDashboardWidget } from "./layoutTypes";
 
 /**
@@ -120,6 +120,11 @@ export type DashboardConfig = {
      * Defaults to false.
      */
     enableFilterValuesResolutionInDrillEvents?: boolean;
+
+    /**
+     * Optionally configure which of the default menu button buttons are visible.
+     */
+    menuButtonItemsVisibility?: IMenuButtonItemsVisibility;
 };
 
 /**

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -280,6 +280,9 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
      *
      * @remarks
      * Defaults to false, meaning the Save as new button is not shown.
+     *
+     * @deprecated
+     * Use {@link IDashboardBaseProps.config}'s `menuButtonItemsVisibility` property instead.
      */
     enableSaveAsNewButton?: boolean;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/DefaultMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/DefaultMenuButton.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useCallback, useState } from "react";
 import cx from "classnames";
 import {
@@ -48,54 +48,56 @@ export const DefaultMenuButton = (props: IMenuButtonProps): JSX.Element | null =
                 onClose={onMenuButtonClick}
             >
                 <ItemsWrapper smallItemsSpacing>
-                    {menuItems.map((menuItem) => {
-                        if (menuItem.type === "separator") {
-                            return <SingleSelectListItem key={menuItem.itemId} type={menuItem.type} />;
-                        }
+                    {menuItems
+                        .filter((item) => item.type !== "button" || item.visible !== false)
+                        .map((menuItem) => {
+                            if (menuItem.type === "separator") {
+                                return <SingleSelectListItem key={menuItem.itemId} type={menuItem.type} />;
+                            }
 
-                        if (menuItem.type === "header") {
-                            return (
+                            if (menuItem.type === "header") {
+                                return (
+                                    <SingleSelectListItem
+                                        key={menuItem.itemId}
+                                        type={menuItem.type}
+                                        title={menuItem.itemName}
+                                    />
+                                );
+                            }
+
+                            const selectorClassName = `gd-menu-item-${menuItem.itemId}`;
+                            const body = (
                                 <SingleSelectListItem
+                                    className={cx("gd-menu-item", `s-${menuItem.itemId}`, {
+                                        [selectorClassName]: menuItem.tooltip,
+                                        "is-disabled": menuItem.disabled,
+                                    })}
                                     key={menuItem.itemId}
-                                    type={menuItem.type}
                                     title={menuItem.itemName}
+                                    onClick={
+                                        menuItem.disabled
+                                            ? undefined
+                                            : () => {
+                                                  menuItem.onClick?.();
+                                                  setIsOpen(false);
+                                              }
+                                    }
                                 />
                             );
-                        }
 
-                        const selectorClassName = `gd-menu-item-${menuItem.itemId}`;
-                        const body = (
-                            <SingleSelectListItem
-                                className={cx("gd-menu-item", `s-${menuItem.itemId}`, {
-                                    [selectorClassName]: menuItem.tooltip,
-                                    "is-disabled": menuItem.disabled,
-                                })}
-                                key={menuItem.itemId}
-                                title={menuItem.itemName}
-                                onClick={
-                                    menuItem.disabled
-                                        ? undefined
-                                        : () => {
-                                              menuItem.onClick?.();
-                                              setIsOpen(false);
-                                          }
-                                }
-                            />
-                        );
+                            if (!menuItem.tooltip) {
+                                return body;
+                            }
 
-                        if (!menuItem.tooltip) {
-                            return body;
-                        }
-
-                        return (
-                            <BubbleHoverTrigger key={menuItem.itemId}>
-                                {body}
-                                <Bubble alignTo={`.${selectorClassName}`} alignPoints={bubbleAlignPoints}>
-                                    <span>{menuItem.tooltip}</span>
-                                </Bubble>
-                            </BubbleHoverTrigger>
-                        );
-                    })}
+                            return (
+                                <BubbleHoverTrigger key={menuItem.itemId}>
+                                    {body}
+                                    <Bubble alignTo={`.${selectorClassName}`} alignPoints={bubbleAlignPoints}>
+                                        <span>{menuItem.tooltip}</span>
+                                    </Bubble>
+                                </BubbleHoverTrigger>
+                            );
+                        })}
                 </ItemsWrapper>
             </Overlay>
         );

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/menuButton/types.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ComponentType } from "react";
 
 /**
@@ -14,7 +14,9 @@ export interface IMenuButtonItemButton {
      */
     tooltip?: string;
     disabled?: boolean;
+    visible?: boolean;
 }
+
 /**
  * @alpha
  */
@@ -22,6 +24,7 @@ export interface IMenuButtonItemSeparator {
     type: "separator";
     itemId: string;
 }
+
 /**
  * @alpha
  */
@@ -30,6 +33,7 @@ export interface IMenuButtonItemHeader {
     itemId: string;
     itemName: string;
 }
+
 /**
  * @alpha
  */

--- a/libs/sdk-ui-dashboard/src/types.ts
+++ b/libs/sdk-ui-dashboard/src/types.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { DrillDefinition, IAccessGrantee, IWidget, ShareStatus } from "@gooddata/sdk-backend-spi";
 import {
@@ -133,4 +133,22 @@ export interface IShareProps {
     isLocked: boolean;
     granteesToAdd: IAccessGrantee[];
     granteesToDelete: IAccessGrantee[];
+}
+
+/**
+ * @alpha
+ */
+export interface IMenuButtonItemsVisibility {
+    /**
+     * If set to true, the Save as new button will be visible. Defaults to false.
+     */
+    saveAsNewButton?: boolean;
+    /**
+     * If set to true, the Export to PDF button will be visible. Defaults to true.
+     */
+    pdfExportButton?: boolean;
+    /**
+     * If set to true, the Schedule emailing button will be visible. Defaults to true.
+     */
+    scheduleEmailButton?: boolean;
 }


### PR DESCRIPTION
This allows the same level of control for all the default items
in the menu button menu (not just save as new).

JIRA: RAIL-3945

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
