### PR TITLE
NAS-2875 -

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import {
     IWorkspaceMeasuresService,
     IMeasureExpressionToken,
@@ -56,7 +56,11 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
         regexToken: IExpressionToken,
         metric: JsonApiMetricOutDocument,
     ): IMeasureExpressionToken {
-        if (regexToken.type === "text" || regexToken.type === "quoted_text") {
+        if (
+            regexToken.type === "text" ||
+            regexToken.type === "quoted_text" ||
+            regexToken.type === "comment"
+        ) {
             return { type: "text", value: regexToken.value };
         }
         const [type, id] = regexToken.value.split("/");

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -1,5 +1,12 @@
-// (C) 2019-2021 GoodData Corporation
-export type ExpressionTokenType = "text" | "quoted_text" | "fact" | "metric" | "attribute" | "label";
+// (C) 2019-2022 GoodData Corporation
+export type ExpressionTokenType =
+    | "text"
+    | "quoted_text"
+    | "fact"
+    | "metric"
+    | "attribute"
+    | "label"
+    | "comment";
 
 export interface IExpressionToken {
     type: ExpressionTokenType;
@@ -8,12 +15,13 @@ export interface IExpressionToken {
 
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
-    ["text", /^[^{}[\]"]+/],
+    ["text", /^[^#{}[\]"]+/],
     ["quoted_text", /^"(?:[^"\\]|\\"|\\\\.)*"/],
     ["fact", /^\{fact\/[^}]*\}/],
     ["metric", /^\{metric\/[^}]*\}/],
     ["label", /^\{label\/[^}]*\}/],
     ["attribute", /^\{attribute\/[^}]*\}/],
+    ["comment", /#[^\n]*/],
 ];
 
 export const tokenizeExpression = (expression: string): IExpressionToken[] => {

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -30,6 +30,42 @@ describe("tokenizeExpression", () => {
             { type: "text", value: "*" },
             { type: "fact", value: "fact/order_lines.quantity" },
             { type: "text", value: ")" },
+        ]);
+    });
+
+    it("parses MAQL with comments", () => {
+        const tokens = tokenizeExpression(
+            'SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity}) # WHERE NOT ({label/customer.c_custkey} IN ("Returned", "Canceled"))',
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM(" },
+            { type: "fact", value: "fact/order_lines.price" },
+            { type: "text", value: "*" },
+            { type: "fact", value: "fact/order_lines.quantity" },
+            { type: "text", value: ") " },
+            { type: "comment", value: '# WHERE NOT (label/customer.c_custkey IN ("Returned", "Canceled"))' },
+        ]);
+    });
+
+    it("parses MAQL with more comments", () => {
+        const tokens = tokenizeExpression(
+            'SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity}) # WHERE NOT\n\rWHERE ({label/customer.c_custkey} IN ("Returned", "Canceled")) # "Invalid"?',
+        );
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT SUM(" },
+            { type: "fact", value: "fact/order_lines.price" },
+            { type: "text", value: "*" },
+            { type: "fact", value: "fact/order_lines.quantity" },
+            { type: "text", value: ") " },
+            { type: "comment", value: "# WHERE NOT" },
+            { type: "text", value: "\n\rWHERE (" },
+            { type: "label", value: "label/customer.c_custkey" },
+            { type: "text", value: " IN (" },
+            { type: "quoted_text", value: '"Returned"' },
+            { type: "text", value: ", " },
+            { type: "quoted_text", value: '"Canceled"' },
+            { type: "text", value: ")) " },
+            { type: "comment", value: '# "Invalid"?' },
         ]);
     });
 });


### PR DESCRIPTION
Comments in tooltip are incorrectly displayed as standard MAQL expression

JIRA: NAS-2875
---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
