### PR TITLE
NAS-2875 - Comments in tooltip are incorrectly displayed as standard MAQL expression

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/master_2022-01-18-13-03.json
+++ b/common/changes/@gooddata/sdk-ui-all/master_2022-01-18-13-03.json
@@ -2,7 +2,7 @@
     "changes": [
         {
             "packageName": "@gooddata/sdk-ui-all",
-            "comment": "Added support for comment tokens in maql expression",
+            "comment": "Added support for comment, bracket, quoted_text and number tokens in maql expression",
             "type": "none"
         }
     ],

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -4,17 +4,27 @@ import filter from "lodash/fp/filter";
 import map from "lodash/fp/map";
 import uniq from "lodash/fp/uniq";
 
-type ExpressionTokenType = "text" | "quoted_text" | "identifier" | "uri" | "element_uri" | "comment";
+type ExpressionTokenType =
+    | "text"
+    | "quoted_text"
+    | "number"
+    | "bracket"
+    | "identifier"
+    | "uri"
+    | "element_uri"
+    | "comment";
 
-interface IExpressionToken {
+export interface IExpressionToken {
     type: ExpressionTokenType;
     value: string;
 }
 
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
-    ["text", /^[^#{}[\]"]+/],
+    ["text", /^[^#{}[\]"()0-9.]+/],
     ["quoted_text", /^"(?:[^"\\]|\\\\.)*"/],
+    ["number", /^[+-]?((\d+(\.\d*)?)|(\.\d+))/],
+    ["bracket", /^[()]+/],
     ["identifier", /^\{[^}]+\}/],
     ["element_uri", /^\[[a-zA-Z0-9\\/]+elements\?id=\d+]/],
     ["uri", /^\[[a-zA-Z0-9\\/]+]/],

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -9,18 +9,23 @@ describe("tokenizeExpression", () => {
         const tokens = tokenizeExpression(expression);
 
         expect(tokens).toEqual([
-            { type: "text", value: "select avg(" },
+            { type: "text", value: "select avg" },
+            { type: "bracket", value: "(" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount" },
-            { type: "text", value: ") where " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " where " },
             { type: "identifier", value: "attr.account.id" },
-            { type: "text", value: " in (" },
+            { type: "text", value: " in " },
+            { type: "bracket", value: "(" },
             {
                 type: "element_uri",
                 value: "/gdc/md/projectId/obj/969/elements?id=123",
             },
-            { type: "text", value: ") and " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " and " },
             { type: "identifier", value: "snapshot.year" },
-            { type: "text", value: " > 2011" },
+            { type: "text", value: " > " },
+            { type: "number", value: "2011" },
         ]);
     });
 
@@ -29,11 +34,12 @@ describe("tokenizeExpression", () => {
             "SELECT SUM({fact.opportunitysnapshot.amount}*{fact.opportunitysnapshot.amount2})",
         );
         expect(tokens).toEqual([
-            { type: "text", value: "SELECT SUM(" },
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount" },
             { type: "text", value: "*" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount2" },
-            { type: "text", value: ")" },
+            { type: "bracket", value: ")" },
         ]);
     });
 
@@ -44,18 +50,24 @@ describe("tokenizeExpression", () => {
         const tokens = tokenizeExpression(expression);
 
         expect(tokens).toEqual([
-            { type: "text", value: "select avg(" },
+            { type: "text", value: "select avg" },
+            { type: "bracket", value: "(" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount" },
-            { type: "text", value: ") where " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " where " },
             { type: "identifier", value: "attr.account.id" },
-            { type: "text", value: " in (" },
+            { type: "text", value: " in " },
+            { type: "bracket", value: "(" },
             {
                 type: "element_uri",
                 value: "/gdc/md/projectId/obj/969/elements?id=123",
             },
-            { type: "text", value: ") and " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " and " },
             { type: "identifier", value: "snapshot.year" },
-            { type: "text", value: " > 2011 " },
+            { type: "text", value: " > " },
+            { type: "number", value: "2011" },
+            { type: "text", value: " " },
             { type: "comment", value: "#test comment" },
         ]);
     });
@@ -67,14 +79,61 @@ describe("tokenizeExpression", () => {
         const tokens = tokenizeExpression(expression);
 
         expect(tokens).toEqual([
-            { type: "text", value: "select avg(" },
+            { type: "text", value: "select avg" },
+            { type: "bracket", value: "(" },
             { type: "identifier", value: "fact.opportunitysnapshot.amount" },
-            { type: "text", value: ") " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " " },
             { type: "comment", value: "# where {attr.account.id} and" },
             { type: "text", value: "\n\rWHERE " },
             { type: "identifier", value: "snapshot.year" },
-            { type: "text", value: " > 2011 " },
+            { type: "text", value: " > " },
+            { type: "number", value: "2011" },
+            { type: "text", value: " " },
             { type: "comment", value: "#test comment" },
+        ]);
+    });
+
+    it("parses MAQL with numbers", () => {
+        const expression = "SELECT 123 WHERE {fact/order_lines.quantity} > 5";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "123" },
+            { type: "text", value: " WHERE " },
+            { type: "identifier", value: "fact/order_lines.quantity" },
+            { type: "text", value: " > " },
+            { type: "number", value: "5" },
+        ]);
+    });
+
+    it("parses MAQL with decimal numbers", () => {
+        const expression = "SELECT 12.3 WHERE {fact/order_lines.quantity} > 5.8";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "12.3" },
+            { type: "text", value: " WHERE " },
+            { type: "identifier", value: "fact/order_lines.quantity" },
+            { type: "text", value: " > " },
+            { type: "number", value: "5.8" },
+        ]);
+    });
+
+    it("parses MAQL with brackets in comment", () => {
+        const expression = "SELECT 123 # WHERE SUM({fact/sum}) > 5";
+
+        const tokens = tokenizeExpression(expression);
+
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "123" },
+            { type: "text", value: " " },
+            { type: "comment", value: "# WHERE SUM({fact/sum}) > 5" },
         ]);
     });
 });

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -345,6 +345,12 @@ export interface IBaseWidget {
 }
 
 // @public
