### PR TITLE
RELATED: RAIL-3991 Fix the convertApiError

### DIFF
--- a/libs/sdk-backend-bear/src/utils/errorHandling.ts
+++ b/libs/sdk-backend-bear/src/utils/errorHandling.ts
@@ -65,7 +65,7 @@ export function convertApiError(error: Error): AnalyticalBackendError {
     }
 
     if (isApiResponseError(error)) {
-        if (error.response.status !== HttpStatusCodes.UNAUTHORIZED) {
+        if (error.response.status === HttpStatusCodes.UNAUTHORIZED) {
             // detect expired passwords using the specific exception code from the backend
             // use responseBody directly (instead of response.json) in case the stream has already been used
             // at this point (which would bomb)


### PR DESCRIPTION
There was unintentionally flipped conditional.

JIRA: RAIL-3991

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
