### PR TITLE
RELATED: RAIL-3969 Fix applink for packages with NOTICE

### DIFF
--- a/tools/applink/src/devConsole/pipeline/publisher.ts
+++ b/tools/applink/src/devConsole/pipeline/publisher.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 
 import { TargetDependency } from "../../base/types";
 import path from "path";
@@ -106,9 +106,11 @@ export class PackagePublisher implements IEventListener {
 
         const prefixes: string[] = [];
 
-        dep.pkg.packageJson.files.forEach((fileEntry) => {
-            prefixes.push(fileEntry.split("/")[0]);
-        });
+        dep.pkg.packageJson.files
+            .filter((f) => f !== "NOTICE") // NOTICE is not a directory and we do not need to sync it anyway
+            .forEach((fileEntry) => {
+                prefixes.push(fileEntry.split("/")[0]);
+            });
 
         return uniq(prefixes).map((dir) => [
             path.join(dep.pkg.directory, dir) + path.sep,


### PR DESCRIPTION
The NOTICE is the only thing in "files" that is not a directory. We need to
exclude it from the sync because it breaks the sync and is useless
in the applink context anyway.

JIRA: RAIL-3969

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
