### PR TITLE
Revert "Handle colorMapping items with null id on tiger"

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/fixLegacyElementUris.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/fixLegacyElementUris.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { isInsightWidget, IWidgetDefinition } from "@gooddata/sdk-backend-spi";
 import {
     IInsightDefinition,
@@ -27,14 +27,10 @@ const FAKE_ELEMENT_URI_REGEX = /\/obj\/\d+\/elements\?id=(.*)/;
 /**
  * @internal
  */
-export type ColorMapping = {
-    color: { type: "guid"; value: string };
-    // TODO: RAIL-3984 unify this with IColorMapping type from sdk-model
-    id: string | null; // id: null means the setting is relevant to (empty value) of the attribute
-};
+type ColorMapping = { color: { type: "guid"; value: string }; id: string };
 
 function fixColorMapping(colorMapping: ColorMapping): ColorMapping {
-    const [uri, labelValue] = colorMapping.id?.match(FAKE_ELEMENT_URI_REGEX) ?? [];
+    const [uri, labelValue] = colorMapping.id.match(FAKE_ELEMENT_URI_REGEX) ?? [];
     if (uri) {
         return {
             ...colorMapping,

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/__snapshots__/fixLegacyElementUris.test.ts.snap
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/__snapshots__/fixLegacyElementUris.test.ts.snap
@@ -1,31 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fixInsightLegacyElementUris color mapping should handle color mapping items with null ids (RAIL-3983) 1`] = `
-Array [
-  Object {
-    "color": Object {
-      "type": "guid",
-      "value": "0",
-    },
-    "id": "CZ",
-  },
-  Object {
-    "color": Object {
-      "type": "guid",
-      "value": "1",
-    },
-    "id": "Czech.Republic",
-  },
-  Object {
-    "color": Object {
-      "type": "guid",
-      "value": "foo",
-    },
-    "id": null,
-  },
-]
-`;
-
 exports[`fixInsightLegacyElementUris color mapping should strip fake uris and keep only label text values 1`] = `
 Array [
   Object {

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/fixLegacyElementUris.fixtures.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/fixLegacyElementUris.fixtures.ts
@@ -9,7 +9,10 @@ import {
 import { IWidget } from "@gooddata/sdk-backend-spi";
 import { newInsightWidget } from "@gooddata/sdk-backend-base";
 
-import { ColorMapping } from "../../fixLegacyElementUris";
+/**
+ * @internal
+ */
+type ColorMapping = { color: { type: "guid"; value: string }; id: string };
 
 const mockColorMapping = (elementIds: string[]): ColorMapping[] => {
     return elementIds.map((id, idx) => ({

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/fixLegacyElementUris.test.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/visualizationObjects/tests/fixLegacyElementUris.test.ts
@@ -1,10 +1,6 @@
-// (C) 2019-2022 GoodData Corporation
+// (C) 2019-2021 GoodData Corporation
 import { IInsightWidget } from "@gooddata/sdk-backend-spi";
-import {
-    ColorMapping,
-    fixInsightLegacyElementUris,
-    fixWidgetLegacyElementUris,
-} from "../../fixLegacyElementUris";
+import { fixInsightLegacyElementUris, fixWidgetLegacyElementUris } from "../../fixLegacyElementUris";
 import { mockInsight, mockWidget } from "./fixLegacyElementUris.fixtures";
 
 describe("fixInsightLegacyElementUris", () => {
@@ -27,22 +23,6 @@ describe("fixInsightLegacyElementUris", () => {
             expect(insightWithoutUris.insight.properties.controls?.colorMapping).toEqual(
                 sanitizedInsightWithoutUris.insight.properties.controls?.colorMapping,
             );
-        });
-
-        it("should handle color mapping items with null ids (RAIL-3983)", () => {
-            const fakeInsight = mockInsight(["/obj/0/elements?id=CZ", "/obj/0/elements?id=Czech.Republic"]);
-            const emptyValueColorMapping: ColorMapping = {
-                id: null, // set this color for the (empty value) attribute value
-                color: {
-                    type: "guid",
-                    value: "foo",
-                },
-            };
-            fakeInsight.insight.properties.controls.colorMapping.push(emptyValueColorMapping);
-
-            expect(
-                fixInsightLegacyElementUris(fakeInsight).insight.properties.controls.colorMapping,
-            ).toMatchSnapshot();
         });
     });
 


### PR DESCRIPTION
This reverts commit df8c40dd5f92b46f9ae6874e07f677828dca8791.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
