### PR TITLE
RELATED: RAIL-3908 Simplify DashboardInsight

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
@@ -30,7 +30,6 @@ import {
     selectSeparators,
     selectSettings,
     useDashboardAsyncRender,
-    useDashboardEventDispatch,
     useDashboardSelector,
     useWidgetExecutionsHandler,
 } from "../../../../../model";
@@ -90,7 +89,6 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
     const effectiveBackend = useBackendStrict(backend);
     const effectiveWorkspace = useWorkspaceStrict(workspace);
 
-    const dispatchEvent = useDashboardEventDispatch();
     const executionsHandler = useWidgetExecutionsHandler(widgetRef(widget));
 
     // State props
@@ -122,7 +120,7 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         [onLoadingChanged, executionsHandler.onLoadingChanged],
     );
 
-    /// Filtering
+    // Filtering
     const {
         result: filtersForInsight,
         status: filtersStatus,
@@ -192,10 +190,10 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
             onError?.(error);
             executionsHandler.onError(error);
         },
-        [onError, dispatchEvent, executionsHandler.onError],
+        [onError, executionsHandler.onError],
     );
 
-    const error = filtersError ?? visualizationError;
+    const effectiveError = filtersError ?? visualizationError;
 
     const visualizationProperties = insightProperties(insightWithAddedWidgetProperties);
     const isZoomable = visualizationProperties?.controls.zoomInsight;
@@ -208,9 +206,9 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
             >
                 <IntlWrapper locale={locale}>
                     {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
-                    {error && (
+                    {effectiveError && (
                         <CustomError
-                            error={error}
+                            error={effectiveError}
                             isCustomWidgetHeightEnabled={!!settings?.enableKDWidgetCustomHeight}
                             height={clientHeight}
                             width={clientWidth}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useCallback, useMemo, useState, CSSProperties } from "react";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { createSelector } from "@reduxjs/toolkit";
@@ -97,7 +97,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         onLoadingChanged?.({ isLoading });
     }, []);
 
-    /// Filtering
+    // Filtering
     const {
         result: filtersForInsight,
         status: filtersStatus,
@@ -149,16 +149,16 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         },
         [onError],
     );
-    const error = filtersError ?? visualizationError;
+    const effectiveError = filtersError ?? visualizationError;
 
     return (
         <div style={insightStyle}>
             <div style={insightPositionStyle}>
                 <IntlWrapper locale={locale}>
                     {(filtersStatus === "running" || isVisualizationLoading) && <LoadingComponent />}
-                    {error && (
+                    {effectiveError && (
                         <CustomError
-                            error={error}
+                            error={effectiveError}
                             // drill dialog does not measure its size but is always large enough to fit the full content
                             forceFullContent
                         />
@@ -166,7 +166,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
                     {filtersStatus === "success" && (
                         <div
                             className="insight-view-visualization"
-                            style={isVisualizationLoading || error ? { height: 0 } : undefined}
+                            style={isVisualizationLoading || effectiveError ? { height: 0 } : undefined}
                         >
                             <InsightRenderer
                                 insight={insightWithAddedWidgetProperties}


### PR DESCRIPTION
The useDashboardEventDispatch was not used anywhere anymore.
Also remove code smell in the file.

JIRA: RAIL-3908

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
