### PR TITLE
RELATED: RAIL-3963 Use interfaces in dashboard component when possible

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -464,9 +464,9 @@ export function clearDateFilterSelection(correlationId?: string): ChangeDateFilt
 export function commandFailedEventHandler<TCommand extends IDashboardCommand>(type: TCommand["type"], handler: DashboardEventHandler<DashboardCommandFailed<TCommand>>["handler"]): DashboardEventHandler<DashboardCommandFailed<TCommand>>;
 
 // @public (undocumented)
-export type CommandProcessingMeta = {
+export interface CommandProcessingMeta {
     readonly uuid: string;
-};
+}
 
 // @internal (undocumented)
 export type CommandProcessingStatus = "running" | "success" | "error";
@@ -704,31 +704,31 @@ export interface DashboardCommandStarted<TCommand extends IDashboardCommand> ext
 export type DashboardCommandType = "GDC.DASH/CMD.INITIALIZE" | "GDC.DASH/CMD.SAVE" | "GDC.DASH/CMD.SAVEAS" | "GDC.DASH/CMD.RESET" | "GDC.DASH/CMD.RENAME" | "GDC.DASH/CMD.DELETE" | "GDC.DASH/CMD.SHARING.CHANGE" | "GDC.DASH/CMD.EXPORT.PDF" | "GDC.DASH/CMD.EVENT.TRIGGER" | "GDC.DASH/CMD.EXECUTION_RESULT.UPSERT" | "GDC.DASH/CMD.FILTER_CONTEXT.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.DATE_FILTER.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADD" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVE" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVE" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.CHANGE_SELECTION" | "GDC.DASH/CMD.FILTER_CONTEXT.ATTRIBUTE_FILTER.SET_PARENT" | "GDC.DASH/CMD.FLUID_LAYOUT.ADD_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_SECTION" | "GDC.DASH/CMD.FLUID_LAYOUT.CHANGE_SECTION_HEADER" | "GDC.DASH/CMD.FLUID_LAYOUT.ADD_ITEMS" | "GDC.DASH/CMD.FLUID_LAYOUT.REPLACE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.MOVE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.REMOVE_ITEM" | "GDC.DASH/CMD.FLUID_LAYOUT.UNDO" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_HEADER" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_MEASURE" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_FILTER_SETTINGS" | "GDC.DASH/CMD.KPI_WIDGET.CHANGE_COMPARISON" | "GDC.DASH/CMD.KPI_WIDGET.REFRESH" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_HEADER" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_FILTER_SETTINGS" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_PROPERTIES" | "GDC.DASH/CMD.INSIGHT_WIDGET.CHANGE_INSIGHT" | "GDC.DASH/CMD.INSIGHT_WIDGET.EXPORT" | "GDC.DASH/CMD.INSIGHT_WIDGET.MODIFY_DRILLS" | "GDC.DASH/CMD.INSIGHT_WIDGET.REMOVE_DRILLS" | "GDC.DASH/CMD.INSIGHT_WIDGET.REFRESH" | "GDC.DASH/CMD.ALERT.CREATE" | "GDC.DASH/CMD.ALERT.UPDATE" | "GDC.DASH/CMD.ALERTS.REMOVE" | "GDC.DASH/CMD.SCHEDULED_EMAIL.CREATE" | "GDC.DASH/CMD.DRILL" | "GDC.DASH/CMD.DRILL.DRILL_DOWN" | "GDC.DASH/CMD.DRILL.DRILL_TO_INSIGHT" | "GDC.DASH/CMD.DRILL.DRILL_TO_DASHBOARD" | "GDC.DASH/CMD.DRILL.DRILL_TO_ATTRIBUTE_URL" | "GDC.DASH/CMD.DRILL.DRILL_TO_CUSTOM_URL" | "GDC.DASH/CMD.DRILL.DRILL_TO_LEGACY_DASHBOARD" | "GDC.DASH/CMD.DRILL.DRILLABLE_ITEMS.CHANGE" | "GDC.DASH/CMD.DRILL_TARGETS.ADD" | "GDC.DASH/CMD.RENDER.ASYNC.REQUEST" | "GDC.DASH/CMD.RENDER.ASYNC.RESOLVE";
 
 // @public
-export type DashboardConfig = {
-    locale?: ILocale;
-    separators?: ISeparators;
-    settings?: ISettings;
-    dateFilterConfig?: IDateFilterConfig;
+export interface DashboardConfig {
     colorPalette?: IColorPalette;
-    objectAvailability?: ObjectAvailabilityConfig;
-    mapboxToken?: string;
-    isReadOnly?: boolean;
-    isEmbedded?: boolean;
-    isExport?: boolean;
+    dateFilterConfig?: IDateFilterConfig;
     disableDefaultDrills?: boolean;
     enableFilterValuesResolutionInDrillEvents?: boolean;
+    isEmbedded?: boolean;
+    isExport?: boolean;
+    isReadOnly?: boolean;
+    locale?: ILocale;
+    mapboxToken?: string;
     menuButtonItemsVisibility?: IMenuButtonItemsVisibility;
-};
+    objectAvailability?: ObjectAvailabilityConfig;
+    separators?: ISeparators;
+    settings?: ISettings;
+}
 
 // @public (undocumented)
