### PR TITLE
RELATED: RAIL-3951 Fix issue with multiple plugins

### DIFF
--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -17,9 +17,10 @@ const PORT = 3001;
 const DEFAULT_BACKEND_URL = "https://live-examples-proxy.herokuapp.com";
 
 // add all the gooddata packages that absolutely need to be shared and singletons because of contexts
-// do not share @gooddata/sdk-ui-dashboard though
+// allow sharing @gooddata/sdk-ui-dashboard here so that multiple plugins can share it among themselves
+// this makes redux related contexts work for example
 const gooddataSharePackagesEntries = [...Object.keys(deps), ...Object.keys(peerDeps)]
-    .filter((pkg) => pkg.startsWith("@gooddata") && pkg !== "@gooddata/sdk-ui-dashboard")
+    .filter((pkg) => pkg.startsWith("@gooddata"))
     .reduce((acc, curr) => {
         acc[curr] = {
             singleton: true,


### PR DESCRIPTION
Previously, each plugin used their own instance of sdk-ui-dashboard,
which caused react-redux provider contexts to fail.
Instead, we want them to share the package. This should be safe, since
we explicitly validate they are compatible with each other.

JIRA: RAIL-3951

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
