### PR TITLE
RELATED: FET-977 Update apidocs symlink automatically

### DIFF
--- a/common/scripts/ci/docker_apidocs_build.sh
+++ b/common/scripts/ci/docker_apidocs_build.sh
@@ -15,13 +15,11 @@ echo "Running apidocs build using ${IMAGE} in root directory ${ROOT_DIR}"
 #
 export CI=true
 
-
 echo "-----------------------------------------------------------------------"
 echo "--- starting: apidocs build"
 echo "-----------------------------------------------------------------------"
 
-
-if [ -z $API_DOCS_VERSION ]; then
+if [ -z "$API_DOCS_VERSION" ]; then
   echo "You did not specify api docs version to create."
   exit 1
 fi
@@ -30,6 +28,12 @@ fi
 # Execute apidocs build using dockerized node - all heavy lifting is done against SDK sources mounted as a volume onto the
 # /workspace directory
 #
+
+if [ "$IS_NEW_LATEST_STABLE" = true ]; then
+  SYMLINK_SWITCH=' --update-symlink'
+else
+  SYMLINK_SWITCH=''
+fi
 
 docker run \
   --env CI \
@@ -41,4 +45,4 @@ docker run \
   -u $(id -u ${USER}):$(id -g ${USER}) \
   -w /workspace \
   ${IMAGE} \
-  /bin/bash -c "cd gooddata-ui-sdk && ./common/scripts/build-docs.js -v $API_DOCS_VERSION"
+  /bin/bash -c "cd gooddata-ui-sdk && ./common/scripts/build-docs.js -v $API_DOCS_VERSION $SYMLINK_SWITCH"


### PR DESCRIPTION
This makes sure that when we add a new release, the symlink that
makes the versionless links work will point to the new version.

JIRA: FET-977

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
