### PR TITLE
Add HeadlessDashboard utility class

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -19,7 +19,7 @@ import { DateString } from '@gooddata/sdk-backend-spi';
 import { Dictionary } from '@reduxjs/toolkit';
 import { Dispatch } from '@reduxjs/toolkit';
 import { DrillDefinition } from '@gooddata/sdk-backend-spi';
-import { EnhancedStore } from '@reduxjs/toolkit';
+import { EntityId } from '@reduxjs/toolkit';
 import { EntityState } from '@reduxjs/toolkit';
 import { ExplicitDrill } from '@gooddata/sdk-ui';
 import { FilterContextItem } from '@gooddata/sdk-backend-spi';
@@ -117,10 +117,13 @@ import { OnFiredDrillEvent } from '@gooddata/sdk-ui';
 import { OnLoadingChanged } from '@gooddata/sdk-ui';
 import { OutputSelector } from '@reduxjs/toolkit';
 import { Patch } from 'immer';
+import { PayloadAction } from '@reduxjs/toolkit';
 import { PlatformEdition } from '@gooddata/sdk-backend-spi';
 import { PropsWithChildren } from 'react';
 import { default as React_2 } from 'react';
 import { ReactReduxContextValue } from 'react-redux';
+import { Reducer } from '@reduxjs/toolkit';
+import { SagaIterator } from 'redux-saga';
 import { ScreenSize } from '@gooddata/sdk-backend-spi';
 import { Selector } from '@reduxjs/toolkit';
 import { ShareStatus } from '@gooddata/sdk-backend-spi';
@@ -198,6 +201,13 @@ export interface AddSectionItems extends IDashboardCommand {
 
 // @internal (undocumented)
 export type AlertsState = EntityState<IWidgetAlert>;
+
+// @internal
+export type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
+    set: QueryCacheReducer<TQuery, TResult, QueryCacheEntry<TQuery, TResult>>;
+    remove: QueryCacheReducer<TQuery, TResult, string>;
+    removeAll: QueryCacheReducer<TQuery, TResult, void>;
+};
 
 // @public
 export function anyDashboardEventHandler(handler: DashboardEventHandler["handler"]): DashboardEventHandler;
