### PR TITLE
RELATED: RAIL-3960 attribute filter scrolling fix

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
@@ -303,6 +303,7 @@ export class AttributeDropdownCore extends React.PureComponent<
                 className={classes}
                 fullscreenOnMobile={fullscreenOnMobile}
                 onOpenStateChanged={this.onDropdownOpenStateChanged}
+                enableEventPropagation={true}
             />
         );
     }


### PR DESCRIPTION
- new property of enableEventPropagation was introduced in the Dropdown component to adjust the onMouseUp event and made it undefined. This caused in AttributeFilter that after releasing the mouse nothing happened and the scroll bar remained active.

JIRA: RAIL-3960

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
