### PR TITLE
RELATED: RAIL-3980 attribute filter button fixes

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -384,7 +384,8 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
     }, [state.searchString]);
 
     /*
-     * This cancelable promise is used to fetch attribute filter elements for the initial selected options.
+     * This cancelable promise is used to fetch attribute filter elements for the initial selected options or
+     * to fetch the elements after selection change coming from the parent component.
      * It's only called on component mounting to ensure we have attribute element titles for elements out of
      * limits in case of huge element number.
      */
@@ -392,7 +393,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         {
             promise: isEmpty(state.selectedFilterOptions)
                 ? null
-                : async () => prepareElementsTitleQuery(state.selectedFilterOptions).query(),
+                : async () => prepareElementsTitleQuery(state.appliedFilterOptions).query(),
             onSuccess: (initialElements) => {
                 setState((prevState) => {
                     const uriToAttributeElementMap = new Map(prevState.uriToAttributeElementMap);
@@ -407,7 +408,13 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 });
             },
         },
-        [props.backend, props.workspace, props.identifier, stringify(currentFilterObjRef)],
+        [
+            props.backend,
+            props.workspace,
+            props.identifier,
+            stringify(currentFilterObjRef),
+            state.appliedFilterOptions,
+        ],
     );
 
     // this cancelable promise loads missing page of data if needed and in the onSuccess callback
@@ -682,12 +689,16 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
              * If the number of selected items is 0 and originalTotalCount is greater than 0, it is
              * considered the selection is empty.
              */
-            const empty = getNumberOfSelectedItems() === 0 && originalTotalCount > 0;
+            const empty =
+                getNumberOfSelectedItems(state.selectedFilterOptions, state.isInverted) === 0 &&
+                originalTotalCount > 0;
             /**
              * All items are selected only in case the number of selected items is equal to original total
              * count.
              */
-            const all = getNumberOfSelectedItems() === originalTotalCount;
+            const all =
+                getNumberOfSelectedItems(state.selectedFilterOptions, state.isInverted) ===
+                originalTotalCount;
             const getAllPartIntl = all ? getAllTitle(props.intl) : getAllExceptTitle(props.intl);
 
             if (empty) {
@@ -800,12 +811,12 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         isOpen ? onDropdownOpen() : onDropdownClosed();
     };
 
-    const getNumberOfSelectedItems = () => {
-        if (state.isInverted) {
-            return originalTotalCount - state.selectedFilterOptions.length;
+    const getNumberOfSelectedItems = (filterOptions: IAttributeElement[], isInverted: boolean) => {
+        if (isInverted) {
+            return originalTotalCount - filterOptions.length;
         }
 
-        return state.selectedFilterOptions.length;
+        return filterOptions.length;
     };
 
     const hasNoData =
@@ -859,7 +870,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
                 isParentFilterTitlesLoading() ||
                 isOriginalTotalCountLoading(),
             searchString: state.searchString,
-            applyDisabled: getNumberOfSelectedItems() === 0,
+            applyDisabled: getNumberOfSelectedItems(state.selectedFilterOptions, state.isInverted) === 0,
             showItemsFilteredMessage:
                 showItemsFilteredMessage(isElementsLoading(), resolvedParentFilters) && !isAllFiltered,
             parentFilterTitles,

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton.tsx
@@ -392,7 +392,7 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         {
             promise: isEmpty(state.selectedFilterOptions)
                 ? null
-                : async () => prepareElementsTitleQuery().query(),
+                : async () => prepareElementsTitleQuery(state.selectedFilterOptions).query(),
             onSuccess: (initialElements) => {
                 setState((prevState) => {
                     const uriToAttributeElementMap = new Map(prevState.uriToAttributeElementMap);
@@ -614,14 +614,14 @@ export const AttributeFilterButtonCore: React.FC<IAttributeFilterButtonProps> = 
         return preparedElementQuery;
     };
 
-    const prepareElementsTitleQuery = () => {
+    const prepareElementsTitleQuery = (elements: IAttributeElement[]) => {
         return getBackend()
             .workspace(props.workspace)
             .attributes()
             .elements()
             .forDisplayForm(getObjRef(currentFilter, props.identifier))
             .withOptions({
-                uris: state.selectedFilterOptions.map((opt) => opt.uri),
+                uris: elements.map((opt) => opt.uri),
             });
     };
 


### PR DESCRIPTION
- elements change from parent handling
- search optimization to prevent race conditions
- refactored functions dependent on state values

JIRA: RAIL-3977, RAIL-3980

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