@@ -1462,9 +1472,6 @@ export type DashboardState = {
 export type DashboardStateChangeCallback = (state: DashboardState, dispatch: DashboardDispatch) => void;
 
 // @internal (undocumented)
-export type DashboardStore = EnhancedStore<DashboardState>;
-
-// @internal (undocumented)
 export const DashboardStoreProvider: React_2.FC<IDashboardStoreProviderProps>;
 
 // @public (undocumented)
@@ -1930,6 +1937,33 @@ export function getDefaultLegacyInsightMenuItems(intl: IntlShape, config: {
 // @internal (undocumented)
 export function getDrillDownAttributeTitle(localIdentifier: string, drillEvent: IDrillEvent): string;
 
+// @internal (undocumented)
+export class HeadlessDashboard {
+    constructor(ctx: DashboardContext, config?: HeadlessDashboardConfig);
+    // (undocumented)
+    protected capturedActions: Array<PayloadAction<any>>;
+    // (undocumented)
+    protected capturedEvents: Array<DashboardEvents>;
+    // (undocumented)
+    dispatch(action: DashboardCommands | PayloadAction<any>): void;
+    dispatchAndWaitFor(action: DashboardCommands | PayloadAction<any>, actionType: DashboardEventType | DashboardCommandType | string, timeout?: number): Promise<any>;
+    // (undocumented)
+    protected getOrCreateMonitoredAction: (actionType: string) => MonitoredAction;
+    // (undocumented)
+    protected monitoredActions: Record<string, MonitoredAction>;
+    query<TResult>(action: IDashboardQuery<TResult>): Promise<TResult>;
+    select<TSelectorFactory extends (...args: any[]) => any>(selectorFactory: TSelectorFactory): ReturnType<TSelectorFactory>;
+    protected state(): DashboardState;
+    waitFor(actionType: DashboardEventType | DashboardCommandType | string, timeout?: number): Promise<any>;
+}
+
+// @internal (undocumented)
+export type HeadlessDashboardConfig = {
+    queryServices?: IDashboardQueryService<any, any>[];
+    backgroundWorkers?: ((context: DashboardContext) => SagaIterator<void>)[];
+    customizationFns?: DashboardModelCustomizationFns;
+};
+
 // @alpha
 export const HiddenButtonBar: () => JSX.Element | null;
 
@@ -2291,6 +2325,16 @@ export interface IDashboardQuery<_TResult = any> {
 
 // @alpha
 export type IDashboardQueryResult<T> = T extends IDashboardQuery<infer TResult> ? TResult : never;
+
+// @internal
+export interface IDashboardQueryService<TQuery extends IDashboardQuery<TResult>, TResult> {
+    // (undocumented)
+    cache?: QueryCache<TQuery, TResult>;
+    // (undocumented)
+    generator: (ctx: DashboardContext, query: TQuery, refresh: boolean) => SagaIterator<TResult>;
+    // (undocumented)
+    name: DashboardQueryType;
+}
 
 // @internal
 export interface IDashboardStoreProviderProps {
@@ -3029,6 +3073,14 @@ export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
 // @alpha
 export function modifyDrillsForInsightWidget(ref: ObjRef, drills: InsightDrillDefinition[], correlationId?: string): ModifyDrillsForInsightWidget;
 
+// @internal (undocumented)
+export type MonitoredAction = {
+    calls: number;
+    promise: Promise<PayloadAction<any>>;
+    resolve: (action: PayloadAction<any>) => void;
+    reject: (e: any) => void;
+};
+
 // @alpha (undocumented)
 export interface MoveAttributeFilter extends IDashboardCommand {
     // (undocumented)
@@ -3212,8 +3264,35 @@ export interface PermissionsState {
     permissions?: IWorkspacePermissions;
 }
 
+// @internal
+export type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerActions<AllQueryCacheReducers<TQuery, TResult>>;
+
 // @alpha
 export function queryAndWaitFor<TQuery extends DashboardQueries>(dispatch: DashboardDispatch, query: TQuery): Promise<IDashboardQueryResult<TQuery>>;
+
+// @internal
+export type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
+    cacheName: string;
+    reducer: Reducer<EntityState<QueryCacheEntry<TQuery, TResult>>>;
+    actions: QueryActions<TQuery, TResult>;
+    selectById: (id: EntityId) => Selector<DashboardState, QueryCacheEntryResult<TResult> | undefined>;
+    selectQueryResult: (query: TQuery) => Selector<DashboardState, QueryCacheEntryResult<TResult> | undefined>;
+};
+
+// @internal
+export type QueryCacheEntry<TQuery extends IDashboardQuery<TResult>, TResult> = QueryCacheEntryResult<TResult> & {
+    query: TQuery;
+};
+
+// @internal
+export type QueryCacheEntryResult<TResult> = {
+    status: "loading" | "success" | "error";
+    result?: TResult;
+    error?: string;
+};
+
+// @internal
+export type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, TPayload> = CaseReducer<EntityState<QueryCacheEntry<TQuery, TResult>>, PayloadAction<TPayload>>;
 
 // @alpha
 export function queryDateDatasetsForInsight(insightOrRef: ObjRef | IInsight, correlationId?: string): QueryInsightDateDatasets;
@@ -3657,18 +3736,10 @@ export const selectDashboardUri: OutputSelector<DashboardState, string | undefin
 export const selectDashboardUriRef: OutputSelector<DashboardState, UriRef | undefined, (res: string | undefined) => UriRef | undefined>;
 
 // @internal
-export const selectDateDatasetsForInsight: (query: QueryInsightDateDatasets) => Selector<DashboardState, {
-status: "error" | "loading" | "success";
-result?: InsightDateDatasets | undefined;
-error?: string | undefined;
-} | undefined>;
+export const selectDateDatasetsForInsight: (query: QueryInsightDateDatasets) => Selector<DashboardState, QueryCacheEntryResult<InsightDateDatasets> | undefined>;
 
 // @internal
-export const selectDateDatasetsForMeasure: (query: QueryMeasureDateDatasets) => Selector<DashboardState, {
-status: "error" | "loading" | "success";
-result?: MeasureDateDatasets | undefined;
-error?: string | undefined;
-} | undefined>;
+export const selectDateDatasetsForMeasure: (query: QueryMeasureDateDatasets) => Selector<DashboardState, QueryCacheEntryResult<MeasureDateDatasets> | undefined>;
 
 // @public
 export const selectDateFilterConfig: OutputSelector<DashboardState, IDateFilterConfig, (res: ResolvedDashboardConfig) => IDateFilterConfig>;
@@ -3785,11 +3856,7 @@ export const selectImplicitDrillsByAvailableDrillTargets: (availableDrillTargets
 export const selectImplicitDrillsDownByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: IDrillTargets | undefined, res2: (ICatalogAttribute | ICatalogDateAttribute)[], res3: boolean) => IImplicitDrillWithPredicates[]>;
 
 // @internal
-export const selectInsightAttributesMeta: (query: QueryInsightAttributesMeta) => Selector<DashboardState, {
-status: "error" | "loading" | "success";
-result?: InsightAttributesMeta | undefined;
-error?: string | undefined;
-} | undefined>;
+export const selectInsightAttributesMeta: (query: QueryInsightAttributesMeta) => Selector<DashboardState, QueryCacheEntryResult<InsightAttributesMeta> | undefined>;
 
 // @alpha
 export const selectInsightByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IInsight | undefined, (res: ObjRefMap<IInsight>) => IInsight | undefined>;

--- a/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
@@ -1,0 +1,214 @@
+// (C) 2022 GoodData Corporation
+
+import { Middleware, PayloadAction } from "@reduxjs/toolkit";
+import { DashboardState } from "../store";
+import { DashboardEvents, DashboardEventType } from "../events";
+import { DashboardContext, DashboardModelCustomizationFns } from "../types/commonTypes";
+import noop from "lodash/noop";
+import { DashboardCommands, DashboardCommandType } from "../commands";
+import { IDashboardQuery } from "../queries";
+import { SagaIterator } from "redux-saga";
+import { IDashboardQueryService } from "../store/_infra/queryService";
+import { createDashboardStore, ReduxedDashboardStore } from "../store/dashboardStore";
+import { queryEnvelopeWithPromise } from "../store/_infra/queryProcessing";
+
+/**
+ * @internal
+ */
+export type MonitoredAction = {
+    calls: number;
+    promise: Promise<PayloadAction<any>>;
+    resolve: (action: PayloadAction<any>) => void;
+    reject: (e: any) => void;
+};
+
+/**
+ * @internal
+ */
+export type HeadlessDashboardConfig = {
+    queryServices?: IDashboardQueryService<any, any>[];
+    backgroundWorkers?: ((context: DashboardContext) => SagaIterator<void>)[];
+    customizationFns?: DashboardModelCustomizationFns;
+};
+
+/**
+ * @internal
+ */
+export class HeadlessDashboard {
+    private readonly reduxedStore: ReduxedDashboardStore;
+    protected monitoredActions: Record<string, MonitoredAction> = {};
+    protected capturedActions: Array<PayloadAction<any>> = [];
+    protected capturedEvents: Array<DashboardEvents> = [];
+
+    constructor(ctx: DashboardContext, config?: HeadlessDashboardConfig) {
+        // Middleware to store the actions and create promises
+        const actionsMiddleware: Middleware = () => (next) => (action) => {
+            if (action.type.startsWith("@@redux/")) {
+                //
+            } else {
+                this.onActionCaptured(action);
+            }
+
+            return next(action);
+        };
+
+        this.reduxedStore = createDashboardStore({
+            dashboardContext: ctx,
+            additionalMiddleware: actionsMiddleware,
+            eventing: {
+                initialEventHandlers: [
+                    {
+                        eval: () => true,
+                        handler: this.eventHandler,
+                    },
+                ],
+            },
+
+            queryServices: config?.queryServices,
+            backgroundWorkers: config?.backgroundWorkers || [],
+            privateContext: config?.customizationFns,
+        });
+    }
+
+    protected getOrCreateMonitoredAction = (actionType: string): MonitoredAction => {
+        const existingAction: MonitoredAction = this.monitoredActions[actionType];
+
+        if (existingAction) {
+            return existingAction;
+        }
+
+        const partialAction = {
+            calls: 0,
+            resolve: noop,
+            reject: noop,
+        };
+
+        const promise = new Promise<PayloadAction<any>>((resolve, reject) => {
+            partialAction.resolve = resolve;
+            partialAction.reject = reject;
+        });
+
+        const newAction: MonitoredAction = {
+            ...partialAction,
+            promise,
+        };
+
+        this.monitoredActions[actionType] = newAction;
+
+        return newAction;
+    };
+
+    private onActionCaptured = (action: PayloadAction<any>): void => {
+        this.capturedActions.push(action);
+
+        const monitoredAction = this.getOrCreateMonitoredAction(action.type);
+        monitoredAction.calls += 1;
+        monitoredAction.resolve(action);
+    };
+
+    private eventHandler = (evt: DashboardEvents): void => {
+        this.capturedEvents.push(evt);
+    };
+
+    public dispatch(action: DashboardCommands | PayloadAction<any>): void {
+        /*
+         * Clearing monitored actions is essential to allow sane usage in tests that need fire a command and wait
+         * for the same type of event multiple times. Monitored actions is what is used to wait in the `waitFor`
+         * method. Without the clearing, the second `waitFor` would bail out immediately and return the very first
+         * captured event.
+         */
+        this.monitoredActions = {};
+        this.reduxedStore.store.dispatch(action);
+    }
+
+    /**
+     * Convenience function that combines both {@link HeadlessDashboard.dispatch} and {@link HeadlessDashboard.waitFor}.
+     *
+     * @param action - action (typically a command) to dispatch
+     * @param actionType - type of action (typically an event type) to wait for
+     * @param timeout - timeout after which the wait fails, default is 1000
+     */
+    public dispatchAndWaitFor(
+        action: DashboardCommands | PayloadAction<any>,
+        actionType: DashboardEventType | DashboardCommandType | string,
+        timeout: number = 1000,
+    ): Promise<any> {
+        this.dispatch(action);
+
+        return this.waitFor(actionType, timeout);
+    }
+
+    private commandFailedRejectsWaitFor = () => {
+        const commandFailed = this.getOrCreateMonitoredAction("GDC.DASH/EVT.COMMAND.FAILED");
+
+        return commandFailed.promise.then((evt) => {
+            // eslint-disable-next-line no-console
+            console.error(`Command processing failed: ${evt.payload.reason} - ${evt.payload.message}`);
+
+            throw evt.payload.error;
+        });
+    };
+
+    private commandRejectedEndsWaitFor = () => {
+        const commandRejected = this.getOrCreateMonitoredAction("GDC.DASH/EVT.COMMAND.REJECTED");
+
+        return commandRejected.promise.then((evt) => {
+            // eslint-disable-next-line no-console
+            console.error(
+                "Command was rejected because dashboard does not know how to handle it. " +
+                    "This is likely because the handler for the rejected command is not registered in the system. See root command handler.",
+            );
+
+            throw evt;
+        });
+    };
+
+    /**
+     * Starts a dashboard query.
+     *
+     * @param action - query action
+     */
+    public query<TResult>(action: IDashboardQuery<TResult>): Promise<TResult> {
+        const { envelope, promise } = queryEnvelopeWithPromise(action);
+        this.reduxedStore.store.dispatch(envelope);
+        return promise;
+    }
+
+    /**
+     * Wait for action to occur. The wait is bounded by a timeout that is 1s by default.
+     *
+     * @param actionType - action type to wait for
+     * @param timeout - timeout after which the wait fails, default is 1000
+     */
+    public waitFor(
+        actionType: DashboardEventType | DashboardCommandType | string,
+        timeout: number = 1000,
+    ): Promise<any> {
+        const includeErrorHandler = actionType !== "GDC.DASH/EVT.COMMAND.FAILED";
+
+        return Promise.race([
+            this.getOrCreateMonitoredAction(actionType).promise,
+            ...(includeErrorHandler ? [this.commandFailedRejectsWaitFor()] : []),
+            this.commandRejectedEndsWaitFor(),
+            new Promise((_, reject) => {
+                setTimeout(() => {
+                    reject(new Error(`Wait for action '${actionType}' timed out after ${timeout}ms`));
+                }, timeout);
+            }),
+        ]);
+    }
+
+    /**
+     * select data from the state
+     */
+    select<TSelectorFactory extends (...args: any[]) => any>(selectorFactory: TSelectorFactory) {
+        return selectorFactory(this.state()) as ReturnType<TSelectorFactory>;
+    }
+
+    /**
+     * Returns dashboard state.
+     */
+    protected state(): DashboardState {
+        return this.reduxedStore.store.getState();
+    }
+}

--- a/libs/sdk-ui-dashboard/src/model/headlessDashboard/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/headlessDashboard/index.ts
@@ -1,0 +1,3 @@
+// (C) 2022 GoodData Corporation
+
+export { HeadlessDashboard, HeadlessDashboardConfig, MonitoredAction } from "./HeadlessDashboard";

--- a/libs/sdk-ui-dashboard/src/model/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/index.ts
@@ -90,3 +90,4 @@ export {
     DashboardEventEvalFn,
 } from "./eventHandlers/eventHandler";
 export { newDrillToSameDashboardHandler } from "./eventHandlers/drillToSameDashboardHandlerFactory";
+export * from "./headlessDashboard";

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
@@ -37,7 +37,7 @@ import capitalize from "lodash/capitalize";
  *
  * @internal
  */
-type QueryCacheEntryResult<TResult> = {
+export type QueryCacheEntryResult<TResult> = {
     /**
      *
      */
@@ -53,23 +53,30 @@ type QueryCacheEntryResult<TResult> = {
  *
  * @internal
  */
-type QueryCacheEntry<TQuery extends IDashboardQuery<TResult>, TResult> = QueryCacheEntryResult<TResult> & {
+export type QueryCacheEntry<
+    TQuery extends IDashboardQuery<TResult>,
+    TResult,
+> = QueryCacheEntryResult<TResult> & {
     query: TQuery;
 };
 
 /**
  * Each slice reducer is typed as toolkit's CaseReducer. This type specializes the case reducer to the purpose of
  * doing reductions on state that holds results for particular query type.
+ *
+ * @internal
  */
-type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, TPayload> = CaseReducer<
+export type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, TPayload> = CaseReducer<
     EntityState<QueryCacheEntry<TQuery, TResult>>,
     PayloadAction<TPayload>
 >;
 
 /**
  * This defines all possible reducers for the cache slice.
+ *
+ * @internal
  */
-type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
     /**
      * Sets value of cache entry.
      */
@@ -88,15 +95,19 @@ type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
 
 /**
  * This is a specialization of toolkit's CaseReducerActions to correctly type the action creators.
+ *
+ * @internal
  */
-type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerActions<
+export type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerActions<
     AllQueryCacheReducers<TQuery, TResult>
 >;
 
 /**
  * Contains all essentials of query cache that can be integrated into redux store and redux sagas.
+ *
+ * @internal
  */
-type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
     /**
      * A name to use as key in _queryCache part of the redux state.
      */
@@ -232,6 +243,8 @@ function createQueryCacheSlice<TQuery extends IDashboardQuery<TResult>, TResult>
  *
  * The dashboard component's infrastructure and hooks ensure that the query result (or query error) will be
  * pushed to the caller code.
+ *
+ * @internal
  */
 export interface IDashboardQueryService<TQuery extends IDashboardQuery<TResult>, TResult> {
     name: DashboardQueryType;

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -172,4 +172,12 @@ export { uiActions } from "./ui";
 
 export { queryAndWaitFor } from "./_infra/queryAndWaitFor";
 export { dispatchAndWaitFor } from "./_infra/dispatchAndWaitFor";
-export { DashboardStore } from "./dashboardStore";
+export {
+    IDashboardQueryService,
+    QueryCache,
+    QueryActions,
+    QueryCacheEntry,
+    QueryCacheEntryResult,
+    AllQueryCacheReducers,
+    QueryCacheReducer,
+} from "./_infra/queryService";

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -1,8 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
+import { PayloadAction } from "@reduxjs/toolkit";
 import { Identifier, idRef } from "@gooddata/sdk-model";
-import { createDashboardStore, ReduxedDashboardStore } from "../store/dashboardStore";
-import { DashboardState } from "../store/types";
 import { DashboardContext, DashboardModelCustomizationFns } from "../types/commonTypes";
 import {
     recordedBackend,
@@ -10,6 +9,11 @@ import {
     defaultRecordedBackendCapabilities,
 } from "@gooddata/sdk-backend-mockingbird";
 import { ReferenceRecordings } from "@gooddata/reference-workspace";
+import { DashboardCommandType, InitializeDashboard, initializeDashboard } from "../commands";
+import { IDashboardQueryService } from "../store/_infra/queryService";
+import { IBackendCapabilities } from "@gooddata/sdk-backend-spi";
+import { HeadlessDashboard, HeadlessDashboardConfig } from "../headlessDashboard";
+import { newRenderingWorker, RenderingWorkerConfiguration } from "../commandHandlers/render/renderingWorker";
 import {
     DashboardEvents,
     DashboardEventType,
@@ -17,26 +21,7 @@ import {
     isDashboardQueryCompleted,
     isDashboardQueryStarted,
 } from "../events";
-import { Middleware, PayloadAction } from "@reduxjs/toolkit";
-import noop from "lodash/noop";
-import {
-    DashboardCommands,
-    DashboardCommandType,
-    InitializeDashboard,
-    initializeDashboard,
-} from "../commands";
-import { IDashboardQuery } from "../queries";
-import { queryEnvelopeWithPromise } from "../store/_infra/queryProcessing";
-import { IDashboardQueryService } from "../store/_infra/queryService";
-import { newRenderingWorker, RenderingWorkerConfiguration } from "../commandHandlers/render/renderingWorker";
-import { IBackendCapabilities } from "@gooddata/sdk-backend-spi";
-
-type MonitoredAction = {
-    calls: number;
-    promise: Promise<PayloadAction<any>>;
-    resolve: (action: PayloadAction<any>) => void;
-    reject: (e: any) => void;
-};
+import { DashboardState } from "../store";
 
 type DashboardTesterConfig = {
     queryServices?: IDashboardQueryService<any, any>[];
@@ -44,105 +29,16 @@ type DashboardTesterConfig = {
     customizationFns?: DashboardModelCustomizationFns;
 };
 
-export class DashboardTester {
-    protected readonly reduxedStore: ReduxedDashboardStore;
-    private monitoredActions: Record<string, MonitoredAction> = {};
-    private capturedActions: Array<PayloadAction<any>> = [];
-    private capturedEvents: Array<DashboardEvents> = [];
-
+export class DashboardTester extends HeadlessDashboard {
     protected constructor(ctx: DashboardContext, config?: DashboardTesterConfig) {
-        // Middleware to store the actions and create promises
-        const testerMiddleware: Middleware = () => (next) => (action) => {
-            if (action.type.startsWith("@@redux/")) {
-                //
-            } else {
-                this.onActionCaptured(action);
-            }
-
-            return next(action);
-        };
-
-        this.reduxedStore = createDashboardStore({
-            dashboardContext: ctx,
-            additionalMiddleware: testerMiddleware,
-            eventing: {
-                initialEventHandlers: [
-                    {
-                        eval: () => true,
-                        handler: this.eventHandler,
-                    },
-                ],
-            },
+        const headlessDahboardConfig: HeadlessDashboardConfig = {
             queryServices: config?.queryServices,
             backgroundWorkers: [newRenderingWorker(config?.renderingWorkerConfig)],
-            privateContext: config?.customizationFns,
-        });
+            customizationFns: config?.customizationFns,
+        };
+
+        super(ctx, headlessDahboardConfig);
     }
-
-    private getOrCreateMonitoredAction = (actionType: string): MonitoredAction => {
-        const existingAction: MonitoredAction = this.monitoredActions[actionType];
-
-        if (existingAction) {
-            return existingAction;
-        }
-
-        const partialAction = {
-            calls: 0,
-            resolve: noop,
-            reject: noop,
-        };
-
-        const promise = new Promise<PayloadAction<any>>((resolve, reject) => {
-            partialAction.resolve = resolve;
-            partialAction.reject = reject;
-        });
-
-        const newAction: MonitoredAction = {
-            ...partialAction,
-            promise,
-        };
-
-        this.monitoredActions[actionType] = newAction;
-
-        return newAction;
-    };
-
-    private onActionCaptured = (action: PayloadAction<any>): void => {
-        this.capturedActions.push(action);
-
-        const monitoredAction = this.getOrCreateMonitoredAction(action.type);
-        monitoredAction.calls += 1;
-        monitoredAction.resolve(action);
-    };
-
-    private eventHandler = (evt: DashboardEvents): void => {
-        this.capturedEvents.push(evt);
-    };
-
-    private commandFailedRejectsWaitFor = () => {
-        const commandFailed = this.getOrCreateMonitoredAction("GDC.DASH/EVT.COMMAND.FAILED");
-
-        return commandFailed.promise.then((evt) => {
-            // eslint-disable-next-line no-console
-            console.error(`Command processing failed: ${evt.payload.reason} - ${evt.payload.message}`);
-
-            throw evt.payload.error;
-        });
-    };
-
-    private commandRejectedEndsWaitFor = () => {
-        const commandRejected = this.getOrCreateMonitoredAction("GDC.DASH/EVT.COMMAND.REJECTED");
-
-        return commandRejected.promise.then((evt) => {
-            // eslint-disable-next-line no-console
-            console.error(
-                "Command was rejected because dashboard does not know how to handle it. " +
-                    "This is likely because the handler for the rejected command is not registered in the system. See root command handler.",
-            );
-
-            throw evt;
-        });
-    };
 
     /**
      * Creates an instance of DashboardTester set up to run tests on top of a dashboard with the provided
@@ -193,75 +89,32 @@ export class DashboardTester {
         return new DashboardTester(ctx, testerConfig);
     }
 
-    public dispatch(action: DashboardCommands | PayloadAction<any>): void {
-        /*
-         * Clearing monitored actions is essential to allow sane usage in tests that need fire a command and wait
-         * for the same type of event multiple times. Monitored actions is what is used to wait in the `waitFor`
-         * method. Without the clearing, the second `waitFor` would bail out immediately and return the very first
-         * captured event.
-         */
-        this.monitoredActions = {};
-        this.reduxedStore.store.dispatch(action);
+    /**
+     * Wait the specified time.
+     *
+     * @param timeout - timeout after which the wait will be resolved
+     * @returns promise
+     */
+    public wait(timeout: number): Promise<void> {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve();
+            }, timeout);
+        });
     }
 
     /**
-     * Convenience function that combines both {@link dispatch} and {@link waitFor}.
-     *
-     * @param action - action (typically a command) to dispatch
-     * @param actionType - type of action (typically an event type) to wait for
-     * @param timeout - timeout after which the wait fails, default is 1000
+     * Returns all actions that were dispatched since the tester was created or since it was last reset.
      */
-    public dispatchAndWaitFor(
-        action: DashboardCommands | PayloadAction<any>,
-        actionType: DashboardEventType | DashboardCommandType | string,
-        timeout: number = 1000,
-    ): Promise<any> {
-        this.dispatch(action);
-
-        return this.waitFor(actionType, timeout);
-    }
-
-    /**
-     * Starts a dashboard query.
-     *
-     * @param action - query action
-     */
-    public query<TResult>(action: IDashboardQuery<TResult>): Promise<TResult> {
-        const { envelope, promise } = queryEnvelopeWithPromise(action);
-        this.reduxedStore.store.dispatch(envelope);
-        return promise;
-    }
-
-    /**
-     * Wait for action to occur. The wait is bounded by a timeout that is 1s by default.
-     *
-     * @param actionType - action type to wait for
-     * @param timeout - timeout after which the wait fails, default is 1000
-     */
-    public waitFor(
-        actionType: DashboardEventType | DashboardCommandType | string,
-        timeout: number = 1000,
-    ): Promise<any> {
-        const includeErrorHandler = actionType !== "GDC.DASH/EVT.COMMAND.FAILED";
-
-        return Promise.race([
-            this.getOrCreateMonitoredAction(actionType).promise,
-            ...(includeErrorHandler ? [this.commandFailedRejectsWaitFor()] : []),
-            this.commandRejectedEndsWaitFor(),
-            new Promise((_, reject) => {
-                setTimeout(() => {
-                    reject(new Error(`Wait for action '${actionType}' timed out after ${timeout}ms`));
-                }, timeout);
-            }),
-        ]);
+    public dispatchedActions(): ReadonlyArray<PayloadAction<any>> {
+        return this.capturedActions.slice();
     }
 
     /**
      * Wait for all of the listed actions to occur. The wait is bounded by a timeout that is 1s by default.
      *
      * This is useful when testing commands that emit multiple events and you need to verify that all of the
-     * events happened. This function does not care about the order in which the events occurred. If you then
-     * need to verify the order, use {@link emittedEvents} or {@link emittedEventsDigest}.
+     * events happened. This function does not care about the order in which the events occurred.
      *
      * @param actionTypes - action types to wait for
      * @param timeout - timeout after which the wait fails
@@ -285,27 +138,6 @@ export class DashboardTester {
     }
 
     /**
-     * Wait the specified time.
-     *
-     * @param timeout - timeout after which the wait will be resolved
-     * @returns promise
-     */
-    public wait(timeout: number): Promise<void> {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve();
-            }, timeout);
-        });
-    }
-
-    /**
-     * Returns all actions that were dispatched since the tester was created or since it was last reset.
-     */
-    public dispatchedActions(): ReadonlyArray<PayloadAction<any>> {
-        return this.capturedActions.slice();
-    }
-
-    /**
      * Returns all events that were emitted during execution. Events are a sub-type of actions - they are
      * actions that are suitable for external consumption and describe what has happened in the dashboard.
      *
@@ -316,13 +148,30 @@ export class DashboardTester {
     }
 
     /**
+     * Resets internal state of the tester's monitors. The captured actions will be cleared up as part
+     * of this.
+     */
+    public resetMonitors(): void {
+        this.capturedActions = [];
+        this.capturedEvents = [];
+        this.monitoredActions = {};
+    }
+
+    /**
+     * Returns dashboard state.
+     */
+    public state(): DashboardState {
+        return super.state();
+    }
+
+    /**
      * Returns digests of all events that were emitted during execution. Digest contains just the event
      * type and the correlation id of the event. The payload is discarded.
      *
      * This is useful for snapshotting event sequence.
      */
     public emittedEventsDigest(): ReadonlyArray<{ type: string; correlationId?: string }> {
-        return this.capturedEvents.map((evt) => {
+        return this.emittedEvents().map((evt) => {
             if (isDashboardQueryStarted(evt) || isDashboardQueryCompleted(evt)) {
                 return {
                     type: evt.type,
@@ -344,23 +193,6 @@ export class DashboardTester {
                 correlationId: evt.correlationId,
             };
         });
-    }
-
-    /**
-     * Resets internal state of the tester's monitors. The captured actions will be cleared up as part
-     * of this.
-     */
-    public resetMonitors(): void {
-        this.capturedActions = [];
-        this.capturedEvents = [];
-        this.monitoredActions = {};
-    }
-
-    /**
-     * Returns dashboard state.
-     */
-    public state(): DashboardState {
-        return this.reduxedStore.store.getState();
     }
 }
 


### PR DESCRIPTION
Jira: TNT-418

The only new code in  HeadlessDashboard is the `select` function. The rest was moved there from DashboardTester which now inherits from HeadlessDasboard.

It was also necessary to export `IDashboardQueryService`


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
