### PR TITLE
RELATED: FET-955 fix and re-enable incremental tests

### DIFF
--- a/common/scripts/ci/docker_apidocs_build.sh
+++ b/common/scripts/ci/docker_apidocs_build.sh
@@ -6,7 +6,7 @@ ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 # go one level up to "see" the gooddata-ui-apidocs too
 ROOT_DIR="$ROOT_DIR/.."
 
-IMAGE="node:16.13.0"
+IMAGE="node:16.13.0-bullseye"
 
 echo "Running apidocs build using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_examples.sh
+++ b/common/scripts/ci/docker_examples.sh
@@ -5,7 +5,7 @@ set -o pipefail
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0"
+IMAGE="node:16.13.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rush.sh
+++ b/common/scripts/ci/docker_rush.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0"
+IMAGE="node:16.13.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/docker_rushx.sh
+++ b/common/scripts/ci/docker_rushx.sh
@@ -3,7 +3,7 @@
 # Absolute root directory - for volumes
 ROOT_DIR=$(echo $(cd $(dirname "${BASH_SOURCE[0]}")/../../.. && pwd -P))
 
-IMAGE="node:16.13.0"
+IMAGE="node:16.13.0-bullseye"
 
 echo "Running \"$*\" using ${IMAGE} in root directory ${ROOT_DIR}"
 

--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -24,7 +24,7 @@ EXTERNAL_FILES_CHANGED=$(git diff --name-only "$ZUUL_BRANCH...HEAD" | grep -Ev '
 
 if [ -z "$EXTERNAL_FILES_CHANGED" ]; then
   echo 'Changes are only in code files, we can make the testing smarter'
-  RUSH_SPECS=" --impacted-by git:$ZUUL_BRANCH"
+  RUSH_SPECS="--impacted-by git:$ZUUL_BRANCH"
   echo "The rush commands would be limited by the following limiter: $RUSH_SPECS"
 else
   echo 'There are some files modified outside of the code:'
@@ -33,7 +33,6 @@ else
   RUSH_SPECS=''
 fi
 
-# TODO pass $RUSH_SPECS to validate-ci and test-ci like $_RUSH validate-ci $RUSH_SPECS
 # always install and build everything, just in case
 # once we are confident this works well
 
@@ -103,7 +102,7 @@ RC=1
   fi
 
   if [ $RC -eq 0 ]; then
-    $_RUSH validate-ci
+    $_RUSH validate-ci $RUSH_SPECS
     RC=$?
   fi
 
@@ -113,7 +112,7 @@ RC=1
     # per-project basis.
     #
 
-    $_RUSH test-ci --parallelism 4
+    $_RUSH test-ci $RUSH_SPECS --parallelism 4
     RC=$?
   fi
 

--- a/libs/sdk-backend-tiger/.gitignore
+++ b/libs/sdk-backend-tiger/.gitignore
@@ -1,0 +1,1 @@
+.wiremock_containerid


### PR DESCRIPTION
Use the bullseye-based Node docker image for the Rush runs.
We need the newer Debian base to have recent-enough git needed
for the advanced Rush features (--impacted-by git:something paramter).

I stuck with Debian (not switching to Alpine for example), as the previously used image was also Debian so let's keep the changes minimal.

Also add  .wiremock_containerid to gitignore in tiger (it was already ignored in bear). 

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
