### PR TITLE
RELATED: RAIL-3987 add support for ingoreFilters to custom widgets

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPlugin.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPlugin.tsx
@@ -14,7 +14,8 @@ const DashboardWithLocalPlugin = (): JSX.Element => (
 
         <p>
             Example on how to embed a dashboard with a local plugin. The example plugin adds a new section to
-            the Dashboard and renders a text there.
+            the Dashboard and renders a custom visualization there. Note that the custom visualization
+            respects the dashboard filters.
         </p>
 
         <ExampleWithSource

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3020,6 +3020,12 @@ export interface IUseCustomWidgetExecutionDataViewConfig {
     widget: ICustomWidget;
 }
 
+// @beta
+export interface IUseCustomWidgetInsightDataViewConfig {
+    insight?: IInsightDefinition | ObjRef;
+    widget: ICustomWidget;
+}
+
 // @alpha (undocumented)
 export type IXlsxExportConfig = {
     format: "xlsx";
@@ -4173,6 +4179,9 @@ export interface UpsertExecutionResult extends IDashboardCommand {
 
 // @beta
 export const useCustomWidgetExecutionDataView: ({ widget, execution, }: IUseCustomWidgetExecutionDataViewConfig) => UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+
+// @beta
+export const useCustomWidgetInsightDataView: ({ widget, insight, }: IUseCustomWidgetInsightDataViewConfig) => UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
 // @internal (undocumented)
 export interface UseDashboardAsyncRender {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -69,6 +69,7 @@ import { IErrorProps } from '@gooddata/sdk-ui';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
+import { IFilterableWidget } from '@gooddata/sdk-backend-spi';
 import { IFilterContext } from '@gooddata/sdk-backend-spi';
 import { IFilterContextDefinition } from '@gooddata/sdk-backend-spi';
 import { IHeaderPredicate } from '@gooddata/sdk-ui';
@@ -1844,10 +1845,10 @@ export const FilterBar: (props: IFilterBarProps) => JSX.Element;
 export function filterContextAttributeFilterToAttributeFilter(filter: IDashboardAttributeFilter): IAttributeFilter;
 
 // @internal
-export function filterContextDateFilterToDateFilter(filter: IDashboardDateFilter, widget: IWidgetDefinition): IDateFilter;
+export function filterContextDateFilterToDateFilter(filter: IDashboardDateFilter, widget: Partial<IFilterableWidget>): IDateFilter;
 
 // @internal
-export function filterContextItemsToFiltersForWidget(filterContextItems: FilterContextItem[], widget: IWidgetDefinition): IDashboardFilter[];
+export function filterContextItemsToFiltersForWidget(filterContextItems: FilterContextItem[], widget: Partial<IFilterableWidget>): IDashboardFilter[];
 
 // @alpha (undocumented)
 export interface FilterContextSelection {
@@ -2032,7 +2033,7 @@ export interface ICustomDashboardEvent<TPayload = any> {
 }
 
 // @public
-export interface ICustomWidget extends ICustomWidgetBase, IDashboardObjectIdentity {
+export interface ICustomWidget extends ICustomWidgetBase, IDashboardObjectIdentity, Partial<IFilterableWidget> {
 }
 
 // @public
@@ -3139,7 +3140,7 @@ export interface MoveSectionItem extends IDashboardCommand {
 export function moveSectionItem(sectionIndex: number, itemIndex: number, toSectionIndex: number, toItemIndex: number, correlationId?: string): MoveSectionItem;
 
 // @public
-export function newCustomWidget<TExtra = void>(identifier: string, customType: string, extras?: TExtra): TExtra & ICustomWidget;
+export function newCustomWidget<TExtra = void>(identifier: string, customType: string, extras?: TExtra & Partial<IFilterableWidget>): TExtra & ICustomWidget;
 
 // @public
 export function newDashboardEngine(): IDashboardEngine;
@@ -4660,7 +4661,7 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
 };
 
 // @alpha
-export const useWidgetFilters: (widget: IWidget | undefined, filters?: IFilter[] | undefined) => {
+export const useWidgetFilters: (widget: ExtendedDashboardWidget | undefined, filters?: IFilter[] | undefined) => {
     result?: IFilter[] | undefined;
     status?: "error" | "running" | "success" | "rejected" | undefined;
     error?: GoodDataSdkError | undefined;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -76,6 +76,7 @@ import { IFilterContext } from '@gooddata/sdk-backend-spi';
 import { IFilterContextDefinition } from '@gooddata/sdk-backend-spi';
 import { IHeaderPredicate } from '@gooddata/sdk-ui';
 import { IInsight } from '@gooddata/sdk-model';
+import { IInsightDefinition } from '@gooddata/sdk-model';
 import { IInsightWidget } from '@gooddata/sdk-backend-spi';
 import { IInsightWidgetDefinition } from '@gooddata/sdk-backend-spi';
 import { IKpiWidget } from '@gooddata/sdk-backend-spi';
@@ -3352,7 +3353,7 @@ export interface QueryInsightWidgetFilters extends IDashboardQuery<IFilter[]> {
     // (undocumented)
     readonly payload: {
         readonly widgetRef: ObjRef;
-        readonly insightFilterOverrides: IFilter[] | undefined;
+        readonly insight?: IInsightDefinition | null;
     };
     // (undocumented)
     readonly type: "GDC.DASH/QUERY.WIDGET.FILTERS";
@@ -3385,7 +3386,7 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
 export function queryWidgetBrokenAlerts(widgetRef: ObjRef, correlationId?: string): QueryWidgetBrokenAlerts;
 
 // @alpha
-export function queryWidgetFilters(widgetRef: ObjRef, insightFilterOverrides?: IFilter[], correlationId?: string): QueryInsightWidgetFilters;
+export function queryWidgetFilters(widgetRef: ObjRef, insight?: IInsightDefinition | null, correlationId?: string): QueryInsightWidgetFilters;
 
 // @alpha (undocumented)
 export const ReactDashboardContext: any;
@@ -4674,14 +4675,7 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
 };
 
 // @public
-export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined): {
-    result?: IFilter[];
-    status?: QueryProcessingStatus;
-    error?: GoodDataSdkError;
-};
-
-// @public
-export function useWidgetFilters(widget: IInsightWidget | undefined, insightFilterOverrides?: IFilter[]): {
+export function useWidgetFilters(widget: ExtendedDashboardWidget | undefined, insight?: IInsightDefinition): {
     result?: IFilter[];
     status?: QueryProcessingStatus;
     error?: GoodDataSdkError;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4661,14 +4661,14 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
     onPushData: (data: IPushData) => void;
 };
 
-// @alpha
+// @public
 export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined): {
     result?: IFilter[];
     status?: QueryProcessingStatus;
     error?: GoodDataSdkError;
 };
 
-// @alpha
+// @public
 export function useWidgetFilters(widget: IInsightWidget | undefined, insightFilterOverrides?: IFilter[]): {
     result?: IFilter[];
     status?: QueryProcessingStatus;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2283,6 +2283,7 @@ export interface IDashboardKpiProps {
     backend?: IAnalyticalBackend;
     // @alpha
     ErrorComponent?: React_2.ComponentType<IErrorProps>;
+    // @deprecated
     filters?: FilterContextItem[];
     kpiWidget: IKpiWidget;
     // @alpha
@@ -3342,7 +3343,7 @@ export interface QueryInsightWidgetFilters extends IDashboardQuery<IFilter[]> {
     // (undocumented)
     readonly payload: {
         readonly widgetRef: ObjRef;
-        readonly widgetFilterOverrides: IFilter[] | undefined;
+        readonly insightFilterOverrides: IFilter[] | undefined;
     };
     // (undocumented)
     readonly type: "GDC.DASH/QUERY.WIDGET.FILTERS";
@@ -3375,7 +3376,7 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
 export function queryWidgetBrokenAlerts(widgetRef: ObjRef, correlationId?: string): QueryWidgetBrokenAlerts;
 
 // @alpha
-export function queryWidgetFilters(widgetRef: ObjRef, widgetFilterOverrides?: IFilter[], correlationId?: string): QueryInsightWidgetFilters;
+export function queryWidgetFilters(widgetRef: ObjRef, insightFilterOverrides?: IFilter[], correlationId?: string): QueryInsightWidgetFilters;
 
 // @alpha (undocumented)
 export const ReactDashboardContext: any;
@@ -4661,10 +4662,17 @@ export function useWidgetExecutionsHandler(widgetRef: ObjRef): {
 };
 
 // @alpha
-export const useWidgetFilters: (widget: ExtendedDashboardWidget | undefined, filters?: IFilter[] | undefined) => {
-    result?: IFilter[] | undefined;
-    status?: "error" | "running" | "success" | "rejected" | undefined;
-    error?: GoodDataSdkError | undefined;
+export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined): {
+    result?: IFilter[];
+    status?: QueryProcessingStatus;
+    error?: GoodDataSdkError;
+};
+
+// @alpha
+export function useWidgetFilters(widget: IInsightWidget | undefined, insightFilterOverrides?: IFilter[]): {
+    result?: IFilter[];
+    status?: QueryProcessingStatus;
+    error?: GoodDataSdkError;
 };
 
 // @public (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2392,10 +2392,10 @@ export interface IDashboardWidgetProps {
     backend?: IAnalyticalBackend;
     dateDataset?: ObjRef;
     // @alpha
-    ErrorComponent?: ComponentType<IErrorProps>;
+    ErrorComponent: ComponentType<IErrorProps>;
     ignoredAttributeFilters?: ObjRefInScope[];
     // @alpha
-    LoadingComponent?: ComponentType<ILoadingProps>;
+    LoadingComponent: ComponentType<ILoadingProps>;
     // @alpha (undocumented)
     onDrill?: OnFiredDashboardViewDrillEvent;
     // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3973,8 +3973,8 @@ export const selectUser: OutputSelector<DashboardState, IUser, (res: UserState) 
 // @internal (undocumented)
 export const selectValidConfiguredDrillsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: IImplicitDrillWithPredicates[], res2: ObjRefMap<IAttributeDisplayFormMetadataObject>, res3: ObjRefMap<IListedDashboard>, res4: ObjRefMap<IInsight>) => IImplicitDrillWithPredicates[]>;
 
-// @alpha @deprecated
-export const selectWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IKpiWidget | IInsightWidget | undefined, (res: ObjRefMap<ExtendedDashboardWidget>) => IKpiWidget | IInsightWidget | undefined>;
+// @alpha
+export const selectWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IKpiWidget | IInsightWidget | ICustomWidget | undefined, (res: ObjRefMap<ExtendedDashboardWidget>) => IKpiWidget | IInsightWidget | ICustomWidget | undefined>;
 
 // @alpha
 export const selectWidgetDrills: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IDrillToLegacyDashboard[] | InsightDrillDefinition[], (res: IKpiWidget | IInsightWidget | undefined) => IDrillToLegacyDashboard[] | InsightDrillDefinition[]>;

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -13,6 +13,7 @@ import { CaseReducer } from '@reduxjs/toolkit';
 import { CaseReducerActions } from '@reduxjs/toolkit';
 import { ComponentType } from 'react';
 import { DashboardDateFilterConfigMode } from '@gooddata/sdk-backend-spi';
+import { DataViewFacade } from '@gooddata/sdk-ui';
 import { DateFilterGranularity } from '@gooddata/sdk-backend-spi';
 import { DateFilterType } from '@gooddata/sdk-backend-spi';
 import { DateString } from '@gooddata/sdk-backend-spi';
@@ -66,6 +67,7 @@ import { IDrillToDashboard } from '@gooddata/sdk-backend-spi';
 import { IDrillToInsight } from '@gooddata/sdk-backend-spi';
 import { IDrillToLegacyDashboard } from '@gooddata/sdk-backend-spi';
 import { IErrorProps } from '@gooddata/sdk-ui';
+import { IExecutionConfiguration } from '@gooddata/sdk-ui';
 import { IExecutionDefinition } from '@gooddata/sdk-model';
 import { IExecutionResult } from '@gooddata/sdk-backend-spi';
 import { IFilter } from '@gooddata/sdk-model';
@@ -130,6 +132,7 @@ import { Selector } from '@reduxjs/toolkit';
 import { ShareStatus } from '@gooddata/sdk-backend-spi';
 import { TypedUseSelectorHook } from 'react-redux';
 import { UriRef } from '@gooddata/sdk-model';
+import { UseCancelablePromiseState } from '@gooddata/sdk-ui';
 import { VisualizationProperties } from '@gooddata/sdk-model';
 import { WithIntlProps } from 'react-intl';
 import { WrappedComponentProps } from 'react-intl';
@@ -3010,6 +3013,12 @@ export interface ITopBarProps {
     titleProps: ITitleProps;
 }
 
+// @beta
+export interface IUseCustomWidgetExecutionDataViewConfig {
+    execution?: Exclude<IExecutionConfiguration, "filters">;
+    widget: ICustomWidget;
+}
+
 // @alpha (undocumented)
 export type IXlsxExportConfig = {
     format: "xlsx";
@@ -4160,6 +4169,9 @@ export interface UpsertExecutionResult extends IDashboardCommand {
     // (undocumented)
     readonly type: "GDC.DASH/CMD.EXECUTION_RESULT.UPSERT";
 }
+
+// @beta
+export const useCustomWidgetExecutionDataView: ({ widget, execution, }: IUseCustomWidgetExecutionDataViewConfig) => UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
 // @internal (undocumented)
 export interface UseDashboardAsyncRender {

--- a/libs/sdk-ui-dashboard/src/converters/filterConverters.ts
+++ b/libs/sdk-ui-dashboard/src/converters/filterConverters.ts
@@ -3,6 +3,7 @@ import {
     FilterContextItem,
     IDashboardAttributeFilter,
     IDashboardDateFilter,
+    IFilterableWidget,
     IFilterContext,
     IFilterContextDefinition,
     isDashboardAttributeFilter,
@@ -18,6 +19,7 @@ import {
     IDateFilter,
 } from "@gooddata/sdk-model";
 import isString from "lodash/isString";
+
 import { IDashboardFilter } from "../types";
 
 /**
@@ -69,7 +71,7 @@ export function filterContextAttributeFilterToAttributeFilter(
  */
 export function filterContextDateFilterToDateFilter(
     filter: IDashboardDateFilter,
-    widget: IWidgetDefinition,
+    widget: Partial<IFilterableWidget>,
 ): IDateFilter {
     if (filter.dateFilter.type === "relative") {
         return newRelativeDateFilter(
@@ -96,7 +98,7 @@ export function filterContextDateFilterToDateFilter(
  */
 export function filterContextItemsToFiltersForWidget(
     filterContextItems: FilterContextItem[],
-    widget: IWidgetDefinition,
+    widget: Partial<IFilterableWidget>,
 ): IDashboardFilter[] {
     return filterContextItems.map((filter) => {
         if (isDashboardAttributeFilter(filter)) {

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToDashboardHandler.ts
@@ -15,7 +15,7 @@ import {
     selectFilterContextAttributeFilters,
     selectFilterContextDateFilter,
 } from "../../store/filterContext/filterContextSelectors";
-import { selectWidgetByRef } from "../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../store/layout/layoutSelectors";
 import { IInsightWidget } from "@gooddata/sdk-backend-spi";
 import { IDashboardFilter } from "../../../types";
 import {
@@ -60,7 +60,9 @@ export function* drillToDashboardHandler(
     );
 
     // decide if we should use date filter (only if enabled and connected to a dataset)
-    const widget: IInsightWidget = yield select(selectWidgetByRef(cmd.payload.drillEvent.widgetRef!));
+    const widget: IInsightWidget = yield select(
+        selectAnalyticalWidgetByRef(cmd.payload.drillEvent.widgetRef!),
+    );
     const insight: IInsight = yield select(selectInsightByRef(widget.insight));
 
     // if this bombs, widget is not an insight widget and something is seriously wrong

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getDrillToUrlFilters.ts
@@ -14,8 +14,8 @@ export function* getDrillToUrlFiltersWithResolvedValues(
     ctx: DashboardContext,
     widgetRef: ObjRef,
 ): SagaIterator<FiltersInfo> {
-    // empty widgetFilterOverrides array is passed to override all insight filters
-    const effectiveFilters: IFilter[] = yield call(query, queryWidgetFilters(widgetRef, []));
+    // override all insight filters by passing null as insight
+    const effectiveFilters: IFilter[] = yield call(query, queryWidgetFilters(widgetRef, null));
     const filters = effectiveFilters.filter(isDashboardFilter);
 
     const enableFilterValuesResolutionInDrillEvents: SagaReturnType<

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/resolveDrillToCustomUrl.ts
@@ -16,7 +16,7 @@ import { DashboardContext } from "../../types/commonTypes";
 import { PromiseFnReturnType } from "../../types/sagas";
 import { SagaIterator } from "redux-saga";
 import { selectDashboardId } from "../../store/meta/metaSelectors";
-import { selectWidgetByRef } from "../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../store/layout/layoutSelectors";
 import { selectInsightByRef } from "../../store/insights/insightsSelectors";
 import { getElementTitle } from "./getElementTitle";
 import { getAttributeIdentifiersPlaceholdersFromUrl } from "../../../_staging/drills/drillingUtils";
@@ -166,7 +166,7 @@ export function* getInsightIdentifiersReplacements(
 ): SagaIterator<IDrillToUrlPlaceholderReplacement[]> {
     const { workspace, clientId, dataProductId } = ctx;
     const dashboardId: ReturnType<typeof selectDashboardId> = yield select(selectDashboardId);
-    const widget: IInsightWidget = yield select(selectWidgetByRef(widgetRef));
+    const widget: IInsightWidget = yield select(selectAnalyticalWidgetByRef(widgetRef));
     const insight: ReturnType<ReturnType<typeof selectInsightByRef>> = yield select(
         selectInsightByRef(widget.insight),
     );

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetFilterSettingsHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetFilterSettingsHandler.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../commands";
 import { attributeDisplayFormRef, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";
 import { DashboardCommandFailed, DashboardInsightWidgetFilterSettingsChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { isDashboardAttributeFilterReference } from "@gooddata/sdk-backend-spi";
 import { ReferenceMd } from "@gooddata/reference-workspace";
 import {
@@ -22,7 +22,7 @@ import {
 } from "../../../tests/fixtures/ComplexDashboard.fixtures";
 
 function ignoredWidgetFilterRefs(tester: DashboardTester, ref: ObjRef) {
-    const widget = selectWidgetByRef(ref)(tester.state());
+    const widget = selectAnalyticalWidgetByRef(ref)(tester.state());
 
     return widget!.ignoreDashboardFilters.filter(isDashboardAttributeFilterReference).map((ignored) => {
         return ignored.displayForm;
@@ -61,7 +61,7 @@ describe("change insight widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.ignoreDashboardFilters).toEqual([]);
         });
@@ -82,7 +82,7 @@ describe("change insight widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.ignoreDashboardFilters).toEqual([]);
         });
@@ -124,7 +124,7 @@ describe("change insight widget filter settings handler", () => {
 
             // this verifies that the widget's ignored filters are updated && importantly the 'native' ref used
             // on the ignored attribute filter is used
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(ignoredWidgetFilterRefs(Tester, TestWidgetRef)).toEqual([
                 ComplexDashboardFilters.FirstAttribute.filter.attributeFilter.displayForm,
                 ComplexDashboardFilters.SecondAttribute.filter.attributeFilter.displayForm,
@@ -198,12 +198,12 @@ describe("change insight widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
         });
 
         it("should modify date dataset when widget already has date filter enabled", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
 
             const event: DashboardInsightWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 enableInsightWidgetDateFilter(WidgetWithAllFilters.ref, ValidDateDatasetIdRef),
@@ -215,13 +215,13 @@ describe("change insight widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.dateDataSet).not.toEqual(originalWidget!.dateDataSet);
         });
 
         it("should not touch the ignored attribute filters", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
 
             const event: DashboardInsightWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 enableInsightWidgetDateFilter(WidgetWithNoFilters.ref, ValidDateDatasetIdRef),
@@ -230,7 +230,7 @@ describe("change insight widget filter settings handler", () => {
 
             // widget with no filters means all attribute filters are in widget's ignore list. ensure they remain
             // the same
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.ignoreDashboardFilters).toEqual(originalWidget!.ignoreDashboardFilters);
             expect(event.payload.ignoredAttributeFilters).not.toEqual([]);
         });
@@ -245,7 +245,7 @@ describe("change insight widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeUndefined();
 
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toBeUndefined();
         });
 
@@ -257,12 +257,12 @@ describe("change insight widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeUndefined();
 
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toBeUndefined();
         });
 
         it("should not touch the ignored attribute filters", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
 
             const event: DashboardInsightWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 disableInsightWidgetDateFilter(WidgetWithNoFilters.ref),
@@ -271,7 +271,7 @@ describe("change insight widget filter settings handler", () => {
 
             // widget with no filters means all attribute filters are in widget's ignore list. ensure they remain
             // the same
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.ignoreDashboardFilters).toEqual(originalWidget!.ignoreDashboardFilters);
             expect(event.payload.ignoredAttributeFilters).not.toEqual([]);
         });
@@ -297,7 +297,7 @@ describe("change insight widget filter settings handler", () => {
         });
 
         it("should not touch the date filter setting", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             const event: DashboardInsightWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 replaceInsightWidgetIgnoredFilters(WidgetWithAllFilters.ref, [
                     ComplexDashboardFilters.FirstAttribute.uriRef,
@@ -307,7 +307,7 @@ describe("change insight widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeDefined();
 
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(originalWidget!.dateDataSet);
         });
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetHeaderHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetHeaderHandler.test.ts
@@ -4,7 +4,7 @@ import { DashboardTester, preloadedTesterFactory } from "../../../tests/Dashboar
 import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
 import { ChangeInsightWidgetHeader, changeInsightWidgetHeader } from "../../../commands";
 import { DashboardCommandFailed, DashboardInsightWidgetHeaderChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { idRef, uriRef } from "@gooddata/sdk-model";
 import {
     ComplexDashboardIdentifier,
@@ -31,7 +31,7 @@ describe("change insight widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 
@@ -44,7 +44,7 @@ describe("change insight widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 
@@ -57,7 +57,7 @@ describe("change insight widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetVisPropertiesHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeInsightWidgetVisPropertiesHandler.test.ts
@@ -4,7 +4,7 @@ import { DashboardTester, preloadedTesterFactory } from "../../../tests/Dashboar
 import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
 import { ChangeInsightWidgetVisProperties, changeInsightWidgetVisProperties } from "../../../commands";
 import { DashboardCommandFailed, DashboardInsightWidgetVisPropertiesChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { idRef, uriRef } from "@gooddata/sdk-model";
 import { IInsightWidget } from "@gooddata/sdk-backend-spi";
 import {
@@ -32,7 +32,7 @@ describe("change insight widget vis properties handler", () => {
             );
 
             expect(event.payload.properties).toEqual(TestProperties);
-            const widgetState = selectWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
             expect(widgetState!.properties).toEqual(TestProperties);
         });
 
@@ -45,7 +45,7 @@ describe("change insight widget vis properties handler", () => {
             );
 
             expect(event.payload.properties).toEqual(TestProperties);
-            const widgetState = selectWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
             expect(widgetState!.properties).toEqual(TestProperties);
         });
 
@@ -58,7 +58,7 @@ describe("change insight widget vis properties handler", () => {
             );
 
             expect(event.payload.properties).toEqual(TestProperties);
-            const widgetState = selectWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
             expect(widgetState!.properties).toEqual(TestProperties);
         });
 
@@ -71,7 +71,7 @@ describe("change insight widget vis properties handler", () => {
             );
 
             expect(event.payload.properties).toBeUndefined();
-            const widgetState = selectWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
             expect(widgetState!.properties).toBeUndefined();
         });
 
@@ -84,7 +84,7 @@ describe("change insight widget vis properties handler", () => {
             );
 
             expect(event.payload.properties).toEqual({});
-            const widgetState = selectWidgetByRef(ref)(Tester.state()) as IInsightWidget;
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IInsightWidget;
             expect(widgetState!.properties).toEqual({});
         });
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetComparisonHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetComparisonHandler.test.ts
@@ -4,7 +4,7 @@ import { DashboardTester, preloadedTesterFactory } from "../../../tests/Dashboar
 import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
 import { ChangeKpiWidgetComparison, changeKpiWidgetComparison, KpiWidgetComparison } from "../../../commands";
 import { DashboardCommandFailed, DashboardKpiWidgetComparisonChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { uriRef } from "@gooddata/sdk-model";
 import {
     ComplexDashboardIdentifier,
@@ -39,7 +39,7 @@ describe("change KPI widget comparison handler", () => {
 
             expect(event.payload.kpi.comparisonType).toEqual("previousPeriod");
             expect(event.payload.kpi.comparisonDirection).toEqual("growIsBad");
-            const widgetState: IKpiWidget = selectWidgetByRef(ref)(Tester.state()) as IKpiWidget;
+            const widgetState: IKpiWidget = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IKpiWidget;
             expect(widgetState.kpi.comparisonType).toEqual(event.payload.kpi.comparisonType);
             expect(widgetState.kpi.comparisonDirection).toEqual(event.payload.kpi.comparisonDirection);
         });
@@ -54,7 +54,7 @@ describe("change KPI widget comparison handler", () => {
 
             expect(event.payload.kpi.comparisonType).toEqual("previousPeriod");
             expect(event.payload.kpi.comparisonDirection).toEqual("growIsGood");
-            const widgetState: IKpiWidget = selectWidgetByRef(ref)(Tester.state()) as IKpiWidget;
+            const widgetState: IKpiWidget = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IKpiWidget;
             expect(widgetState.kpi.comparisonType).toEqual(event.payload.kpi.comparisonType);
             expect(widgetState.kpi.comparisonDirection).toEqual(event.payload.kpi.comparisonDirection);
         });
@@ -69,7 +69,7 @@ describe("change KPI widget comparison handler", () => {
 
             expect(event.payload.kpi.comparisonType).toEqual("none");
             expect(event.payload.kpi.comparisonDirection).toBeUndefined();
-            const widgetState: IKpiWidget = selectWidgetByRef(ref)(Tester.state()) as IKpiWidget;
+            const widgetState: IKpiWidget = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IKpiWidget;
             expect(widgetState.kpi.comparisonType).toEqual(event.payload.kpi.comparisonType);
             expect(widgetState.kpi.comparisonDirection).toBeUndefined();
         });
@@ -84,7 +84,7 @@ describe("change KPI widget comparison handler", () => {
 
             expect(event.payload.kpi.comparisonType).toEqual("none");
             expect(event.payload.kpi.comparisonDirection).toBeUndefined();
-            const widgetState: IKpiWidget = selectWidgetByRef(ref)(Tester.state()) as IKpiWidget;
+            const widgetState: IKpiWidget = selectAnalyticalWidgetByRef(ref)(Tester.state()) as IKpiWidget;
             expect(widgetState.kpi.comparisonType).toEqual(event.payload.kpi.comparisonType);
             expect(widgetState.kpi.comparisonDirection).toBeUndefined();
         });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetFilterSettingsHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetFilterSettingsHandler.test.ts
@@ -12,7 +12,7 @@ import {
 } from "../../../commands";
 import { attributeDisplayFormRef, idRef, ObjRef, uriRef } from "@gooddata/sdk-model";
 import { DashboardCommandFailed, DashboardKpiWidgetFilterSettingsChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { isDashboardAttributeFilterReference } from "@gooddata/sdk-backend-spi";
 import { ReferenceMd } from "@gooddata/reference-workspace";
 import {
@@ -22,7 +22,7 @@ import {
 } from "../../../tests/fixtures/ComplexDashboard.fixtures";
 
 function ignoredWidgetFilterRefs(tester: DashboardTester, ref: ObjRef) {
-    const widget = selectWidgetByRef(ref)(tester.state());
+    const widget = selectAnalyticalWidgetByRef(ref)(tester.state());
 
     return widget!.ignoreDashboardFilters.filter(isDashboardAttributeFilterReference).map((ignored) => {
         return ignored.displayForm;
@@ -61,7 +61,7 @@ describe("change KPI widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.ignoreDashboardFilters).toEqual([]);
         });
@@ -82,7 +82,7 @@ describe("change KPI widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.ignoreDashboardFilters).toEqual([]);
         });
@@ -124,7 +124,7 @@ describe("change KPI widget filter settings handler", () => {
 
             // this verifies that the widget's ignored filters are updated && importantly the 'native' ref used
             // on the ignored attribute filter is used
-            const widget = selectWidgetByRef(TestWidgetRef)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(TestWidgetRef)(Tester.state());
             expect(ignoredWidgetFilterRefs(Tester, TestWidgetRef)).toEqual([
                 ComplexDashboardFilters.FirstAttribute.filter.attributeFilter.displayForm,
                 ComplexDashboardFilters.SecondAttribute.filter.attributeFilter.displayForm,
@@ -198,12 +198,12 @@ describe("change KPI widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
         });
 
         it("should modify date dataset when widget already has date filter enabled", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
 
             const event: DashboardKpiWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 enableKpiWidgetDateFilter(WidgetWithAllFilters.ref, ValidDateDatasetIdRef),
@@ -215,13 +215,13 @@ describe("change KPI widget filter settings handler", () => {
 
             // this verifies that the widget's date dataset is updated && importantly the 'native' ref used
             // on the catalog date dataset is used.
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(event.payload.dateDatasetForFiltering!.dataSet.ref);
             expect(widget!.dateDataSet).not.toEqual(originalWidget!.dateDataSet);
         });
 
         it("should not touch the ignored attribute filters", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
 
             const event: DashboardKpiWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 enableKpiWidgetDateFilter(WidgetWithNoFilters.ref, ValidDateDatasetIdRef),
@@ -230,7 +230,7 @@ describe("change KPI widget filter settings handler", () => {
 
             // widget with no filters means all attribute filters are in widget's ignore list. ensure they remain
             // the same
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.ignoreDashboardFilters).toEqual(originalWidget!.ignoreDashboardFilters);
             expect(event.payload.ignoredAttributeFilters).not.toEqual([]);
         });
@@ -245,7 +245,7 @@ describe("change KPI widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeUndefined();
 
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toBeUndefined();
         });
 
@@ -257,12 +257,12 @@ describe("change KPI widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeUndefined();
 
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toBeUndefined();
         });
 
         it("should not touch the ignored attribute filters", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
 
             const event: DashboardKpiWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 disableKpiWidgetDateFilter(WidgetWithNoFilters.ref),
@@ -271,7 +271,7 @@ describe("change KPI widget filter settings handler", () => {
 
             // widget with no filters means all attribute filters are in widget's ignore list. ensure they remain
             // the same
-            const widget = selectWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithNoFilters.ref)(Tester.state());
             expect(widget!.ignoreDashboardFilters).toEqual(originalWidget!.ignoreDashboardFilters);
             expect(event.payload.ignoredAttributeFilters).not.toEqual([]);
         });
@@ -297,7 +297,7 @@ describe("change KPI widget filter settings handler", () => {
         });
 
         it("should not touch the date filter setting", async () => {
-            const originalWidget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             const event: DashboardKpiWidgetFilterSettingsChanged = await Tester.dispatchAndWaitFor(
                 replaceKpiWidgetIgnoredFilters(WidgetWithAllFilters.ref, [
                     ComplexDashboardFilters.FirstAttribute.uriRef,
@@ -307,7 +307,7 @@ describe("change KPI widget filter settings handler", () => {
 
             expect(event.payload.dateDatasetForFiltering).toBeDefined();
 
-            const widget = selectWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
+            const widget = selectAnalyticalWidgetByRef(WidgetWithAllFilters.ref)(Tester.state());
             expect(widget!.dateDataSet).toEqual(originalWidget!.dateDataSet);
         });
     });

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetHeaderHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetHeaderHandler.test.ts
@@ -4,7 +4,7 @@ import { DashboardTester, preloadedTesterFactory } from "../../../tests/Dashboar
 import { TestCorrelation } from "../../../tests/fixtures/Dashboard.fixtures";
 import { ChangeKpiWidgetHeader, changeKpiWidgetHeader } from "../../../commands";
 import { DashboardCommandFailed, DashboardKpiWidgetHeaderChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { idRef, uriRef } from "@gooddata/sdk-model";
 import {
     ComplexDashboardIdentifier,
@@ -31,7 +31,7 @@ describe("change KPI widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 
@@ -44,7 +44,7 @@ describe("change KPI widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 
@@ -57,7 +57,7 @@ describe("change KPI widget header handler", () => {
             );
 
             expect(event.payload.header).toEqual(TestHeader);
-            const widgetState = selectWidgetByRef(ref)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(ref)(Tester.state());
             expect(widgetState!.title).toEqual(TestHeader.title);
         });
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetMeasure.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/changeKpiWidgetMeasure.test.ts
@@ -5,7 +5,7 @@ import { ChangeKpiWidgetMeasure, changeKpiWidgetMeasure, initializeDashboard } f
 import { ReferenceMd } from "@gooddata/reference-workspace";
 import { measureItem, uriRef } from "@gooddata/sdk-model";
 import { DashboardCommandFailed, DashboardKpiWidgetMeasureChanged } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import {
     ComplexDashboardIdentifier,
     ComplexDashboardWidgets,
@@ -117,7 +117,7 @@ describe("change KPI widget measure handler", () => {
             await Tester.dispatchAndWaitFor(initializeDashboard(), "GDC.DASH/EVT.INITIALIZED");
             Tester.resetMonitors();
 
-            const originalWidget = selectWidgetByRef(WidgetWithDateDataset.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithDateDataset.ref)(Tester.state());
             const event: DashboardKpiWidgetMeasureChanged = await Tester.dispatchAndWaitFor(
                 changeKpiWidgetMeasure(WidgetWithDateDataset.ref, measureItem(ReferenceMd.Won)),
                 "GDC.DASH/EVT.KPI_WIDGET.MEASURE_CHANGED",
@@ -139,7 +139,7 @@ describe("change KPI widget measure handler", () => {
             await Tester.dispatchAndWaitFor(initializeDashboard(), "GDC.DASH/EVT.INITIALIZED");
             Tester.resetMonitors();
 
-            const originalWidget = selectWidgetByRef(WidgetWithDateDataset.ref)(Tester.state());
+            const originalWidget = selectAnalyticalWidgetByRef(WidgetWithDateDataset.ref)(Tester.state());
             const event: DashboardKpiWidgetMeasureChanged = await Tester.dispatchAndWaitFor(
                 changeKpiWidgetMeasure(WidgetWithDateDataset.ref, measureItem(ReferenceMd.Won)),
                 "GDC.DASH/EVT.KPI_WIDGET.MEASURE_CHANGED",

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/modifyDrillsForInsightWidgetHandler.test.ts
@@ -9,7 +9,7 @@ import {
     modifyDrillsForInsightWidget,
 } from "../../../commands";
 import { DashboardCommandFailed, DashboardInsightWidgetDrillsModified } from "../../../events";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { idRef, uriRef } from "@gooddata/sdk-model";
 import { DrillOrigin } from "@gooddata/sdk-backend-spi";
 import {
@@ -70,7 +70,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
         it("should add one drill to state for widget and emit event with one add drill def. No items from state are updated", async () => {
             const drills = [DrillToDashboardFromProductAttributeDefinition];
 
-            const origWidgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const origWidgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
             const origStateDrill = origWidgetState?.drills[0];
 
             const event: DashboardInsightWidgetDrillsModified = await Tester.dispatchAndWaitFor(
@@ -81,7 +81,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             expect(event.payload.updated).toEqual([]);
             expect(event.payload.added).toEqual([DrillToDashboardFromProductAttributeDefinition]);
 
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(2);
             expect(widgetState?.drills).toContainEqual(origStateDrill);
@@ -102,7 +102,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             expect(event.payload.updated).toEqual([DrillToToInsightFromWonMeasureDefinition]);
             expect(event.payload.added).toEqual([DrillToDashboardFromProductAttributeDefinition]);
 
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(2);
             expect(widgetState?.drills).toContainEqual(DrillToToInsightFromWonMeasureDefinition);
@@ -114,7 +114,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             drillToDashboardUriTarget.target = uriRef(ComplexDashboardWithReferences.dashboard.uri);
             const drills = [drillToDashboardUriTarget];
 
-            const origWidgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const origWidgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
             const origStateDrill = origWidgetState?.drills[0];
 
             const event: DashboardInsightWidgetDrillsModified = await Tester.dispatchAndWaitFor(
@@ -125,7 +125,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             expect(event.payload.updated).toEqual([]);
             expect(event.payload.added).toEqual([DrillToDashboardFromProductAttributeDefinition]);
 
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(2);
             expect(widgetState?.drills).toContainEqual(origStateDrill);
@@ -143,7 +143,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             );
 
             expect(event.payload.updated).toEqual([DrillToToInsightFromWonMeasureDefinition]);
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(1);
             expect(widgetState?.drills).toContainEqual(DrillToToInsightFromWonMeasureDefinition);
@@ -158,7 +158,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             );
 
             expect(event.payload.updated).toEqual([DrillToCustomUrlFromMeasureDefinition]);
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(1);
             expect(widgetState?.drills).toContainEqual(DrillToCustomUrlFromMeasureDefinition);
@@ -173,7 +173,7 @@ describe("modifyDrillsForInsightWidgetHandler", () => {
             );
 
             expect(event.payload.added).toEqual([DrillToAttributeUrlFromMeasureDefinition]);
-            const widgetState = selectWidgetByRef(drillToAttributeUrlWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(drillToAttributeUrlWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(1);
             expect(widgetState?.drills).toContainEqual(DrillToAttributeUrlFromMeasureDefinition);

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/removeDrillsForInsightWidgetHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/tests/removeDrillsForInsightWidgetHandler.test.ts
@@ -9,7 +9,7 @@ import {
     removeDrillsForInsightWidget,
 } from "../../../commands";
 import { localIdRef, uriRef } from "@gooddata/sdk-model";
-import { selectWidgetByRef } from "../../../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../../../store/layout/layoutSelectors";
 import { DashboardInsightWidgetDrillsRemoved } from "../../../events/insight";
 import { DashboardCommandFailed } from "../../../events";
 import {
@@ -72,7 +72,7 @@ describe("removeDrillsForInsightWidgetHandler", () => {
             expect(event.payload.removed).toEqual([DrillToToInsightFromWonMeasureDefinition]);
             expect(event.payload.ref).toEqual(SimpleSortedTableWidgetRef);
 
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(1);
             expect(widgetState?.drills).toContainEqual(DrillToDashboardFromProductAttributeDefinition);
@@ -89,7 +89,7 @@ describe("removeDrillsForInsightWidgetHandler", () => {
             expect(event.payload.removed).toContainEqual(DrillToDashboardFromProductAttributeDefinition);
             expect(event.payload.ref).toEqual(SimpleSortedTableWidgetRef);
 
-            const widgetState = selectWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
+            const widgetState = selectAnalyticalWidgetByRef(SimpleSortedTableWidgetRef)(Tester.state());
 
             expect(widgetState?.drills.length).toBe(0);
             expect(widgetState?.drills).toEqual([]);

--- a/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
@@ -24,7 +24,8 @@ export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
  * Creates action thought which you can query dashboard component for filters that should be used by a given widget.
  *
  * @param widgetRef - reference to insight widget
- * @param widgetFilterOverrides - optionally specify filters to be applied on top of the dashboard and insight filters
+ * @param widgetFilterOverrides - optionally specify filters to be applied instead of insight filters for InsightWidgets
+ *  or instead of dashboard filters for KpiWidgets and CustomWidgets
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
@@ -16,7 +16,7 @@ export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
     readonly type: "GDC.DASH/QUERY.WIDGET.FILTERS";
     readonly payload: {
         readonly widgetRef: ObjRef;
-        readonly widgetFilterOverrides: IFilter[] | undefined;
+        readonly insightFilterOverrides: IFilter[] | undefined;
     };
 }
 
@@ -24,15 +24,15 @@ export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
  * Creates action thought which you can query dashboard component for filters that should be used by a given widget.
  *
  * @param widgetRef - reference to insight widget
- * @param widgetFilterOverrides - optionally specify filters to be applied instead of insight filters for InsightWidgets
- *  or instead of dashboard filters for KpiWidgets and CustomWidgets
+ * @param insightFilterOverrides - optionally specify filters to be applied instead of insight filters for InsightWidgets,
+ *  for Custom- and KpiWidgets this is ignored
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha
  */
 export function queryWidgetFilters(
     widgetRef: ObjRef,
-    widgetFilterOverrides?: IFilter[],
+    insightFilterOverrides?: IFilter[],
     correlationId?: string,
 ): QueryWidgetFilters {
     return {
@@ -40,7 +40,7 @@ export function queryWidgetFilters(
         correlationId,
         payload: {
             widgetRef,
-            widgetFilterOverrides,
+            insightFilterOverrides,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 
-import { IFilter, ObjRef } from "@gooddata/sdk-model";
+import { IFilter, IInsightDefinition, ObjRef } from "@gooddata/sdk-model";
 import { IBrokenAlertFilterBasicInfo } from "../types/alertTypes";
 import { IDashboardQuery } from "./base";
 
@@ -16,7 +16,7 @@ export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
     readonly type: "GDC.DASH/QUERY.WIDGET.FILTERS";
     readonly payload: {
         readonly widgetRef: ObjRef;
-        readonly insightFilterOverrides: IFilter[] | undefined;
+        readonly insight?: IInsightDefinition | null;
     };
 }
 
@@ -24,15 +24,16 @@ export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
  * Creates action thought which you can query dashboard component for filters that should be used by a given widget.
  *
  * @param widgetRef - reference to insight widget
- * @param insightFilterOverrides - optionally specify filters to be applied instead of insight filters for InsightWidgets,
- *  for Custom- and KpiWidgets this is ignored
+ * @param insight - optionally specify insight to evaluate the filters for in context of the widget.
+ *  If null, InsightWidgets will ignore the insight the are referencing.
+ *  If not specified, InsightWidgets will default to the insights they reference, Custom- and KpiWidgets will ignore it.
  * @param correlationId - optionally specify correlation id to use for this command. this will be included in all
  *  events that will be emitted during the command processing
  * @alpha
  */
 export function queryWidgetFilters(
     widgetRef: ObjRef,
-    insightFilterOverrides?: IFilter[],
+    insight?: IInsightDefinition | null,
     correlationId?: string,
 ): QueryWidgetFilters {
     return {
@@ -40,7 +41,7 @@ export function queryWidgetFilters(
         correlationId,
         payload: {
             widgetRef,
-            insightFilterOverrides,
+            insight,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetBrokenAlerts.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetBrokenAlerts.ts
@@ -19,7 +19,7 @@ import { invalidQueryArguments } from "../events/general";
 import { QueryWidgetBrokenAlerts } from "../queries/widgets";
 import { selectAlertByWidgetRef } from "../store/alerts/alertsSelectors";
 import { selectFilterContextFilters } from "../store/filterContext/filterContextSelectors";
-import { selectWidgetByRef } from "../store/layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../store/layout/layoutSelectors";
 import { createQueryService } from "../store/_infra/queryService";
 import { IBrokenAlertFilterBasicInfo } from "../types/alertTypes";
 import { DashboardContext } from "../types/commonTypes";
@@ -77,7 +77,7 @@ function* getKpiWidgetAndAlert(
     ctx: DashboardContext,
     correlationId?: string,
 ): SagaIterator<GetKpiWidgetAndAlertResult> {
-    const widgetSelector = selectWidgetByRef(widgetRef);
+    const widgetSelector = selectAnalyticalWidgetByRef(widgetRef);
     const kpiWidget: ReturnType<typeof widgetSelector> = yield select(widgetSelector);
 
     if (!kpiWidget) {

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -177,18 +177,11 @@ function selectResolvedInsightDateFilters(
         return insightDateFilters;
     }
 
-    const allDateFilters = [...insightDateFilters, ...dashboardDateFilters];
-    const allDateFilterDateDatasetPairs = selectDateDatasetsForDateFilters(state, allDateFilters);
-
-    return resolveDateFilters(allDateFilterDateDatasetPairs);
+    return selectResolvedDateFilters(state, [...insightDateFilters, ...dashboardDateFilters]);
 }
 
-function selectResolvedDateFilters(
-    state: DashboardState,
-    dashboardDateFilters: IDateFilter[],
-): IDateFilter[] {
-    const allDateFilterDateDatasetPairs = selectDateDatasetsForDateFilters(state, dashboardDateFilters);
-
+function selectResolvedDateFilters(state: DashboardState, dateFilters: IDateFilter[]): IDateFilter[] {
+    const allDateFilterDateDatasetPairs = selectDateDatasetsForDateFilters(state, dateFilters);
     return resolveDateFilters(allDateFilterDateDatasetPairs);
 }
 
@@ -288,7 +281,7 @@ function* queryForKpiOrCustomWidget(
         widgetAwareDashboardFiltersSelector,
     );
 
-    // use the widgetFilterOverrides if specified instead of insight filters
+    // use the widgetFilterOverrides if specified instead of dashboard filters
     const effectiveDashboardFilters = widgetFilterOverrides ?? widgetAwareDashboardFilters;
 
     const [dateFilters, attributeFilters] = yield all([

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -27,7 +27,7 @@ import {
     uriRef,
 } from "@gooddata/sdk-model";
 import { QueryWidgetFilters } from "../queries/widgets";
-import { selectAllFiltersForWidgetByRef, selectWidgetByRef } from "../store/layout/layoutSelectors";
+import { selectAllFiltersForWidgetByRef, selectAnalyticalWidgetByRef } from "../store/layout/layoutSelectors";
 import { selectInsightByRef } from "../store/insights/insightsSelectors";
 import { invalidQueryArguments } from "../events/general";
 import {
@@ -312,7 +312,7 @@ function* queryService(ctx: DashboardContext, query: QueryWidgetFilters): SagaIt
         payload: { widgetRef, widgetFilterOverrides },
         correlationId,
     } = query;
-    const widgetSelector = selectWidgetByRef(widgetRef);
+    const widgetSelector = selectAnalyticalWidgetByRef(widgetRef);
     const widget: ReturnType<typeof widgetSelector> = yield select(widgetSelector);
 
     if (!widget) {

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { DashboardContext } from "../types/commonTypes";
 import { SagaIterator } from "redux-saga";
 import { all, call, SagaReturnType, select } from "redux-saga/effects";
@@ -162,18 +162,9 @@ function resolveWidgetFilterIgnore(
  * global date filter is desired because otherwise there is a large chance that the intersection of global date filter
  * and measure's date filters would lead to empty set and no data shown for the insight?
  */
-export function isDateFilterIgnoredForInsight(insight: IInsight): boolean {
+export function isDashboardDateFilterIgnoredForInsight(insight: IInsight): boolean {
     const simpleMeasures = insightMeasures(insight, isSimpleMeasure);
-
-    if (simpleMeasures.length === 0) {
-        return false;
-    }
-
-    const simpleMeasuresWithDateFilter = simpleMeasures.filter((m) =>
-        (measureFilters(m) ?? []).some(isDateFilter),
-    );
-
-    return simpleMeasures.length === simpleMeasuresWithDateFilter.length;
+    return simpleMeasures.length > 0 && simpleMeasures.every((m) => measureFilters(m)?.some(isDateFilter));
 }
 
 function selectResolvedInsightDateFilters(
@@ -182,7 +173,7 @@ function selectResolvedInsightDateFilters(
     dashboardDateFilters: IDateFilter[],
     insightDateFilters: IDateFilter[],
 ): IDateFilter[] {
-    if (isDateFilterIgnoredForInsight(insight)) {
+    if (isDashboardDateFilterIgnoredForInsight(insight)) {
         return insightDateFilters;
     }
 

--- a/libs/sdk-ui-dashboard/src/model/store/executionResults/executionResultsSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/executionResults/executionResultsSelectors.ts
@@ -6,7 +6,7 @@ import { DashboardState } from "../types";
 import { createMemoizedSelector } from "../_infra/selectors";
 import { executionResultsAdapter } from "./executionResultsEntityAdapter";
 import { IExecutionResultEnvelope } from "./types";
-import { selectWidgetByRef } from "../layout/layoutSelectors";
+import { selectAnalyticalWidgetByRef } from "../layout/layoutSelectors";
 import { isNonExportableError } from "../../../_staging/errors/errorPredicates";
 import { selectPermissions } from "../permissions/permissionsSelectors";
 import { selectSettings } from "../config/configSelectors";
@@ -42,14 +42,18 @@ export const selectExecutionResultByRef = createMemoizedSelector((ref: ObjRef) =
  * @alpha
  */
 export const selectIsExecutionResultReadyForExportByRef = createMemoizedSelector((ref: ObjRef) =>
-    createSelector(selectExecutionResultByRef(ref), selectWidgetByRef(ref), (widgetExecution): boolean => {
-        if (!widgetExecution) {
-            return false;
-        }
+    createSelector(
+        selectExecutionResultByRef(ref),
+        selectAnalyticalWidgetByRef(ref),
+        (widgetExecution): boolean => {
+            if (!widgetExecution) {
+                return false;
+            }
 
-        const { isLoading, error, executionResult } = widgetExecution;
-        return !!executionResult && !isLoading && !isNonExportableError(error);
-    }),
+            const { isLoading, error, executionResult } = widgetExecution;
+            return !!executionResult && !isLoading && !isNonExportableError(error);
+        },
+    ),
 );
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021-2022 GoodData Corporation
+// (C) 2021 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { ObjRef, objRefToString } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -178,14 +178,10 @@ export const selectWidgetDrills = createMemoizedSelector((ref: ObjRef | undefine
  * @internal
  */
 export const selectAllFiltersForWidgetByRef = createMemoizedSelector((ref: ObjRef) => {
-    return createSelector(
-        selectAnalyticalWidgetByRef(ref),
-        selectFilterContextFilters,
-        (widget, dashboardFilters) => {
-            invariant(widget, `widget with ref ${objRefToString(ref)} does not exist in the state`);
-            return filterContextItemsToFiltersForWidget(dashboardFilters, widget);
-        },
-    );
+    return createSelector(selectWidgetByRef(ref), selectFilterContextFilters, (widget, dashboardFilters) => {
+        invariant(widget, `widget with ref ${objRefToString(ref)} does not exist in the state`);
+        return filterContextItemsToFiltersForWidget(dashboardFilters, widget);
+    });
 });
 
 const selectAllWidgets = createSelector(selectWidgetsMap, (widgetMap) => {

--- a/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/layout/layoutSelectors.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
 import { ObjRef, objRefToString } from "@gooddata/sdk-model";
 import invariant from "ts-invariant";
@@ -118,15 +118,34 @@ export const selectWidgetsMap = createSelector(selectLayout, (layout) => {
 });
 
 /**
- * Selects analytical widget by its ref. This selector will return undefined if the provided
- * widget ref is for a custom widget.
+ * Selects widget by its ref (including custom widgets).
  *
- * @deprecated use {@link selectAnalyticalWidgetByRef} instead; this selector will in near future to return all widget
- *  types - even custom widgets
+ * @remarks
+ * To limit the scope only to analytical widgets, use {@link selectAnalyticalWidgetByRef}.
+ *
  * @alpha
  */
 export const selectWidgetByRef = createMemoizedSelector((ref: ObjRef | undefined) =>
-    createSelector(selectWidgetsMap, (widgetMap) => {
+    createSelector(selectWidgetsMap, (widgetMap): ExtendedDashboardWidget | undefined => {
+        if (!ref) {
+            return undefined;
+        }
+
+        return widgetMap.get(ref);
+    }),
+);
+
+/**
+ * Selects analytical widget by its ref. This selector will return undefined if the provided
+ * widget ref is for a custom widget.
+ *
+ * @remarks
+ * To include custom widgets as well, use {@link selectWidgetByRef}.
+ *
+ * @alpha
+ */
+export const selectAnalyticalWidgetByRef = createMemoizedSelector((ref: ObjRef | undefined) =>
+    createSelector(selectWidgetsMap, (widgetMap): IWidget | undefined => {
         if (!ref) {
             return undefined;
         }
@@ -142,20 +161,12 @@ export const selectWidgetByRef = createMemoizedSelector((ref: ObjRef | undefined
 );
 
 /**
- * Selects analytical widget by its ref. This selector will return undefined if the provided
- * widget ref is for a custom widget.
- *
- * @alpha
- */
-export const selectAnalyticalWidgetByRef = selectWidgetByRef;
-
-/**
  * Selects widget drills by the widget ref.
  *
  * @alpha
  */
 export const selectWidgetDrills = createMemoizedSelector((ref: ObjRef | undefined) =>
-    createSelector(selectWidgetByRef(ref), (widget) => widget?.drills ?? []),
+    createSelector(selectAnalyticalWidgetByRef(ref), (widget) => widget?.drills ?? []),
 );
 
 /**
@@ -167,10 +178,14 @@ export const selectWidgetDrills = createMemoizedSelector((ref: ObjRef | undefine
  * @internal
  */
 export const selectAllFiltersForWidgetByRef = createMemoizedSelector((ref: ObjRef) => {
-    return createSelector(selectWidgetByRef(ref), selectFilterContextFilters, (widget, dashboardFilters) => {
-        invariant(widget, `widget with ref ${objRefToString(ref)} does not exist in the state`);
-        return filterContextItemsToFiltersForWidget(dashboardFilters, widget);
-    });
+    return createSelector(
+        selectAnalyticalWidgetByRef(ref),
+        selectFilterContextFilters,
+        (widget, dashboardFilters) => {
+            invariant(widget, `widget with ref ${objRefToString(ref)} does not exist in the state`);
+            return filterContextItemsToFiltersForWidget(dashboardFilters, widget);
+        },
+    );
 });
 
 const selectAllWidgets = createSelector(selectWidgetsMap, (widgetMap) => {

--- a/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/layoutTypes.ts
@@ -7,6 +7,7 @@ import {
     IDashboardLayoutSectionHeader,
     IDashboardLayoutSizeByScreenSize,
     IDashboardObjectIdentity,
+    IFilterableWidget,
     isWidget,
     IWidget,
     IWidgetDefinition,
@@ -31,7 +32,10 @@ export interface ICustomWidgetBase extends IBaseWidget {
  *
  * @public
  */
-export interface ICustomWidget extends ICustomWidgetBase, IDashboardObjectIdentity {}
+export interface ICustomWidget
+    extends ICustomWidgetBase,
+        IDashboardObjectIdentity,
+        Partial<IFilterableWidget> {}
 
 /**
  * Definition of custom widget. The definition may not specify identity. In that case a temporary identity
@@ -54,7 +58,7 @@ export interface ICustomWidgetDefinition extends ICustomWidgetBase, Partial<IDas
 export function newCustomWidget<TExtra = void>(
     identifier: string,
     customType: string,
-    extras?: TExtra,
+    extras?: TExtra & Partial<IFilterableWidget>,
 ): TExtra & ICustomWidget {
     const extrasCopy = extras ? cloneDeep(extras) : {};
 

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -26,6 +26,7 @@ import {
     IDashboardLayoutWidgetRenderer,
 } from "./DefaultDashboardLayoutRenderer";
 import { ObjRefMap } from "../../_staging/metadata/objRefMap";
+import { useDashboardComponentsContext } from "../dashboardContexts";
 
 function calculateWidgetMinHeight(
     widget: ExtendedDashboardWidget,
@@ -81,6 +82,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     const { item, screen, DefaultWidgetRenderer, onDrill, onFiltersChange, onError } = props;
     const insights = useDashboardSelector(selectInsightsMap);
     const settings = useDashboardSelector(selectSettings);
+    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
     // TODO: we should probably do something more meaningful when item has no widget; should that even
     //  be allowed? undefined widget will make things explode down the line away so..
     const widget = item.widget()!;
@@ -113,6 +115,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 onError={onError}
                 onFiltersChange={onFiltersChange}
                 widget={widget as ExtendedDashboardWidget}
+                ErrorComponent={ErrorComponent}
+                LoadingComponent={LoadingComponent}
             />
         </DefaultWidgetRenderer>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/index.ts
@@ -3,3 +3,4 @@ export * from "./useExportHandler";
 export * from "./useInsightExport";
 export * from "./useWidgetFilters";
 export * from "./useInsightWidgetDataView";
+export * from "./useCustomWidgetExecutionDataView";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/index.ts
@@ -4,3 +4,4 @@ export * from "./useInsightExport";
 export * from "./useWidgetFilters";
 export * from "./useInsightWidgetDataView";
 export * from "./useCustomWidgetExecutionDataView";
+export * from "./useCustomWidgetInsightDataView";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetExecutionDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetExecutionDataView.ts
@@ -1,0 +1,81 @@
+// (C) 2022 GoodData Corporation
+import {
+    DataViewFacade,
+    GoodDataSdkError,
+    IExecutionConfiguration,
+    UseCancelablePromiseState,
+    useExecutionDataView,
+} from "@gooddata/sdk-ui";
+
+import { ICustomWidget } from "../../../model";
+
+import { useWidgetFilters } from "./useWidgetFilters";
+
+/**
+ * Configuration options for the {@link useCustomWidgetExecutionDataView} hook.
+ *
+ * @beta
+ */
+export interface IUseCustomWidgetExecutionDataViewConfig {
+    /**
+     * Custom widget in the context of which the execution should be run. This affects which filters will be used.
+     */
+    widget: ICustomWidget;
+    /**
+     * Definition of the execution to execute (without filters). The filters will be filled automatically.
+     *
+     * Note: When the execution is not provided, hook is locked in a "pending" state.
+     */
+    execution?: Exclude<IExecutionConfiguration, "filters">;
+}
+
+/**
+ * This hook provides an easy way to read a data view from a custom widget. It resolves the appropriate filters
+ * for the widget based on the filters currently set on the whole dashboard.
+ *
+ * @beta
+ */
+export const useCustomWidgetExecutionDataView = ({
+    widget,
+    execution,
+}: IUseCustomWidgetExecutionDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> => {
+    const { result: filters, status: filtersStatus, error: filtersError } = useWidgetFilters(widget);
+    const { result, error, status } = useExecutionDataView({
+        execution: execution
+            ? {
+                  ...execution,
+                  filters,
+              }
+            : undefined,
+    });
+
+    if (!filtersStatus || status === "pending") {
+        return {
+            error: undefined,
+            result: undefined,
+            status: "pending",
+        };
+    }
+
+    if (filtersStatus === "running" || status === "loading") {
+        return {
+            error: undefined,
+            result: undefined,
+            status: "loading",
+        };
+    }
+
+    if (filtersError || error) {
+        return {
+            error: (error ?? filtersError)!,
+            result: undefined,
+            status: "error",
+        };
+    }
+
+    return {
+        error: undefined,
+        result: result!,
+        status: "success",
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
@@ -1,0 +1,141 @@
+// (C) 2022 GoodData Corporation
+import { useMemo } from "react";
+import { IInsightDefinition, insightSetFilters, isInsight, ObjRef } from "@gooddata/sdk-model";
+import {
+    DataViewFacade,
+    GoodDataSdkError,
+    useBackendStrict,
+    useCancelablePromise,
+    UseCancelablePromiseState,
+    useExecutionDataView,
+    useWorkspaceStrict,
+} from "@gooddata/sdk-ui";
+import stringify from "json-stable-stringify";
+
+import { ICustomWidget } from "../../../model";
+
+import { useWidgetFilters } from "./useWidgetFilters";
+
+/**
+ * Configuration options for the {@link useCustomWidgetInsightDataView} hook.
+ *
+ * @beta
+ */
+export interface IUseCustomWidgetInsightDataViewConfig {
+    /**
+     * Custom widget in the context of which the execution should be run. This affects which filters will be used.
+     */
+    widget: ICustomWidget;
+    /**
+     * Insight to execute or a reference to it. The filters will be automatically merged with the filters on the dashboard.
+     *
+     * Note: When the insight is not provided, hook is locked in a "pending" state.
+     */
+    insight?: IInsightDefinition | ObjRef;
+}
+
+/**
+ * This hook provides an easy way to read a data view for an insight from a custom widget.
+ * It resolves the appropriate filters for the widget based on the filters currently set on the whole dashboard.
+ *
+ * @beta
+ */
+export const useCustomWidgetInsightDataView = ({
+    widget,
+    insight,
+}: IUseCustomWidgetInsightDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> => {
+    const backend = useBackendStrict();
+    const workspace = useWorkspaceStrict();
+
+    const {
+        result: effectiveInsight,
+        error: insightError,
+        status: insightStatus,
+    } = useCancelablePromise(
+        {
+            promise: insight
+                ? async () => {
+                      return isInsight(insight)
+                          ? insight
+                          : backend
+                                .workspace(workspace)
+                                .insights()
+                                .getInsight(insight as ObjRef);
+                  }
+                : null,
+        },
+        [backend, workspace, insight],
+    );
+
+    const {
+        result: filters,
+        status: filtersStatus,
+        error: filtersError,
+    } = useWidgetFilters(
+        // only pass the widget in when the insight is ready to not start the filter query while the insight is loading
+        effectiveInsight ? widget : undefined,
+        effectiveInsight,
+    );
+
+    const insightWithAddedFilters = useMemo(
+        () => (effectiveInsight ? insightSetFilters(effectiveInsight, filters) : undefined),
+        [
+            effectiveInsight,
+            /**
+             * We use stringified value to avoid setting equal filters. This prevents cascading cache invalidation
+             * and expensive re-renders down the line. The stringification is worth it as the filters are usually
+             * pretty small thus saving more time than it is taking.
+             */
+            stringify(filters),
+        ],
+    );
+
+    const insightExecution = useMemo(() => {
+        return insightWithAddedFilters
+            ? backend.workspace(workspace).execution().forInsight(insightWithAddedFilters)
+            : undefined;
+    }, [backend, workspace, insightWithAddedFilters, widget]);
+
+    const { result, error, status } = useExecutionDataView({
+        execution: insightExecution,
+    });
+
+    // insight non-success status has precedence, other things cannot run without an insight
+    if (insightStatus !== "success") {
+        return {
+            error: insightError,
+            result: undefined,
+            status: insightStatus,
+        };
+    }
+
+    if (!filtersStatus || status === "pending") {
+        return {
+            error: undefined,
+            result: undefined,
+            status: "pending",
+        };
+    }
+
+    if (filtersStatus === "running" || status === "loading") {
+        return {
+            error: undefined,
+            result: undefined,
+            status: "loading",
+        };
+    }
+
+    if (filtersError || error) {
+        return {
+            error: (error ?? filtersError)!,
+            result: undefined,
+            status: "error",
+        };
+    }
+
+    return {
+        error: undefined,
+        result: result!,
+        status: "success",
+    };
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
@@ -4,7 +4,6 @@ import {
     DataViewFacade,
     GoodDataSdkError,
     useBackendStrict,
-    useCancelablePromise,
     UseCancelablePromiseState,
     useExecutionDataView,
     useWorkspaceStrict,
@@ -59,17 +58,11 @@ export function useInsightWidgetDataView(
         ],
     );
 
-    const insightWidgetExecutionPromise = useCancelablePromise(
-        {
-            promise:
-                insightWithAddedFilters && insightWidget
-                    ? async () => {
-                          return backend.workspace(workspace).execution().forInsight(insightWithAddedFilters);
-                      }
-                    : null,
-        },
-        [backend, workspace, insightWithAddedFilters, insightWidget],
-    );
+    const insightExecution = useMemo(() => {
+        return insightWithAddedFilters && insightWidget
+            ? backend.workspace(workspace).execution().forInsight(insightWithAddedFilters)
+            : undefined;
+    }, [backend, workspace, insightWithAddedFilters, insightWidget]);
 
-    return useExecutionDataView({ execution: insightWidgetExecutionPromise.result });
+    return useExecutionDataView({ execution: insightExecution });
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
@@ -10,7 +10,7 @@ import {
     useWorkspaceStrict,
 } from "@gooddata/sdk-ui";
 import { useMemo } from "react";
-import { IFilter, insightSetFilters } from "@gooddata/sdk-model";
+import { insightSetFilters } from "@gooddata/sdk-model";
 import stringify from "json-stable-stringify";
 import { selectInsightByRef, useDashboardSelector } from "../../../model";
 import { useWidgetFilters } from "./useWidgetFilters";
@@ -27,11 +27,6 @@ export interface IUseInsightWidgetDataView {
      * Note: When the insight widget is not provided, hook is locked in a "pending" state.
      */
     insightWidget?: IInsightWidget;
-
-    /**
-     * If specified, these filters will be used instead of the filters set on the insight.
-     */
-    insightFilterOverrides?: IFilter[];
 }
 
 /**
@@ -45,11 +40,11 @@ export interface IUseInsightWidgetDataView {
 export function useInsightWidgetDataView(
     config: IUseInsightWidgetDataView,
 ): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
-    const { insightWidget, insightFilterOverrides } = config;
+    const { insightWidget } = config;
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
     const insight = useDashboardSelector(selectInsightByRef(insightWidget?.insight));
-    const widgetFiltersPromise = useWidgetFilters(insightWidget, insightFilterOverrides);
+    const widgetFiltersPromise = useWidgetFilters(insightWidget);
 
     const insightWithAddedFilters = useMemo(
         () => insightSetFilters(insight!, widgetFiltersPromise.result),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useInsightWidgetDataView.ts
@@ -29,10 +29,9 @@ export interface IUseInsightWidgetDataView {
     insightWidget?: IInsightWidget;
 
     /**
-     * Additional filters to the data view. These additional filters are used alongside the
-     * filters used by the insight.
+     * If specified, these filters will be used instead of the filters set on the insight.
      */
-    additionalFilters?: IFilter[];
+    insightFilterOverrides?: IFilter[];
 }
 
 /**
@@ -46,11 +45,11 @@ export interface IUseInsightWidgetDataView {
 export function useInsightWidgetDataView(
     config: IUseInsightWidgetDataView,
 ): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
-    const { insightWidget, additionalFilters } = config;
+    const { insightWidget, insightFilterOverrides } = config;
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
     const insight = useDashboardSelector(selectInsightByRef(insightWidget?.insight));
-    const widgetFiltersPromise = useWidgetFilters(insightWidget, additionalFilters);
+    const widgetFiltersPromise = useWidgetFilters(insightWidget, insightFilterOverrides);
 
     const insightWithAddedFilters = useMemo(
         () => insightSetFilters(insight!, widgetFiltersPromise.result),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
@@ -1,11 +1,6 @@
 // (C) 2020-2021 GoodData Corporation
 import { useEffect, useMemo, useState } from "react";
-import {
-    FilterContextItem,
-    isDashboardAttributeFilter,
-    isInsightWidget,
-    IWidget,
-} from "@gooddata/sdk-backend-spi";
+import { FilterContextItem, isDashboardAttributeFilter, isInsightWidget } from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, filterObjRef, IFilter, ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import stringify from "json-stable-stringify";
@@ -16,6 +11,7 @@ import isEqual from "lodash/isEqual";
 import sortBy from "lodash/fp/sortBy";
 
 import {
+    ExtendedDashboardWidget,
     QueryProcessingStatus,
     queryWidgetFilters,
     selectFilterContextFilters,
@@ -33,7 +29,7 @@ import {
  * @alpha
  */
 export const useWidgetFilters = (
-    widget: IWidget | undefined,
+    widget: ExtendedDashboardWidget | undefined,
     filters?: IFilter[],
 ): {
     result?: IFilter[];
@@ -109,7 +105,7 @@ export const useWidgetFilters = (
  *
  * @param widget - widget to get the non-ignored filters for
  */
-function useNonIgnoredFilters(widget: IWidget | undefined) {
+function useNonIgnoredFilters(widget: ExtendedDashboardWidget | undefined) {
     const dashboardFilters = useDashboardSelector(selectFilterContextFilters);
     const widgetIgnoresDateFilter = !widget?.dateDataSet;
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
@@ -1,6 +1,12 @@
 // (C) 2020-2021 GoodData Corporation
 import { useEffect, useMemo, useState } from "react";
-import { FilterContextItem, isDashboardAttributeFilter, isInsightWidget } from "@gooddata/sdk-backend-spi";
+import {
+    FilterContextItem,
+    IInsightWidget,
+    IKpiWidget,
+    isDashboardAttributeFilter,
+    isInsightWidget,
+} from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, filterObjRef, IFilter, ObjRef } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import stringify from "json-stable-stringify";
@@ -12,6 +18,7 @@ import sortBy from "lodash/fp/sortBy";
 
 import {
     ExtendedDashboardWidget,
+    ICustomWidget,
     QueryProcessingStatus,
     queryWidgetFilters,
     selectFilterContextFilters,
@@ -23,19 +30,49 @@ import {
  * Hook for obtaining the effective filters for a widget.
  *
  * @param widget - widget to get effective filters for
- * @param filters - additional filters to apply
  * @returns set of filters that should be used to execute the given widget
  *
  * @alpha
  */
-export const useWidgetFilters = (
-    widget: ExtendedDashboardWidget | undefined,
-    filters?: IFilter[],
+export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined): {
+    result?: IFilter[];
+    status?: QueryProcessingStatus;
+    error?: GoodDataSdkError;
+};
+/**
+ * Hook for obtaining the effective filters for a widget.
+ *
+ * @param widget - widget to get effective filters for
+ * @param insightFilterOverrides - filters to use instead of the insight filters
+ * @returns set of filters that should be used to execute the given widget
+ *
+ * @alpha
+ */
+export function useWidgetFilters(
+    widget: IInsightWidget | undefined,
+    insightFilterOverrides?: IFilter[],
 ): {
     result?: IFilter[];
     status?: QueryProcessingStatus;
     error?: GoodDataSdkError;
-} => {
+};
+/**
+ * Hook for obtaining the effective filters for a widget.
+ *
+ * @param widget - widget to get effective filters for
+ * @param insightFilterOverrides - filters to use instead of the insight filters
+ * @returns set of filters that should be used to execute the given widget
+ *
+ * @alpha
+ */
+export function useWidgetFilters(
+    widget: ExtendedDashboardWidget | undefined,
+    insightFilterOverrides?: IFilter[],
+): {
+    result?: IFilter[];
+    status?: QueryProcessingStatus;
+    error?: GoodDataSdkError;
+} {
     const [effectiveFiltersState, setEffectiveFiltersState] = useState<{
         filters: IFilter[];
         filterQueryStatus?: QueryProcessingStatus;
@@ -85,9 +122,9 @@ export const useWidgetFilters = (
     // only run the "full" filters query if any of the non-ignored filters has changed
     useEffect(() => {
         if (widget && nonIgnoredFiltersStatus === "success") {
-            runFiltersQuery(widget, filters);
+            runFiltersQuery(widget, insightFilterOverrides);
         }
-    }, [widget, stringify(nonIgnoredFilters), filters, nonIgnoredFiltersStatus]);
+    }, [widget, stringify(nonIgnoredFilters), insightFilterOverrides, nonIgnoredFiltersStatus]);
 
     return {
         result: effectiveFiltersState.filters,
@@ -98,7 +135,7 @@ export const useWidgetFilters = (
         ),
         error: nonIgnoredFiltersError ?? error,
     };
-};
+}
 
 /**
  * Hook that retrieves the non-ignored dashboard level filters for a widget.

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
@@ -32,7 +32,7 @@ import {
  * @param widget - widget to get effective filters for
  * @returns set of filters that should be used to execute the given widget
  *
- * @alpha
+ * @public
  */
 export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined): {
     result?: IFilter[];
@@ -42,11 +42,15 @@ export function useWidgetFilters(widget: ICustomWidget | IKpiWidget | undefined)
 /**
  * Hook for obtaining the effective filters for a widget.
  *
+ * @remarks
+ * The filters returned should be used with {@link @gooddata/sdk-model#insightSetFilters} to obtain
+ * insight that is ready for execution.
+ *
  * @param widget - widget to get effective filters for
  * @param insightFilterOverrides - filters to use instead of the insight filters
  * @returns set of filters that should be used to execute the given widget
  *
- * @alpha
+ * @public
  */
 export function useWidgetFilters(
     widget: IInsightWidget | undefined,
@@ -63,7 +67,7 @@ export function useWidgetFilters(
  * @param insightFilterOverrides - filters to use instead of the insight filters
  * @returns set of filters that should be used to execute the given widget
  *
- * @alpha
+ * @public
  */
 export function useWidgetFilters(
     widget: ExtendedDashboardWidget | undefined,

--- a/libs/sdk-ui-dashboard/src/presentation/widget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/index.ts
@@ -3,6 +3,8 @@ export {
     useWidgetFilters,
     useCustomWidgetExecutionDataView,
     IUseCustomWidgetExecutionDataViewConfig,
+    useCustomWidgetInsightDataView,
+    IUseCustomWidgetInsightDataViewConfig,
 } from "./common";
 
 export * from "./insight";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/index.ts
@@ -1,5 +1,9 @@
 // (C) 2021 GoodData Corporation
-export { useWidgetFilters } from "./common";
+export {
+    useWidgetFilters,
+    useCustomWidgetExecutionDataView,
+    IUseCustomWidgetExecutionDataViewConfig,
+} from "./common";
 
 export * from "./insight";
 export * from "./insightMenu";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback, useMemo, useState, CSSProperties } from "react";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { createSelector } from "@reduxjs/toolkit";
-import { insightFilters, insightSetFilters, insightVisualizationUrl } from "@gooddata/sdk-model";
+import { insightSetFilters, insightVisualizationUrl } from "@gooddata/sdk-model";
 import {
     GoodDataSdkError,
     IPushData,
@@ -91,7 +91,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
         result: filtersForInsight,
         status: filtersStatus,
         error: filtersError,
-    } = useWidgetFilters(widget, insight && insightFilters(insight));
+    } = useWidgetFilters(widget, insight);
 
     const insightWithAddedFilters = useMemo(
         () => insightSetFilters(insight, filtersForInsight),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
@@ -24,7 +24,6 @@ export const DashboardKpiCore = (props: IDashboardKpiProps): JSX.Element => {
     const {
         kpiWidget,
         alert,
-        filters,
         onFiltersChange,
         onDrill,
         onError,
@@ -53,7 +52,6 @@ export const DashboardKpiCore = (props: IDashboardKpiProps): JSX.Element => {
     const kpiData = useKpiData({
         kpiWidget,
         backend,
-        filters,
         dashboardFilters,
         workspace,
     });

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useKpiData.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useKpiData.ts
@@ -25,12 +25,10 @@ import invariant from "ts-invariant";
 import { filterContextItemsToFiltersForWidget } from "../../../../converters";
 import { IDashboardFilter } from "../../../../types";
 import { useWidgetFilters } from "../../common";
-import { useMemo } from "react";
 
 interface IUseKpiDataConfig {
     kpiWidget?: IKpiWidget;
     dashboardFilters: FilterContextItem[];
-    filters?: FilterContextItem[];
     backend?: IAnalyticalBackend;
     workspace?: string;
     onError?: OnError;
@@ -48,7 +46,6 @@ interface IUseKpiDataResult {
  */
 export function useKpiData({
     kpiWidget,
-    filters,
     dashboardFilters,
     backend,
     workspace,
@@ -56,12 +53,7 @@ export function useKpiData({
     const effectiveBackend = useBackendStrict(backend);
     const effectiveWorkspace = useWorkspaceStrict(workspace);
 
-    const convertedFilters = useMemo(
-        () => filters && kpiWidget && filterContextItemsToFiltersForWidget(filters, kpiWidget),
-        [filters, kpiWidget],
-    );
-
-    const { status, result } = useWidgetFilters(kpiWidget, convertedFilters);
+    const { status, result } = useWidgetFilters(kpiWidget);
 
     // we only put IDashboardFilters in, so we must get IDashboardFilters out as well
     const effectiveFilters = result as IDashboardFilter[] | undefined;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/types.ts
@@ -55,6 +55,7 @@ export interface IDashboardKpiProps {
     /**
      * Optionally, specify filters to be applied to the KPI.
      *
+     * @deprecated Do not use, made part of the public API by accident. Will do nothing.
      * @public
      */
     filters?: FilterContextItem[];

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/types.ts
@@ -64,14 +64,14 @@ export interface IDashboardWidgetProps {
      *
      * @alpha
      */
-    ErrorComponent?: ComponentType<IErrorProps>;
+    ErrorComponent: ComponentType<IErrorProps>;
 
     /**
      * Loading component to use while loading and preparing data to render.
      *
      * @alpha
      */
-    LoadingComponent?: ComponentType<ILoadingProps>;
+    LoadingComponent: ComponentType<ILoadingProps>;
 
     /**
      * @alpha


### PR DESCRIPTION
Now custom widgets can choose to implement the `IFilterableWidget` interface, imitating how standard widgets specify 
* attribute filters to ignore
* date dataset to use for date filters

To leverage this, the `useWidgetFilters` was marked as public and its API made more precise.
Also, two new hooks were added to improve the DX there:
* `useCustomWidgetExecutionDataView` for freeform execution
* `useCustomWidgetInsightDataView` for inisght execution

The `IDashboardKpiProps.filters` prop was deprecated and ignored in code (it is a remnant of DashboardView).
The payload of `QueryInsightWidgetFilters` was improved for naming and the overrides only allowed for InsightWidgets (it makes very little sense for Kpi- and CustomWidgets).

`selectWidgetByRef` semantics  were changed so that it returns custom widgets as well.

The `ErrorComponent` and `LoadingComponent` of the `IDashboardWidgetProps` type were made mandatory to make them easier to use (similarly as was done in #2149 for insights).

The Dashboard example with Local plugin was extended to showcase the new hook and `IFilterableWidget` props.

There were some simplifications done in the `queryWidgetFilters` service to make the code less redundant and more to-the-point.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
