### PR TITLE
Fix dashboard plugin readme

### DIFF
--- a/tools/dashboard-plugin-template/README.template.md
+++ b/tools/dashboard-plugin-template/README.template.md
@@ -79,7 +79,7 @@ Building a new plugin is easy. Before you start, ensure that your `.env` and `.e
     the tool among the devDependencies together with convenience script to add plugin to either workspace specified
     in your `.env` file (default) or another workspace that you specify on the command line.
 
-    Run the `{{packageManager}} run add-plugin -- "https://your.hosting/pluginDirOfYourChoice/dp_{{pluginIdentifier}}.js"` to
+    Run the `{{packageManager}} run add-plugin -- "https://your.hosting/pluginDirOfYourChoice/{{pluginIdentifier}}.js"` to
     create a new dashboard plugin object in the workspace specified in the `.env` file. The created dashboard object
     point to the URL of the built plugin.
 


### PR DESCRIPTION
- dp_ prefix is doubled in the plugin readme

TRIVIAL

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
