### PR TITLE
Custom Node.js SDK factory

### DIFF
--- a/libs/api-client-bear/src/gooddata-custom.ts
+++ b/libs/api-client-bear/src/gooddata-custom.ts
@@ -1,0 +1,21 @@
+// (C) 2007-2022 GoodData Corporation
+
+import fetchCookie from "fetch-cookie";
+import nodeFetch from "node-fetch";
+
+import { factory, SDK } from "./gooddata";
+
+const factoryNode = (config?: any) => factory(fetchCookie(nodeFetch as any))(config);
+
+// Fetch requests will be sent through the node-fetch wrapped by the fetch-cookie.
+// This is necessary in order to preserve cookies between requests like it would be
+// done in the browser environment. Otherwise the SDK would forget about authentication
+// immediately.
+// Factory always reinitializes fetch-cookie. This way, when factory initialization
+// happens between requests, new instance of fetch-cookie and uderlying cookie jar
+// will be used.
+export { factoryNode as factory, SDK };
+
+export * from "./api";
+
+export default factoryNode();

--- a/libs/api-client-bear/tsconfig.build.json
+++ b/libs/api-client-bear/tsconfig.build.json
@@ -1,6 +1,11 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/gooddata-node.ts", "src/gooddata-browser.ts", "src/typings.d.ts"],
+    "include": [
+        "src/gooddata-node.ts",
+        "src/gooddata-browser.ts",
+        "src/gooddata-custom.ts",
+        "src/typings.d.ts"
+    ],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null,


### PR DESCRIPTION
In order to always reinitialize fetch-cookie when creating a new SDK instance while using Node.js, we need to wrap factory into a function. Changes are encapsulated in a separate entry file.

JIRA: TNT-418

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
