### PR TITLE
RELATED: RAIL-3988 add option for plugins to hide the filter bar

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import max from "lodash/max";
 import {
@@ -146,6 +146,7 @@ class LocalPlugin extends DashboardPluginV1 {
                 ),
             );
         });
+        customize.filterBar().setFilterBarRenderingMode("default").setFilterBarRenderingMode("hidden");
     }
 }
 

--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -146,7 +146,6 @@ class LocalPlugin extends DashboardPluginV1 {
                 ),
             );
         });
-        customize.filterBar().setFilterBarRenderingMode("default").setFilterBarRenderingMode("hidden");
     }
 }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -1871,6 +1871,9 @@ export function extendedWidgetDebugStr(widget: ExtendedDashboardWidget): string;
 export const FilterBar: (props: IFilterBarProps) => JSX.Element;
 
 // @public
+export type FilterBarRenderingMode = "default" | "hidden";
+
+// @public
 export function filterContextItemsToDashboardFiltersByDateDataSet(filterContextItems: FilterContextItem[], dateDataSet: ObjRef): IDashboardFilter[];
 
 // @public
@@ -2149,6 +2152,7 @@ export interface IDashboardCustomizationProps extends IDashboardCustomComponentP
 // @public (undocumented)
 export interface IDashboardCustomizer {
     customWidgets(): IDashboardWidgetCustomizer;
+    filterBar(): IFilterBarCustomizer;
     insightWidgets(): IDashboardInsightCustomizer;
     kpiWidgets(): IDashboardKpiCustomizer;
     layout(): IDashboardLayoutCustomizer;
@@ -2490,6 +2494,11 @@ export interface IExecutionResultEnvelope {
 
 // @alpha (undocumented)
 export type IExportConfig = ICsvExportConfig | IXlsxExportConfig;
+
+// @public (undocumented)
+export interface IFilterBarCustomizer {
+    setFilterBarRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
+}
 
 // @alpha (undocumented)
 export interface IFilterBarProps {

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2497,7 +2497,7 @@ export type IExportConfig = ICsvExportConfig | IXlsxExportConfig;
 
 // @public (undocumented)
 export interface IFilterBarCustomizer {
-    setFilterBarRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
+    setRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
 }
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
@@ -8,7 +8,7 @@ import {
     IDashboardWidgetCustomizer,
     IFilterBarCustomizer,
 } from "../customizer";
-import { DefaultFilterBar, HiddenFilterBar, IDashboardExtensionProps } from "../../presentation";
+import { IDashboardExtensionProps } from "../../presentation";
 import { DefaultInsightCustomizer } from "./insightCustomizer";
 import { DashboardCustomizationLogger } from "./customizationLogging";
 import { IDashboardPluginContract_V1 } from "../plugin";
@@ -77,7 +77,7 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
     };
 
     public build = (): IDashboardExtensionProps => {
-        const filterBarCustomizerResult = this.filterBarCustomizer.getFilterBarCustomizerResult();
+        const filterBarCustomizerResult = this.filterBarCustomizer.getCustomizerResult();
 
         const props: IDashboardExtensionProps = {
             InsightComponentProvider: this.insightCustomizer.getInsightProvider(),
@@ -86,10 +86,7 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
             customizationFns: {
                 existingDashboardTransformFn: this.layoutCustomizer.getExistingDashboardTransformFn(),
             },
-            FilterBarComponent:
-                filterBarCustomizerResult.filterBarRenderingMode === "hidden"
-                    ? HiddenFilterBar
-                    : DefaultFilterBar,
+            FilterBarComponent: filterBarCustomizerResult.FilterBarComponent,
         };
 
         this.sealCustomizers();

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationBuilder.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import {
     IDashboardCustomizer,
@@ -6,14 +6,16 @@ import {
     IDashboardKpiCustomizer,
     IDashboardLayoutCustomizer,
     IDashboardWidgetCustomizer,
+    IFilterBarCustomizer,
 } from "../customizer";
-import { IDashboardExtensionProps } from "../../presentation";
+import { DefaultFilterBar, HiddenFilterBar, IDashboardExtensionProps } from "../../presentation";
 import { DefaultInsightCustomizer } from "./insightCustomizer";
 import { DashboardCustomizationLogger } from "./customizationLogging";
 import { IDashboardPluginContract_V1 } from "../plugin";
 import { DefaultKpiCustomizer } from "./kpiCustomizer";
 import { DefaultWidgetCustomizer } from "./widgetCustomizer";
 import { DefaultLayoutCustomizer } from "./layoutCustomizer";
+import { DefaultFilterBarCustomizer } from "./filterBarCustomizer";
 
 /**
  * @internal
@@ -24,6 +26,9 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
     private readonly kpiCustomizer: DefaultKpiCustomizer = new DefaultKpiCustomizer(this.logger);
     private readonly widgetCustomizer: DefaultWidgetCustomizer = new DefaultWidgetCustomizer(this.logger);
     private readonly layoutCustomizer: DefaultLayoutCustomizer = new DefaultLayoutCustomizer(this.logger);
+    private readonly filterBarCustomizer: DefaultFilterBarCustomizer = new DefaultFilterBarCustomizer(
+        this.logger,
+    );
 
     private sealCustomizers = (): void => {
         this.insightCustomizer.sealCustomizer();
@@ -48,6 +53,10 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
         return this.layoutCustomizer;
     };
 
+    public filterBar = (): IFilterBarCustomizer => {
+        return this.filterBarCustomizer;
+    };
+
     public onBeforePluginRegister = (plugin: IDashboardPluginContract_V1): void => {
         this.logger.setCurrentPlugin(plugin);
         this.logger.log("Starting registration.");
@@ -68,6 +77,8 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
     };
 
     public build = (): IDashboardExtensionProps => {
+        const filterBarCustomizerResult = this.filterBarCustomizer.getFilterBarCustomizerResult();
+
         const props: IDashboardExtensionProps = {
             InsightComponentProvider: this.insightCustomizer.getInsightProvider(),
             KpiComponentProvider: this.kpiCustomizer.getKpiProvider(),
@@ -75,6 +86,10 @@ export class DashboardCustomizationBuilder implements IDashboardCustomizer {
             customizationFns: {
                 existingDashboardTransformFn: this.layoutCustomizer.getExistingDashboardTransformFn(),
             },
+            FilterBarComponent:
+                filterBarCustomizerResult.filterBarRenderingMode === "hidden"
+                    ? HiddenFilterBar
+                    : DefaultFilterBar,
         };
 
         this.sealCustomizers();

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationLogging.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/customizationLogging.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardPluginContract_V1 } from "../plugin";
 import { pluginDebugStr } from "./pluginUtils";
@@ -7,11 +7,19 @@ function addPluginInfoToMessage(plugin: IDashboardPluginContract_V1 | undefined,
     return plugin ? `${pluginDebugStr(plugin)}: ${message}` : message;
 }
 
+export interface IDashboardCustomizationLogger {
+    setCurrentPlugin(plugin: IDashboardPluginContract_V1 | undefined): void;
+
+    log(message: string, ...optionalParams: any[]): void;
+    warn(message: string, ...optionalParams: any[]): void;
+    error(message: string, ...optionalParams: any[]): void;
+}
+
 /**
  * Common logger to use for all events that occur during customization. The logger is responsible for adding
  * information about plugin whose registration code triggered those events.
  */
-export class DashboardCustomizationLogger {
+export class DashboardCustomizationLogger implements IDashboardCustomizationLogger {
     private currentPlugin: IDashboardPluginContract_V1 | undefined;
 
     public setCurrentPlugin = (plugin: IDashboardPluginContract_V1 | undefined): void => {

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
@@ -1,6 +1,6 @@
 // (C) 2022 GoodData Corporation
 import { FilterBarRenderingMode, IFilterBarCustomizer } from "../customizer";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 
 interface IFilterBarCustomizerState {
     setFilterBarRenderingMode(mode: FilterBarRenderingMode): void;
@@ -14,7 +14,7 @@ interface IFilterBarCustomizerResult {
 class FilterBarCustomizerState implements IFilterBarCustomizerState {
     private renderingMode: FilterBarRenderingMode | undefined = undefined;
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     getFilterBarRenderingMode = (): FilterBarRenderingMode => {
         return this.renderingMode ?? "default";
@@ -33,7 +33,7 @@ class FilterBarCustomizerState implements IFilterBarCustomizerState {
 class SealedFilterBarCustomizerState implements IFilterBarCustomizerState {
     constructor(
         private readonly state: IFilterBarCustomizerState,
-        private readonly logger: DashboardCustomizationLogger,
+        private readonly logger: IDashboardCustomizationLogger,
     ) {}
 
     getFilterBarRenderingMode = (): FilterBarRenderingMode => {
@@ -53,7 +53,7 @@ class SealedFilterBarCustomizerState implements IFilterBarCustomizerState {
 export class DefaultFilterBarCustomizer implements IFilterBarCustomizer {
     private state: IFilterBarCustomizerState = new FilterBarCustomizerState(this.logger);
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     setFilterBarRenderingMode = (mode: FilterBarRenderingMode): this => {
         this.state.setFilterBarRenderingMode(mode);

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
@@ -1,0 +1,75 @@
+// (C) 2022 GoodData Corporation
+import { FilterBarRenderingMode, IFilterBarCustomizer } from "../customizer";
+import { DashboardCustomizationLogger } from "./customizationLogging";
+
+interface IFilterBarCustomizerState {
+    setFilterBarRenderingMode(mode: FilterBarRenderingMode): void;
+    getFilterBarRenderingMode(): FilterBarRenderingMode;
+}
+
+interface IFilterBarCustomizerResult {
+    filterBarRenderingMode: FilterBarRenderingMode;
+}
+
+class FilterBarCustomizerState implements IFilterBarCustomizerState {
+    private renderingMode: FilterBarRenderingMode | undefined = undefined;
+
+    constructor(private readonly logger: DashboardCustomizationLogger) {}
+
+    getFilterBarRenderingMode = (): FilterBarRenderingMode => {
+        return this.renderingMode ?? "default";
+    };
+
+    setFilterBarRenderingMode = (renderingMode: FilterBarRenderingMode): void => {
+        if (this.renderingMode) {
+            this.logger.warn(
+                `Redefining filter bar rendering mode to "${renderingMode}". Previous definition will be discarded.`,
+            );
+        }
+        this.renderingMode = renderingMode;
+    };
+}
+
+class SealedFilterBarCustomizerState implements IFilterBarCustomizerState {
+    constructor(
+        private readonly state: IFilterBarCustomizerState,
+        private readonly logger: DashboardCustomizationLogger,
+    ) {}
+
+    getFilterBarRenderingMode = (): FilterBarRenderingMode => {
+        return this.state.getFilterBarRenderingMode();
+    };
+
+    setFilterBarRenderingMode = (_renderingMode: FilterBarRenderingMode): void => {
+        this.logger.warn(
+            `Attempting to set filter bar rendering mode outside of plugin registration. Ignoring.`,
+        );
+    };
+}
+
+/**
+ * @internal
+ */
+export class DefaultFilterBarCustomizer implements IFilterBarCustomizer {
+    private state: IFilterBarCustomizerState = new FilterBarCustomizerState(this.logger);
+
+    constructor(private readonly logger: DashboardCustomizationLogger) {}
+
+    setFilterBarRenderingMode = (mode: FilterBarRenderingMode): this => {
+        this.state.setFilterBarRenderingMode(mode);
+
+        return this;
+    };
+
+    getFilterBarCustomizerResult = (): IFilterBarCustomizerResult => {
+        return {
+            filterBarRenderingMode: this.state.getFilterBarRenderingMode(),
+        };
+    };
+
+    sealCustomizer = (): this => {
+        this.state = new SealedFilterBarCustomizerState(this.state, this.logger);
+
+        return this;
+    };
+}

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/filterBarCustomizer.ts
@@ -1,14 +1,15 @@
 // (C) 2022 GoodData Corporation
+import { CustomFilterBarComponent, DefaultFilterBar, HiddenFilterBar } from "../../presentation";
 import { FilterBarRenderingMode, IFilterBarCustomizer } from "../customizer";
 import { IDashboardCustomizationLogger } from "./customizationLogging";
 
 interface IFilterBarCustomizerState {
-    setFilterBarRenderingMode(mode: FilterBarRenderingMode): void;
-    getFilterBarRenderingMode(): FilterBarRenderingMode;
+    setRenderingMode(mode: FilterBarRenderingMode): void;
+    getRenderingMode(): FilterBarRenderingMode;
 }
 
 interface IFilterBarCustomizerResult {
-    filterBarRenderingMode: FilterBarRenderingMode;
+    FilterBarComponent: CustomFilterBarComponent;
 }
 
 class FilterBarCustomizerState implements IFilterBarCustomizerState {
@@ -16,11 +17,11 @@ class FilterBarCustomizerState implements IFilterBarCustomizerState {
 
     constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
-    getFilterBarRenderingMode = (): FilterBarRenderingMode => {
+    getRenderingMode = (): FilterBarRenderingMode => {
         return this.renderingMode ?? "default";
     };
 
-    setFilterBarRenderingMode = (renderingMode: FilterBarRenderingMode): void => {
+    setRenderingMode = (renderingMode: FilterBarRenderingMode): void => {
         if (this.renderingMode) {
             this.logger.warn(
                 `Redefining filter bar rendering mode to "${renderingMode}". Previous definition will be discarded.`,
@@ -36,11 +37,11 @@ class SealedFilterBarCustomizerState implements IFilterBarCustomizerState {
         private readonly logger: IDashboardCustomizationLogger,
     ) {}
 
-    getFilterBarRenderingMode = (): FilterBarRenderingMode => {
-        return this.state.getFilterBarRenderingMode();
+    getRenderingMode = (): FilterBarRenderingMode => {
+        return this.state.getRenderingMode();
     };
 
-    setFilterBarRenderingMode = (_renderingMode: FilterBarRenderingMode): void => {
+    setRenderingMode = (_renderingMode: FilterBarRenderingMode): void => {
         this.logger.warn(
             `Attempting to set filter bar rendering mode outside of plugin registration. Ignoring.`,
         );
@@ -55,15 +56,16 @@ export class DefaultFilterBarCustomizer implements IFilterBarCustomizer {
 
     constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
-    setFilterBarRenderingMode = (mode: FilterBarRenderingMode): this => {
-        this.state.setFilterBarRenderingMode(mode);
+    setRenderingMode = (mode: FilterBarRenderingMode): this => {
+        this.state.setRenderingMode(mode);
 
         return this;
     };
 
-    getFilterBarCustomizerResult = (): IFilterBarCustomizerResult => {
+    getCustomizerResult = (): IFilterBarCustomizerResult => {
         return {
-            filterBarRenderingMode: this.state.getFilterBarRenderingMode(),
+            FilterBarComponent:
+                this.state.getRenderingMode() === "hidden" ? HiddenFilterBar : DefaultFilterBar,
         };
     };
 

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/fluidLayoutCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/fluidLayoutCustomizer.ts
@@ -1,10 +1,10 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IDashboardLayout, IDashboardLayoutItem, IDashboardLayoutSection } from "@gooddata/sdk-backend-spi";
 import { IFluidLayoutCustomizer } from "../customizer";
 import { ExtendedDashboardWidget, ICustomWidget } from "../../model";
 import { DashboardLayoutBuilder } from "../../_staging/dashboard/fluidLayout";
 import isEmpty from "lodash/isEmpty";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 import cloneDeep from "lodash/cloneDeep";
 
 type AddItemOp = {
@@ -22,7 +22,7 @@ export class FluidLayoutCustomizer implements IFluidLayoutCustomizer {
     private readonly addItemOps: AddItemOp[] = [];
     private readonly addSectionOps: AddSectionOp[] = [];
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     public addItem = (
         sectionIdx: number,

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/insightCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/insightCustomizer.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IDashboardInsightCustomizer } from "../customizer";
 import {
     CustomDashboardInsightComponent,
@@ -9,7 +9,7 @@ import {
 import { InvariantError } from "ts-invariant";
 import includes from "lodash/includes";
 import { insightTags } from "@gooddata/sdk-model";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 
 const DefaultInsightRendererProvider: InsightComponentProvider = () => {
     return DefaultDashboardInsight;
@@ -70,9 +70,9 @@ class DefaultInsightCustomizerState implements IInsightCustomizerState {
      */
     private rootProvider: InsightComponentProvider = this.coreProvider;
 
-    private logger: DashboardCustomizationLogger;
+    private logger: IDashboardCustomizationLogger;
 
-    constructor(logger: DashboardCustomizationLogger, defaultProvider: InsightComponentProvider) {
+    constructor(logger: IDashboardCustomizationLogger, defaultProvider: InsightComponentProvider) {
         this.logger = logger;
         this.coreProviderChain = [defaultProvider];
     }
@@ -118,7 +118,7 @@ class DefaultInsightCustomizerState implements IInsightCustomizerState {
  */
 class SealedInsightCustomizerState implements IInsightCustomizerState {
     constructor(
-        private readonly logger: DashboardCustomizationLogger,
+        private readonly logger: IDashboardCustomizationLogger,
         private readonly state: IInsightCustomizerState,
     ) {}
 
@@ -162,11 +162,11 @@ class SealedInsightCustomizerState implements IInsightCustomizerState {
  * @internal
  */
 export class DefaultInsightCustomizer implements IDashboardInsightCustomizer {
-    private readonly logger: DashboardCustomizationLogger;
+    private readonly logger: IDashboardCustomizationLogger;
     private state: IInsightCustomizerState;
 
     constructor(
-        logger: DashboardCustomizationLogger,
+        logger: IDashboardCustomizationLogger,
         defaultProvider: InsightComponentProvider = DefaultInsightRendererProvider,
     ) {
         this.logger = logger;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/kpiCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/kpiCustomizer.tsx
@@ -1,8 +1,8 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IDashboardKpiCustomizer } from "../customizer";
 import { DefaultDashboardKpi, KpiComponentProvider, OptionalKpiComponentProvider } from "../../presentation";
 import { InvariantError } from "ts-invariant";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 
 const DefaultKpiRendererProvider: KpiComponentProvider = () => {
     return DefaultDashboardKpi;
@@ -83,7 +83,7 @@ class DefaultKpiCustomizerState implements IKpiCustomizerState {
  */
 class SealedKpiCustomizerState implements IKpiCustomizerState {
     constructor(
-        private readonly logger: DashboardCustomizationLogger,
+        private readonly logger: IDashboardCustomizationLogger,
         private readonly state: IKpiCustomizerState,
     ) {}
 
@@ -115,11 +115,11 @@ class SealedKpiCustomizerState implements IKpiCustomizerState {
  * @internal
  */
 export class DefaultKpiCustomizer implements IDashboardKpiCustomizer {
-    private readonly logger: DashboardCustomizationLogger;
+    private readonly logger: IDashboardCustomizationLogger;
     private state: IKpiCustomizerState;
 
     constructor(
-        logger: DashboardCustomizationLogger,
+        logger: IDashboardCustomizationLogger,
         defaultProvider: KpiComponentProvider = DefaultKpiRendererProvider,
     ) {
         this.logger = logger;

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/layoutCustomizer.ts
@@ -1,6 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { FluidLayoutCustomizationFn, IDashboardLayoutCustomizer } from "../customizer";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 import { FluidLayoutCustomizer } from "./fluidLayoutCustomizer";
 import { IDashboardLayout } from "@gooddata/sdk-backend-spi";
 import { DashboardTransformFn, ExtendedDashboardWidget } from "../../model";
@@ -9,7 +9,7 @@ export class DefaultLayoutCustomizer implements IDashboardLayoutCustomizer {
     private sealed = false;
     private readonly fluidLayoutTransformations: FluidLayoutCustomizationFn[] = [];
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     public customizeFluidLayout = (
         customizationFn: FluidLayoutCustomizationFn,

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
@@ -1,4 +1,5 @@
 // (C) 2022 GoodData Corporation
+import { DefaultFilterBar, HiddenFilterBar } from "../../../presentation";
 import { DefaultFilterBarCustomizer } from "../filterBarCustomizer";
 import { TestingDashboardCustomizationLogger } from "./fixtures/TestingDashboardCustomizationLogger";
 
@@ -14,28 +15,34 @@ describe("filter bar customizer", () => {
     });
 
     describe("filter bar rendering mode", () => {
-        it('should return "default" if no mode was explicitly set', () => {
-            const actual = Customizer.getFilterBarCustomizerResult();
-            expect(actual.filterBarRenderingMode).toEqual("default");
+        it("should return DefaultFilterBar if no mode was explicitly set", () => {
+            const actual = Customizer.getCustomizerResult();
+            expect(actual.FilterBarComponent).toEqual(DefaultFilterBar);
         });
 
-        it("should return the mode set using the setter", () => {
-            Customizer.setFilterBarRenderingMode("hidden");
-            const actual = Customizer.getFilterBarCustomizerResult();
-            expect(actual.filterBarRenderingMode).toEqual("hidden");
+        it("should return DefaultFilterBar if mode: default was explicitly set", () => {
+            Customizer.setRenderingMode("default");
+            const actual = Customizer.getCustomizerResult();
+            expect(actual.FilterBarComponent).toEqual(DefaultFilterBar);
+        });
+
+        it("should return HiddenFilterBar if mode: hidden set using the setter", () => {
+            Customizer.setRenderingMode("hidden");
+            const actual = Customizer.getCustomizerResult();
+            expect(actual.FilterBarComponent).toEqual(HiddenFilterBar);
         });
 
         it("should use the last provided mode if set multiple times", () => {
-            Customizer.setFilterBarRenderingMode("default");
-            Customizer.setFilterBarRenderingMode("hidden");
+            Customizer.setRenderingMode("default");
+            Customizer.setRenderingMode("hidden");
 
-            const actual = Customizer.getFilterBarCustomizerResult();
-            expect(actual.filterBarRenderingMode).toEqual("hidden");
+            const actual = Customizer.getCustomizerResult();
+            expect(actual.FilterBarComponent).toEqual(HiddenFilterBar);
         });
 
         it("should issue a warning if filter bar rendering mode is set multiple times", () => {
-            Customizer.setFilterBarRenderingMode("default");
-            Customizer.setFilterBarRenderingMode("hidden");
+            Customizer.setRenderingMode("default");
+            Customizer.setRenderingMode("hidden");
 
             expect(mockWarn).toHaveBeenCalled();
         });

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
@@ -1,29 +1,43 @@
 // (C) 2022 GoodData Corporation
-import { DashboardCustomizationLogger } from "../customizationLogging";
 import { DefaultFilterBarCustomizer } from "../filterBarCustomizer";
+import { TestingDashboardCustomizationLogger } from "./fixtures/TestingDashboardCustomizationLogger";
 
 describe("filter bar customizer", () => {
     let Customizer: DefaultFilterBarCustomizer;
+    let mockWarn: ReturnType<typeof jest.fn>;
 
     beforeEach(() => {
-        Customizer = new DefaultFilterBarCustomizer(new DashboardCustomizationLogger());
+        mockWarn = jest.fn();
+        Customizer = new DefaultFilterBarCustomizer(
+            new TestingDashboardCustomizationLogger({ warn: mockWarn }),
+        );
     });
 
-    it('should return "default" if no mode was explicitly set', () => {
-        const actual = Customizer.getFilterBarCustomizerResult();
-        expect(actual.filterBarRenderingMode).toEqual("default");
-    });
+    describe("filter bar rendering mode", () => {
+        it('should return "default" if no mode was explicitly set', () => {
+            const actual = Customizer.getFilterBarCustomizerResult();
+            expect(actual.filterBarRenderingMode).toEqual("default");
+        });
 
-    it("should return the mode set using the setter", () => {
-        Customizer.setFilterBarRenderingMode("hidden");
-        const actual = Customizer.getFilterBarCustomizerResult();
-        expect(actual.filterBarRenderingMode).toEqual("hidden");
-    });
+        it("should return the mode set using the setter", () => {
+            Customizer.setFilterBarRenderingMode("hidden");
+            const actual = Customizer.getFilterBarCustomizerResult();
+            expect(actual.filterBarRenderingMode).toEqual("hidden");
+        });
 
-    it("should use the last provided mode if set multiple times", () => {
-        Customizer.setFilterBarRenderingMode("default");
-        Customizer.setFilterBarRenderingMode("hidden");
-        const actual = Customizer.getFilterBarCustomizerResult();
-        expect(actual.filterBarRenderingMode).toEqual("hidden");
+        it("should use the last provided mode if set multiple times", () => {
+            Customizer.setFilterBarRenderingMode("default");
+            Customizer.setFilterBarRenderingMode("hidden");
+
+            const actual = Customizer.getFilterBarCustomizerResult();
+            expect(actual.filterBarRenderingMode).toEqual("hidden");
+        });
+
+        it("should issue a warning if filter bar rendering mode is set multiple times", () => {
+            Customizer.setFilterBarRenderingMode("default");
+            Customizer.setFilterBarRenderingMode("hidden");
+
+            expect(mockWarn).toHaveBeenCalled();
+        });
     });
 });

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/filterBarCustomizer.test.ts
@@ -1,0 +1,29 @@
+// (C) 2022 GoodData Corporation
+import { DashboardCustomizationLogger } from "../customizationLogging";
+import { DefaultFilterBarCustomizer } from "../filterBarCustomizer";
+
+describe("filter bar customizer", () => {
+    let Customizer: DefaultFilterBarCustomizer;
+
+    beforeEach(() => {
+        Customizer = new DefaultFilterBarCustomizer(new DashboardCustomizationLogger());
+    });
+
+    it('should return "default" if no mode was explicitly set', () => {
+        const actual = Customizer.getFilterBarCustomizerResult();
+        expect(actual.filterBarRenderingMode).toEqual("default");
+    });
+
+    it("should return the mode set using the setter", () => {
+        Customizer.setFilterBarRenderingMode("hidden");
+        const actual = Customizer.getFilterBarCustomizerResult();
+        expect(actual.filterBarRenderingMode).toEqual("hidden");
+    });
+
+    it("should use the last provided mode if set multiple times", () => {
+        Customizer.setFilterBarRenderingMode("default");
+        Customizer.setFilterBarRenderingMode("hidden");
+        const actual = Customizer.getFilterBarCustomizerResult();
+        expect(actual.filterBarRenderingMode).toEqual("hidden");
+    });
+});

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/fixtures/TestingDashboardCustomizationLogger.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/tests/fixtures/TestingDashboardCustomizationLogger.ts
@@ -1,0 +1,30 @@
+// (C) 2022 GoodData Corporation
+import { IDashboardPluginContract_V1 } from "../../../plugin";
+import { IDashboardCustomizationLogger } from "../../customizationLogging";
+
+export class TestingDashboardCustomizationLogger implements IDashboardCustomizationLogger {
+    private readonly setCurrentPluginImpl: IDashboardCustomizationLogger["setCurrentPlugin"] | undefined;
+    private readonly logImpl: IDashboardCustomizationLogger["log"] | undefined;
+    private readonly warnImpl: IDashboardCustomizationLogger["warn"] | undefined;
+    private readonly errorImpl: IDashboardCustomizationLogger["error"] | undefined;
+
+    constructor(functions: Partial<IDashboardCustomizationLogger>) {
+        this.setCurrentPluginImpl = functions.setCurrentPlugin;
+        this.logImpl = functions.log;
+        this.warnImpl = functions.warn;
+        this.errorImpl = functions.error;
+    }
+
+    setCurrentPlugin(plugin: IDashboardPluginContract_V1 | undefined): void {
+        this.setCurrentPluginImpl?.(plugin);
+    }
+    log(message: string, ...optionalParams: any[]): void {
+        this.logImpl?.(message, optionalParams);
+    }
+    warn(message: string, ...optionalParams: any[]): void {
+        this.warnImpl?.(message, optionalParams);
+    }
+    error(message: string, ...optionalParams: any[]): void {
+        this.errorImpl?.(message, optionalParams);
+    }
+}

--- a/libs/sdk-ui-dashboard/src/plugins/customizationApis/widgetCustomizer.tsx
+++ b/libs/sdk-ui-dashboard/src/plugins/customizationApis/widgetCustomizer.tsx
@@ -1,7 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardWidgetCustomizer } from "../customizer";
-import { DashboardCustomizationLogger } from "./customizationLogging";
+import { IDashboardCustomizationLogger } from "./customizationLogging";
 import { CustomDashboardWidgetComponent, OptionalWidgetComponentProvider } from "../../presentation";
 import { isCustomWidget } from "../../model";
 
@@ -35,7 +35,7 @@ interface IWidgetCustomizerState {
 class WidgetCustomizerState implements IWidgetCustomizerState {
     private readonly customWidgetMap: CustomWidgetMap = new Map();
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     public addDefinition = (definition: IDashboardWidgetDefinition): void => {
         if (this.customWidgetMap.has(definition.widgetType)) {
@@ -55,7 +55,7 @@ class WidgetCustomizerState implements IWidgetCustomizerState {
 class SealedCustomizerState implements IWidgetCustomizerState {
     constructor(
         private readonly state: IWidgetCustomizerState,
-        private readonly logger: DashboardCustomizationLogger,
+        private readonly logger: IDashboardCustomizationLogger,
     ) {}
 
     public addDefinition = (_definition: IDashboardWidgetDefinition): void => {
@@ -70,7 +70,7 @@ class SealedCustomizerState implements IWidgetCustomizerState {
 export class DefaultWidgetCustomizer implements IDashboardWidgetCustomizer {
     private state: IWidgetCustomizerState = new WidgetCustomizerState(this.logger);
 
-    constructor(private readonly logger: DashboardCustomizationLogger) {}
+    constructor(private readonly logger: IDashboardCustomizationLogger) {}
 
     public addCustomWidget = (
         widgetType: string,

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     CustomDashboardInsightComponent,
     CustomDashboardWidgetComponent,
@@ -256,6 +256,27 @@ export interface IDashboardLayoutCustomizer {
 }
 
 /**
+ * Mode of rendering of the FilterBar:
+ * - default - the default implementation is used
+ * - hidden - the filter bar is hidden. Note that the filters set on the dashboard are still active, just not visible.
+ *
+ * @public
+ */
+export type FilterBarRenderingMode = "default" | "hidden";
+
+/**
+ * @public
+ */
+export interface IFilterBarCustomizer {
+    /**
+     * Set the rendering mode of the FilterBar.
+     *
+     * @param mode - the mode to use, see {@link FilterBarRenderingMode} for info on individual values
+     */
+    setFilterBarRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
+}
+
+/**
  * @public
  */
 export interface IDashboardCustomizer {
@@ -280,6 +301,11 @@ export interface IDashboardCustomizer {
      * before it is rendered.
      */
     layout(): IDashboardLayoutCustomizer;
+
+    /**
+     * Customize the filter bar.
+     */
+    filterBar(): IFilterBarCustomizer;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -273,7 +273,7 @@ export interface IFilterBarCustomizer {
      *
      * @param mode - the mode to use, see {@link FilterBarRenderingMode} for info on individual values
      */
-    setFilterBarRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
+    setRenderingMode(mode: FilterBarRenderingMode): IFilterBarCustomizer;
 }
 
 /**

--- a/libs/sdk-ui-dashboard/src/plugins/index.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 export { IDashboardPluginContract_V1, DashboardPluginV1, DashboardPluginDescriptor } from "./plugin";
 export { IDashboardEngine, newDashboardEngine } from "./engine";
 export {
@@ -10,5 +10,7 @@ export {
     IDashboardWidgetCustomizer,
     FluidLayoutCustomizationFn,
     IFluidLayoutCustomizer,
+    IFilterBarCustomizer,
     DashboardStateChangeCallback,
+    FilterBarRenderingMode,
 } from "./customizer";


### PR DESCRIPTION
* Add new customizer section for filterBar
* Add a function to set the rendering mode there
* Improve architecture slightly to allow easier testing of logging

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
