### PR TITLE
NAS-2875 - Comments in tooltip are incorrectly displayed as standard MAQL expression

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/master_2022-01-18-13-03.json
+++ b/common/changes/@gooddata/sdk-ui-all/master_2022-01-18-13-03.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Added support for comment tokens in maql expression",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { GdcMetadata, GdcMetadataObject } from "@gooddata/api-model-bear";
 import {
     IMeasureExpressionToken,
@@ -129,6 +129,11 @@ export class BearWorkspaceMeasures implements IWorkspaceMeasuresService {
                     value: meta.title,
                     id: meta.id,
                     ref: meta.ref,
+                };
+            } else if (token.type === "comment") {
+                return {
+                    type: "comment",
+                    value: token.value,
                 };
             }
 

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -1,10 +1,10 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import flow from "lodash/flow";
 import filter from "lodash/fp/filter";
 import map from "lodash/fp/map";
 import uniq from "lodash/fp/uniq";
 
-type ExpressionTokenType = "text" | "quoted_text" | "identifier" | "uri" | "element_uri";
+type ExpressionTokenType = "text" | "quoted_text" | "identifier" | "uri" | "element_uri" | "comment";
 
 interface IExpressionToken {
     type: ExpressionTokenType;
@@ -13,11 +13,12 @@ interface IExpressionToken {
 
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
-    ["text", /^[^{}[\]]+/],
+    ["text", /^[^#{}[\]"]+/],
     ["quoted_text", /^"(?:[^"\\]|\\\\.)*"/],
     ["identifier", /^\{[^}]+\}/],
     ["element_uri", /^\[[a-zA-Z0-9\\/]+elements\?id=\d+]/],
     ["uri", /^\[[a-zA-Z0-9\\/]+]/],
+    ["comment", /#[^\n]*/],
 ];
 
 export const getTokenValuesOfType = (tokenType: ExpressionTokenType, tokens: IExpressionToken[]): string[] =>
@@ -52,6 +53,6 @@ export const tokenizeExpression = (expression: string): IExpressionToken[] => {
 
     return tokens.map((token) => ({
         ...token,
-        value: token.value.replace(REMOVE_BRACKETS_REGEXP, ""),
+        value: token.type === "comment" ? token.value : token.value.replace(REMOVE_BRACKETS_REGEXP, ""),
     }));
 };

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { tokenizeExpression } from "../measureExpressionTokens";
 
 describe("tokenizeExpression", () => {
@@ -34,6 +34,47 @@ describe("tokenizeExpression", () => {
             { type: "text", value: "*" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount2" },
             { type: "text", value: ")" },
+        ]);
+    });
+
+    it("parses MAQL with comments", () => {
+        const expression =
+            "select avg({fact.opportunitysnapshot.amount}) where {attr.account.id} in ([/gdc/md/projectId/obj/969/elements?id=123]) and {snapshot.year} > 2011 #test comment";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "select avg(" },
+            { type: "identifier", value: "fact.opportunitysnapshot.amount" },
+            { type: "text", value: ") where " },
+            { type: "identifier", value: "attr.account.id" },
+            { type: "text", value: " in (" },
+            {
+                type: "element_uri",
+                value: "/gdc/md/projectId/obj/969/elements?id=123",
+            },
+            { type: "text", value: ") and " },
+            { type: "identifier", value: "snapshot.year" },
+            { type: "text", value: " > 2011 " },
+            { type: "comment", value: "#test comment" },
+        ]);
+    });
+
+    it("parses MAQL with more comments", () => {
+        const expression =
+            "select avg({fact.opportunitysnapshot.amount}) # where {attr.account.id} and\n\rWHERE {snapshot.year} > 2011 #test comment";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "select avg(" },
+            { type: "identifier", value: "fact.opportunitysnapshot.amount" },
+            { type: "text", value: ") " },
+            { type: "comment", value: "# where {attr.account.id} and" },
+            { type: "text", value: "\n\rWHERE " },
+            { type: "identifier", value: "snapshot.year" },
+            { type: "text", value: " > 2011 " },
+            { type: "comment", value: "#test comment" },
         ]);
     });
 });

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -392,6 +392,12 @@ export interface ICatalogMeasure extends IGroupableCatalogItemBase {
     type: "measure";
 }
 
