### PR TITLE
Add required AttributeFilterButton css selectors for KD cypress tests

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -63,6 +63,7 @@ import stringify from "json-stable-stringify";
 import { IElementQueryResultWithEmptyItems, isNonEmptyListItem } from "./AttributeDropdown/types";
 import { AttributeDropdownAllFilteredOutBody } from "./AttributeDropdown/AttributeDropdownAllFilteredOutBody";
 import { ShortenedText } from "@gooddata/sdk-ui-kit";
+import { stringUtils } from "@gooddata/util";
 
 /**
  * @public
@@ -196,7 +197,8 @@ const DropdownButton: React.FC<{
     subtitleText: string;
     subtitleItemCount: number;
     isFiltering?: boolean;
-}> = ({ isMobile, isOpen, title, subtitleItemCount, subtitleText, isFiltering }) => {
+    isLoaded?: boolean;
+}> = ({ isMobile, isOpen, title, subtitleItemCount, subtitleText, isFiltering, isLoaded }) => {
     const subtitleSelectedItemsRef = useRef(null);
     const [displayItemCount, setDisplayItemCount] = useState(false);
     const [subtitle, setSubtitle] = useState("");
@@ -222,11 +224,17 @@ const DropdownButton: React.FC<{
 
     return (
         <div
-            className={cx("attribute-filter-button", "s-attribute-filter", {
-                "is-active": isOpen,
-                "gd-attribute-filter-button-mobile": isMobile,
-                "gd-attribute-filter-button-is-filtering": isFiltering,
-            })}
+            className={cx(
+                "attribute-filter-button",
+                "s-attribute-filter",
+                `s-${stringUtils.simplifyText(title)}`,
+                {
+                    "is-active": isOpen,
+                    "gd-attribute-filter-button-mobile": isMobile,
+                    "gd-attribute-filter-button-is-filtering": isFiltering,
+                    "is-loaded": isLoaded,
+                },
+            )}
         >
             <div className="button-content">
                 <div className="button-title">
@@ -889,6 +897,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                                     }
                                     subtitleText={getSubtitle()}
                                     subtitleItemCount={state.selectedFilterOptions.length}
+                                    isLoaded={!isOriginalTotalCountLoading()}
                                 />
                             </span>
                         )}


### PR DESCRIPTION
JIRA: RAIL-3958

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
