### PR TITLE
Introduce getFactory for Node.js

### DIFF
--- a/libs/api-client-bear/src/gooddata-browser.ts
+++ b/libs/api-client-bear/src/gooddata-browser.ts
@@ -1,14 +1,19 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import { factory, SDK } from "./gooddata";
 
+const getFactoryBrowser = (config?: any) => factory(fetch.bind(window))(config);
+
+/**
+ * @deprecated use getFactory instead
+ */
 const factoryBrowser = factory(fetch.bind(window));
 
 // Fetch requests will be sent through the isomorphic-fetch. Our authentication
 // relies on cookies, so it will work in browser environment automatically.
 
 // For node see `gooddata-node.js` file.
-export { factoryBrowser as factory, SDK };
+export { factoryBrowser as factory, getFactoryBrowser as getFactory, SDK };
 export * from "./api";
 
 export default factoryBrowser();

--- a/libs/api-client-bear/src/gooddata-node.ts
+++ b/libs/api-client-bear/src/gooddata-node.ts
@@ -1,17 +1,25 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 import fetchCookie from "fetch-cookie";
 import nodeFetch from "node-fetch";
 
 import { factory, SDK } from "./gooddata";
 
+// Calling getFactoryNode always reinitializes fetch-cookie. This way, when factory
+// initialization happens between requests, new instance of fetch-cookie and uderlying
+// cookie jar will be used.
+const getFactoryNode = (config?: any) => factory(fetchCookie(nodeFetch as any))(config);
+
+/**
+ * @deprecated use getFactory instead
+ */
 const factoryNode = factory(fetchCookie(nodeFetch as any));
 
 // Fetch requests will be sent through the node-fetch wrapped by the fetch-cookie.
 // This is necessary in order to preserve cookies between requests like it would be
 // done in the browser environment. Otherwise the SDK would forget about authentication
 // immediately.
-export { factoryNode as factory, SDK };
+export { factoryNode as factory, getFactoryNode as getFactory, SDK };
 
 export * from "./api";
 

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { factory as createSdk, SDK } from "@gooddata/api-client-bear";
 import {
     IAnalyticalBackendConfig,
@@ -124,6 +124,13 @@ type LegacyFunctionsSubscription = {
 };
 
 /**
+ * Provides a way to use custom factory for creating SDK instances.
+ */
+type FactoryFunction = {
+    factory?: (config?: any) => SDK;
+};
+
+/**
  * This implementation of analytical backend uses the gooddata-js API client to realize the SPI.
  *
  * The only thing worth noting about this impl is the handling of SDK instance creation and authentication:
@@ -151,7 +158,7 @@ export class BearBackend implements IAnalyticalBackend {
 
     constructor(
         config?: IAnalyticalBackendConfig,
-        implConfig?: BearBackendConfig & LegacyFunctionsSubscription,
+        implConfig?: BearBackendConfig & LegacyFunctionsSubscription & FactoryFunction,
         telemetry?: TelemetryData,
         authProvider?: IAuthProviderCallGuard,
     ) {
@@ -435,10 +442,10 @@ function telemetrySanitize(telemetry?: TelemetryData): TelemetryData {
 
 function newSdkInstance(
     config: IAnalyticalBackendConfig,
-    implConfig: BearBackendConfig,
+    implConfig: BearBackendConfig & FactoryFunction,
     telemetry: TelemetryData,
 ): SDK {
-    const sdk = createSdk();
+    const sdk = implConfig.factory ? implConfig.factory() : createSdk();
 
     if (config.hostname) {
         sdk.config.setCustomDomain(config.hostname);


### PR DESCRIPTION
AbstractFactory may be used in cases when fetch-cookie needs to be reinitialized while creating a new SDK instance.

JIRA: TNT-418

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
