### PR TITLE
RELATED: FET-955 Add mechanisms for incremental testing

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -10,15 +10,48 @@ export WIREMOCK_NET="wiremock-sdk-ui-${RANDOM}"
 _RUSH="${DIR}/docker_rush.sh"
 
 # ---------------------------------------------------------------------
-# Support for starting wiremock on a dedicated docker network
+# START: testing mechanisms for incremental tests
 # ---------------------------------------------------------------------
 
+echo 'Evaluating possible incremental test/validation optimizations'
+
+# get all prefixes only two levels deep to determine which packages were changed
+TARGET_BRANCH=$ZUUL_BRANCH
+PREFIXES=$(git diff --name-only "$TARGET_BRANCH...HEAD" | awk -F'[ /]' '{ printf "%s/%s\n",$1,$2 }' | sort | uniq)
+
+# if there are any changes outside examples, libs, and tools, we must re-test everything as these often mean
+# configuration changes that can affect anything
+OUTSIDE_FILES_COUNT=$(echo "$PREFIXES" | grep -Evc '^(examples|libs|tools)')
+
+RUSH_SPECS=''
+
+if [ $OUTSIDE_FILES_COUNT -ne 0 ]; then
+  echo 'There are some files modified outside of the code, falling back to testing everything...'
+else
+  echo 'Changes are only in code files, we can make the testing smarter'
+  # create an --impacted-by caluse for every changed pacakge
+  RUSH_SPECS=$(echo "$PREFIXES" | awk -F'[ /]' '{ printf " --impacted-by %s",$2 }')
+  echo 'The rush commands would be limited by the following limiters:'
+  echo "$RUSH_SPECS"
+fi
+
+# TODO pass $RUSH_SPECS to validate-ci and test-ci like $_RUSH validate-ci $RUSH_SPECS
+# always install and build everything, just in case
+# once we are confident this works well
+
+# ---------------------------------------------------------------------
+# END: testing mechanisms for incremental tests
+# ---------------------------------------------------------------------
+
+# ---------------------------------------------------------------------
+# Support for starting wiremock on a dedicated docker network
+# ---------------------------------------------------------------------
 
 #
 # Start wiremock server(s) needed by the integrated tests. This will create a dedicated docker bridge network
 # that will be used by the containers.
 #
-start_wiremocks () {
+start_wiremocks() {
   WIREMOCK_DIR="${DIR}/../../../libs/sdk-backend-bear/tests/wiremock"
   _WIREMOCK_START="${WIREMOCK_DIR}/start_wiremock.sh"
   _WIREMOCK_STOP="${WIREMOCK_DIR}/stop_wiremock.sh"
@@ -27,7 +60,7 @@ start_wiremocks () {
   _TIGER_WIREMOCK_START="${TIGER_WIREMOCK_DIR}/start_wiremock.sh"
   _TIGER_WIREMOCK_STOP="${TIGER_WIREMOCK_DIR}/stop_wiremock.sh"
 
-  docker network create ${WIREMOCK_NET} || { echo "Network creation failed" && exit 1 ; }
+  docker network create ${WIREMOCK_NET} || { echo "Network creation failed" && exit 1; }
 
   echo "Starting wiremock server for bear integrated tests"
   $_WIREMOCK_START detached
@@ -38,7 +71,7 @@ start_wiremocks () {
 #
 # Stop wiremock server(s) & destroy the network
 #
-stop_wiremocks () {
+stop_wiremocks() {
   echo "Stopping wiremock server for bear integrated tests."
   $_WIREMOCK_STOP
 
@@ -52,12 +85,12 @@ stop_wiremocks () {
 # The execution of the actual tasks
 # ---------------------------------------------------------------------
 
-if ! start_wiremocks ; then
-    echo "Failed to start wiremock. Please make sure Docker is installed and up and running. If running, check for port conflicts."
+if ! start_wiremocks; then
+  echo "Failed to start wiremock. Please make sure Docker is installed and up and running. If running, check for port conflicts."
 
-    stop_wiremocks
+  stop_wiremocks
 
-    exit 1
+  exit 1
 fi
 
 RC=1
@@ -69,12 +102,12 @@ RC=1
   if [ $RC -eq 0 ]; then
     $_RUSH build
     RC=$?
-  fi;
+  fi
 
   if [ $RC -eq 0 ]; then
     $_RUSH validate-ci
     RC=$?
-  fi;
+  fi
 
   if [ $RC -eq 0 ]; then
     #
@@ -90,6 +123,5 @@ RC=1
 } || {
   stop_wiremocks
 }
-
 
 exit ${RC}


### PR DESCRIPTION
For now we will just print the optimizations we would like to run
if this was enabled to observe if the detection works well before
we actually enable the optimizations for real.

JIRA: FET-955

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
