### PR TITLE
RELATED: RAIL-3993 Add --legacy-peer-deps flag for npm

### DIFF
--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions, TargetAppLanguage } from "../_base/types";
 import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import * as path from "path";
@@ -178,6 +178,7 @@ async function prepareProject(target: string, config: InitCmdActionConfig): Prom
 
 function runInstall(target: string, config: InitCmdActionConfig): void {
     const { skipInstall, packageManager } = config;
+    const isNpm = packageManager === "npm";
 
     if (skipInstall) {
         logWarn(
@@ -188,7 +189,13 @@ function runInstall(target: string, config: InitCmdActionConfig): void {
     }
 
     try {
-        const result = spawnSync(packageManager, ["install"], {
+        const args = ["install"];
+        if (isNpm) {
+            args.push("--legacy-peer-deps");
+            logInfo("Command will run with '--legacy-peer-deps' flag.");
+        }
+
+        const result = spawnSync(packageManager, args, {
             cwd: target,
             stdio: ["ignore", "inherit", "inherit"],
         });


### PR DESCRIPTION
- Add --legacy-peer-deps flag to prevent user to run into an issue on newest version of NPM

JIRA: RAIL-3993

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
