### PR TITLE
Add note about multiple plugins before 8.8.0

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/mkn-rail-3935-readme_2022-01-19-08-36.json
+++ b/common/changes/@gooddata/sdk-ui-all/mkn-rail-3935-readme_2022-01-19-08-36.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Add possibility to set dashboard plugin compatibility with minEngineVersion and maxEngineVersion properties.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/tools/dashboard-plugin-template/README.template.md
+++ b/tools/dashboard-plugin-template/README.template.md
@@ -141,7 +141,7 @@ that is contained in the [src/harness/backend.ts](src/harness/backend.ts) - this
 ### How can I setup compatibility of the plugin?
 
 You can modify minEngineVersion and maxEngineVersion properties in `src/{{pluginIdentifier}}\_entry/index`.
-By default, we guarantee that plugin will be compatible only with the exact version of the dashboard engine used during its build (`"bundled"` option). But if you are sure, that plugin is compatible also with the other engine versions, you can set concrete range of the versions (e.g. `"minEngineVersion": "8.8.0", "maxEngineVersion": "8.9.0"`).
+By default, we guarantee that plugin will be compatible only with the exact version of the dashboard engine used during its build (`"bundled"` option). But if you are sure, that plugin is compatible also with the other engine versions, you can set concrete range of the versions (e.g. `"minEngineVersion": "8.8.0", "maxEngineVersion": "8.9.0"`). Note that combining multiple plugins created before version `8.8.0` may not work.
 
 ### How do plugin dependencies work?
 


### PR DESCRIPTION
- Add note that combining multiple plugins before 8.8.0 may not work
- Also add missing changelog about minEngineVersion and maxEngineVersion properties

JIRA: RAIL-3935, RAIL-3910

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
