### PR TITLE
RELATED: RAIL-3936 Replace uniqueId by lodash with uuid

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -4773,8 +4773,8 @@ packages:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: false
 
-  /@types/uuid/8.3.3:
-    resolution: {integrity: sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==}
+  /@types/uuid/8.3.4:
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
     dev: false
 
   /@types/webpack-env/1.16.3:
@@ -5904,7 +5904,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.14.5_debug@4.3.3
+      follow-redirects: 1.14.5
     transitivePeerDependencies:
       - debug
     dev: false
@@ -9839,6 +9839,16 @@ packages:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.7
+    dev: false
+
+  /follow-redirects/1.14.5:
+    resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /follow-redirects/1.14.5_debug@4.1.1:
@@ -20926,7 +20936,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-eLxAvrXyj8m5+Bp+/TkDap3NLOsIwbsbcVcBXGHdXCpFOXYMKCCIo8dMnULjTk05zR1Qe7yBsBR65n+SDSVdQQ==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-iOqd60IKzBScyCzePY5bOwuKOAboJ/zcaJ28QIb8CMjXMgy1Yyw5xksC8qYNEMh9aqoVhy1Xwk1bdTGj1EGsaQ==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -20991,7 +21001,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-GsFmXek/8RjlQmm3VzKhYPBgnz7RDehYmRBx7jXPFuMrRO4ywDnYy5QgNURi34ke8FHOQiBUX3huphsnQSZt+Q==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-IVGA6aDPI2+ZujIMkYX9cxYVwNbtoUlDnmoK29m5OqEVTGHO4i7Sf7KsmAI9gWBIy6qvBFAPyQBsVuYHJufWPQ==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21132,7 +21142,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-CHax6YgmXmTtfA95mdxae4XMNbJEgF9em3WkmHwRDRN5US6WuLyFtlD2SD4pRa3mK1TNm3xkydmkduUzHcPNBg==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-BckOAx011rjPLSFjewQ6TRrgGCHaFQq0V0Y91f4lkFLbhLrpyv6nVqGF/4F6VW0hfS2fjBJtGCFen/MfScEEsA==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21184,7 +21194,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-5O/T6VXx6oVDiK9NhjACqFIzz6tVVBqK6eo9x712MpEl9V3JWCKDCbF4kHC739TMhTkCDYkKTmQjNdkg5Ru/+g==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-bRBf6fvpREBk/apJ/YhJ0+cULgUYTuaSMPRBUHw25fowQFQY2i3k9QGj+NN2pUSA0dY+CdjzorjDZj6yQOGPvw==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21261,7 +21271,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-+kRWo+MMRgmak7yENRESLwlQQksnJLtk7OtvRZ+rJhSu1/xvCJ39j3//8hAauZuxZMvGg3sTiZHQWJ0CdChpSQ==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-R6LQMAtqd3yUDQNkjDxTGzBrQiR1OQiC6LqUAq+XE0866nRyHT1CS7bTfqu6sskv6vwAjnpT5m+SwAqes88HRg==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21301,7 +21311,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-0JYa7Rj3vsz2HCpjACS5m2LCmDrtK2SJHr7M/ZiEmclhqm0avfOKgS5YIpKDcRidcmJue6IlTzhqKcQrzgl3QA==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-ZpRwZy10VsQI2ZTUXJ+GJU1kQP6aL+x0auhdzeUdOgpv9j0CIEj5u32HYsgkV29Pnyp4hud0QDFEhrWSLQCkxw==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -21340,7 +21350,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-nDn6baa1Eun6dqwXCFSgMMAdr/u22cSdMdSQDe2HkF9+0MrdouJOr0EtQjpmcuAa+3OsajkW3bciT20XHCJ3mw==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-xPkpv+r4xHiWirHWorqZfLfjaErATOsprupXxbzGSqIVVLr4nmc08tGO6XyesI/2G2dybaPIsNFFugrOdMOgXw==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -21392,7 +21402,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-RE+MdIX7xTAhLlDsP9SBGYH1aNVWy1c0+Vt0gPF4RP03gJc9vKFj9YVxkR+LgGh3xk2EtNKI8NGat55p8HN/QQ==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-5gyqBD97RnalghxoRsT1LfsZ0J6Rm4DHiasTq2BF7ENF4KwIZCh5i3HISP1Cb617tr0ALasNxeSEkf85dS/h3w==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -21476,7 +21486,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-HTGvCX094h5aHlp7DUng2YK6PyQ4sdUlL12yrIS4z6PyIAJhsjuVDRkU5P+ltVvZf12HA3n9VaQlplrcAecM5g==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-oJ0fphi1r+bjZNSa2XlSYeFTtK/b/rayXQydgyN8cebuDlemU7HSIUsFuQkMZXlORnZfuklbeCSJgLGgedV1sw==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -21538,7 +21548,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-g2z51ltLskHxxX0EpnpfPvvWitp3cbC1QQm5FVvaSt09RzeSX0NfUPjJuI7mIGRn6CM2J1G2QyrLyeO+ZXgQkg==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-EguRiE4slt92oPC4E8MdG8gXsQLynF3aMCzQ+7MPhs+O8cfM2nYXKH0gyXWO0bt6a50kcdFj3EqJJW/q6EqASA==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -21576,7 +21586,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-irwQh/ZTe49Ybnca27XAg0qOn3sDNYr3cEW1gVYnoXx1Zr7IAvj/DTqsv4xgJsynno4VIAgOPfYUIMIk9Pw8XQ==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-W1XkbGWcO7+Zquy80MqG7cA+aC912xvotcbrrbKUBAR4K2KUhpFitNXFpF5iIgJytiRGzOvzDuf6zlMzzflbvA==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -21615,7 +21625,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-pPzxtNWNfAILWHSY6mP3JuUvHuXNHUgYlMlsRLtlcxemBZFgsMvzvQcM0e1jV055//N+odIoxVO3zGGbsOUfXg==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-DMBptqE4005cWe+xv1NzmNfzTChZfGZr1Kl30h+WVosFR2x1+g4Q5EsQcVago8b4PWfA4sWbJa8mCb7xTit/bA==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -21629,7 +21639,7 @@ packages:
       '@types/lodash': 4.14.177
       '@types/lru-cache': 5.1.1
       '@types/spark-md5': 3.0.2
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       concurrently: 6.4.0
@@ -21666,7 +21676,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-T0oRRnljSIVw+gAj76JCQwVUI6aitZGh4wCkisb1BaxgTSxl2m5GopR9hD/0wCg6WXarM0r8bK/uMNl7XcnzLA==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-o/FvI4Vkia+FQOP5MnW2+AEPxBgNZiB8mQfmorR4SSfTL00Pv7sajTISDUJVyouP3cvV26ELRPngG79rAUQ7vw==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -21678,7 +21688,7 @@ packages:
       '@types/json-stable-stringify': 1.0.33
       '@types/lodash': 4.14.177
       '@types/spark-md5': 3.0.2
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       concurrently: 6.4.0
@@ -21717,7 +21727,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-uudqGLowoA9YnhLnC17MwoZxwBqW5kI0VZy9OJzxL1sjUlVCrN05iQ8ohaR4lxizAfnNIJhZFD/2+hqASB36ww==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-HqEa8gxkIo2MXk7Jk8B2OH68c2GlVwecmju15f0A+HjJakcLyixYJh+meiL6ffvQdMR2ZV7UwDqvT7SCyNuKrw==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -21727,7 +21737,7 @@ packages:
       '@microsoft/api-extractor': 7.18.19
       '@types/jest': 27.0.3
       '@types/lodash': 4.14.177
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       concurrently: 6.4.0
@@ -21761,7 +21771,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-McBr/uSBQb/vd7KTFQJNnZTCN8jfx5AwrECU9LIE9TSvntpGyLhc4aiqB/LUuA95JYlZymR4GJ2N5RKGRyxdpQ==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-KHaJg+iuPRTa+/hvhgcNMnjRHsxj0QQnbIo+UTBHqbyVHbdWy/BYp8FnLoUOucQEooD4zm3nT3tOKOB2+zpiXQ==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -21805,7 +21815,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-S6sH6fFH95bQw7D8GQjXAapMYfHOIsfIZ9CMZ5zhUf5SiFEwJZD6gcsCnSArUE/3Q0g86VZ0JYyBM+NlZ5yEEw==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-wXefqXD6ebMfOpUl0mHftwWTTgi0ry7Z3768jEoAvSHFc73l7ZA1RGJbowwJmsga59F94WX9oCvIHICmArmdQg==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -21816,7 +21826,7 @@ packages:
       '@types/jest': 27.0.3
       '@types/lodash': 4.14.177
       '@types/spark-md5': 3.0.2
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       axios: 0.21.4
@@ -21857,7 +21867,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-RgCUqsuBzRRrEthnbYiMIppxub7gvI9v7mOzLTujg7249vbxTuPoEkY0Zg63vsMbdfv7j6nE0XMAk6Rhjoc0mA==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-Vqk+IweJ07Hfh90yD6n7G+7jgbfI/2LIldp0yxeHL43stmD2ZdpEvAr4OIcoF3kQEXlYzAkYzlrEFEB2Npqimg==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -21899,7 +21909,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-iNISUBh10An2EMCRi2kgFi2j1TCEkXMdvG1xYd5Gg7XoYlBTSAVKVLc9sambF2OIYLGqT6kXqNMfyVMK+Ps7pA==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-2tyU+ciYBRZtSBJwfBtpy/u6TYlxt+mgQQCv2rle1eiXsXaDN/1/waZFrmasQy8qEwW8wa76Ov+rISHE3t6ZOw==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22157,7 +22167,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-ily10ezyNm4Cli28gztyk7wDV3ojG2TH1gXzmjyI58fl4aCmPlpQmD+gWRX9zFpMl3WlGTFfftkq/nGho5DjyA==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-M8bUeAC4LtvcbZV8xRPuZLNw5evWmWTwTBVBEqi3SBz9zKSQAP7f8ACjxAy82lqKp4eXHPavIR+mVBcNEqAV3A==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22196,7 +22206,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-MY3sqkeKy8wW7fXjkuqWOviQUemACIJchf6Am/fnqIEnuWRW6GNLyN9orB/rxQgRyJL5L7MGx1Cp1VWywRxsBQ==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-8kjMeClH3OKGdONY/NbRX8MyvYaa4J0rDTrY/yXV2bqexZIRbFx3S+ER1+WvF58rybHfY68N7mvQvgfDUzILpg==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22214,7 +22224,7 @@ packages:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       '@types/react-measure': 2.0.5
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22272,7 +22282,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-csFjJz6Qk6RpSD5Y/30cJ1xj5Zc+M739aIAsPo6LHUOk4Agw0+l6I8hZ4hJqC10s9KtxlZQeeZwbbjCF8oRj2w==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-xije6NhAWZgwCSZ8dbgngM/A0ggsoHG7MfwjPF8Z3zosIROgNAvPOohKlvXhUJoNHLewuKLLM9Lv2bzXnIn9Xw==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -22294,7 +22304,7 @@ packages:
       '@types/react-select': 3.1.2
       '@types/react-transition-group': 4.4.4
       '@types/react-truncate': 2.3.4
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22357,7 +22367,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-X+Sl3DHhpfKTyPi5QfPyY9AX+XRow6lAUV2o/N6u0p9aFKdDWJpvFLvhgvYvjIlEPhvtwgWOD8ecEJSVmAxyaQ==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-XDWcNv7AUQRzWG7lOocvxb94Ryoyg3JzUr5aKequNgx0Ar6NH4yHh/xlD6TbrmwJylS8p3VEA39cFMd4u4d0Mg==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -22379,7 +22389,7 @@ packages:
       '@types/react-select': 3.1.2
       '@types/react-transition-group': 4.4.4
       '@types/react-truncate': 2.3.4
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22441,7 +22451,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-WbFX2BwtrhfLnL/B8B+a3N4/HmO6R/alvWG33QJyU/hIxefh9CYnGzbmNBeuiWQG6IH7gj4L+CHJl8GYkCa/SA==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-LdQBR7KBJmuwVuBg+NBNnn2ntaYN0pR/Ty5skfI9G65BKLC+ZDkyXUubCLfFxN01bkaSIosRu4K7aKX9+Z9oMQ==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -22519,7 +22529,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-jCLmp3VBwzU4UH32+MTC0tiC8yJJUrxHWhhSq4LZPN/8o/wD2Q7JxpxTJxdhAhF83oa1clkfRZG6PttTqJHfKA==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-hKD2C1uV5p8QI299O29vWfaMRZUHCwZWFSCpFSO/1gcq9G6qJ/cBui+YxtWq01amKmSOLMi0KZAipS1NyzSWgQ==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -22536,7 +22546,7 @@ packages:
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
       '@types/react-measure': 2.0.5
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22589,7 +22599,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-TgwlyKqY04dwxVgREnC+b/QaVD516451owIBie1KPEy69hJIWUQWAThTwBMbIV8/ikFfATG/E8JFhmO/C07nPQ==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-XbDPdreQ//1wUD/WCOqsbFl4ot5JJQtrWlJ6bSGCpkaOQydMJqNjrdKo7BNlMYglQmZHs2KGI6S7Kpjb9P871A==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -22616,7 +22626,7 @@ packages:
       '@types/react-select': 3.1.2
       '@types/react-transition-group': 4.4.4
       '@types/tinycolor2': 1.4.3
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22685,7 +22695,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-MsuW220XPPaycLagq3BeVJ+A0g/9DyL4X+ETJHwFW7V0r9ibeR4aobdOUns+F8YuILWcwPryFBbqGFcROBJRcg==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-N4Hpn6hpnQS/siMVuu2umcqF/S23ZP3PfZVj050IIo29iCyZx51yyPTekzut77MFlBnX0FrJWNVmzYc5H4BIjw==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -22744,7 +22754,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-RDI1j3mqaaiho2kbkMGLFQP6vW1wbIs4+w1c/M/l4RVbs4saaKpiaeaogYV/WDrvi5K9ZnhxJjBcc27yMVcsZQ==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-ahgswLHmNlSaU+o27q5HOcDAYjmcVmrC5XG1oUdS6bTUW9K7ZAV1Xp2HHS+MGcmHJ/S8Dq0IhOO738nunt6vmg==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -22763,7 +22773,7 @@ packages:
       '@types/raf': 3.4.0
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22817,7 +22827,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-3yQaZyBePWXmRsQv5i3UTcn5bRMXej+W2gDa3G8s1+JUYbkSfP+rko4oYDkyKf4BG90SlQx2mftfBERGpQ7o5A==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-RQ4uHjeuPLK8lrS60+0WoNo0LrKHkIqAMCfHosJ7yh4vhrOyUbMjaD7A382eWTqThUswLzev/Z3R8BpqjldB7A==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -22917,7 +22927,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-vY5DrLko3CQjxw9hgzEr31eG6LbHIBi6NZRxwSRFm/veKIDD+3V3F4obtfaIr4BkFzmrmCXV5tAAYrzUJv9kFQ==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-jAX4MJ/pzWPVEzArWOaO+fSlVnOSABQGJ5KGMEg220nTcJAOIToAjDWBJRZtg9mE8c6XFw29eHP4oy8He/rQ+A==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -22944,6 +22954,7 @@ packages:
       '@types/react-dom': 17.0.11
       '@types/react-responsive': 8.0.4
       '@types/spark-md5': 3.0.2
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0
@@ -22988,6 +22999,7 @@ packages:
       ts-node: 10.4.0_9dd118e102296836d641836d8e42e390
       tslib: 2.3.1
       typescript: 4.0.2
