### PR TITLE
RELATED: FET-955 Remove the testing logs in the unit tests script

### DIFF
--- a/common/scripts/ci/run_unit_tests.sh
+++ b/common/scripts/ci/run_unit_tests.sh
@@ -9,10 +9,6 @@ export WIREMOCK_NET="wiremock-sdk-ui-${RANDOM}"
 
 _RUSH="${DIR}/docker_rush.sh"
 
-# ---------------------------------------------------------------------
-# START: testing mechanisms for incremental tests
-# ---------------------------------------------------------------------
-
 echo 'Evaluating possible incremental test/validation optimizations'
 
 # if there are any changes outside examples, libs, and tools, we must re-test everything as these often mean
@@ -25,20 +21,12 @@ EXTERNAL_FILES_CHANGED=$(git diff --name-only "$ZUUL_BRANCH...HEAD" | grep -Ev '
 if [ -z "$EXTERNAL_FILES_CHANGED" ]; then
   echo 'Changes are only in code files, we can make the testing smarter'
   RUSH_SPECS="--impacted-by git:$ZUUL_BRANCH"
-  echo "The rush commands would be limited by the following limiter: $RUSH_SPECS"
 else
   echo 'There are some files modified outside of the code:'
   echo "$EXTERNAL_FILES_CHANGED"
   echo 'Falling back to testing everything...'
   RUSH_SPECS=''
 fi
-
-# always install and build everything, just in case
-# once we are confident this works well
-
-# ---------------------------------------------------------------------
-# END: testing mechanisms for incremental tests
-# ---------------------------------------------------------------------
 
 # ---------------------------------------------------------------------
 # Support for starting wiremock on a dedicated docker network
@@ -97,6 +85,7 @@ RC=1
   RC=$?
 
   if [ $RC -eq 0 ]; then
+    # always install and build everything, just in case
     $_RUSH build
     RC=$?
   fi


### PR DESCRIPTION
Now that the incremental tests are run for real, remove some obsolete
comments and echos.

JIRA: FET-955

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
