### PR TITLE
Get execution from pluggable visualizations

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { IAnalyticalBackend, IExecutionFactory, ISettings, ITheme } from "@gooddata/sdk-backend-spi";
 import {
     IInsight,
@@ -28,6 +28,7 @@ import {
     IVisConstruct,
     IVisualization,
     IDrillDownContext,
+    IVisProps,
 } from "../interfaces/Visualization";
 import { PluggableVisualizationFactory } from "../interfaces/VisualizationDescriptor";
 import { FullVisualizationCatalog, IVisualizationCatalog } from "./VisualizationCatalog";
@@ -219,21 +220,7 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         }
 
         this.visualization.update(
-            {
-                locale: this.props.locale,
-                dateFormat: this.props.dateFormat,
-                dimensions: {
-                    width: this.props.width,
-                    height: this.props.height,
-                },
-                custom: {
-                    drillableItems: this.props.drillableItems,
-                    totalsEditAllowed: this.props.totalsEditAllowed,
-                },
-                config: this.props.config,
-                theme: this.props.theme,
-                executionConfig: this.props.executionConfig,
-            },
+            this.getVisualizationProps(),
             this.props.insight,
             this.props.insightPropertiesMeta,
             this.executionFactory,
@@ -270,10 +257,40 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         return !isEqual(omit(currentReferencePoint, "properties"), omit(nextReferencePoint, "properties"));
     }
 
