### PR TITLE
Use deburr from lodash to strip the diacritics for variable names in catalog-export

### DIFF
--- a/tools/catalog-export/src/transform/tests/titles.test.ts
+++ b/tools/catalog-export/src/transform/tests/titles.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 import { createUniqueName, createUniqueVariableName } from "../titles";
 
@@ -20,6 +20,10 @@ describe("createUniqueVariableName", () => {
             ["NrOfOpportunities", "# Of Opportunities"],
             ["$Spent", "$ - Spent"],
             ["MinExecTime", "min_exec_time"],
+            ["ZavislostNaPoctu", "Závislost na počtu"],
+            ["NecoAndHackem", "Něco&háčkem"],
+            ["NecoSHackem", "Něco s háčkem"],
+            ["NecoSHackem", "Něco_s_háčkem"],
         ];
 
         it.each(TEST_DATA)("should return '%s' when input is '%s'", (expectedResult, input) => {

--- a/tools/catalog-export/src/transform/titles.ts
+++ b/tools/catalog-export/src/transform/titles.ts
@@ -1,5 +1,6 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import has from "lodash/has";
+import deburr from "lodash/deburr";
 
 const NonAlphaNumRegex = /[^\w\d$]+/g;
 
@@ -11,11 +12,16 @@ const NonAlphaNumRegex = /[^\w\d$]+/g;
  */
 export function stringToVariableName(input: string): string {
     /*
-     * First do special substitution of chars that have common meaning
+     * Remove diacritic
+     */
+    const removedDiacritic = deburr(input);
+
+    /*
+     * Do special substitution of chars that have common meaning
      *
      * Then replace all non-chars and non-digits (except for $) with whitespace
      */
-    const onlyAlphaNumWithSpaces = input
+    const onlyAlphaNumWithSpaces = removedDiacritic
         .replace(/&/g, " and ")
         .replace(/#/g, "Nr")
         .replace(/%/g, "Percent")


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
