### PR TITLE
RELATED: RAIL-3987 Improve typings around useDashboardQueryProcessing

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -45,7 +45,7 @@ const simpleCurrencyFormatter = new Intl.NumberFormat("en-US", {
  * then that data will be available in the `widget` prop.
  */
 const MyCustomWidget: CustomDashboardWidgetComponent = ({ widget, LoadingComponent, ErrorComponent }) => {
-    const { result, status, error } = useCustomWidgetExecutionDataView({
+    const dataViewTask = useCustomWidgetExecutionDataView({
         widget: widget as ICustomWidget,
         execution: {
             seriesBy: [Md.$TotalSales, Md.$FranchisedSales],
@@ -53,15 +53,15 @@ const MyCustomWidget: CustomDashboardWidgetComponent = ({ widget, LoadingCompone
         },
     });
 
-    if (status === "pending" || status === "loading") {
+    if (dataViewTask.status === "pending" || dataViewTask.status === "loading") {
         return <LoadingComponent />;
     }
 
-    if (status === "error") {
-        return <ErrorComponent message={error?.message ?? "Unknown error"} />;
+    if (dataViewTask.status === "error") {
+        return <ErrorComponent message={dataViewTask.error.message ?? "Unknown error"} />;
     }
 
-    const data = result!
+    const data = dataViewTask.result
         .data()
         .slices()
         .toArray()

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -208,7 +208,7 @@ export interface AddSectionItems extends IDashboardCommand {
 export type AlertsState = EntityState<IWidgetAlert>;
 
 // @internal
-export type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type AllQueryCacheReducers<TQuery extends IDashboardQuery, TResult> = {
     set: QueryCacheReducer<TQuery, TResult, QueryCacheEntry<TQuery, TResult>>;
     remove: QueryCacheReducer<TQuery, TResult, string>;
     removeAll: QueryCacheReducer<TQuery, TResult, void>;
@@ -1356,7 +1356,7 @@ export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
 export type DashboardQueries = QueryInsightDateDatasets | QueryInsightAttributesMeta | QueryWidgetFilters | QueryWidgetBrokenAlerts;
 
 // @alpha
-export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult> extends IDashboardEvent {
+export interface DashboardQueryCompleted<TQuery extends IDashboardQuery, TResult> extends IDashboardEvent {
     // (undocumented)
     readonly payload: {
         readonly query: TQuery;
@@ -2334,13 +2334,13 @@ export interface IDashboardProps extends IDashboardBaseProps, IDashboardExtensio
 }
 
 // @alpha
-export interface IDashboardQuery<_TResult = any> {
+export interface IDashboardQuery {
     readonly correlationId?: string;
     readonly type: DashboardQueryType;
 }
 
 // @internal
-export interface IDashboardQueryService<TQuery extends IDashboardQuery<TResult>, TResult> {
+export interface IDashboardQueryService<TQuery extends IDashboardQuery, TResult> {
     // (undocumented)
     cache?: QueryCache<TQuery, TResult>;
     // (undocumented)
@@ -3299,7 +3299,7 @@ export type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerA
 export function queryAndWaitFor<TQuery extends DashboardQueries, TQueryResult>(dispatch: DashboardDispatch, query: TQuery): Promise<TQueryResult>;
 
 // @internal
-export type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type QueryCache<TQuery extends IDashboardQuery, TResult> = {
     cacheName: string;
     reducer: Reducer<EntityState<QueryCacheEntry<TQuery, TResult>>>;
     actions: QueryActions<TQuery, TResult>;
@@ -3308,7 +3308,7 @@ export type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
 };
 
 // @internal
-export type QueryCacheEntry<TQuery extends IDashboardQuery<TResult>, TResult> = QueryCacheEntryResult<TResult> & {
+export type QueryCacheEntry<TQuery extends IDashboardQuery, TResult> = QueryCacheEntryResult<TResult> & {
     query: TQuery;
 };
 
@@ -3320,7 +3320,7 @@ export type QueryCacheEntryResult<TResult> = {
 };
 
 // @internal
-export type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, TPayload> = CaseReducer<EntityState<QueryCacheEntry<TQuery, TResult>>, PayloadAction<TPayload>>;
+export type QueryCacheReducer<TQuery extends IDashboardQuery, TResult, TPayload> = CaseReducer<EntityState<QueryCacheEntry<TQuery, TResult>>, PayloadAction<TPayload>>;
 
 // @alpha
 export function queryDateDatasetsForInsight(insightOrRef: ObjRef | IInsight, correlationId?: string): QueryInsightDateDatasets;
@@ -3329,7 +3329,7 @@ export function queryDateDatasetsForInsight(insightOrRef: ObjRef | IInsight, cor
 export function queryDateDatasetsForMeasure(measureRef: ObjRef, correlationId?: string): QueryMeasureDateDatasets;
 
 // @alpha
-export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
+export interface QueryInsightAttributesMeta extends IDashboardQuery {
     // (undocumented)
     readonly payload: {
         readonly insightOrRef: ObjRef | IInsight;
@@ -3342,7 +3342,7 @@ export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttri
 export function queryInsightAttributesMeta(insightOrRef: ObjRef | IInsight, correlationId?: string): QueryInsightAttributesMeta;
 
 // @alpha
-export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDatasets> {
+export interface QueryInsightDateDatasets extends IDashboardQuery {
     // (undocumented)
     readonly payload: {
         readonly insightOrRef: ObjRef | IInsight;
@@ -3352,7 +3352,7 @@ export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDat
 }
 
 // @alpha
-export interface QueryMeasureDateDatasets extends IDashboardQuery<MeasureDateDatasets> {
+export interface QueryMeasureDateDatasets extends IDashboardQuery {
     // (undocumented)
     readonly payload: {
         readonly measureRef: ObjRef;
@@ -3403,7 +3403,7 @@ export type QueryProcessingSuccessState<TResult> = {
 };
 
 // @alpha
-export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFilterBasicInfo[]> {
+export interface QueryWidgetBrokenAlerts extends IDashboardQuery {
     // (undocumented)
     readonly payload: {
         readonly widgetRef: ObjRef;
@@ -3416,7 +3416,7 @@ export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFil
 export function queryWidgetBrokenAlerts(widgetRef: ObjRef, correlationId?: string): QueryWidgetBrokenAlerts;
 
 // @alpha
-export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
+export interface QueryWidgetFilters extends IDashboardQuery {
     // (undocumented)
     readonly payload: {
         readonly widgetRef: ObjRef;

--- a/libs/sdk-ui-dashboard/src/model/events/general.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/general.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardEvent } from "./base";
 import { DashboardContext } from "../types/commonTypes";
@@ -321,8 +321,7 @@ export const isDashboardQueryStarted = eventGuard<DashboardQueryStarted>("GDC.DA
  *
  * @alpha
  */
-export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>, TResult>
-    extends IDashboardEvent {
+export interface DashboardQueryCompleted<TQuery extends IDashboardQuery, TResult> extends IDashboardEvent {
     readonly type: "GDC.DASH/EVT.QUERY.COMPLETED";
     readonly payload: {
         readonly query: TQuery;
@@ -330,7 +329,7 @@ export interface DashboardQueryCompleted<TQuery extends IDashboardQuery<TResult>
     };
 }
 
-export function queryCompleted<TQuery extends IDashboardQuery<TResult>, TResult>(
+export function queryCompleted<TQuery extends IDashboardQuery, TResult>(
     ctx: DashboardContext,
     query: TQuery,
     result: TResult,

--- a/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
@@ -168,8 +168,8 @@ export class HeadlessDashboard {
      *
      * @param action - query action
      */
-    public query<TResult>(action: IDashboardQuery<TResult>): Promise<TResult> {
-        const { envelope, promise } = queryEnvelopeWithPromise(action);
+    public query<TQueryResult>(action: IDashboardQuery): Promise<TQueryResult> {
+        const { envelope, promise } = queryEnvelopeWithPromise<any, TQueryResult>(action);
         this.reduxedStore.store.dispatch(envelope);
         return promise;
     }

--- a/libs/sdk-ui-dashboard/src/model/queries/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/base.ts
@@ -28,10 +28,3 @@ export interface IDashboardQuery<_TResult = any> {
      */
     readonly correlationId?: string;
 }
-
-/**
- * Utility type to extract the type of the {@link IDashboardQuery} result.
- *
- * @alpha
- */
-export type IDashboardQueryResult<T> = T extends IDashboardQuery<infer TResult> ? TResult : never;

--- a/libs/sdk-ui-dashboard/src/model/queries/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/base.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 /**
  * @alpha
@@ -16,7 +16,7 @@ export type DashboardQueryType =
  *
  * @alpha
  */
-export interface IDashboardQuery<_TResult = any> {
+export interface IDashboardQuery {
     /**
      * Query type. Always starts with "GDC.DASH/QUERY".
      */

--- a/libs/sdk-ui-dashboard/src/model/queries/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/index.ts
@@ -3,7 +3,7 @@
 import { QueryInsightAttributesMeta, QueryInsightDateDatasets } from "./insights";
 import { QueryWidgetBrokenAlerts, QueryWidgetFilters } from "./widgets";
 
-export { IDashboardQuery, DashboardQueryType, IDashboardQueryResult } from "./base";
+export { IDashboardQuery, DashboardQueryType } from "./base";
 export {
     QueryInsightDateDatasets,
     InsightDateDatasets,
@@ -15,7 +15,7 @@ export {
 } from "./insights";
 export { QueryMeasureDateDatasets, queryDateDatasetsForMeasure, MeasureDateDatasets } from "./kpis";
 export {
-    QueryWidgetFilters as QueryInsightWidgetFilters,
+    QueryWidgetFilters,
     queryWidgetFilters,
     QueryWidgetBrokenAlerts,
     queryWidgetBrokenAlerts,

--- a/libs/sdk-ui-dashboard/src/model/queries/insights.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/insights.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IDashboardQuery } from "./base";
 import { IInsight, InsightDisplayFormUsage, ObjRef } from "@gooddata/sdk-model";
 import {
@@ -13,7 +13,7 @@ import {
  *
  * @alpha
  */
-export interface QueryInsightDateDatasets extends IDashboardQuery<InsightDateDatasets> {
+export interface QueryInsightDateDatasets extends IDashboardQuery {
     readonly type: "GDC.DASH/QUERY.INSIGHT.DATE.DATASETS";
     readonly payload: {
         readonly insightOrRef: ObjRef | IInsight;
@@ -144,7 +144,7 @@ export function insightSelectDateDataset(queryResult: InsightDateDatasets): ICat
  *
  * @alpha
  */
-export interface QueryInsightAttributesMeta extends IDashboardQuery<InsightAttributesMeta> {
+export interface QueryInsightAttributesMeta extends IDashboardQuery {
     readonly type: "GDC.DASH/QUERY.INSIGHT.ATTRIBUTE.META";
     readonly payload: {
         readonly insightOrRef: ObjRef | IInsight;

--- a/libs/sdk-ui-dashboard/src/model/queries/kpis.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/kpis.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IDashboardQuery } from "./base";
 import { ObjRef } from "@gooddata/sdk-model";
 import { ICatalogDateDataset } from "@gooddata/sdk-backend-spi";
@@ -9,7 +9,7 @@ import { ICatalogDateDataset } from "@gooddata/sdk-backend-spi";
  *
  * @alpha
  */
-export interface QueryMeasureDateDatasets extends IDashboardQuery<MeasureDateDatasets> {
+export interface QueryMeasureDateDatasets extends IDashboardQuery {
     readonly type: "GDC.DASH/QUERY.MEASURE.DATE.DATASETS";
     readonly payload: {
         readonly measureRef: ObjRef;

--- a/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/widgets.ts
@@ -1,7 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
-import { IFilter, IInsightDefinition, ObjRef } from "@gooddata/sdk-model";
-import { IBrokenAlertFilterBasicInfo } from "../types/alertTypes";
+import { IInsightDefinition, ObjRef } from "@gooddata/sdk-model";
 import { IDashboardQuery } from "./base";
 
 /**
@@ -12,7 +11,7 @@ import { IDashboardQuery } from "./base";
  *
  * @alpha
  */
-export interface QueryWidgetFilters extends IDashboardQuery<IFilter[]> {
+export interface QueryWidgetFilters extends IDashboardQuery {
     readonly type: "GDC.DASH/QUERY.WIDGET.FILTERS";
     readonly payload: {
         readonly widgetRef: ObjRef;
@@ -51,7 +50,7 @@ export function queryWidgetFilters(
  * In case any broken alert filters query return empty array.
  * @alpha
  */
-export interface QueryWidgetBrokenAlerts extends IDashboardQuery<IBrokenAlertFilterBasicInfo[]> {
+export interface QueryWidgetBrokenAlerts extends IDashboardQuery {
     readonly type: "GDC.DASH/QUERY.WIDGET.BROKEN_ALERTS";
     readonly payload: {
         readonly widgetRef: ObjRef;

--- a/libs/sdk-ui-dashboard/src/model/react/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/index.ts
@@ -8,7 +8,17 @@ export {
 export { IDashboardEventsContext, useDashboardEventsContext } from "./DashboardEventsContext";
 export { useDashboardCommandProcessing, CommandProcessingStatus } from "./useDashboardCommandProcessing";
 export { useDashboardEventDispatch } from "./useDashboardEventDispatch";
-export { useDashboardQueryProcessing, QueryProcessingStatus } from "./useDashboardQueryProcessing";
+export {
+    useDashboardQueryProcessing,
+    QueryProcessingStatus,
+    QueryProcessingErrorState,
+    QueryProcessingPendingState,
+    QueryProcessingRejectedState,
+    QueryProcessingRunningState,
+    QueryProcessingState,
+    QueryProcessingSuccessState,
+    UseDashboardQueryProcessingResult,
+} from "./useDashboardQueryProcessing";
 export { useDashboardUserInteraction } from "./useDashboardUserInteraction";
 export { useDashboardAsyncRender, UseDashboardAsyncRender } from "./useDashboardAsyncRender";
 export { IDashboardStoreProviderProps } from "./types";

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryAndWaitFor.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryAndWaitFor.ts
@@ -1,6 +1,6 @@
 // (C) 2021 GoodData Corporation
 
-import { DashboardQueries, IDashboardQueryResult } from "../../queries";
+import { DashboardQueries } from "../../queries";
 import { DashboardDispatch } from "../types";
 import { queryEnvelopeWithPromise } from "./queryProcessing";
 
@@ -12,11 +12,11 @@ import { queryEnvelopeWithPromise } from "./queryProcessing";
  * @returns Promise of the query result
  * @alpha
  */
-export async function queryAndWaitFor<TQuery extends DashboardQueries>(
+export async function queryAndWaitFor<TQuery extends DashboardQueries, TQueryResult>(
     dispatch: DashboardDispatch,
     query: TQuery,
-): Promise<IDashboardQueryResult<TQuery>> {
-    const { promise, envelope } = queryEnvelopeWithPromise(query);
+): Promise<TQueryResult> {
+    const { promise, envelope } = queryEnvelopeWithPromise<TQuery, TQueryResult>(query);
 
     dispatch(envelope);
 

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryCall.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryCall.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardQuery } from "../../queries";
 import { queryEnvelopeWithPromise } from "./queryProcessing";
@@ -33,6 +33,6 @@ export function* query<TQuery extends IDashboardQuery, TQueryResult>(
  *
  * @param q - query to run
  */
-export function* queryFresh<TResult>(q: IDashboardQuery<TResult>): SagaIterator<TResult> {
+export function* queryFresh<TResult>(q: IDashboardQuery): SagaIterator<TResult> {
     return yield call(query, q, true);
 }

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryCall.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryCall.ts
@@ -11,9 +11,12 @@ import { SagaIterator } from "redux-saga";
  * @param q - query to run
  * @param refresh - indicates whether the query should ignore cached results and re-load data from backend
  */
-export function* query<TResult>(q: IDashboardQuery<TResult>, refresh = false): SagaIterator<TResult> {
-    const { promise, envelope } = queryEnvelopeWithPromise(q, refresh);
-    const waitForResult = (): Promise<TResult> => {
+export function* query<TQuery extends IDashboardQuery, TQueryResult>(
+    q: TQuery,
+    refresh = false,
+): SagaIterator<TQueryResult> {
+    const { promise, envelope } = queryEnvelopeWithPromise<TQuery, TQueryResult>(q, refresh);
+    const waitForResult = () => {
         return promise;
     };
 

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryService.ts
@@ -53,10 +53,7 @@ export type QueryCacheEntryResult<TResult> = {
  *
  * @internal
  */
-export type QueryCacheEntry<
-    TQuery extends IDashboardQuery<TResult>,
-    TResult,
-> = QueryCacheEntryResult<TResult> & {
+export type QueryCacheEntry<TQuery extends IDashboardQuery, TResult> = QueryCacheEntryResult<TResult> & {
     query: TQuery;
 };
 
@@ -66,7 +63,7 @@ export type QueryCacheEntry<
  *
  * @internal
  */
-export type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, TPayload> = CaseReducer<
+export type QueryCacheReducer<TQuery extends IDashboardQuery, TResult, TPayload> = CaseReducer<
     EntityState<QueryCacheEntry<TQuery, TResult>>,
     PayloadAction<TPayload>
 >;
@@ -76,7 +73,7 @@ export type QueryCacheReducer<TQuery extends IDashboardQuery<TResult>, TResult, 
  *
  * @internal
  */
-export type AllQueryCacheReducers<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type AllQueryCacheReducers<TQuery extends IDashboardQuery, TResult> = {
     /**
      * Sets value of cache entry.
      */
@@ -107,7 +104,7 @@ export type QueryActions<TQuery extends IDashboardQuery, TResult> = CaseReducerA
  *
  * @internal
  */
-export type QueryCache<TQuery extends IDashboardQuery<TResult>, TResult> = {
+export type QueryCache<TQuery extends IDashboardQuery, TResult> = {
     /**
      * A name to use as key in _queryCache part of the redux state.
      */
@@ -170,7 +167,7 @@ export function createSliceNameForQueryCache(queryName: string): string {
     return `${segments.join("")}Cache`;
 }
 
-function createQueryCacheSlice<TQuery extends IDashboardQuery<TResult>, TResult>(
+function createQueryCacheSlice<TQuery extends IDashboardQuery, TResult>(
     queryName: string,
     selectId: IdSelector<TQuery>,
 ): QueryCache<TQuery, TResult> {
@@ -241,7 +238,7 @@ function createQueryCacheSlice<TQuery extends IDashboardQuery<TResult>, TResult>
  *
  * @internal
  */
-export interface IDashboardQueryService<TQuery extends IDashboardQuery<TResult>, TResult> {
+export interface IDashboardQueryService<TQuery extends IDashboardQuery, TResult> {
     name: DashboardQueryType;
     generator: (ctx: DashboardContext, query: TQuery, refresh: boolean) => SagaIterator<TResult>;
     cache?: QueryCache<TQuery, TResult>;
@@ -257,7 +254,7 @@ export interface IDashboardQueryService<TQuery extends IDashboardQuery<TResult>,
  * @param generator - the generator function that processes the query
  * @param queryToCacheKey - function to map query into a cache key under which to store the results
  */
-export function createCachedQueryService<TQuery extends IDashboardQuery<TResult>, TResult>(
+export function createCachedQueryService<TQuery extends IDashboardQuery, TResult>(
     queryName: DashboardQueryType,
     generator: (ctx: DashboardContext, query: TQuery) => SagaIterator<TResult>,
     queryToCacheKey: (query: TQuery) => EntityId,
@@ -323,7 +320,7 @@ export function createCachedQueryService<TQuery extends IDashboardQuery<TResult>
  * @param queryName - name of the query
  * @param generator - the generator function that processes the query
  */
-export function createQueryService<TQuery extends IDashboardQuery<TResult>, TResult>(
+export function createQueryService<TQuery extends IDashboardQuery, TResult>(
     queryName: DashboardQueryType,
     generator: (ctx: DashboardContext, query: TQuery) => SagaIterator<TResult>,
 ): IDashboardQueryService<TQuery, TResult> {


### PR DESCRIPTION
* fully type its results with discriminated unions
* remove IDashboardQueryResult: It never worked properly and always returned unknown. There is no reasonable way of fixing it, so remove it to prevent confusion. Also remove the generic parameter of the IDashboardQuery as it is unusable anyway (for the same reasons).
* avoid the need of some ! assertions by handling the types better:
  destructuring apparently breaks the type narrowing, so avoid it

JIRA: RAIL-3987

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
