### PR TITLE
Omit filter context in scheduled e-mail if it's not changed

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1843,6 +1843,7 @@ export interface FilterContextState {
     attributeFilterDisplayForms?: IAttributeDisplayFormMetadataObject[];
     filterContextDefinition?: IFilterContextDefinition;
     filterContextIdentity?: IDashboardObjectIdentity;
+    originalFilterContextDefinition?: IFilterContextDefinition;
 }
 
 // @internal
@@ -3860,6 +3861,12 @@ export const selectMenuButtonItemsVisibility: OutputSelector<DashboardState, IMe
 
 // @public
 export const selectObjectAvailabilityConfig: OutputSelector<DashboardState, ObjectAvailabilityConfig, (res: ResolvedDashboardConfig) => ObjectAvailabilityConfig>;
+
+// @alpha
+export const selectOriginalFilterContextDefinition: OutputSelector<DashboardState, IFilterContextDefinition | undefined, (res: FilterContextState) => IFilterContextDefinition | undefined>;
+
+// @alpha
+export const selectOriginalFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition | undefined) => FilterContextItem[]>;
 
 // @public
 export const selectPermissions: OutputSelector<DashboardState, IWorkspacePermissions, (res: PermissionsState) => IWorkspacePermissions>;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { PayloadAction } from "@reduxjs/toolkit";
 import {
@@ -118,6 +118,7 @@ export function* actionsToInitializeExistingDashboard(
 
     return [
         filterContextActions.setFilterContext({
+            originalFilterContextDefinition: filterContextDefinition,
             filterContextDefinition,
             filterContextIdentity,
             attributeFilterDisplayForms,

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextReducers.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { Action, CaseReducer, PayloadAction } from "@reduxjs/toolkit";
 import { v4 as uuidv4 } from "uuid";
@@ -35,12 +35,18 @@ const generateFilterLocalIdentifier = (): string => uuidv4().replace(/-/g, "");
 
 type SetFilterContextPayload = {
     filterContextDefinition: IFilterContextDefinition;
+    originalFilterContextDefinition?: IFilterContextDefinition;
     attributeFilterDisplayForms: IAttributeDisplayFormMetadataObject[];
     filterContextIdentity?: IDashboardObjectIdentity;
 };
 
 const setFilterContext: FilterContextReducer<PayloadAction<SetFilterContextPayload>> = (state, action) => {
-    const { filterContextDefinition, filterContextIdentity, attributeFilterDisplayForms } = action.payload;
+    const {
+        filterContextDefinition,
+        originalFilterContextDefinition,
+        filterContextIdentity,
+        attributeFilterDisplayForms,
+    } = action.payload;
 
     state.filterContextDefinition = {
         ...filterContextDefinition,
@@ -57,6 +63,8 @@ const setFilterContext: FilterContextReducer<PayloadAction<SetFilterContextPaylo
                 : filter,
         ),
     };
+
+    state.originalFilterContextDefinition = originalFilterContextDefinition;
 
     state.filterContextIdentity = filterContextIdentity;
     state.attributeFilterDisplayForms = attributeFilterDisplayForms;

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { DashboardState } from "../types";
 import invariant from "ts-invariant";
@@ -20,7 +20,33 @@ const selectSelf = createSelector(
 );
 
 /**
- * This selector returns dashboard's filter context definition. It is expected that the selector is called only after the filter
+ * This selector returns original (stored) dashboard's filter context definition. It is expected that the selector is called only after the filter
+ * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ *
+ * @alpha
+ */
+export const selectOriginalFilterContextDefinition = createSelector(selectSelf, (filterContextState) => {
+    invariant(
+        filterContextState.filterContextDefinition,
+        "attempting to access uninitialized filter context state",
+    );
+
+    return filterContextState.originalFilterContextDefinition;
+});
+
+/**
+ * This selector returns original (stored) dashboard's filter context definition. It is expected that the selector is called only after the filter
+ * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ *
+ * @alpha
+ */
+export const selectOriginalFilterContextFilters = createSelector(
+    selectOriginalFilterContextDefinition,
+    (filterContext): FilterContextItem[] => filterContext?.filters ?? [],
+);
+
+/**
+ * This selector returns original (stored) dashboard's filter context filters. It is expected that the selector is called only after the filter
  * context state is correctly initialized. Invocations before initialization lead to invariant errors.
  *
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import {
     IAttributeDisplayFormMetadataObject,
@@ -14,6 +14,11 @@ export interface FilterContextState {
      * Filter context definition contains the actual filters to use. Filter context definition is present
      */
     filterContextDefinition?: IFilterContextDefinition;
+
+    /**
+     * Filter context definition contains the original dashboard filters stored on the backend.
+     */
+    originalFilterContextDefinition?: IFilterContextDefinition;
 
     /**
      * Filter context identity is available for persisted filter contexts. This property may be undefined in

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -56,6 +56,8 @@ export {
     selectAttributeFilterDisplayFormsMap,
     selectAttributeFilterDisplayForms,
     selectFilterContextAttributeFilterByDisplayForm,
+    selectOriginalFilterContextDefinition,
+    selectOriginalFilterContextFilters,
 } from "./filterContext/filterContextSelectors";
 export {
     // Core drills

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -105,5 +105,5 @@ export const selectIsKpiAlertHighlightedByWidgetRef = createMemoizedSelector(
  */
 export const selectMenuButtonItemsVisibility = createSelector(
     selectSelf,
-    (state) => state.menuButton.itemsVisibility,
+    (state) => state.menuButton.itemsVisibility ?? {},
 );


### PR DESCRIPTION
- When filters on the dashboard are not changed, do not store them in the scheduled e-mail filter context
- With this change, future filter changes stored in the original dashboard filter context are correctly propagated to these scheduled emails

JIRA: RAIL-3944

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