+// @public
+export interface ICommentExpressionToken {
+    type: "comment";
+    value: string;
+}
+
 // @alpha
 export interface IDashboard<TWidget = IDashboardWidget> extends IDashboardBase, IDashboardObjectIdentity, Readonly<Required<IAuditableDates>>, Readonly<IAuditableUsers>, IAccessControlAware {
     readonly dateFilterConfig?: IDashboardDateFilterConfig;
@@ -1032,7 +1038,7 @@ export interface IMeasureDescriptor {
 }
 
 // @public
-export type IMeasureExpressionToken = IObjectExpressionToken | IAttributeElementExpressionToken | ITextExpressionToken;
+export type IMeasureExpressionToken = IObjectExpressionToken | IAttributeElementExpressionToken | ITextExpressionToken | ICommentExpressionToken;
 
 // @public
 export interface IMeasureGroupDescriptor {

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 /**
  * This package provides definitions of the Service Provider Interface (SPI) for the Analytical Backend.
  *
@@ -432,6 +432,7 @@ export {
     IObjectExpressionToken,
     IAttributeElementExpressionToken,
     ITextExpressionToken,
+    ICommentExpressionToken,
 } from "./workspace/fromModel/ldm/measure";
 
 export { IOrganization, IOrganizations, IOrganizationDescriptor } from "./organization";

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { ObjectType, ObjRef } from "@gooddata/sdk-model";
 
 /**
@@ -41,7 +41,8 @@ import { ObjectType, ObjRef } from "@gooddata/sdk-model";
 export type IMeasureExpressionToken =
     | IObjectExpressionToken
     | IAttributeElementExpressionToken
-    | ITextExpressionToken;
+    | ITextExpressionToken
+    | ICommentExpressionToken;
 
 /**
  * Parsed {@link https://help.gooddata.com/pages/viewpage.action?pageId=86795279 | MAQL} token referencing a metadata object.
@@ -111,6 +112,26 @@ export interface ITextExpressionToken {
      * Expression token type
      */
     type: "text";
+
+    /**
+     * Plain text
+     */
+    value: string;
+}
+
+/**
+ * Parsed {@link https://help.gooddata.com/pages/viewpage.action?pageId=86795279 | MAQL} comment text.
+ *
+ * @remarks
+ * See {@link IMeasureExpressionToken} for more information.
+ *
+ * @public
+ */
+export interface ICommentExpressionToken {
+    /**
+     * Expression token type
+     */
+    type: "comment";
 
     /**
      * Plain text

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -56,12 +56,11 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
         regexToken: IExpressionToken,
         metric: JsonApiMetricOutDocument,
     ): IMeasureExpressionToken {
-        if (
-            regexToken.type === "text" ||
-            regexToken.type === "quoted_text" ||
-            regexToken.type === "comment"
-        ) {
+        if (regexToken.type === "text" || regexToken.type === "quoted_text") {
             return { type: "text", value: regexToken.value };
+        }
+        if (regexToken.type === "comment") {
+            return { type: "comment", value: regexToken.value };
         }
         const [type, id] = regexToken.value.split("/");
         if (type === "metric" || type === "fact" || type === "attribute" || type === "label") {

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -49,6 +49,6 @@ export const tokenizeExpression = (expression: string): IExpressionToken[] => {
 
     return tokens.map((token) => ({
         ...token,
-        value: token.value.replace(REMOVE_BRACKETS_REGEXP, ""),
+        value: token.type === "comment" ? token.value : token.value.replace(REMOVE_BRACKETS_REGEXP, ""),
     }));
 };

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -43,7 +43,10 @@ describe("tokenizeExpression", () => {
             { type: "text", value: "*" },
             { type: "fact", value: "fact/order_lines.quantity" },
             { type: "text", value: ") " },
-            { type: "comment", value: '# WHERE NOT (label/customer.c_custkey IN ("Returned", "Canceled"))' },
+            {
+                type: "comment",
+                value: '# WHERE NOT ({label/customer.c_custkey} IN ("Returned", "Canceled"))',
+            },
         ]);
     });
 


### PR DESCRIPTION
Comments in tooltip are incorrectly displayed as standard MAQL expression

JIRA: NAS-2875

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
