### PR TITLE
RELATED: RAIL-3966 - AttributeFilterButton examples fixes

### DIFF
--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterButtonExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterButtonExample.tsx
@@ -95,7 +95,7 @@ export class AttributeFilterButtonExample extends Component<unknown, IAttributeF
 
     public render(): React.ReactNode {
         const { filters } = this.state;
-        const filter = filters?.[0] ?? newNegativeAttributeFilter(Md.LocationResort, []);
+        const filter = filters?.[0] ?? newNegativeAttributeFilter(Md.LocationResort, { uris: [] });
 
         return (
             <div className="s-attribute-filter">

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonExample.tsx
@@ -39,10 +39,22 @@ export const AttributeParentChildFilterButtonExample: React.FC = () => {
         console.info("AttributeFilterExample onLoadingChanged", ...params);
     };
 
+    /**
+     * What happens with the component depending on the child filters is handled outside the AttributeFilterButton component.
+     */
+    const onParentApply = (filter: IAttributeFilter) => {
+        setFilter(
+            newNegativeAttributeFilter(attributeDisplayFormRef(Md.LocationCity), {
+                uris: [],
+            }),
+        );
+        setParentFilter(filter);
+    };
+
     return (
         <div className="s-attribute-filter">
             <div style={{ display: "flex" }}>
-                <AttributeFilterButton filter={parentFilter} onApply={setParentFilter} />
+                <AttributeFilterButton filter={parentFilter} onApply={onParentApply} />
                 <AttributeFilterButton
                     filter={filter}
                     parentFilters={parentFilter ? [parentFilter] : []}

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholderExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholderExample.tsx
@@ -7,6 +7,7 @@ import {
     OnError,
     OnLoadingChanged,
     PlaceholdersProvider,
+    usePlaceholder,
     useResolveValueWithPlaceholders,
 } from "@gooddata/sdk-ui";
 import { AttributeFilterButton } from "@gooddata/sdk-ui-filters";
@@ -31,7 +32,7 @@ const stateFilterPlaceholder = newPlaceholder<IAttributeFilter>(
     }),
 );
 
-let cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+const cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
     newNegativeAttributeFilter(attributeDisplayFormRef(Md.LocationCity), {
         uris: [],
     }),
@@ -55,11 +56,13 @@ const AttributeParentChildFilterButtonWithPlaceholder: React.FC = () => {
 
     const parentFilter = useResolveValueWithPlaceholders(stateFilterPlaceholder);
 
+    const [, setChildFilter] = usePlaceholder(cityFilterPlaceholder);
+
     /**
      * What happens with the component depending on the child filters is handled outside the AttributeFilterButton component.
      */
     useEffect(() => {
-        cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+        setChildFilter(
             newNegativeAttributeFilter(attributeDisplayFormRef(Md.LocationCity), {
                 uris: [],
             }),

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholderExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeParentChildFilterButtonWithPlaceholderExample.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
-import React from "react";
+import React, { useEffect } from "react";
 import {
     IPlaceholder,
     newComposedPlaceholder,
@@ -7,6 +7,7 @@ import {
     OnError,
     OnLoadingChanged,
     PlaceholdersProvider,
+    useResolveValueWithPlaceholders,
 } from "@gooddata/sdk-ui";
 import { AttributeFilterButton } from "@gooddata/sdk-ui-filters";
 import { BarChart } from "@gooddata/sdk-ui-charts";
@@ -30,7 +31,7 @@ const stateFilterPlaceholder = newPlaceholder<IAttributeFilter>(
     }),
 );
 
-const cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+let cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
     newNegativeAttributeFilter(attributeDisplayFormRef(Md.LocationCity), {
         uris: [],
     }),
@@ -51,6 +52,19 @@ const AttributeParentChildFilterButtonWithPlaceholder: React.FC = () => {
         // eslint-disable-next-line no-console
         console.info("AttributeFilterExample onLoadingChanged", ...params);
     };
+
+    const parentFilter = useResolveValueWithPlaceholders(stateFilterPlaceholder);
+
+    /**
+     * What happens with the component depending on the child filters is handled outside the AttributeFilterButton component.
+     */
+    useEffect(() => {
+        cityFilterPlaceholder = newPlaceholder<IAttributeFilter>(
+            newNegativeAttributeFilter(attributeDisplayFormRef(Md.LocationCity), {
+                uris: [],
+            }),
+        );
+    }, [parentFilter]);
 
     return (
         <div className="s-attribute-filter">

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import cx from "classnames";
 import { injectIntl, WrappedComponentProps } from "react-intl";
@@ -295,7 +295,9 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         };
     });
 
-    const prevParentFilters = usePrevious(props.parentFilters);
+    const resolvedParentFilters = useResolveValueWithPlaceholders(props.parentFilters);
+
+    const prevParentFilters = usePrevious(resolvedParentFilters);
 
     useEffect(() => {
         setState((prevState) => {
@@ -343,10 +345,8 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         });
     }, [currentFilter]);
 
-    const resolvedParentFilters = useResolveValueWithPlaceholders(props.parentFilters);
-
     useEffect(() => {
-        if (!isEmpty(props.parentFilters) && !isEqual(prevParentFilters, props.parentFilters)) {
+        if (!isEmpty(props.parentFilters) && !isEqual(prevParentFilters, resolvedParentFilters)) {
             setState((prevState) => {
                 return {
                     ...prevState,

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import {
     IAnalyticalBackend,
@@ -64,8 +64,13 @@ export const getItemsTitles = (
 ): string => {
     return selectedFilterOptions
         .map((selectedOption) =>
-            selectedOption?.uri ? elementTitles.get(selectedOption.uri)?.title : undefined,
+            selectedOption?.uri
+                ? elementTitles.get(selectedOption.uri)?.title
+                : selectedOption?.title
+                ? selectedOption.title
+                : undefined,
         )
+        .filter((title) => !isEmpty(title))
         .join(", ");
 };
 
@@ -92,8 +97,8 @@ export const updateSelectedOptionsWithData = (
     if (isEmpty(items)) {
         return selection.map((item) => {
             return {
-                title: item.title ?? "",
-                uri: item.uri ?? "",
+                title: item?.title ?? "",
+                uri: item?.uri ?? "",
             };
         });
     }
@@ -103,8 +108,8 @@ export const updateSelectedOptionsWithData = (
     return selection.map((selectedItem) => {
         return nonEmptyItems.find(
             (item) =>
-                (selectedItem.uri && item.uri === selectedItem.uri) ||
-                (selectedItem.title && item.title === selectedItem.title),
+                (selectedItem?.uri && item.uri === selectedItem.uri) ||
+                (selectedItem?.title && item.title === selectedItem.title),
         );
     });
 };


### PR DESCRIPTION
- compare previous and actual parent filters after placeholder resolution
- handling components depending on child filter in the parent component
- attributeFilterButton always defined by refs in examples
- conidering title prop in AttributeFilterButton subtitle resolution

There is a need to handle child-filter-dependent components in all AttributeFilterButton parent-child examples, hence the effects reflecting the parent-filter changes.

In `getItemsTitles` function in `AttributeFilterUtils` the support for using attribute element title property if the filter is defined by values instead of refs. In the same function, we accept the possibility that the element's title will be resolved as undefined, that's why resolved titles are in addition filtered to remove falsy values.

JIRA: RAIL-3966, RAIL-3956

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
