### PR TITLE
RELATED: RAIL-3999 Avoid webpack warning, remove non-sensical peerDep

### DIFF
--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -63,8 +63,7 @@
         "@gooddata/sdk-ui-charts": "^8.9.0-alpha.35",
         "@gooddata/sdk-ui-ext": "^8.9.0-alpha.35",
         "react": "^16.10.0 || ^17.0.0",
-        "react-dom": "^16.10.0 || ^17.0.0",
-        "react-intl": "^3.6.0"
+        "react-dom": "^16.10.0 || ^17.0.0"
     },
     "devDependencies": {
         "@babel/core": "^7.7.2",

--- a/tools/dashboard-plugin-template/src/plugin_entry/index.ts
+++ b/tools/dashboard-plugin-template/src/plugin_entry/index.ts
@@ -1,8 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import type { DashboardPluginDescriptor } from "@gooddata/sdk-ui-dashboard";
 
-import { MODULE_FEDERATION_NAME } from "../metadata.json";
-
+import metadataJson from "../metadata.json";
 import packageJson from "../../package.json";
 
 type PluginEntryPoint = DashboardPluginDescriptor & {
@@ -23,8 +22,8 @@ const entryPoint: PluginEntryPoint = {
     minEngineVersion: "bundled",
     maxEngineVersion: "bundled",
     // These two must fit the values in the webpack config. Do not edit them unless you know what you are doing
-    engineKey: `./${MODULE_FEDERATION_NAME}_ENGINE`,
-    pluginKey: `./${MODULE_FEDERATION_NAME}_PLUGIN`,
+    engineKey: `./${metadataJson.MODULE_FEDERATION_NAME}_ENGINE`,
+    pluginKey: `./${metadataJson.MODULE_FEDERATION_NAME}_PLUGIN`,
 };
 
 export default entryPoint;


### PR DESCRIPTION
Fix two minor problems in the dashboard plugin template:
* change the way the metadata.json file is imported to avoid
  `Should not import the named export 'MODULE_FEDERATION_NAME' (imported as 'MODULE_FEDERATION_NAME') from default-exporting module (only default export is available soon)` warning
* remove forgotten react-intl peerDependency

JIRA: RAIL-3999

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