+export interface IBracketExpressionToken {
+    type: "bracket";
+    value: string;
+}
+
+// @public
 export interface ICatalogAttribute extends IGroupableCatalogItemBase {
     attribute: IAttributeMetadataObject;
     defaultDisplayForm: IAttributeDisplayFormMetadataObject;
@@ -1038,7 +1044,7 @@ export interface IMeasureDescriptor {
 }
 
 // @public
-export type IMeasureExpressionToken = IObjectExpressionToken | IAttributeElementExpressionToken | ITextExpressionToken | ICommentExpressionToken;
+export type IMeasureExpressionToken = IObjectExpressionToken | IAttributeElementExpressionToken | ITextExpressionToken | ICommentExpressionToken | IBracketExpressionToken;
 
 // @public
 export interface IMeasureGroupDescriptor {
@@ -1530,7 +1536,7 @@ export interface ITempFilterContext {
 
 // @public
 export interface ITextExpressionToken {
-    type: "text";
+    type: "text" | "quoted_text" | "number";
     value: string;
 }
 

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -433,6 +433,7 @@ export {
     IAttributeElementExpressionToken,
     ITextExpressionToken,
     ICommentExpressionToken,
+    IBracketExpressionToken,
 } from "./workspace/fromModel/ldm/measure";
 
 export { IOrganization, IOrganizations, IOrganizationDescriptor } from "./organization";

--- a/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
+++ b/libs/sdk-backend-spi/src/workspace/fromModel/ldm/measure.ts
@@ -42,7 +42,8 @@ export type IMeasureExpressionToken =
     | IObjectExpressionToken
     | IAttributeElementExpressionToken
     | ITextExpressionToken
-    | ICommentExpressionToken;
+    | ICommentExpressionToken
+    | IBracketExpressionToken;
 
 /**
  * Parsed {@link https://help.gooddata.com/pages/viewpage.action?pageId=86795279 | MAQL} token referencing a metadata object.
@@ -111,7 +112,27 @@ export interface ITextExpressionToken {
     /**
      * Expression token type
      */
-    type: "text";
+    type: "text" | "quoted_text" | "number";
+
+    /**
+     * Plain text
+     */
+    value: string;
+}
+
+/**
+ * Parsed {@link https://help.gooddata.com/pages/viewpage.action?pageId=86795279 | MAQL} bracket.
+ *
+ * @remarks
+ * See {@link IMeasureExpressionToken} for more information.
+ *
+ * @public
+ */
+export interface IBracketExpressionToken {
+    /**
+     * Expression token type
+     */
+    type: "bracket";
 
     /**
      * Plain text

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -56,11 +56,14 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
         regexToken: IExpressionToken,
         metric: JsonApiMetricOutDocument,
     ): IMeasureExpressionToken {
-        if (regexToken.type === "text" || regexToken.type === "quoted_text") {
-            return { type: "text", value: regexToken.value };
-        }
-        if (regexToken.type === "comment") {
-            return { type: "comment", value: regexToken.value };
+        if (
+            regexToken.type === "text" ||
+            regexToken.type === "quoted_text" ||
+            regexToken.type === "comment" ||
+            regexToken.type === "number" ||
+            regexToken.type === "bracket"
+        ) {
+            return { type: regexToken.type, value: regexToken.value };
         }
         const [type, id] = regexToken.value.split("/");
         if (type === "metric" || type === "fact" || type === "attribute" || type === "label") {

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -2,6 +2,8 @@
 export type ExpressionTokenType =
     | "text"
     | "quoted_text"
+    | "number"
+    | "bracket"
     | "fact"
     | "metric"
     | "attribute"
@@ -15,8 +17,10 @@ export interface IExpressionToken {
 
 const REMOVE_BRACKETS_REGEXP = /[[\]{}]/g;
 const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
-    ["text", /^[^#{}[\]"]+/],
+    ["text", /^[^#{}[\]"()0-9.]+/],
     ["quoted_text", /^"(?:[^"\\]|\\"|\\\\.)*"/],
+    ["number", /^[+-]?((\d+(\.\d*)?)|(\.\d+))/],
+    ["bracket", /^[()]+/],
     ["fact", /^\{fact\/[^}]*\}/],
     ["metric", /^\{metric\/[^}]*\}/],
     ["label", /^\{label\/[^}]*\}/],

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -11,13 +11,16 @@ describe("tokenizeExpression", () => {
             { type: "metric", value: "metric/Volume" },
             { type: "text", value: " * " },
             { type: "fact", value: "fact/customer.c_acctbal" },
-            { type: "text", value: " WHERE NOT (" },
+            { type: "text", value: " WHERE NOT " },
+            { type: "bracket", value: "(" },
             { type: "label", value: "label/customer.c_custkey" },
-            { type: "text", value: " IN (" },
+            { type: "text", value: " IN " },
+            { type: "bracket", value: "(" },
             { type: "quoted_text", value: '"Returned"' },
             { type: "text", value: ", " },
             { type: "quoted_text", value: '"Canceled"' },
-            { type: "text", value: ")) by all except " },
+            { type: "bracket", value: "))" },
+            { type: "text", value: " by all except " },
             { type: "attribute", value: "attribute/attr.customer.c_custkey" },
         ]);
     });
@@ -25,11 +28,12 @@ describe("tokenizeExpression", () => {
     it("parses MAQL without whitespace around operators (RAIL-3132)", () => {
         const tokens = tokenizeExpression("SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity})");
         expect(tokens).toEqual([
-            { type: "text", value: "SELECT SUM(" },
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
             { type: "fact", value: "fact/order_lines.price" },
             { type: "text", value: "*" },
             { type: "fact", value: "fact/order_lines.quantity" },
-            { type: "text", value: ")" },
+            { type: "bracket", value: ")" },
         ]);
     });
 
@@ -38,11 +42,13 @@ describe("tokenizeExpression", () => {
             'SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity}) # WHERE NOT ({label/customer.c_custkey} IN ("Returned", "Canceled"))',
         );
         expect(tokens).toEqual([
-            { type: "text", value: "SELECT SUM(" },
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
             { type: "fact", value: "fact/order_lines.price" },
             { type: "text", value: "*" },
             { type: "fact", value: "fact/order_lines.quantity" },
-            { type: "text", value: ") " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " " },
             {
                 type: "comment",
                 value: '# WHERE NOT ({label/customer.c_custkey} IN ("Returned", "Canceled"))',
@@ -55,20 +61,59 @@ describe("tokenizeExpression", () => {
             'SELECT SUM({fact/order_lines.price}*{fact/order_lines.quantity}) # WHERE NOT\n\rWHERE ({label/customer.c_custkey} IN ("Returned", "Canceled")) # "Invalid"?',
         );
         expect(tokens).toEqual([
-            { type: "text", value: "SELECT SUM(" },
+            { type: "text", value: "SELECT SUM" },
+            { type: "bracket", value: "(" },
             { type: "fact", value: "fact/order_lines.price" },
             { type: "text", value: "*" },
             { type: "fact", value: "fact/order_lines.quantity" },
-            { type: "text", value: ") " },
+            { type: "bracket", value: ")" },
+            { type: "text", value: " " },
             { type: "comment", value: "# WHERE NOT" },
-            { type: "text", value: "\n\rWHERE (" },
+            { type: "text", value: "\n\rWHERE " },
+            { type: "bracket", value: "(" },
             { type: "label", value: "label/customer.c_custkey" },
-            { type: "text", value: " IN (" },
+            { type: "text", value: " IN " },
+            { type: "bracket", value: "(" },
             { type: "quoted_text", value: '"Returned"' },
             { type: "text", value: ", " },
             { type: "quoted_text", value: '"Canceled"' },
-            { type: "text", value: ")) " },
+            { type: "bracket", value: "))" },
+            { type: "text", value: " " },
             { type: "comment", value: '# "Invalid"?' },
+        ]);
+    });
+
+    it("parses MAQL with numbers", () => {
+        const tokens = tokenizeExpression("SELECT 123 WHERE {fact/order_lines.quantity} > 5");
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "123" },
+            { type: "text", value: " WHERE " },
+            { type: "fact", value: "fact/order_lines.quantity" },
+            { type: "text", value: " > " },
+            { type: "number", value: "5" },
+        ]);
+    });
+
+    it("parses MAQL with decimal numbers", () => {
+        const tokens = tokenizeExpression("SELECT 12.3 WHERE {fact/order_lines.quantity} > 5.8");
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "12.3" },
+            { type: "text", value: " WHERE " },
+            { type: "fact", value: "fact/order_lines.quantity" },
+            { type: "text", value: " > " },
+            { type: "number", value: "5.8" },
+        ]);
+    });
+
+    it("parses MAQL with brackets in comment", () => {
+        const tokens = tokenizeExpression("SELECT 123 # WHERE SUM({fact/sum}) > 5");
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT " },
+            { type: "number", value: "123" },
+            { type: "text", value: " " },
+            { type: "comment", value: "# WHERE SUM({fact/sum}) > 5" },
         ]);
     });
 });


### PR DESCRIPTION
Comments in tooltip are incorrectly displayed as standard MAQL expression

JIRA: NAS-2875

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
