### PR TITLE
RELATED: FET-973 Migrate to official Wiremock docker images

### DIFF
--- a/common/scripts/ci/run_cypress_tests.sh
+++ b/common/scripts/ci/run_cypress_tests.sh
@@ -5,7 +5,7 @@ _RUSH="${DIR}/docker_rush.sh"
 _RUSHX="${DIR}/docker_rushx.sh"
 
 $_RUSH install
-$_RUSH build
+$_RUSH build -t sdk-ui-tests-e2e
 $_RUSHX libs/sdk-ui-tests-e2e build-scenarios
 
 docker build --file ./libs/sdk-ui-tests-e2e/Dockerfile -t gooddata-ui-sdk-scenarios . || exit 1

--- a/libs/sdk-backend-bear/.gitignore
+++ b/libs/sdk-backend-bear/.gitignore
@@ -1,4 +1,5 @@
 .wiremock_containerid
+.wiremock/
 tests/wiremock/recordings/mappings/*login*
 tests/wiremock/recordings/mappings/*token*
 tests/wiremock/recordings/__files/*login*

--- a/libs/sdk-backend-bear/tests/wiremock/start_wiremock.sh
+++ b/libs/sdk-backend-bear/tests/wiremock/start_wiremock.sh
@@ -61,7 +61,7 @@ if [ ${mode} = "interactive" ]; then
       --user $(id -u):$(id -g) \
       --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
       --publish 8443:8443 \
-      rodolpheche/wiremock:2.26.3-alpine \
+      wiremock/wiremock:2.32.0 \
         --https-port 8443 --enable-browser-proxying --verbose
 else
   if [ -z ${WIREMOCK_NET} ]; then
@@ -76,7 +76,7 @@ else
         --user $(id -u):$(id -g) \
         --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
         --publish 8443:8443 \
-        rodolpheche/wiremock:2.26.3-alpine \
+        wiremock/wiremock:2.32.0 \
           --https-port 8443 --enable-browser-proxying)
   else
     #
@@ -89,7 +89,7 @@ else
         --user $(id -u):$(id -g) \
         --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
         --net "${WIREMOCK_NET}" --net-alias bear \
-        rodolpheche/wiremock:2.26.3-alpine \
+        wiremock/wiremock:2.32.0 \
           --https-port 8443 --enable-browser-proxying)
   fi
 

--- a/libs/sdk-backend-tiger/.gitignore
+++ b/libs/sdk-backend-tiger/.gitignore
@@ -1,1 +1,2 @@
 .wiremock_containerid
+.wiremock/

--- a/libs/sdk-backend-tiger/tests/wiremock/start_wiremock.sh
+++ b/libs/sdk-backend-tiger/tests/wiremock/start_wiremock.sh
@@ -61,7 +61,7 @@ if [ ${mode} = "interactive" ]; then
       --user $(id -u):$(id -g) \
       --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
       --publish 8442:8442 \
-      rodolpheche/wiremock:2.26.3-alpine \
+      wiremock/wiremock:2.32.0 \
         --https-port 8442 --enable-browser-proxying --verbose
 else
   if [ -z ${WIREMOCK_NET} ]; then
@@ -76,7 +76,7 @@ else
         --user $(id -u):$(id -g) \
         --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
         --publish 8442:8442 \
-        rodolpheche/wiremock:2.26.3-alpine \
+        wiremock/wiremock:2.32.0 \
           --https-port 8442 --enable-browser-proxying)
   else
     #
@@ -89,7 +89,7 @@ else
         --user $(id -u):$(id -g) \
         --volume ${RECORDINGS_DIR}:/home/wiremock:Z \
         --net "${WIREMOCK_NET}" --net-alias tiger \
-        rodolpheche/wiremock:2.26.3-alpine \
+        wiremock/wiremock:2.32.0 \
           --https-port 8442 --enable-browser-proxying)
   fi
 

--- a/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
+++ b/libs/sdk-ui-tests-e2e/docker-compose-isolated.yaml
@@ -26,7 +26,7 @@ services:
       - backend-mock
 
   backend-mock:
-    image: harbor.intgdc.com/3rdparty/rodolpheche/wiremock
+    image: wiremock/wiremock:2.32.0
     command: "--preserve-host-header --proxy-all=https://${HOST:-staging3.intgdc.com} --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer"
 #    --extensions org.gooddata.extensions.ResponseHeadersTransformer,org.gooddata.extensions.RequestHeadersTransformer --verbose"
     volumes:


### PR DESCRIPTION
* the currently used images were deprecated
* the new offical ones should work natively with M1 Macs as well

Also optimize the e2e test run on CI: only build the packages necessary, not everything. This makes the e2e build phase 40% faster (saving approx. 2 minutes).

JIRA: FET-973

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [ ] `check-extended` passes
-   [x] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
