### PR TITLE
NAS-2719 - Disable feature "enableAlternativeDisplayFormSelection"

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -62,7 +62,7 @@ export const DefaultUiSettings: ISettings = {
     ADCatalogGroupsExpanded: true,
     enableCustomColorPicker: true,
     enableAdAdditionalDateAttributes: true,
-    enableAlternativeDisplayFormSelection: true,
+    enableAlternativeDisplayFormSelection: false,
     enableNewAnalyticalDashboardsNavigation: false, // TODO TNT-278 switch to true for verification or New navigation rollout
     enableAnalyticalDashboardPermissions: false,
 


### PR DESCRIPTION
Disable feature "enableAlternativeDisplayFormSelection" fr tiger due to problems with current abstraction on client.

**Filtering on tiger needs to be done by only primaryLabels** - now in SDK is not true

**In execution filter is defined by used label (and values of that label) not by primary, same in filter context** - this is wrong and its conflict with previous statement

**Problems:**

 - Abstraction for execution on SPI level allows to specified filter using non primary labels and its working
 - Filter context has same behaviour

JIRA: NAS-2719

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
