### PR TITLE
RELATED: FET-955 Try preventing CI fails

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -23,10 +23,9 @@ PREFIXES=$(git diff --name-only "$TARGET_BRANCH...HEAD" | awk -F'[ /]' '{ printf
 # configuration changes that can affect anything
 OUTSIDE_FILES_COUNT=$(echo "$PREFIXES" | grep -Evc '^(examples|libs|tools)')
 
-RUSH_SPECS=''
-
 if [ $OUTSIDE_FILES_COUNT -ne 0 ]; then
   echo 'There are some files modified outside of the code, falling back to testing everything...'
+  RUSH_SPECS=''
 else
   echo 'Changes are only in code files, we can make the testing smarter'
   # create an --impacted-by caluse for every changed pacakge


### PR DESCRIPTION
JIRA: FET-955

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