+      uuid: 8.3.2
     transitivePeerDependencies:
       - '@storybook/builder-webpack5'
       - '@storybook/manager-webpack5'
@@ -23017,7 +23029,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-NLBvDX5Yrohn0uufnT8xx40HJa8vC2Tp9I52upoVAzL4bB6r3ODirmfwTE82wRO9A65bxqycr6hSQKL0htxEzA==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-aSm3sAX4rwA94vWoyoFM2hrFtgYJ0/Xs4BE7Wdg6X//3WVJW5khWu7XDTrR5Zl14jvJu8bu+k6Bsr7HS/7BpKQ==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23075,7 +23087,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-glKCvZ9IMBQ2c7tL5nOAZO6Gx/gDkv9y4NT80PpieUTQ0S3qc/6SQy6qdfR8bpaDHK5AfYBvxPFmz9bFoAGJ8Q==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-wZNVdD5rN2DdFVSn3KwGih6Gbix9sK1HsZR9FwOlIIj0Lc3p26DF5A2Yx8K2Y96h7N7J+vhdfboAoL1Y+A+0Ug==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23139,7 +23151,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.4.0:
-    resolution: {integrity: sha512-oj1+42IMXT3dV7ETJEdvxirIX1k3ad+9my4GL9VLM2iWOAlFCB+ZK2jN+1fa0DIxSFDRJqEJBWhoC9g36UsioQ==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-F7p1dMNXGJUNZkaRc3xOdk77Wmk3FXgugNzV76y3udPEoHL30JPdB4WdSPzlDE4GqZNLBbKDlcEUTiOyk+o7hQ==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0
@@ -23159,7 +23171,7 @@ packages:
       '@types/raf': 3.4.0
       '@types/react': 17.0.37
       '@types/react-dom': 17.0.11
-      '@types/uuid': 8.3.3
+      '@types/uuid': 8.3.4
       '@typescript-eslint/eslint-plugin': 5.5.0_0b653047a985f39af74c471038804c7e
       '@typescript-eslint/parser': 5.5.0_eslint@8.3.0+typescript@4.0.2
       '@wojtekmaj/enzyme-adapter-react-17': 0.6.5_fae758709a8810ba97b4c03852dde4d0

--- a/libs/sdk-backend-base/package.json
+++ b/libs/sdk-backend-base/package.json
@@ -68,7 +68,7 @@
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.158",
         "@types/spark-md5": "^3.0.1",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "concurrently": "^6.0.2",

--- a/libs/sdk-backend-bear/package.json
+++ b/libs/sdk-backend-bear/package.json
@@ -81,7 +81,7 @@
         "@types/json-stable-stringify": "^1.0.32",
         "@types/lodash": "^4.14.158",
         "@types/spark-md5": "^3.0.1",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "concurrently": "^6.0.2",

--- a/libs/sdk-backend-mockingbird/package.json
+++ b/libs/sdk-backend-mockingbird/package.json
@@ -64,7 +64,7 @@
         "@microsoft/api-extractor": "^7.18.4",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.158",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "concurrently": "^6.0.2",

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -80,7 +80,7 @@
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.158",
         "@types/spark-md5": "^3.0.1",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "concurrently": "^6.0.2",

--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -102,7 +102,7 @@
         "@types/react": "^17.0.34",
         "@types/react-dom": "^17.0.11",
         "@types/react-measure": "2.0.5",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -113,7 +113,7 @@
         "@types/react-select": "^3.0.12",
         "@types/react-transition-group": "^4.4.4",
         "@types/react-truncate": "^2.3.3",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
@@ -1,7 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
 import isEmpty from "lodash/isEmpty";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import cx from "classnames";
 import { FormattedMessage, injectIntl } from "react-intl";
 import { IAttributeDropdownListItemProps } from "@gooddata/sdk-ui-filters";
@@ -35,7 +35,7 @@ const AttributeDropdownListItem: React.FC<IAttributeDropdownListItemProps> = (pr
         props.onOnly?.(props.source);
     }
 
-    const itemId = uniqueId("attr-filter-item-");
+    const itemId = `attr-filter-item-${uuid()}`;
 
     return (
         <div

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeFilterBody.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeFilterBody.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import {
@@ -12,7 +12,7 @@ import {
 } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
 import { AllItemsFilteredMessage } from "./AllItemsFilteredMessage";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import { ItemsFilteredMessage } from "./ItemsFilteredMessage";
 import { ConfigurationButton } from "./configuration/ConfigurationButton";
 import { DeleteButton } from "./DeleteButton";
@@ -126,7 +126,7 @@ const AttributeFilterBodyCore: React.FC<IAttributeDropdownBodyExtendedProps> = (
             itemsCount={props.totalCount}
             isLoading={isElementsLoading}
             isLoadingClass={LoadingMask}
-            getItemKey={(item: IAttributeElement) => (item && item.uri) || uniqueId()}
+            getItemKey={(item: IAttributeElement) => (item && item.uri) || uuid()}
             itemHeight={currentItemHeight}
             height={getDropdownBodyHeight()}
             searchPlaceholder={intl.formatMessage({ id: "attributeFilterDropdown.searchPlaceholder" })}

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -113,7 +113,7 @@
         "@types/react-select": "^3.0.12",
         "@types/react-transition-group": "^4.4.4",
         "@types/react-truncate": "^2.3.3",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -92,7 +92,7 @@
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.158",
         "@types/mapbox-gl": "^2.6.0",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@types/react-dom": "^17.0.11",
         "@types/react-measure": "2.0.5",
         "@types/react": "^17.0.34",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -121,7 +121,7 @@
         "@types/react-transition-group": "^4.4.4",
         "@types/react": "^17.0.34",
         "@types/tinycolor2": "^1.4.2",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
@@ -1,7 +1,7 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import pickBy from "lodash/pickBy";
 
 /**
@@ -37,7 +37,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
     };
 
     public readonly state: Readonly<IBubbleTriggerState> = {
-        bubbleId: uniqueId("bubble-"),
+        bubbleId: `bubble-${uuid()}`,
         isBubbleVisible: false,
     };
 

--- a/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
@@ -1,6 +1,6 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import debounce from "lodash/debounce";
 import noop from "lodash/noop";
 import format from "date-fns/format";
@@ -143,7 +143,7 @@ export class WrappedDatePicker extends React.PureComponent<DatePickerProps, IDat
     }
 
     private getInputClasses() {
-        return classNames("input-text", "small-12", this.props.size, uniqueId("gd-datepicker-input-"));
+        return classNames("input-text", "small-12", this.props.size, `gd-datepicker-input-${uuid()}`);
     }
 
     private getComponentClasses() {

--- a/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
+++ b/libs/sdk-ui-kit/src/Dropdown/Dropdown.tsx
@@ -1,6 +1,6 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { useState, useCallback, useEffect, useRef } from "react";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import noop from "lodash/noop";
 
 import { FullScreenOverlay, Overlay } from "../Overlay";
@@ -131,7 +131,7 @@ export const Dropdown: React.FC<IDropdownProps> = (props) => {
     } = props;
     const [{ isOpen, dropdownId }, setState] = useState<IDropdownState>({
         isOpen: !!openOnInit,
-        dropdownId: uniqueId("dropdown-"),
+        dropdownId: `dropdown-${uuid()}`,
     });
 
     const _renderButton = (renderProps: IDropdownButtonRenderProps) => (

--- a/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
+++ b/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
@@ -1,6 +1,6 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component, ReactNode, RefObject } from "react";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import identity from "lodash/identity";
 import TextareaAutosize from "react-textarea-autosize";
 import cx from "classnames";
@@ -200,7 +200,7 @@ export class EditableLabel extends Component<IEditableLabelProps, IEditableLabel
     };
 
     renderTextAreaInOverlay(): ReactNode {
-        const alignId = uniqueId("gd-editable-label-");
+        const alignId = `gd-editable-label-${uuid()}`;
 
         const style = {
             width: this.state.textareaWidth,

--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -1,11 +1,11 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component, createRef } from "react";
 import { WrappedComponentProps, injectIntl, FormattedMessage } from "react-intl";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 import cx from "classnames";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import debounce from "lodash/debounce";
 
 import { Overlay } from "../Overlay";
@@ -60,7 +60,7 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
 
         this.state = {
             childrenWidth: 0,
-            guid: uniqueId("header-"),
+            guid: `header-${uuid()}`,
             isOverlayMenuOpen: false,
             responsiveMode: false,
             isHelpMenuOpen: false,

--- a/libs/sdk-ui-kit/src/Header/HeaderDataMenu.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderDataMenu.tsx
@@ -1,7 +1,7 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, IntlShape } from "react-intl";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import cx from "classnames";
 
 import { Button } from "../Button";
@@ -72,7 +72,7 @@ export const CoreHeaderDataMenu: React.FC<IHeaderDataMenuProps> = ({
     const dataMenuClassName = cx("gd-data-header-menu-section", className);
     return (
         <div className="gd-data-header-menu-wrapper">
-            <ul key={uniqueId("section-")} className={dataMenuClassName}>
+            <ul key={`section-${uuid()}`} className={dataMenuClassName}>
                 {renderSection(dataMenuItems)}
             </ul>
         </div>

--- a/libs/sdk-ui-kit/src/Header/HeaderMenu.tsx
+++ b/libs/sdk-ui-kit/src/Header/HeaderMenu.tsx
@@ -1,7 +1,7 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { PureComponent, ReactNode } from "react";
 import { injectIntl, FormattedMessage, WrappedComponentProps } from "react-intl";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import identity from "lodash/identity";
 import cx from "classnames";
 
@@ -49,7 +49,7 @@ class WrappedHeaderMenu extends PureComponent<IHeaderMenuProps & WrappedComponen
     renderSections(): ReactNode {
         return this.props.sections.map((items) => {
             return (
-                <ul key={uniqueId("section-")} className="gd-header-menu-section gd-header-measure">
+                <ul key={`section-${uuid()}`} className="gd-header-menu-section gd-header-measure">
                     {this.renderSection(items)}
                 </ul>
             );

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -96,7 +96,7 @@
         "@types/raf": "^3.4.0",
         "@types/react-dom": "^17.0.11",
         "@types/react": "^17.0.34",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",

--- a/libs/sdk-ui-tests/package.json
+++ b/libs/sdk-ui-tests/package.json
@@ -92,7 +92,8 @@
         "ts-invariant": "^0.7.3",
         "ts-jest": "^27.0.5",
         "ts-loader": "^8.3.0",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
     },
     "peerDependencies": {
         "@gooddata/sdk-ui": "^8.8.0-alpha.49",
@@ -127,6 +128,7 @@
         "@types/react-responsive": "^8.0.2",
         "@types/react": "^17.0.34",
         "@types/spark-md5": "^3.0.1",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "css-loader": "^5.2.4",

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Button/Button.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Button/Button.tsx
@@ -1,7 +1,7 @@
 // (C) 2020 GoodData Corporation
 import { Button } from "@gooddata/sdk-ui-kit";
 import React from "react";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 
 import { storiesOf } from "@storybook/react";
 import { UiKit } from "../../../_infra/storyGroups";
@@ -237,7 +237,7 @@ const icons = [
 const getButtons = () => {
     return types.map((item) => {
         return (
-            <tr key={uniqueId("button-")}>
+            <tr key={`button-${uuid()}`}>
                 <td>
                     <Button
                         value={item.title}
@@ -272,7 +272,7 @@ const getButtons = () => {
 };
 
 const getGroupButtons = () => (
-    <tr key={uniqueId("button-")}>
+    <tr key={`button-${uuid()}`}>
         <td>
             <div className="gd-button-group">
                 <Button className="gd-button-secondary" value="1" />
@@ -288,7 +288,7 @@ const getGroupButtons = () => (
 
 const getIcons = () => {
     return icons.map((item) => {
-        return <Button key={uniqueId("button-")} value={item} className={`gd-button-link gd-icon-${item}`} />;
+        return <Button key={`button-${uuid()}`} value={item} className={`gd-button-link gd-icon-${item}`} />;
     });
 };
 

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Messages/Messages.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Messages/Messages.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import reject from "lodash/reject";
 import keys from "lodash/keys";
-import uniqueId from "lodash/uniqueId";
+import { v4 as uuid } from "uuid";
 import { Button, Messages, Message, IMessage, MessageType } from "@gooddata/sdk-ui-kit";
 import { wrapWithTheme } from "../../themeWrapper";
 
@@ -86,7 +86,7 @@ class MessagesExamples extends React.Component<unknown, IMessagesExamplesState> 
         const buttons = keys(info.messages).map((type) => {
             return (
                 <Button
-                    key={uniqueId("msg-")}
+                    key={`msg-${uuid()}`}
                     className="gd-button-primary"
                     value={`Add ${type}`}
                     onClick={() => {

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -93,7 +93,7 @@
         "@types/raf": "^3.4.0",
         "@types/react-dom": "^17.0.11",
         "@types/react": "^17.0.34",
-        "@types/uuid": "^8.3.0",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.5",


### PR DESCRIPTION
- Replace uniqueId by lodash with uuid
- update @types/uuid version 8.3.0 -> 8.3.4

Using uniqueId by lodash is causing issues with duplicate IDs while using SDK Dashboard component with the plugins as Dashboard Plugins introduce second instance of lodash, it can cause some major issue. 

As a solution/follow-up uniqueId by lodash is replaced with uuid through out the whole SDK codebase.

JIRA: RAIL-3936

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
