### PR TITLE
RELATED: RAIL-3970 Filters with elements defined by value support

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -261,8 +261,9 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     const [resolvedPlaceholder, setPlaceholderValue] = usePlaceholder(props.connectToPlaceholder);
 
     const currentFilter = resolvedPlaceholder || props.filter;
-
     const filterRef = filterObjRef(currentFilter);
+    const isElementsByRef = isAttributeElementsByRef(filterAttributeElements(currentFilter));
+
     const currentFilterObjRef = useMemo(() => filterRef, [stringify(filterRef)]);
 
     const getInitialSelectedOptions = (): IAttributeElement[] =>
@@ -387,7 +388,8 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 setState((prevState) => {
                     const uriToAttributeElementMap = new Map(prevState.uriToAttributeElementMap);
                     initialElements.items?.forEach((item) => {
-                        uriToAttributeElementMap.set(item.uri, item);
+                        const key = isElementsByRef ? item.uri : item.title;
+                        uriToAttributeElementMap.set(key, item);
                     });
 
                     return {
@@ -418,7 +420,8 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                     const { items } = mergedValidElements;
 
                     items.filter(isNonEmptyListItem).forEach((item) => {
-                        newUriToAttributeElementMap.set(item.uri, item);
+                        const key = isElementsByRef ? item.uri : item.title;
+                        newUriToAttributeElementMap.set(key, item);
                     });
 
                     // make sure that selected items have both title and uri, otherwise selection in InvertableList won't work
@@ -426,10 +429,12 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                     const updatedSelectedItems = updateSelectedOptionsWithDataByMap(
                         prevState.selectedFilterOptions,
                         newUriToAttributeElementMap,
+                        isElementsByRef,
                     );
                     const updatedAppliedItems = updateSelectedOptionsWithDataByMap(
                         prevState.appliedFilterOptions,
                         newUriToAttributeElementMap,
+                        isElementsByRef,
                     );
 
                     const validOptions = resolvedParentFilters?.length ? newElements : mergedValidElements;
@@ -684,8 +689,13 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 ? `${getAllPartIntl} ${getItemsTitles(
                       state.selectedFilterOptions,
                       state.uriToAttributeElementMap,
+                      isElementsByRef,
                   )}`
-                : `${getItemsTitles(state.selectedFilterOptions, state.uriToAttributeElementMap)}`;
+                : `${getItemsTitles(
+                      state.selectedFilterOptions,
+                      state.uriToAttributeElementMap,
+                      isElementsByRef,
+                  )}`;
         }
         return "";
     };

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -61,15 +61,17 @@ export const getNoneTitleIntl = (intl: IntlShape): string => {
 export const getItemsTitles = (
     selectedFilterOptions: IAttributeElement[],
     elementTitles: Map<string, IAttributeElement>,
+    isElementsByRef: boolean,
 ): string => {
     return selectedFilterOptions
-        .map((selectedOption) =>
-            selectedOption?.uri
-                ? elementTitles.get(selectedOption.uri)?.title
+        .map((selectedOption) => {
+            const key = isElementsByRef ? selectedOption.uri : selectedOption.title;
+            return key
+                ? elementTitles.get(key)?.title
                 : selectedOption?.title
                 ? selectedOption.title
-                : undefined,
-        )
+                : undefined;
+        })
         .filter((title) => !isEmpty(title))
         .join(", ");
 };
@@ -77,9 +79,11 @@ export const getItemsTitles = (
 export const updateSelectedOptionsWithDataByMap = (
     selection: Array<Partial<IAttributeElement>>,
     validElements: Map<string, IAttributeElement>,
+    isElementsByRef: boolean,
 ): Array<IAttributeElement> => {
     return selection.map((selectedItem) => {
-        return validElements.get(selectedItem.uri);
+        const key = isElementsByRef ? selectedItem.uri : selectedItem.title;
+        return validElements.get(key);
     });
 };
 


### PR DESCRIPTION
- Add support for filter with elements defined by value in AttributeFilterButton component

JIRA: RAIL-3970

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
