### PR TITLE
Fix css selectors and bugs for KD cypress tests

### DIFF
--- a/libs/sdk-ui-dashboard/src/_staging/testUtils/getTestClassname.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/testUtils/getTestClassname.ts
@@ -1,0 +1,6 @@
+// (C) 2007-2022 GoodData Corporation
+import { stringUtils } from "@gooddata/util";
+
+export function getTestClassname(title: string): string {
+    return `s-${stringUtils.simplifyText(title)}`;
+}

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectListBody.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectListBody.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 
 import { DrillSelectList } from "./DrillSelectList";
@@ -19,7 +19,7 @@ export const DrillSelectListBody: React.FC<DrillSelectListBodyProps> = (props) =
 
     return (
         <div
-            className="gd-drill-modal-picker-dropdown s-drill-measure-selector-dropdown"
+            className="gd-drill-modal-picker-dropdown s-drill-item-selector-dropdown"
             onScroll={stopPropagation}
         >
             <div className="gd-drill-modal-picker-body">

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/ConfigurationParentItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/ConfigurationParentItem.tsx
@@ -1,11 +1,11 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
 import { ObjRef } from "@gooddata/sdk-model";
 import { FormattedMessage } from "react-intl";
 import { DisabledConfigurationParentItem } from "./DisabledConfigurationParentItem";
 import cx from "classnames";
-import { stringUtils } from "@gooddata/util/dist";
 import { ConnectingAttributesDropdown } from "../connectingAttributesDropdown/ConnectingAttributesDropdown";
+import { getTestClassname } from "../../../../../_staging/testUtils/getTestClassname";
 
 export interface IConnectingAttribute {
     ref: ObjRef;
@@ -49,7 +49,7 @@ export const ConfigurationParentItem: React.FC<IConfigurationParentItemProps> = 
 
     const itemClassName = cx(
         "gd-list-item attribute-filter-item s-attribute-filter-dropdown-configuration-item",
-        `s-${stringUtils.simplifyText(title)}`,
+        getTestClassname(title),
         {
             "is-selected": isSelected,
         },

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBarContainer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/filterBar/DefaultFilterBarContainer.tsx
@@ -1,6 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
 import Measure from "react-measure";
+import cx from "classnames";
 
 import { IntlWrapper } from "../../localization";
 import {
@@ -37,7 +38,12 @@ const DefaultFilterBarContainerCore: React.FC = ({ children }) => {
 
     return (
         <div className="dash-filters-wrapper s-gd-dashboard-filter-bar">
-            <div className="dash-filters-visible" style={dashFiltersVisibleStyle}>
+            <div
+                className={cx("dash-filters-visible", {
+                    "s-dash-filters-visible-all": filterBarExpanded,
+                })}
+                style={dashFiltersVisibleStyle}
+            >
                 <Measure
                     bounds
                     onResize={(dimensions) => onAttributeFilterBarHeightChange(dimensions.bounds!.height)}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import {
     isWidget,
@@ -22,6 +22,7 @@ import {
     getDashboardLayoutItemHeight,
     getDashboardLayoutItemHeightForRatioAndScreen,
     getDashboardLayoutWidgetDefaultHeight,
+    IDashboardLayoutItemFacade,
     IDashboardLayoutWidgetRenderer,
 } from "./DefaultDashboardLayoutRenderer";
 import { ObjRefMap } from "../../_staging/metadata/objRefMap";
@@ -56,6 +57,21 @@ function calculateWidgetMinHeight(
 }
 
 /**
+ * Tests in KD require widget index for css selectors.
+ * Widget index equals to the widget order in the layout.
+ */
+function getWidgetIndex(item: IDashboardLayoutItemFacade<ExtendedDashboardWidget>): number {
+    const sectionIndex = item.section().index();
+    let itemsInSectionsBefore = 0;
+    for (let i = 0; i < sectionIndex; i += 1) {
+        itemsInSectionsBefore += item.section().layout().section(i)?.items().count() ?? 0;
+    }
+    const index = itemsInSectionsBefore + item.index();
+
+    return index;
+}
+
+/**
  * @internal
  */
 export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
@@ -77,6 +93,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
 
     const allowOverflow = !!currentSize.heightAsRatio;
     const className = settings.enableKDWidgetCustomHeight ? "custom-height" : undefined;
+    const index = getWidgetIndex(item);
 
     return (
         <DefaultWidgetRenderer
@@ -89,6 +106,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
             className={className}
         >
             <DashboardWidget
+                // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+                index={index}
                 screen={screen}
                 onDrill={onDrill}
                 onError={onError}

--- a/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IErrorProps } from "@gooddata/sdk-ui";
@@ -13,6 +13,7 @@ const EmptyDashboardErrorCore: React.FC<IEmptyDashboardErrorProps & WrappedCompo
 }) => {
     return (
         <ErrorComponent
+            className="s-layout-error"
             message={intl.formatMessage({ id: "dashboard.error.empty.heading" })}
             description={intl.formatMessage({ id: "dashboard.error.empty.text" })}
         />

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/DefaultTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/DefaultTitle.tsx
@@ -12,7 +12,7 @@ export const DefaultTitle: CustomTitleComponent = (props) => {
 
     return (
         <TitleWrapper>
-            <div className={"s-gd-dashboard-title dash-title static"}>{title}</div>
+            <div className={"s-gd-dashboard-title s-dash-title dash-title static"}>{title}</div>
         </TitleWrapper>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/title/EditableTitle.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/title/EditableTitle.tsx
@@ -15,7 +15,7 @@ export const EditableTitle: CustomTitleComponent = (props) => {
             <EditableLabel
                 value={title}
                 onSubmit={onTitleChanged!}
-                className="s-gd-dashboard-title dash-title editable"
+                className="s-gd-dashboard-title s-dash-title dash-title editable"
             >
                 {title}
             </EditableLabel>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useMemo } from "react";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import { extendedWidgetDebugStr } from "../../../model";
@@ -19,7 +19,11 @@ const MissingWidget: React.FC = () => {
  */
 export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
     const { WidgetComponentProvider } = useDashboardComponentsContext();
-    const { widget } = props;
+    const {
+        widget,
+        // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+        index,
+    } = props;
     const WidgetComponent = useMemo((): React.ComponentType<IDashboardWidgetProps> => {
         // TODO: we need to get rid of this; the widget being optional at this point is the problem; the parent
         //  components (or possibly the model) should deal with layout items that have no valid widgets associated
@@ -50,5 +54,11 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
         }
     }, [widget]);
 
-    return <WidgetComponent {...props} />;
+    return (
+        <WidgetComponent
+            {...props}
+            // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+            index={index}
+        />
+    );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -34,7 +34,11 @@ interface IDefaultDashboardInsightWidgetProps {
 const DefaultDashboardInsightWidgetWrapper: React.FC<
     IDefaultDashboardInsightWidgetProps & WrappedComponentProps
 > = (props) => {
-    const { widget } = props;
+    const {
+        widget,
+        // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+        index,
+    } = props;
     const insights = useDashboardSelector(selectInsightsMap);
     const insight = insights.get(widget.insight);
 
@@ -46,7 +50,14 @@ const DefaultDashboardInsightWidgetWrapper: React.FC<
         return null;
     }
 
-    return <DefaultDashboardInsightWidgetCore {...props} insight={insight} />;
+    return (
+        <DefaultDashboardInsightWidgetCore
+            {...props}
+            insight={insight}
+            // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+            index={index}
+        />
+    );
 };
 
 /**
@@ -54,7 +65,17 @@ const DefaultDashboardInsightWidgetWrapper: React.FC<
  */
 const DefaultDashboardInsightWidgetCore: React.FC<
     IDefaultDashboardInsightWidgetProps & WrappedComponentProps & { insight: IInsight }
-> = ({ widget, insight, screen, onError, onExportReady, onLoadingChanged, intl }) => {
+> = ({
+    widget,
+    insight,
+    screen,
+    onError,
+    onExportReady,
+    onLoadingChanged,
+    intl,
+    // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+    index,
+}) => {
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
 
     const { exportCSVEnabled, exportXLSXEnabled, onExportCSV, onExportXLSX } = useInsightExport({
@@ -88,6 +109,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     return (
         <DashboardItem
             className={cx(
+                `s-dash-item-${index}`,
                 "type-visualization",
                 "gd-dashboard-view-widget",
                 getVisTypeCssClass(widget.type, visType),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -1,5 +1,6 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useMemo } from "react";
+import cx from "classnames";
 import {
     IDataView,
     isWidget,
@@ -25,7 +26,15 @@ import { DefaultDashboardInsightWidget } from "./DefaultDashboardInsightWidget";
  * @internal
  */
 export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
-    const { onError, onFiltersChange, screen, widget, backend } = props;
+    const {
+        onError,
+        onFiltersChange,
+        screen,
+        widget,
+        backend,
+        // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+        index,
+    } = props;
 
     const widgetRef = widget?.ref;
     const alertSelector = selectAlertByWidgetRef(widgetRef!);
@@ -76,9 +85,14 @@ export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Elemen
         return (
             <BackendProvider backend={backendWithEventing}>
                 {isInsightWidget(widget) ? (
-                    <DefaultDashboardInsightWidget widget={widget} screen={screen} />
+                    <DefaultDashboardInsightWidget
+                        widget={widget}
+                        screen={screen}
+                        // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
+                        index={index}
+                    />
                 ) : (
-                    <DashboardItem className="type-kpi" screen={screen}>
+                    <DashboardItem className={cx("type-kpi", `s-dash-item-${index}`)} screen={screen}>
                         <DashboardKpi
                             kpiWidget={widget}
                             alert={alert}


### PR DESCRIPTION
- This fixes for most of the failing cypress tests in KD after enabling dashboardComponentDevRollout FF

JIRA: RAIL-3958

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
