### PR TITLE
Revert "Enable incremental unit test optimization"

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -24,7 +24,7 @@ EXTERNAL_FILES_CHANGED=$(git diff --name-only "$ZUUL_BRANCH...HEAD" | grep -Ev '
 
 if [ -z "$EXTERNAL_FILES_CHANGED" ]; then
   echo 'Changes are only in code files, we can make the testing smarter'
-  RUSH_SPECS="--impacted-by git:$ZUUL_BRANCH"
+  RUSH_SPECS=" --impacted-by git:$ZUUL_BRANCH"
   echo "The rush commands would be limited by the following limiter: $RUSH_SPECS"
 else
   echo 'There are some files modified outside of the code:'
@@ -103,7 +103,7 @@ RC=1
   fi
 
   if [ $RC -eq 0 ]; then
-    $_RUSH validate-ci $RUSH_SPECS
+    $_RUSH validate-ci
     RC=$?
   fi
 
@@ -113,7 +113,7 @@ RC=1
     # per-project basis.
     #
 
-    $_RUSH test-ci --parallelism 4 $RUSH_SPECS
+    $_RUSH test-ci --parallelism 4
     RC=$?
   fi
 


### PR DESCRIPTION
This reverts commit abef00883cd433bd1713a7769c1f94ef40e48b58.

Turns out there is a problem with the CI git version. Disabling for now.

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