+    private getVisualizationProps(): IVisProps {
+        return {
+            locale: this.props.locale,
+            dateFormat: this.props.dateFormat,
+            dimensions: {
+                width: this.props.width,
+                height: this.props.height,
+            },
+            custom: {
+                drillableItems: this.props.drillableItems,
+                totalsEditAllowed: this.props.totalsEditAllowed,
+            },
+            config: this.props.config,
+            theme: this.props.theme,
+            executionConfig: this.props.executionConfig,
+        };
+    }
+
     public getInsightWithDrillDownApplied(
         sourceVisualization: IInsight,
         drillDownContext: IDrillDownContext,
     ): IInsight {
         return this.visualization.getInsightWithDrillDownApplied(sourceVisualization, drillDownContext);
+    }
+
+    public getExecution() {
+        if (!this.visualization) {
+            this.setupVisualization(this.props);
+        }
+
+        return this.visualization.getExecution(
+            this.getVisualizationProps(),
+            this.props.insight,
+            this.executionFactory,
+        );
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import {
     IBucketItem,
@@ -17,7 +17,7 @@ import {
 } from "../../interfaces/Visualization";
 import { findDerivedBucketItem, hasDerivedBucketItems, isDerivedBucketItem } from "../../utils/bucketHelper";
 import { IInsight, IInsightDefinition, insightHasDataDefined, insightProperties } from "@gooddata/sdk-model";
-import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
+import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import {
     DefaultLocale,
     GoodDataSdkError,
@@ -140,6 +140,19 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
 
         this.renderConfigurationPanel(insight);
     }
+
+    /**
+     * Get visualization execution based on provided options, insight and execution factory.
+     *
+     * @param options - visualization options
+     * @param insight - insight to be executed
+     * @param executionFactory - execution factory to use when triggering calculation on backend
+     */
+    public abstract getExecution(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ): IPreparedExecution;
 
     /**
      * This method will be called during the {@link update} processing. This is where internal properties of the

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/PluggableGeoPushpinChart.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 
 import {
@@ -96,6 +96,21 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
 
     public getUiConfig(): IUiConfig {
         return cloneDeep(GEO_PUSHPIN_CHART_UICONFIG);
+    }
+
+    public getExecution(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ) {
+        const { executionConfig } = options;
+        const buckets = this.prepareBuckets(insight);
+
+        return executionFactory
+            .forBuckets(buckets, insightFilters(insight))
+            .withDimensions(getGeoChartDimensions)
+            .withSorting(...this.createSort(insight))
+            .withExecConfig(executionConfig);
     }
 
     protected getSupportedPropertiesList(): string[] {
@@ -218,7 +233,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ): void {
-        const { dimensions = { height: undefined }, custom = {}, locale, theme, executionConfig } = options;
+        const { dimensions = { height: undefined }, custom = {}, locale, theme } = options;
         const { height } = dimensions;
         const { geoPushpinElement, intl } = this;
 
@@ -227,60 +242,7 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
         const { drillableItems } = custom;
         const supportedControls: IVisualizationProperties = this.visualizationProperties.controls || {};
         const fullConfig = this.buildVisualizationConfig(options, supportedControls);
-
-        // we need to shallow copy the buckets so that we can add more without mutating the original array
-        const buckets = [...insightBuckets(insight)];
-
-        if (supportedControls && supportedControls?.tooltipText) {
-            const tooltipText: string = supportedControls?.tooltipText;
-            /*
-             * The display form to use for tooltip text is provided in properties :( This is unfortunate; the chart
-             * props could very well contain an extra prop for the tooltip bucket.
-             *
-             * Current guess is that this is because AD creates insight buckets; in order to create the tooltip
-             * bucket, AD would have to actually show the tooltip bucket in the UI - which is not desired. Thus the
-             * displayForm to add as bucket is passed in visualization properties.
-             *
-             * This workaround is highly unfortunate for two reasons:
-             *
-             * 1.  It leaks all the way to the API of geo chart: bucket geo does not have the tooltip bucket. Instead
-             *     it duplicates then here logic in chart transform
-             *
-             * 2.  The executeVisualization endpoint is useless for GeoChart; cannot be used to render geo chart because
-             *     the buckets stored in vis object are not complete. execVisualization takes buckets as is.
-             */
-
-            const locationBucket = insightBucket(insight, BucketNames.LOCATION);
-            let ref: ObjRef = idRef(tooltipText, "displayForm");
-            let alias = "";
-
-            if (locationBucket) {
-                const attribute = bucketAttribute(locationBucket);
-                if (attribute) {
-                    alias = attributeAlias(attribute);
-
-                    if (isUriRef(attributeDisplayFormRef(attribute))) {
-                        ref = uriRef(tooltipText);
-                    }
-                }
-            }
-
-            const existingTooltipTextBucket = insightBucket(insight, BucketNames.TOOLTIP_TEXT);
-            if (!existingTooltipTextBucket) {
-                buckets.push(
-                    newBucket(
-                        BucketNames.TOOLTIP_TEXT,
-                        newAttribute(ref, (m) => m.localId("tooltipText_df").alias(alias)),
-                    ),
-                );
-            }
-        }
-
-        const execution = executionFactory
-            .forBuckets(buckets, insightFilters(insight))
-            .withDimensions(getGeoChartDimensions)
-            .withSorting(...this.createSort(insight))
-            .withExecConfig(executionConfig);
+        const execution = this.getExecution(options, insight, executionFactory);
 
         const geoPushpinProps = {
             drillableItems,
@@ -412,5 +374,59 @@ export class PluggableGeoPushpinChart extends PluggableBaseChart {
             set(referencePointConfigured, "references", this.references);
         }
         return referencePointConfigured;
+    }
+
+    private prepareBuckets(insight: IInsightDefinition) {
+        const supportedControls: IVisualizationProperties = this.visualizationProperties?.controls || {};
+
+        // we need to shallow copy the buckets so that we can add more without mutating the original array
+        const buckets = [...insightBuckets(insight)];
+
+        if (supportedControls && supportedControls?.tooltipText) {
+            const tooltipText: string = supportedControls?.tooltipText;
+            /*
+             * The display form to use for tooltip text is provided in properties :( This is unfortunate; the chart
+             * props could very well contain an extra prop for the tooltip bucket.
+             *
+             * Current guess is that this is because AD creates insight buckets; in order to create the tooltip
+             * bucket, AD would have to actually show the tooltip bucket in the UI - which is not desired. Thus the
+             * displayForm to add as bucket is passed in visualization properties.
+             *
+             * This workaround is highly unfortunate for two reasons:
+             *
+             * 1.  It leaks all the way to the API of geo chart: bucket geo does not have the tooltip bucket. Instead
+             *     it duplicates then here logic in chart transform
+             *
+             * 2.  The executeVisualization endpoint is useless for GeoChart; cannot be used to render geo chart because
+             *     the buckets stored in vis object are not complete. execVisualization takes buckets as is.
+             */
+
+            const locationBucket = insightBucket(insight, BucketNames.LOCATION);
+            let ref: ObjRef = idRef(tooltipText, "displayForm");
+            let alias = "";
+
+            if (locationBucket) {
+                const attribute = bucketAttribute(locationBucket);
+                if (attribute) {
+                    alias = attributeAlias(attribute);
+
+                    if (isUriRef(attributeDisplayFormRef(attribute))) {
+                        ref = uriRef(tooltipText);
+                    }
+                }
+            }
+
+            const existingTooltipTextBucket = insightBucket(insight, BucketNames.TOOLTIP_TEXT);
+            if (!existingTooltipTextBucket) {
+                buckets.push(
+                    newBucket(
+                        BucketNames.TOOLTIP_TEXT,
+                        newAttribute(ref, (m) => m.localId("tooltipText_df").alias(alias)),
+                    ),
+                );
+            }
+        }
+
+        return buckets;
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/PluggableHeadline.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import { IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";
 import { bucketIsEmpty, IInsightDefinition, insightBucket, insightHasDataDefined } from "@gooddata/sdk-model";
@@ -115,6 +115,20 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
+    public getExecution(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ) {
+        const { dateFormat, executionConfig } = options;
+
+        return executionFactory
+            .forInsight(insight)
+            .withDimensions({ itemIdentifiers: ["measureGroup"] })
+            .withDateFormat(dateFormat)
+            .withExecConfig(executionConfig);
+    }
+
     protected checkBeforeRender(insight: IInsightDefinition): boolean {
         super.checkBeforeRender(insight);
 
@@ -139,20 +153,9 @@ export class PluggableHeadline extends AbstractPluggableVisualization {
             return;
         }
 
-        const {
-            locale,
-            dateFormat,
-            custom = {},
-            config,
-            customVisualizationConfig,
-            executionConfig,
-        } = options;
+        const { locale, custom = {}, config, customVisualizationConfig } = options;
         const { drillableItems } = custom;
-        const execution = executionFactory
-            .forInsight(insight)
-            .withDimensions({ itemIdentifiers: ["measureGroup"] })
-            .withDateFormat(dateFormat)
-            .withExecConfig(executionConfig);
+        const execution = this.getExecution(options, insight, executionFactory);
 
         this.renderFun(
             <CoreHeadline

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import {
     addIntersectionFiltersToInsight,
@@ -241,6 +241,21 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         return sanitizeTableProperties(insightSanitize(drillDownInsightWithFilters));
     }
 
+    public getExecution(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ) {
+        const { dateFormat, executionConfig } = options;
+
+        return executionFactory
+            .forInsight(insight)
+            .withDimensions(...this.getDimensions(insight))
+            .withSorting(...getPivotTableSortItems(insight))
+            .withDateFormat(dateFormat)
+            .withExecConfig(executionConfig);
+    }
+
     private createCorePivotTableProps = () => {
         const onColumnResized = isManualResizingEnabled(this.settings) ? this.onColumnResized : undefined;
 
@@ -286,26 +301,11 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
             return;
         }
 
-        const {
-            locale,
-            dateFormat,
-            custom,
-            dimensions,
-            config = {},
-            customVisualizationConfig = {},
-            theme,
-            executionConfig,
-        } = options;
+        const { locale, custom, dimensions, config = {}, customVisualizationConfig = {}, theme } = options;
         const { maxHeight, maxWidth } = config;
         const height = dimensions?.height;
         const { drillableItems } = custom;
-
-        const execution = executionFactory
-            .forInsight(insight)
-            .withDimensions(...this.getDimensions(insight))
-            .withSorting(...getPivotTableSortItems(insight))
-            .withDateFormat(dateFormat)
-            .withExecConfig(executionConfig);
+        const execution = this.getExecution(options, insight, executionFactory);
 
         const columnWidths: ColumnWidthItem[] | undefined = getColumnWidthsFromProperties(
             insightProperties(insight),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/AbstractPluggableVisualization.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/AbstractPluggableVisualization.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { IVisProps, IDrillDownContext } from "../../../interfaces/Visualization";
 import { AbstractPluggableVisualization } from "../AbstractPluggableVisualization";
 import { BucketNames } from "@gooddata/sdk-ui";
@@ -38,6 +38,14 @@ describe("AbstractPluggableVisualization", () => {
             _executionFactory: IExecutionFactory,
         ): void {
             return;
+        }
+
+        public getExecution(
+            _options: IVisProps,
+            insight: IInsightDefinition,
+            executionFactory: IExecutionFactory,
+        ) {
+            return executionFactory.forInsight(insight);
         }
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/PluggableXirr.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import { IExecutionFactory, ISettings } from "@gooddata/sdk-backend-spi";
 import {
@@ -86,17 +86,27 @@ export class PluggableXirr extends AbstractPluggableVisualization {
         return sanitizeFilters(newReferencePoint);
     };
 
+    public getExecution(
+        options: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ) {
+        const { dateFormat } = options;
+
+        return executionFactory
+            .forInsight(insight)
+            .withDimensions(...this.getXirrDimensions(insight))
+            .withDateFormat(dateFormat);
+    }
+
     protected renderVisualization(
         options: IVisProps,
         insight: IInsightDefinition,
         executionFactory: IExecutionFactory,
     ): void {
-        const { locale, dateFormat, custom = {}, config } = options;
+        const { locale, custom = {}, config } = options;
         const { drillableItems } = custom;
-        const execution = executionFactory
-            .forInsight(insight)
-            .withDimensions(...this.getXirrDimensions(insight))
-            .withDateFormat(dateFormat);
+        const execution = this.getExecution(options, insight, executionFactory);
 
         this.renderFun(
             <CoreXirr

--- a/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import noop from "lodash/noop";
 import { shallow } from "enzyme";
@@ -21,12 +21,13 @@ import { VisualizationTypes, IDrillableItem } from "@gooddata/sdk-ui";
 import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
 import { CatalogViaTypeToClassMap, IVisualizationCatalog } from "../VisualizationCatalog";
 import { IInsight, IInsightDefinition } from "@gooddata/sdk-model";
-import { IExecutionFactory } from "@gooddata/sdk-backend-spi";
+import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { DummyVisConstruct } from "../pluggableVisualizations/tests/visConstruct.fixture";
 import { BaseChartDescriptor } from "../pluggableVisualizations/baseChart/BaseChartDescriptor";
 import { PluggableVisualizationFactory } from "../../interfaces/VisualizationDescriptor";
 
 const { delay } = testUtils;
+const pluggableVisualizationGetExecutionMock = jest.fn(() => ({} as IPreparedExecution));
 
 class DummyClass extends AbstractPluggableVisualization {
     constructor(props: IVisConstruct) {
@@ -61,6 +62,14 @@ class DummyClass extends AbstractPluggableVisualization {
     }
     public unmount() {
         return;
+    }
+
+    public getExecution(
+        _options: IVisProps,
+        _insight: IInsightDefinition,
+        _executionFactory: IExecutionFactory,
+    ) {
+        return pluggableVisualizationGetExecutionMock();
     }
 }
 
@@ -466,5 +475,13 @@ describe("BaseVisualization", () => {
         const { onExportReady } = getDummyComponent();
         await delay();
         expect(onExportReady).toHaveBeenCalledTimes(1);
+    });
+
+    it("should call pluggable visualization's getExecution method", () => {
+        const visualization = new BaseVisualization(defaultProps);
+
+        expect(pluggableVisualizationGetExecutionMock).toHaveBeenCalledTimes(0);
+        visualization.getExecution();
+        expect(pluggableVisualizationGetExecutionMock).toHaveBeenCalledTimes(1);
     });
 });

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -1,7 +1,13 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
 import isEmpty from "lodash/isEmpty";
-import { IAnalyticalBackend, IExecutionFactory, ISettings, ITheme } from "@gooddata/sdk-backend-spi";
+import {
+    IAnalyticalBackend,
+    IExecutionFactory,
+    IPreparedExecution,
+    ISettings,
+    ITheme,
+} from "@gooddata/sdk-backend-spi";
 import {
     IColorPalette,
     IInsight,
@@ -352,6 +358,19 @@ export interface IVisualization {
         insightPropertiesMeta: any,
         executionFactory: IExecutionFactory,
     ): void;
+
+    /**
+     * Get visualization execution based on provided props, insight and execution factory.
+     *
+     * @param props - visualization properties
+     * @param insight - insight to be executed
+     * @param executionFactory - execution factory to use when triggering calculation on backend
+     */
+    getExecution(
+        props: IVisProps,
+        insight: IInsightDefinition,
+        executionFactory: IExecutionFactory,
+    ): IPreparedExecution;
 
     unmount(): void;
 


### PR DESCRIPTION
In order to be able to get execution from visualizations, we need to extend all pluggable visualization with public getExecution method.

JIRA: TNT-418

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
