### PR TITLE
Define SDK error for failing dynamic script load

### DIFF
--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/dynamicComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/dynamicComponentLoaders.ts
@@ -6,6 +6,7 @@ import { LoadedPlugin, ModuleFederationIntegration } from "../types";
 import invariant from "ts-invariant";
 import isEmpty from "lodash/isEmpty";
 import { determineDashboardEngine } from "./determineDashboardEngine";
+import { DynamicScriptLoadSdkError } from "@gooddata/sdk-ui";
 
 /**
  * @internal
@@ -145,9 +146,10 @@ function addScriptTag(url: string): { element: HTMLScriptElement; promise: Promi
         };
 
         element.onerror = () => {
+            const message = `Dynamic Script Error: ${url}`;
             // eslint-disable-next-line no-console
-            console.error(`Dynamic Script Error: ${url}`);
-            reject();
+            console.error(message);
+            reject(new DynamicScriptLoadSdkError(message));
         };
 
         document.head.appendChild(element);

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -357,6 +357,11 @@ export class DerivedMeasureTitleSuffixFactory {
 export type DrillEventIntersectionElementHeader = IAttributeDescriptor | IMeasureDescriptor | ITotalDescriptor | IDrillIntersectionAttributeItem;
 
 // @public
+export class DynamicScriptLoadSdkError extends GoodDataSdkError {
+    constructor(message?: string, cause?: Error);
+}
+
+// @public
 export const ErrorCodes: {
     BAD_REQUEST: string;
     UNAUTHORIZED: string;
@@ -370,6 +375,7 @@ export const ErrorCodes: {
     PROTECTED_REPORT: string;
     UNKNOWN_ERROR: string;
     CANCELLED: string;
+    DYNAMIC_SCRIPT_LOAD_ERROR: string;
 };
 
 // @public
@@ -1210,6 +1216,9 @@ export function isDrillableItemUri(item: unknown): item is IDrillableItemUri;
 
 // @public (undocumented)
 export function isDrillIntersectionAttributeItem(header: DrillEventIntersectionElementHeader): header is IDrillIntersectionAttributeItem;
+
+// @public
+export function isDynamicScriptLoadSdkError(obj: unknown): obj is DynamicScriptLoadSdkError;
 
 export { ISeparators }
 

--- a/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
+++ b/libs/sdk-ui/src/base/errors/GoodDataSdkError.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 import isEmpty from "lodash/isEmpty";
 import { AuthenticationFlow } from "@gooddata/sdk-backend-spi";
@@ -21,6 +21,7 @@ export const ErrorCodes = {
     PROTECTED_REPORT: "PROTECTED_REPORT",
     UNKNOWN_ERROR: "UNKNOWN_ERROR",
     CANCELLED: "CANCELLED",
+    DYNAMIC_SCRIPT_LOAD_ERROR: "DYNAMIC_SCRIPT_LOAD_ERROR",
 };
 
 /**
@@ -210,6 +211,17 @@ export class CancelledSdkError extends GoodDataSdkError {
     }
 }
 
+/**
+ * This error means that loading of dynamic script/plugin failed.
+ *
+ * @public
+ */
+export class DynamicScriptLoadSdkError extends GoodDataSdkError {
+    constructor(message?: string, cause?: Error) {
+        super(ErrorCodes.DYNAMIC_SCRIPT_LOAD_ERROR as SdkErrorType, message, cause);
+    }
+}
+
 //
 //
 //
@@ -329,4 +341,13 @@ export function isUnknownSdkError(obj: unknown): obj is UnexpectedSdkError {
  */
 export function isCancelledSdkError(obj: unknown): obj is CancelledSdkError {
     return !isEmpty(obj) && (obj as GoodDataSdkError).seType === "CANCELLED";
+}
+
+/**
+ * Typeguard checking whether input is an instance of {@link DynamicScriptLoadSdkError};
+ *
+ * @public
+ */
+export function isDynamicScriptLoadSdkError(obj: unknown): obj is DynamicScriptLoadSdkError {
+    return !isEmpty(obj) && (obj as GoodDataSdkError).seType === "DYNAMIC_SCRIPT_LOAD_ERROR";
 }

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 /*
  *
@@ -27,6 +27,7 @@ export {
     GeoLocationMissingSdkError,
     BadRequestSdkError,
     GeoTokenMissingSdkError,
+    DynamicScriptLoadSdkError,
     isGoodDataSdkError,
     isBadRequest,
     isCancelledSdkError,
@@ -40,6 +41,7 @@ export {
     isProtectedReport,
     isUnauthorized,
     isUnknownSdkError,
+    isDynamicScriptLoadSdkError,
 } from "./errors/GoodDataSdkError";
 export {
     IErrorDescriptors,


### PR DESCRIPTION
- add DynamicScriptLoadSdkError
- define DynamicScriptLoadSdkError when script loading failed.

JIRA: RAIL-3938

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