-export type DashboardContext = {
+export interface DashboardContext {
     backend: IAnalyticalBackend;
-    workspace: string;
-    dashboardRef?: ObjRef;
-    filterContextRef?: ObjRef;
     clientId?: string;
+    dashboardRef?: ObjRef;
     dataProductId?: string;
-};
+    filterContextRef?: ObjRef;
+    workspace: string;
+}
 
 // @public
 export interface DashboardCopySaved extends IDashboardEvent {
@@ -979,10 +979,10 @@ export type DashboardEventBody<T extends IDashboardEvent | ICustomDashboardEvent
 export type DashboardEventEvalFn = (event: DashboardEvents | ICustomDashboardEvent) => boolean;
 
 // @public
-export type DashboardEventHandler<TEvents extends DashboardEvents | ICustomDashboardEvent = any> = {
+export interface DashboardEventHandler<TEvents extends DashboardEvents | ICustomDashboardEvent = any> {
     eval: DashboardEventEvalFn;
     handler: DashboardEventHandlerFn<TEvents>;
-};
+}
 
 // @public (undocumented)
 export type DashboardEventHandlerFn<TEvents extends DashboardEvents | ICustomDashboardEvent> = (event: TEvents, dashboardDispatch: Dispatch<AnyAction>, stateSelect: DashboardSelectorEvaluator) => void;
@@ -1327,21 +1327,21 @@ export interface DashboardMetaState {
 }
 
 // @public (undocumented)
-export type DashboardModelCustomizationFns = {
+export interface DashboardModelCustomizationFns {
     existingDashboardTransformFn?: DashboardTransformFn;
-};
+}
 
-// @public (undocumented)
-export type DashboardPluginDescriptor = {
+// @public
+export interface DashboardPluginDescriptor {
     readonly author: string;
-    readonly displayName: string;
-    readonly version: string;
-    readonly shortDescription?: string;
-    readonly longDescription?: string;
     readonly debugName?: string;
-    readonly minEngineVersion: string;
+    readonly displayName: string;
+    readonly longDescription?: string;
     readonly maxEngineVersion?: string;
-};
+    readonly minEngineVersion: string;
+    readonly shortDescription?: string;
+    readonly version: string;
+}
 
 // @public
 export abstract class DashboardPluginV1 implements IDashboardPluginContract_V1 {
@@ -1467,30 +1467,48 @@ export interface DashboardSharingChanged extends IDashboardEvent {
 }
 
 // @alpha
-export type DashboardState = {
-    loading: LoadingState;
-    saving: SavingState;
-    backendCapabilities: BackendCapabilitiesState;
-    config: ConfigState;
-    permissions: PermissionsState;
-    filterContext: FilterContextState;
-    layout: LayoutState;
-    dateFilterConfig: DateFilterConfigState;
-    catalog: CatalogState;
-    user: UserState;
-    meta: DashboardMetaState;
-    drill: DrillState;
-    insights: EntityState<IInsight>;
-    alerts: EntityState<IWidgetAlert>;
-    drillTargets: EntityState<IDrillTargets>;
-    listedDashboards: EntityState<IListedDashboard>;
+export interface DashboardState {
+    // (undocumented)
     accessibleDashboards: EntityState<IListedDashboard>;
-    ui: UiState;
+    // (undocumented)
+    alerts: EntityState<IWidgetAlert>;
+    // (undocumented)
+    backendCapabilities: BackendCapabilitiesState;
+    // (undocumented)
+    catalog: CatalogState;
+    // (undocumented)
+    config: ConfigState;
+    // (undocumented)
+    dateFilterConfig: DateFilterConfigState;
+    // (undocumented)
+    drill: DrillState;
+    // (undocumented)
+    drillTargets: EntityState<IDrillTargets>;
     executionResults: EntityState<IExecutionResultEnvelope>;
+    // (undocumented)
+    filterContext: FilterContextState;
+    // (undocumented)
+    insights: EntityState<IInsight>;
+    // (undocumented)
+    layout: LayoutState;
+    // (undocumented)
+    listedDashboards: EntityState<IListedDashboard>;
+    // (undocumented)
+    loading: LoadingState;
+    // (undocumented)
+    meta: DashboardMetaState;
+    // (undocumented)
+    permissions: PermissionsState;
+    // @internal
     _queryCache: {
         [queryName: string]: any;
     };
-};
+    // (undocumented)
+    saving: SavingState;
+    ui: UiState;
+    // (undocumented)
+    user: UserState;
+}
 
 // @public
 export type DashboardStateChangeCallback = (state: DashboardState, dispatch: DashboardDispatch) => void;
@@ -2008,11 +2026,14 @@ export class HeadlessDashboard {
 }
 
 // @internal (undocumented)
-export type HeadlessDashboardConfig = {
-    queryServices?: IDashboardQueryService<any, any>[];
+export interface HeadlessDashboardConfig {
+    // (undocumented)
     backgroundWorkers?: ((context: DashboardContext) => SagaIterator<void>)[];
+    // (undocumented)
     customizationFns?: DashboardModelCustomizationFns;
-};
+    // (undocumented)
+    queryServices?: IDashboardQueryService<any, any>[];
+}
 
 // @alpha
 export const HiddenButtonBar: () => JSX.Element | null;
@@ -2057,9 +2078,10 @@ export interface IButtonBarProps {
 }
 
 // @alpha (undocumented)
-export type ICsvExportConfig = {
+export interface ICsvExportConfig {
+    // (undocumented)
     format: "csv";
-};
+}
 
 // @public
 export interface ICustomDashboardEvent<TPayload = any> {
@@ -2230,9 +2252,9 @@ export interface IDashboardEventsContext {
 }
 
 // @public
-export type IDashboardExtensionProps = IDashboardEventing & IDashboardCustomizationProps & IDashboardThemingProps & {
+export interface IDashboardExtensionProps extends IDashboardEventing, IDashboardCustomizationProps, IDashboardThemingProps {
     additionalReduxContext?: React_2.Context<ReactReduxContextValue>;
-};
+}
 
 // @beta
 export type IDashboardFilter = IAbsoluteDateFilter | IRelativeDateFilter | IPositiveAttributeFilter | INegativeAttributeFilter;
@@ -2648,26 +2670,26 @@ export function initializeDashboard(config?: DashboardConfig, permissions?: IWor
 export const InitialLoadCorrelationId = "initialLoad";
 
 // @alpha (undocumented)
-export type InsightAttributesMeta = {
-    usage: InsightDisplayFormUsage;
-    displayForms: ReadonlyArray<IAttributeDisplayFormMetadataObject>;
+export interface InsightAttributesMeta {
     attributes: ReadonlyArray<IAttributeMetadataObject>;
-};
+    displayForms: ReadonlyArray<IAttributeDisplayFormMetadataObject>;
+    usage: InsightDisplayFormUsage;
+}
 
 // @public (undocumented)
 export type InsightComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightComponent;
 
 // @alpha
-export type InsightDateDatasets = {
+export interface InsightDateDatasets {
+    readonly allAvailableDateDatasets: ICatalogDateDataset[];
+    readonly dateDatasetDisplayNames: Record<string, string>;
     readonly dateDatasets: ReadonlyArray<ICatalogDateDataset>;
     readonly dateDatasetsOrdered: ReadonlyArray<ICatalogDateDataset>;
-    readonly usedInDateFilters: ReadonlyArray<ICatalogDateDataset>;
-    readonly usedInAttributes: ReadonlyArray<ICatalogDateDataset | undefined>;
-    readonly usedInAttributeFilters: ReadonlyArray<ICatalogDateDataset | undefined>;
     readonly mostImportantFromInsight: ICatalogDateDataset | undefined;
-    readonly dateDatasetDisplayNames: Record<string, string>;
-    readonly allAvailableDateDatasets: ICatalogDateDataset[];
-};
+    readonly usedInAttributeFilters: ReadonlyArray<ICatalogDateDataset | undefined>;
+    readonly usedInAttributes: ReadonlyArray<ICatalogDateDataset | undefined>;
+    readonly usedInDateFilters: ReadonlyArray<ICatalogDateDataset>;
+}
 
 // @alpha (undocumented)
 export type InsightMenuButtonComponentProvider = (insight: IInsight, widget: IInsightWidget) => CustomDashboardInsightMenuButtonComponent;
@@ -2679,9 +2701,10 @@ export type InsightMenuComponentProvider = (insight: IInsight, widget: IInsightW
 export type InsightMenuItemsProvider = (insight: IInsight, widget: IInsightWidget, defaultItems: IInsightMenuItem[], closeMenu: () => void) => IInsightMenuItem[];
 
 // @alpha (undocumented)
-export type InsightPlaceholderWidget = ICustomWidgetBase & {
+export interface InsightPlaceholderWidget extends ICustomWidgetBase {
+    // (undocumented)
     readonly customType: "insightPlaceholder";
-};
+}
 
 // @alpha
 export function insightSelectDateDataset(queryResult: InsightDateDatasets): ICatalogDateDataset | undefined;
@@ -3060,12 +3083,13 @@ export interface IUseCustomWidgetInsightDataViewConfig {
 }
 
 // @alpha (undocumented)
-export type IXlsxExportConfig = {
+export interface IXlsxExportConfig {
+    // (undocumented)
     format: "xlsx";
-    title?: string;
     mergeHeaders?: boolean;
     showFilters?: boolean;
-};
+    title?: string;
+}
 
 // @alpha (undocumented)
 export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kpiAlertDialogOpened", {
@@ -3076,15 +3100,16 @@ export type KpiAlertDialogOpenedPayload = UserInteractionPayloadWithDataBase<"kp
 export type KpiComponentProvider = (kpi: ILegacyKpi, widget: IKpiWidget) => CustomDashboardKpiComponent;
 
 // @alpha (undocumented)
-export type KpiPlaceholderWidget = ICustomWidgetBase & {
+export interface KpiPlaceholderWidget extends ICustomWidgetBase {
+    // (undocumented)
     readonly customType: "kpiPlaceholder";
-};
+}
 
 // @alpha (undocumented)
-export type KpiWidgetComparison = {
-    comparisonType?: ILegacyKpiComparisonTypeComparison;
+export interface KpiWidgetComparison {
     comparisonDirection?: ILegacyKpiComparisonDirection;
-};
+    comparisonType?: ILegacyKpiComparisonTypeComparison;
+}
 
 // @alpha (undocumented)
 export type LayoutStash = Record<string, ExtendedDashboardItem[]>;
@@ -3104,21 +3129,24 @@ export const LegacyDashboardInsightMenu: (props: IDashboardInsightMenuProps) => 
 export const LegacyDashboardInsightMenuButton: (props: IDashboardInsightMenuButtonProps) => JSX.Element;
 
 // @alpha (undocumented)
-export type LoadingState = {
-    loading: boolean;
-    result?: boolean;
+export interface LoadingState {
+    // (undocumented)
     error?: Error;
-};
+    // (undocumented)
+    loading: boolean;
+    // (undocumented)
+    result?: boolean;
+}
 
 // @alpha (undocumented)
 export const LockedStatusIndicator: React_2.ComponentType<Pick<ILockedStatusProps, "isLocked">>;
 
 // @alpha
-export type MeasureDateDatasets = {
+export interface MeasureDateDatasets {
+    readonly dateDatasetDisplayNames: Record<string, string>;
     readonly dateDatasets: ReadonlyArray<ICatalogDateDataset>;
     readonly dateDatasetsOrdered: ReadonlyArray<ICatalogDateDataset>;
-    readonly dateDatasetDisplayNames: Record<string, string>;
-};
+}
 
 // @internal (undocumented)
 export const MenuButton: (props: IMenuButtonProps) => JSX.Element;
@@ -3138,12 +3166,16 @@ export interface ModifyDrillsForInsightWidget extends IDashboardCommand {
 export function modifyDrillsForInsightWidget(ref: ObjRef, drills: InsightDrillDefinition[], correlationId?: string): ModifyDrillsForInsightWidget;
 
 // @internal (undocumented)
-export type MonitoredAction = {
+export interface MonitoredAction {
+    // (undocumented)
     calls: number;
+    // (undocumented)
     promise: Promise<PayloadAction<any>>;
-    resolve: (action: PayloadAction<any>) => void;
+    // (undocumented)
     reject: (e: any) => void;
-};
+    // (undocumented)
+    resolve: (action: PayloadAction<any>) => void;
+}
 
 // @alpha (undocumented)
 export interface MoveAttributeFilter extends IDashboardCommand {
@@ -3213,10 +3245,10 @@ export function newDisplayFormMap(items: ReadonlyArray<IAttributeDisplayFormMeta
 export const newDrillToSameDashboardHandler: (dashboardRef: ObjRef) => DashboardEventHandler<DashboardDrillToDashboardResolved>;
 
 // @public
-export type ObjectAvailabilityConfig = {
+export interface ObjectAvailabilityConfig {
     excludeObjectsWithTags?: string[];
     includeObjectsWithTags?: string[];
-};
+}
 
 // @alpha
 export class ObjRefMap<T> {
@@ -3242,13 +3274,13 @@ export class ObjRefMap<T> {
 }
 
 // @alpha
-export type ObjRefMapConfig<T> = {
-    readonly refExtract: (obj: T) => ObjRef;
+export interface ObjRefMapConfig<T> {
     readonly idExtract: (obj: T) => Identifier;
-    readonly uriExtract: (obj: T) => string;
+    readonly refExtract: (obj: T) => ObjRef;
     readonly strictTypeCheck: boolean;
     readonly type?: ObjectType;
-};
+    readonly uriExtract: (obj: T) => string;
+}
 
 // @internal (undocumented)
 export type OnDashboardDrill = (cmd: Drill) => void;
@@ -3398,32 +3430,44 @@ export interface QueryMeasureDateDatasets extends IDashboardQuery {
 }
 
 // @internal (undocumented)
-export type QueryProcessingErrorState = {
-    status: "error";
+export interface QueryProcessingErrorState {
+    // (undocumented)
     error: GoodDataSdkError;
+    // (undocumented)
     result: undefined;
-};
+    // (undocumented)
+    status: "error";
+}
 
 // @internal (undocumented)
-export type QueryProcessingPendingState = {
+export interface QueryProcessingPendingState {
+    // (undocumented)
+    error: undefined;
+    // (undocumented)
+    result: undefined;
+    // (undocumented)
     status: "pending";
-    error: undefined;
-    result: undefined;
-};
+}
 
 // @internal (undocumented)
-export type QueryProcessingRejectedState = {
+export interface QueryProcessingRejectedState {
+    // (undocumented)
+    error: undefined;
+    // (undocumented)
+    result: undefined;
+    // (undocumented)
     status: "rejected";
-    error: undefined;
-    result: undefined;
-};
+}
 
 // @internal (undocumented)
-export type QueryProcessingRunningState = {
-    status: "running";
+export interface QueryProcessingRunningState {
+    // (undocumented)
     error: undefined;
+    // (undocumented)
     result: undefined;
-};
+    // (undocumented)
+    status: "running";
+}
 
 // @internal (undocumented)
 export type QueryProcessingState<TResult> = QueryProcessingPendingState | QueryProcessingRunningState | QueryProcessingErrorState | QueryProcessingRejectedState | QueryProcessingSuccessState<TResult>;
@@ -3432,11 +3476,14 @@ export type QueryProcessingState<TResult> = QueryProcessingPendingState | QueryP
 export type QueryProcessingStatus = QueryProcessingState<any>["status"];
 
 // @internal (undocumented)
-export type QueryProcessingSuccessState<TResult> = {
-    status: "success";
+export interface QueryProcessingSuccessState<TResult> {
+    // (undocumented)
     error: undefined;
+    // (undocumented)
     result: TResult;
-};
+    // (undocumented)
+    status: "success";
+}
 
 // @alpha
 export interface QueryWidgetBrokenAlerts extends IDashboardQuery {
@@ -3690,11 +3737,14 @@ export interface SaveDashboardAs extends IDashboardCommand {
 export function saveDashboardAs(title?: string, switchToCopy?: boolean, useOriginalFilterContext?: boolean, correlationId?: string): SaveDashboardAs;
 
 // @alpha (undocumented)
-export type SavingState = {
-    saving: boolean;
-    result?: boolean;
+export interface SavingState {
+    // (undocumented)
     error?: Error;
-};
+    // (undocumented)
+    result?: boolean;
+    // (undocumented)
+    saving: boolean;
+}
 
 // @internal (undocumented)
 export const ScheduledEmailDialog: (props: IScheduledEmailDialogProps) => JSX.Element;
@@ -4178,43 +4228,50 @@ type: string;
 }>;
 
 // @alpha (undocumented)
-export type UiState = {
-    scheduleEmailDialog: {
-        open: boolean;
-    };
-    saveAsDialog: {
-        open: boolean;
-    };
-    shareDialog: {
-        open: boolean;
-    };
+export interface UiState {
+    // (undocumented)
     filterBar: {
         height: number;
         expanded: boolean;
     };
+    // (undocumented)
     kpiAlerts: {
         openedWidgetRef: ObjRef | undefined;
         highlightedWidgetRef: ObjRef | undefined;
     };
+    // (undocumented)
     menuButton: {
         itemsVisibility: IMenuButtonItemsVisibility;
     };
-};
+    // (undocumented)
+    saveAsDialog: {
+        open: boolean;
+    };
+    // (undocumented)
+    scheduleEmailDialog: {
+        open: boolean;
+    };
+    // (undocumented)
+    shareDialog: {
+        open: boolean;
+    };
+}
 
 // @alpha
-export type UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> {
+    // (undocumented)
     _undo: {
         undoPointer: number;
         undoStack: UndoEntry<T>[];
     };
-};
+}
 
 // @alpha
-export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoEntry<T extends IDashboardCommand = IDashboardCommand> {
     cmd: T;
-    undoPatches: Patch[];
     redoPatches: Patch[];
-};
+    undoPatches: Patch[];
+}
 
 // @alpha (undocumented)
 export interface UndoLayoutChanges extends IDashboardCommand {
@@ -4775,26 +4832,35 @@ export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => Custo
 export type WidgetFilterOperation = FilterOpEnableDateFilter | FilterOpDisableDateFilter | FilterOpReplaceAttributeIgnores | FilterOpIgnoreAttributeFilter | FilterOpUnignoreAttributeFilter | FilterOpReplaceAll;
 
 // @alpha (undocumented)
-export type WidgetHeader = {
+export interface WidgetHeader {
     title?: string;
-};
+}
 
 // @internal (undocumented)
 export function WithDrillSelect({ widgetRef, children, insight, onDrillDownSuccess, onDrillToInsightSuccess, onDrillToDashboardSuccess, onDrillToAttributeUrlSuccess, onDrillToCustomUrlSuccess, onError, }: WithDrillSelectProps): JSX.Element;
 
 // @internal (undocumented)
-export type WithDrillSelectProps = {
-    widgetRef: ObjRef;
-    insight: IInsight;
-    onDrillDownSuccess?: OnDrillDownSuccess;
-    onDrillToInsightSuccess?: OnDrillToInsightSuccess;
-    onDrillToDashboardSuccess?: OnDrillToDashboardSuccess;
-    onDrillToAttributeUrlSuccess?: OnDrillToAttributeUrlSuccess;
-    onDrillToCustomUrlSuccess?: OnDrillToCustomUrlSuccess;
-    onError?: (error: any) => void;
+export interface WithDrillSelectProps {
+    // (undocumented)
     children: (props: {
         onDrill: OnWidgetDrill;
     }) => JSX.Element;
-};
+    // (undocumented)
+    insight: IInsight;
+    // (undocumented)
+    onDrillDownSuccess?: OnDrillDownSuccess;
+    // (undocumented)
+    onDrillToAttributeUrlSuccess?: OnDrillToAttributeUrlSuccess;
+    // (undocumented)
+    onDrillToCustomUrlSuccess?: OnDrillToCustomUrlSuccess;
+    // (undocumented)
+    onDrillToDashboardSuccess?: OnDrillToDashboardSuccess;
+    // (undocumented)
+    onDrillToInsightSuccess?: OnDrillToInsightSuccess;
+    // (undocumented)
+    onError?: (error: any) => void;
+    // (undocumented)
+    widgetRef: ObjRef;
+}
 
 ```

--- a/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/objRefMap.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     IAttributeDisplayFormMetadataObject,
     IAttributeMetadataObject,
@@ -25,7 +25,7 @@ import values from "lodash/values";
  *
  * @alpha
  */
-export type ObjRefMapConfig<T> = {
+export interface ObjRefMapConfig<T> {
     /**
      * Function that extracts `ref` from object
      */
@@ -55,7 +55,7 @@ export type ObjRefMapConfig<T> = {
      * Type of object stored in the map.
      */
     readonly type?: ObjectType;
-};
+}
 
 /**
  * Utility class that assists with type-agnostic mapping of metadata objects by ObjRef.

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/mergeDateFilterConfigs.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/mergeDateFilterConfigs.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { IDashboardDateFilterConfig, IDateFilterConfig } from "@gooddata/sdk-backend-spi";
 
@@ -9,10 +9,10 @@ import { dispatchDashboardEvent } from "../../../store/_infra/eventDispatcher";
 import { dateFilterValidationFailed } from "../../../events/dashboard";
 import { DashboardContext } from "../../../types/commonTypes";
 
-export type DateFilterMergeResult = {
+export interface DateFilterMergeResult {
     config: IDateFilterConfig;
     source: "workspace" | "dashboard";
-};
+}
 
 export function* mergeDateFilterConfigWithOverrides(
     ctx: DashboardContext,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/stashValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/stashValidation.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import {
     ExtendedDashboardItem,
@@ -8,7 +8,7 @@ import {
 } from "../../../types/layoutTypes";
 import { LayoutStash } from "../../../store/layout/layoutState";
 
-export type ItemResolutionResult = {
+export interface ItemResolutionResult {
     /**
      * Existing layout stashes that were used by the item definitions.
      */
@@ -36,7 +36,7 @@ export type ItemResolutionResult = {
      * but were stashed.
      */
     newItemBitmap: boolean[];
-};
+}
 
 /**
  * Given layout stash and a list of dashboard item definitions, this function will validate and resolve those

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/filterOperations.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/widgets/common/filterOperations.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     ICatalogDateDataset,
     IDashboardAttributeFilter,
@@ -207,7 +207,7 @@ function* unignoreAttributeFilter(
  * Result of the filter operation. This is fully resolved variant of filter settings that should be set as-is
  * on the widget.
  */
-export type FilterOpResult = {
+export interface FilterOpResult {
     /**
      * Date data set (if any) to use for date filtering the widget
      */
@@ -217,7 +217,7 @@ export type FilterOpResult = {
      * Attribute filters to ignore on the widget.
      */
     ignoredFilters?: IDashboardAttributeFilter[];
-};
+}
 
 export type DateDatasetValidator<T extends IAnalyticalWidget> = (
     ctx: DashboardContext,
@@ -236,11 +236,11 @@ export type FilterValidators<T extends IAnalyticalWidget> = {
     attributeFilterValidator: AttributeFilterValidator<T>;
 };
 
-export type FilterOpCommand = IDashboardCommand & {
+export interface FilterOpCommand extends IDashboardCommand {
     payload: {
         readonly operation: WidgetFilterOperation;
     };
-};
+}
 
 /**
  * This is one of the more complex event handlers. Here is a little introduction to make studying easier. You

--- a/libs/sdk-ui-dashboard/src/model/commands/base.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/base.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 /**
  * All available command types.
  *
@@ -68,12 +68,12 @@ export type DashboardCommandType =
 /**
  * @public
  */
-export type CommandProcessingMeta = {
+export interface CommandProcessingMeta {
     /**
      * Unique identifier assigned at the time command was submitted for processing.
      */
     readonly uuid: string;
-};
+}
 
 /**
  * Base type for all commands.

--- a/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/kpi.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardCommand } from "./base";
 import { isObjRef, ObjRef } from "@gooddata/sdk-model";
@@ -333,7 +333,7 @@ export function unignoreFilterOnKpiWidget(
 /**
  * @alpha
  */
-export type KpiWidgetComparison = {
+export interface KpiWidgetComparison {
     /**
      * Type of comparison to do. May be period-over-period, previous period or no
      * comparison.
@@ -349,7 +349,7 @@ export type KpiWidgetComparison = {
      * a good thing or a bad thing. This setting influences the visuals (red vs green indicators)
      */
     comparisonDirection?: ILegacyKpiComparisonDirection;
-};
+}
 
 /**
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/eventHandlers/eventHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/eventHandlers/eventHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { AnyAction, Dispatch } from "@reduxjs/toolkit";
 import { IDashboardCommand } from "../commands";
 import { DashboardSelectorEvaluator } from "../store/types";
@@ -33,7 +33,7 @@ export type DashboardEventEvalFn = (event: DashboardEvents | ICustomDashboardEve
  *
  * @public
  */
-export type DashboardEventHandler<TEvents extends DashboardEvents | ICustomDashboardEvent = any> = {
+export interface DashboardEventHandler<TEvents extends DashboardEvents | ICustomDashboardEvent = any> {
     /**
      * Specify event evaluation function. This will be used by dashboard's event emitter to determine
      * whether event of particular type should be dispatched to this handler.
@@ -50,7 +50,7 @@ export type DashboardEventHandler<TEvents extends DashboardEvents | ICustomDashb
      * @param stateSelect - callback to execute arbitrary selectors against the dashboard state
      */
     handler: DashboardEventHandlerFn<TEvents>;
-};
+}
 
 /**
  * Creates a {@link DashboardEventHandler} instance that will be invoked for any event (event for custom events).

--- a/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
+++ b/libs/sdk-ui-dashboard/src/model/headlessDashboard/HeadlessDashboard.ts
@@ -15,21 +15,21 @@ import { queryEnvelopeWithPromise } from "../store/_infra/queryProcessing";
 /**
  * @internal
  */
-export type MonitoredAction = {
+export interface MonitoredAction {
     calls: number;
     promise: Promise<PayloadAction<any>>;
     resolve: (action: PayloadAction<any>) => void;
     reject: (e: any) => void;
-};
+}
 
 /**
  * @internal
  */
-export type HeadlessDashboardConfig = {
+export interface HeadlessDashboardConfig {
     queryServices?: IDashboardQueryService<any, any>[];
     backgroundWorkers?: ((context: DashboardContext) => SagaIterator<void>)[];
     customizationFns?: DashboardModelCustomizationFns;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/queries/insights.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/insights.ts
@@ -58,7 +58,7 @@ export function queryDateDatasetsForInsight(
  *
  * @alpha
  */
-export type InsightDateDatasets = {
+export interface InsightDateDatasets {
     /**
      * Date datasets that are available for filtering of the insight. The available datasets are obtained by inspecting
      * the LDM entities used in the insight and how they relate to date datasets in the workspace's logical data model.
@@ -118,7 +118,7 @@ export type InsightDateDatasets = {
      * date datasets listed in this result.
      */
     readonly allAvailableDateDatasets: ICatalogDateDataset[];
-};
+}
 
 /**
  * Given results of a query of date datasets available to use for filtering an insight, this function will
@@ -154,7 +154,7 @@ export interface QueryInsightAttributesMeta extends IDashboardQuery {
 /**
  * @alpha
  */
-export type InsightAttributesMeta = {
+export interface InsightAttributesMeta {
     /**
      * High-level break down of how different display forms are used in the insight.
      */
@@ -169,7 +169,7 @@ export type InsightAttributesMeta = {
      * List of attributes to which the used display forms belong.
      */
     attributes: ReadonlyArray<IAttributeMetadataObject>;
-};
+}
 
 /**
  * Creates action thought which you can query dashboard component for information about display forms and

--- a/libs/sdk-ui-dashboard/src/model/queries/kpis.ts
+++ b/libs/sdk-ui-dashboard/src/model/queries/kpis.ts
@@ -47,7 +47,7 @@ export function queryDateDatasetsForMeasure(
  *
  * @alpha
  */
-export type MeasureDateDatasets = {
+export interface MeasureDateDatasets {
     /**
      * Date datasets that are available for filtering of the measure. The available datasets are obtained by inspecting
      * relation of measure and the different date datasets in the workspace's logical data model.
@@ -65,4 +65,4 @@ export type MeasureDateDatasets = {
      * that figure in the result structure have their titles included in this mapping
      */
     readonly dateDatasetDisplayNames: Record<string, string>;
-};
+}

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardQueryProcessing.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardQueryProcessing.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuid } from "uuid";
 import { GoodDataSdkError, UnexpectedSdkError } from "@gooddata/sdk-ui";
@@ -16,47 +16,47 @@ import {
 /**
  * @internal
  */
-export type QueryProcessingPendingState = {
+export interface QueryProcessingPendingState {
     status: "pending";
     error: undefined;
     result: undefined;
-};
+}
 
 /**
  * @internal
  */
-export type QueryProcessingRunningState = {
+export interface QueryProcessingRunningState {
     status: "running";
     error: undefined;
     result: undefined;
-};
+}
 
 /**
  * @internal
  */
-export type QueryProcessingErrorState = {
+export interface QueryProcessingErrorState {
     status: "error";
     error: GoodDataSdkError;
     result: undefined;
-};
+}
 
 /**
  * @internal
  */
-export type QueryProcessingRejectedState = {
+export interface QueryProcessingRejectedState {
     status: "rejected";
     error: undefined;
     result: undefined;
-};
+}
 
 /**
  * @internal
  */
-export type QueryProcessingSuccessState<TResult> = {
+export interface QueryProcessingSuccessState<TResult> {
     status: "success";
     error: undefined;
     result: TResult;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/queryProcessing.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/queryProcessing.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardQueryService } from "./queryService";
 import { Saga, SagaIterator } from "redux-saga";
@@ -23,7 +23,7 @@ import { getDashboardContext } from "./contexts";
 /**
  * Query processing component has multiple pieces that need to be integrated into the redux store.
  */
-export type QueryProcessingModule = {
+export interface QueryProcessingModule {
     /**
      * Query services may store the results in state for caching purposes. All services that use caching implement
      * the cache as a separate slice of the internal `_queryCache` part of the state. This reducer is a combined
@@ -35,7 +35,7 @@ export type QueryProcessingModule = {
      * A single saga is in place to handle query processing requests. Query requests will be processed concurrently.
      */
     rootQueryProcessor: Saga;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/rootEventEmitter.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/rootEventEmitter.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { actionChannel, select, take } from "redux-saga/effects";
 
@@ -6,11 +6,11 @@ import { DashboardEventHandler } from "../../eventHandlers/eventHandler";
 import { DashboardEvents, isDashboardEventOrCustomDashboardEvent } from "../../events";
 import { DashboardDispatch, DashboardSelectorEvaluator, DashboardState } from "../types";
 
-export type EventEmitter = {
+export interface EventEmitter {
     registerHandler: (handler: DashboardEventHandler) => void;
     unregisterHandler: (handler: DashboardEventHandler) => void;
     eventEmitterSaga: () => SagaIterator<void>;
-};
+}
 
 /**
  * Creates root event emitter that will be responsible for emitting events to all registered handlers.

--- a/libs/sdk-ui-dashboard/src/model/store/_infra/undoEnhancer.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/_infra/undoEnhancer.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import produce, { applyPatches, enablePatches, original, Patch, produceWithPatches } from "immer";
 import { CaseReducer, Draft, PayloadAction } from "@reduxjs/toolkit";
 import { IDashboardCommand } from "../../commands";
@@ -15,7 +15,7 @@ enablePatches();
  *
  * @alpha
  */
-export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoEntry<T extends IDashboardCommand = IDashboardCommand> {
     /**
      * Dashboard command that has initiated the state changes.
      */
@@ -30,19 +30,19 @@ export type UndoEntry<T extends IDashboardCommand = IDashboardCommand> = {
      * Patches to apply in order to redo the undone changes.
      */
     redoPatches: Patch[];
-};
+}
 
 /**
  * Slice that can be undo-enabled needs to include the undo section which will contain the essential undo metadata.
  *
  * @alpha
  */
-export type UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoEnhancedState<T extends IDashboardCommand = IDashboardCommand> {
     _undo: {
         undoPointer: number;
         undoStack: UndoEntry<T>[];
     };
-};
+}
 
 /**
  * Initial value of the undo state.
@@ -57,7 +57,7 @@ export const InitialUndoState: UndoEnhancedState<any> = {
 /**
  * Actions that can be undone need to contain extra information in order to perform the undo correctly.
  */
-export type UndoPayload<T extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoPayload<T extends IDashboardCommand = IDashboardCommand> {
     /**
      * Undo-related information. If not specified, then no undo will be possible for the action
      */
@@ -70,7 +70,7 @@ export type UndoPayload<T extends IDashboardCommand = IDashboardCommand> = {
          */
         cmd: T;
     };
-};
+}
 
 /**
  * Signature of the reducer enhanced to with undo - the payload action requires additional `undo` part in the payload.
@@ -192,7 +192,7 @@ export const resetUndoReducer = <TState extends UndoEnhancedState>(state: Draft<
     state._undo = InitialUndoState._undo;
 };
 
-export type UndoableCommand<TCmd extends IDashboardCommand = IDashboardCommand> = {
+export interface UndoableCommand<TCmd extends IDashboardCommand = IDashboardCommand> {
     /**
      * Command that can be un-done.
      */
@@ -206,7 +206,7 @@ export type UndoableCommand<TCmd extends IDashboardCommand = IDashboardCommand> 
      * patches is done on particular reducer level (which the batch-actions reducer calls in sequence).
      */
     firstOccurrenceOnStack: number;
-};
+}
 
 /**
  * Given the undo information stored in state, this function produces an array of commands that can be un-done. The commands

--- a/libs/sdk-ui-dashboard/src/model/store/dashboardStore.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/dashboardStore.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     combineReducers,
     configureStore,
@@ -102,7 +102,7 @@ const nonSerializableEventsAndCommands: (DashboardEventType | DashboardCommandTy
  */
 export type DashboardStore = EnhancedStore<DashboardState>;
 
-export type DashboardStoreEventing = {
+export interface DashboardStoreEventing {
     /**
      * Optionally specify event handlers to register during the initialization.
      */
@@ -125,9 +125,9 @@ export type DashboardStoreEventing = {
         registerEventHandler: (handler: DashboardEventHandler) => void,
         unregisterEventHandler: (handler: DashboardEventHandler) => void,
     ) => void;
-};
+}
 
-export type DashboardStoreConfig = {
+export interface DashboardStoreConfig {
     /**
      * Specifies context that will be hammered into the saga middleware. All sagas can then access the values
      * from the context.
@@ -173,7 +173,7 @@ export type DashboardStoreConfig = {
      * Background workers are processed last in the chain of all command and event processing.
      */
     backgroundWorkers: ((context: DashboardContext) => SagaIterator<void>)[];
-};
+}
 
 function* rootSaga(
     eventEmitter: Saga,
@@ -199,12 +199,12 @@ function* rootSaga(
 /**
  * Fully configured and initialized dashboard store realized by redux and with redux-sagas.
  */
-export type ReduxedDashboardStore = {
+export interface ReduxedDashboardStore {
     store: DashboardStore;
     registerEventHandler: (handler: DashboardEventHandler) => void;
     unregisterEventHandler: (handler: DashboardEventHandler) => void;
     rootSagaTask: Task;
-};
+}
 
 /**
  * This middleware ensures that actions occurring in the dashboard have their meta enriched with appropriate

--- a/libs/sdk-ui-dashboard/src/model/store/loading/loadingState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/loading/loadingState.ts
@@ -1,12 +1,12 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 /**
  * @alpha
  */
-export type LoadingState = {
+export interface LoadingState {
     loading: boolean;
     result?: boolean;
     error?: Error;
-};
+}
 
 export const loadingInitialState: LoadingState = { loading: false };

--- a/libs/sdk-ui-dashboard/src/model/store/saving/savingState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/saving/savingState.ts
@@ -1,12 +1,12 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 /**
  * @alpha
  */
-export type SavingState = {
+export interface SavingState {
     saving: boolean;
     result?: boolean;
     error?: Error;
-};
+}
 
 export const savingInitialState: SavingState = { saving: false };

--- a/libs/sdk-ui-dashboard/src/model/store/types.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/types.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { AnyAction, Dispatch, EntityState } from "@reduxjs/toolkit";
 import { IInsight } from "@gooddata/sdk-model";
 import { LoadingState } from "./loading/loadingState";
@@ -36,7 +36,7 @@ import { UiState } from "./ui/uiState";
  *
  * @alpha
  */
-export type DashboardState = {
+export interface DashboardState {
     loading: LoadingState;
     saving: SavingState;
     backendCapabilities: BackendCapabilitiesState;
@@ -74,7 +74,7 @@ export type DashboardState = {
     _queryCache: {
         [queryName: string]: any;
     };
-};
+}
 
 /**
  * @public

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -6,7 +6,7 @@ import { IMenuButtonItemsVisibility } from "../../../types";
 /**
  * @alpha
  */
-export type UiState = {
+export interface UiState {
     scheduleEmailDialog: {
         open: boolean;
     };
@@ -27,7 +27,7 @@ export type UiState = {
     menuButton: {
         itemsVisibility: IMenuButtonItemsVisibility;
     };
-};
+}
 
 export const uiInitialState: UiState = {
     scheduleEmailDialog: {

--- a/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/DashboardTester.ts
@@ -188,7 +188,7 @@ export class DashboardTester extends HeadlessDashboard {
     }
 }
 
-export type PreloadedTesterOptions = {
+export interface PreloadedTesterOptions {
     /**
      * Customize the load command.
      *
@@ -211,7 +211,7 @@ export type PreloadedTesterOptions = {
      * on the recorded analytical backend.
      */
     queryServices?: IDashboardQueryService<any, any>[];
-};
+}
 
 /**
  * This factory will return a function that can be integrated into jest's `beforeAll` or `beforeEach` statements. That returned

--- a/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/commonTypes.ts
@@ -23,7 +23,7 @@ import { ExtendedDashboardWidget } from "./layoutTypes";
  *
  * @public
  */
-export type ObjectAvailabilityConfig = {
+export interface ObjectAvailabilityConfig {
     /**
      * Specify tags to exclude objects by. If any of these tags appears on an object, then it will be not
      * available for use.
@@ -36,14 +36,14 @@ export type ObjectAvailabilityConfig = {
      * range of objects may be excluded at first and then a subset will be cherry-picked using this prop.
      */
     includeObjectsWithTags?: string[];
-};
+}
 
 /**
  * Dashboard configuration can influence the available features, look and feel and behavior of the dashboard.
  *
  * @public
  */
-export type DashboardConfig = {
+export interface DashboardConfig {
     /**
      * Locale to use for the dashboard.
      */
@@ -125,7 +125,7 @@ export type DashboardConfig = {
      * Optionally configure which of the default menu button buttons are visible.
      */
     menuButtonItemsVisibility?: IMenuButtonItemsVisibility;
-};
+}
 
 /**
  * Dashboard configuration resolved using the config passed in via props and any essential data retrieved from
@@ -167,7 +167,7 @@ export function isResolvedConfig(config?: DashboardConfig): config is ResolvedDa
 /**
  * @public
  */
-export type DashboardContext = {
+export interface DashboardContext {
     /**
      * Analytical Backend where the dashboard exists.
      */
@@ -198,7 +198,7 @@ export type DashboardContext = {
      * Data product identifier - it's required, if the backend implementation supports it and workspace is provisioned via LCM.
      */
     dataProductId?: string;
-};
+}
 
 /**
  * @internal
@@ -221,7 +221,7 @@ export type DashboardTransformFn = (
 /**
  * @public
  */
-export type DashboardModelCustomizationFns = {
+export interface DashboardModelCustomizationFns {
     /**
      * Optionally provide a function that will be used during dashboard initialization of an existing dashboard.
      * This function will be called after the dashboard is loaded from backend and before it is dispatched for
@@ -232,7 +232,7 @@ export type DashboardModelCustomizationFns = {
      *    dashboard will be used as-is.
      */
     existingDashboardTransformFn?: DashboardTransformFn;
-};
+}
 
 /**
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/types/exportTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/exportTypes.ts
@@ -1,16 +1,16 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 /**
  * @alpha
  */
-export type ICsvExportConfig = {
+export interface ICsvExportConfig {
     format: "csv";
-};
+}
 
 /**
  * @alpha
  */
-export type IXlsxExportConfig = {
+export interface IXlsxExportConfig {
     format: "xlsx";
     /**
      * Optionally specify title of the workbook.
@@ -30,7 +30,7 @@ export type IXlsxExportConfig = {
      * into the XLSX in a human readable form.
      */
     showFilters?: boolean;
-};
+}
 
 /**
  * @alpha

--- a/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
+++ b/libs/sdk-ui-dashboard/src/model/types/widgetTypes.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { ObjRef } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
@@ -6,12 +6,12 @@ import isEmpty from "lodash/isEmpty";
 /**
  * @alpha
  */
-export type WidgetHeader = {
+export interface WidgetHeader {
     /**
      * Title to set. If not defined then widget will have no title.
      */
     title?: string;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/model/utils/attributeResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/attributeResolver.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
 import { SagaIterator } from "redux-saga";
 import { IAttributeMetadataObject } from "@gooddata/sdk-backend-spi";
@@ -19,10 +19,10 @@ async function loadAttributesMetadata(
     return ctx.backend.workspace(ctx.workspace).attributes().getAttributes(refs);
 }
 
-export type AttributeResolutionResult = {
+export interface AttributeResolutionResult {
     resolved: ObjRefMap<IAttributeMetadataObject>;
     missing: ObjRef[];
-};
+}
 
 /**
  * Given a set of attribute refs (which may be of any type.. uri or id), this function returns a list of

--- a/libs/sdk-ui-dashboard/src/model/utils/insightResolver.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/insightResolver.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { DashboardContext } from "../types/commonTypes";
 import { IInsight, isInsight, isObjRef, ObjRef } from "@gooddata/sdk-model";
@@ -30,7 +30,7 @@ async function loadInsightsFromBackend(
     };
 }
 
-export type InsightResolutionResult = {
+export interface InsightResolutionResult {
     /**
      * Map containing all resolved insights.
      */
@@ -45,7 +45,7 @@ export type InsightResolutionResult = {
      * List of ObjRefs that could not be resolved.
      */
     missing: ObjRef[];
-};
+}
 
 /**
  * Given a list of insight ObjRefs, this generator will resolve those refs to actual IInsight objects. The resolution

--- a/libs/sdk-ui-dashboard/src/plugins/customizer.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/customizer.ts
@@ -309,10 +309,14 @@ export interface IDashboardCustomizer {
 }
 
 /**
- * TODO: move to common location
+ * Callback called whenever the Dashboard's internal state changes.
+ *
+ * @param state - the new value of the state
+ * @param dispatch - the new dispatcher function that can be used to dispatch commands
  *
  * @public
  */
+// TODO: move to common location
 export type DashboardStateChangeCallback = (state: DashboardState, dispatch: DashboardDispatch) => void;
 
 /**

--- a/libs/sdk-ui-dashboard/src/plugins/plugin.ts
+++ b/libs/sdk-ui-dashboard/src/plugins/plugin.ts
@@ -1,12 +1,14 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardCustomizer, IDashboardEventHandling } from "./customizer";
 import { DashboardContext } from "../model";
 
 /**
+ * Basic set of information about a Dashboard plugin.
+ *
  * @public
  */
-export type DashboardPluginDescriptor = {
+export interface DashboardPluginDescriptor {
     /**
      * Author of the plugin. This should ideally contain name and contact (email) for the author.
      */
@@ -56,7 +58,7 @@ export type DashboardPluginDescriptor = {
      * Another option is to specify exact maximum version of the SDK - e.g. "8.8.0".
      */
     readonly maxEngineVersion?: string;
-};
+}
 
 /**
  * This is the raw, low-level interface that the dashboard plugins need to implement. Through this interface

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/types.ts
@@ -418,21 +418,24 @@ export interface IDashboardBaseProps {
  *
  * @public
  */
-export type IDashboardExtensionProps = IDashboardEventing &
-    IDashboardCustomizationProps &
-    IDashboardThemingProps & {
-        /**
-         * Pass instance of ReactReduxContext where the dashboard component's store should be saved.
-         *
-         * This is essential if you are dynamically loading dashboard engine and then enriching the
-         * dashboard with embedded, local plugins. If such plugins are compiled against sdk-ui-dashboard and
-         * use Redux hooks (useDashboardSelect, useDashboardDispatch) then your solution will not work
-         * unless you explicitly send your application's `ReactDashboardContext` into this prop.
-         *
-         * Note: there is no need to use this prop unless you are dynamically loading the engine bundle.
-         */
-        additionalReduxContext?: React.Context<ReactReduxContextValue>;
-    };
+export interface IDashboardExtensionProps
+    extends IDashboardEventing,
+        IDashboardCustomizationProps,
+        IDashboardThemingProps {
+    /**
+     * Pass instance of ReactReduxContext where the dashboard component's store should be saved.
+     *
+     * @remarks
+     *
+     * This is essential if you are dynamically loading dashboard engine and then enriching the
+     * dashboard with embedded, local plugins. If such plugins are compiled against sdk-ui-dashboard and
+     * use Redux hooks (useDashboardSelect, useDashboardDispatch) then your solution will not work
+     * unless you explicitly send your application's `ReactDashboardContext` into this prop.
+     *
+     * Note: there is no need to use this prop unless you are dynamically loading the engine bundle.
+     */
+    additionalReduxContext?: React.Context<ReactReduxContextValue>;
+}
 
 /**
  * @public

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/WithDrillSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/WithDrillSelect.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useState, useCallback, useRef } from "react";
 import cx from "classnames";
 import { v4 as uuid } from "uuid";
@@ -40,7 +40,7 @@ import { useDrills } from "../hooks/useDrills";
 /**
  * @internal
  */
-export type WithDrillSelectProps = {
+export interface WithDrillSelectProps {
     widgetRef: ObjRef;
     insight: IInsight;
     onDrillDownSuccess?: OnDrillDownSuccess;
@@ -50,7 +50,7 @@ export type WithDrillSelectProps = {
     onDrillToCustomUrlSuccess?: OnDrillToCustomUrlSuccess;
     onError?: (error: any) => void;
     children: (props: { onDrill: OnWidgetDrill }) => JSX.Element;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/presentation/drill/hooks/useDrills.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/hooks/useDrills.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import {
     OnDashboardDrill,
     OnDashboardDrillSuccess,
@@ -27,7 +27,7 @@ import { useDrillToLegacyDashboard } from "./useDrillToLegacyDashboard";
 /**
  * @internal
  */
-export type UseDrillsProps = {
+export interface UseDrillsProps {
     onDrill?: OnDashboardDrill;
     onDrillSuccess?: OnDashboardDrillSuccess;
     onDrillError?: OnDashboardDrillError;
@@ -57,7 +57,7 @@ export type UseDrillsProps = {
     onDrillToLegacyDashboardError?: OnDashboardDrillError;
     // Common error handler
     onError?: OnDashboardDrillError;
-};
+}
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/interfaces.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/interfaces.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { IDashboardWidget, IDashboardLayout, ScreenSize } from "@gooddata/sdk-backend-spi";
 import {
     IDashboardLayoutItemFacade,
@@ -40,7 +40,7 @@ export type IDashboardLayoutSectionKeyGetter<TWidget = IDashboardWidget> = (
  *
  * @alpha
  */
-export type IDashboardLayoutSectionRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutSectionRenderProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout section.
      */
@@ -75,7 +75,7 @@ export type IDashboardLayoutSectionRenderProps<TWidget = IDashboardWidget> = {
      * Is hidden section? Use this to hide the section without remounting it.
      */
     isHidden?: boolean;
-};
+}
 
 /**
  * Dashboard layout section renderer.
@@ -92,7 +92,7 @@ export type IDashboardLayoutSectionRenderer<TWidget = IDashboardWidget, TCustomP
  *
  * @alpha
  */
-export type IDashboardLayoutSectionHeaderRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutSectionHeaderRenderProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout section.
      */
@@ -107,7 +107,7 @@ export type IDashboardLayoutSectionHeaderRenderProps<TWidget = IDashboardWidget>
      * Default renderer of the section header - can be used as a fallback for custom sectionHeaderRenderer.
      */
     DefaultSectionHeaderRenderer: IDashboardLayoutSectionHeaderRenderer<TWidget>;
-};
+}
 
 /**
  * Dashboard layout section heder renderer.
@@ -124,7 +124,7 @@ export type IDashboardLayoutSectionHeaderRenderer<TWidget = IDashboardWidget, TC
  *
  * @alpha
  */
-export type IDashboardLayoutItemKeyGetterProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutItemKeyGetterProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout item.
      */
@@ -134,7 +134,7 @@ export type IDashboardLayoutItemKeyGetterProps<TWidget = IDashboardWidget> = {
      * Current screen type with respect to the set breakpoints.
      */
     screen: ScreenSize;
-};
+}
 
 /**
  * Dashboard layout item key getter.
@@ -154,7 +154,7 @@ export type IDashboardLayoutItemKeyGetter<TWidget = IDashboardWidget> = (
  *
  * @alpha
  */
-export type IDashboardLayoutItemRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutItemRenderProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout item.
      */
@@ -189,7 +189,7 @@ export type IDashboardLayoutItemRenderProps<TWidget = IDashboardWidget> = {
      * Widget rendered by widgetRenderer.
      */
     children: React.ReactNode;
-};
+}
 
 /**
  * Dashboard layout item renderer.
@@ -206,7 +206,7 @@ export type IDashboardLayoutItemRenderer<TWidget = IDashboardWidget, TCustomProp
  *
  * @alpha
  */
-export type IDashboardLayoutWidgetRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutWidgetRenderProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout item.
      */
@@ -262,7 +262,7 @@ export type IDashboardLayoutWidgetRenderProps<TWidget = IDashboardWidget> = {
      * Default widget renderer - can be used as a fallback for custom widgetRenderer.
      */
     DefaultWidgetRenderer: IDashboardLayoutWidgetRenderer<TWidget>;
-};
+}
 
 /**
  * Dashboard layout content renderer.
@@ -279,7 +279,7 @@ export type IDashboardLayoutWidgetRenderer<TWidget = IDashboardWidget, TCustomPr
  *
  * @alpha
  */
-export type IDashboardLayoutGridRowRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutGridRowRenderProps<TWidget = IDashboardWidget> {
     /**
      * Items rendered in one row.
      */
@@ -299,7 +299,7 @@ export type IDashboardLayoutGridRowRenderProps<TWidget = IDashboardWidget> = {
      * Current screen type with respect to the set breakpoints.
      */
     screen: ScreenSize;
-};
+}
 
 /**
  * Dashboard layout grid row renderer.
@@ -318,7 +318,7 @@ export type IDashboardLayoutGridRowRenderer<TWidget = IDashboardWidget, TCustomP
  *
  * @alpha
  */
-export type IDashboardLayoutRenderProps<TWidget = IDashboardWidget> = {
+export interface IDashboardLayoutRenderProps<TWidget = IDashboardWidget> {
     /**
      * Dashboard layout definition to render.
      */
@@ -381,7 +381,7 @@ export type IDashboardLayoutRenderProps<TWidget = IDashboardWidget> = {
      * Checks if feature flag enableKDWidgetCustomHeight is enabled
      */
     enableCustomHeight?: boolean;
-};
+}
 
 /**
  * Dashboard layout renderer.

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -1,9 +1,9 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { normalizeTime, ConfirmDialogBase, Overlay, Alignment } from "@gooddata/sdk-ui-kit";
-import { IAnalyticalBackend, IScheduledMailDefinition, IUser } from "@gooddata/sdk-backend-spi";
-import { ObjRef } from "@gooddata/sdk-model";
+import { IAnalyticalBackend, IScheduledMailDefinition } from "@gooddata/sdk-backend-spi";
+import { ObjRef, IUser } from "@gooddata/sdk-model";
 import { GoodDataSdkError } from "@gooddata/sdk-ui";
 import memoize from "lodash/memoize";
 
@@ -42,7 +42,7 @@ const MAX_SUBJECT_LENGTH = 200;
 const MAX_DASHBOARD_TITLE_LENGTH = DASHBOARD_TITLE_MAX_LENGTH;
 const MAX_HYPHEN_LENGTH = 3;
 
-export type IScheduledMailDialogRendererOwnProps = {
+export interface IScheduledMailDialogRendererOwnProps {
     /**
      * Reference of the dashboard to be attached to the scheduled email.
      */
@@ -109,7 +109,7 @@ export type IScheduledMailDialogRendererOwnProps = {
      * Callback to be called, when error occurs.
      */
     onError?: (error: GoodDataSdkError) => void;
-};
+}
 
 export type IScheduledMailDialogRendererProps = IScheduledMailDialogRendererOwnProps & WrappedComponentProps;
 

--- a/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
+++ b/libs/sdk-ui-dashboard/src/widgets/placeholders/types.ts
@@ -1,13 +1,13 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { ICustomWidgetBase } from "../../model";
 
 /**
  * @alpha
  */
-export type KpiPlaceholderWidget = ICustomWidgetBase & {
+export interface KpiPlaceholderWidget extends ICustomWidgetBase {
     readonly customType: "kpiPlaceholder";
-};
+}
 
 /**
  * Tests whether an object is a {@link KpiPlaceholderWidget}.
@@ -22,9 +22,9 @@ export function isKpiPlaceholderWidget(obj: unknown): obj is KpiPlaceholderWidge
 /**
  * @alpha
  */
-export type InsightPlaceholderWidget = ICustomWidgetBase & {
+export interface InsightPlaceholderWidget extends ICustomWidgetBase {
     readonly customType: "insightPlaceholder";
-};
+}
 
 /**
  * Tests whether an object is a {@link InsightPlaceholderWidget}.


### PR DESCRIPTION
Turns out the api-documenter works much better with interfaces instead of types:
the individual members' docs are shown in a table (for types they are not shown at all).

JIRA: RAIL-3963

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
