### PR TITLE
RELATED: RAIL-3991 Provide more details for NotAuthenticated

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -2146,13 +2146,17 @@ export class NoDataError extends AnalyticalBackendError {
 
 // @public
 export class NotAuthenticated extends AnalyticalBackendError {
-    constructor(message: string, cause?: Error);
+    constructor(message: string, cause?: Error, reason?: NotAuthenticatedReason);
     // (undocumented)
     authenticationFlow?: AuthenticationFlow;
+    reason?: NotAuthenticatedReason;
 }
 
 // @public
 export type NotAuthenticatedHandler = (context: IAuthenticationContext, error: NotAuthenticated) => void;
+
+// @public
+export type NotAuthenticatedReason = "invalid_credentials" | "credentials_expired";
 
 // @public
 export class NotImplemented extends AnalyticalBackendError {

--- a/libs/sdk-backend-spi/src/errors/index.ts
+++ b/libs/sdk-backend-spi/src/errors/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { IDataView } from "../workspace/execution";
 
@@ -141,6 +141,16 @@ export type AuthenticationFlow = {
 };
 
 /**
+ * More detailed reason of the NotAuthenticated error.
+ *
+ * - invalid_credentials - the provided credentials were invalid
+ * - credentials_expired - the credentials' validity expired
+ *
+ * @public
+ */
+export type NotAuthenticatedReason = "invalid_credentials" | "credentials_expired";
+
+/**
  * This exception is thrown when client code triggers an operation which requires authentication but the client
  * code did not provide credentials or the credentials are invalid.
  *
@@ -148,9 +158,17 @@ export type AuthenticationFlow = {
  */
 export class NotAuthenticated extends AnalyticalBackendError {
     public authenticationFlow?: AuthenticationFlow;
+    /**
+     * More detailed reason of the NotAuthenticated error. See {@link NotAuthenticatedReason} for more information.
+     *
+     * @remarks
+     * MAY be undefined if the particular backend implementation does not provide this value.
+     */
+    public reason?: NotAuthenticatedReason;
 
-    constructor(message: string, cause?: Error) {
+    constructor(message: string, cause?: Error, reason?: NotAuthenticatedReason) {
         super(message, AnalyticalBackendErrorTypes.NOT_AUTHENTICATED, cause);
+        this.reason = reason;
     }
 }
 

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -132,6 +132,7 @@ export {
     NotSupported,
     NotImplemented,
     NotAuthenticated,
+    NotAuthenticatedReason,
     ErrorConverter,
     isAnalyticalBackendError,
     isNoDataError,


### PR DESCRIPTION
This is to allow clients to distinguish between more nuanced reasons:
* expired password
* plain wrong credentials

JIRA: RAIL-3991

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
