### PR TITLE
Fixed: enableRenamingMeasureToMetric FF does not work for user level.

### DIFF
--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -1543,6 +1543,9 @@ export const RawExecute: React_2.ComponentClass<IRawExecuteProps, any>;
 // @beta (undocumented)
 export const removeAllInsightToReportTranslations: (translations: Record<string, string>) => Record<string, string>;
 
+// @beta
+export const removeAllWordingTranslationsWithSpecialSuffix: (translations: Record<string, string>) => Record<string, string>;
+
 // @alpha
 export const ResolvedClientWorkspaceProvider: React_2.FC<IClientWorkspaceIdentifiers>;
 

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -183,6 +183,7 @@ export {
     pickCorrectMetricWording,
     pickCorrectWording,
     removeAllInsightToReportTranslations,
+    removeAllWordingTranslationsWithSpecialSuffix,
 } from "./localization/TranslationsCustomizationProvider";
 
 /*

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/index.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/index.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export {
     ITranslationsCustomizationContextProviderProps,
     TranslationsCustomizationContextProvider,
@@ -13,4 +13,5 @@ export {
     pickCorrectMetricWording,
     pickCorrectWording,
     removeAllInsightToReportTranslations,
+    removeAllWordingTranslationsWithSpecialSuffix,
 } from "./utils";

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
@@ -1,6 +1,10 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
-import { pickCorrectInsightWording, removeAllInsightToReportTranslations } from "../utils";
+import {
+    pickCorrectInsightWording,
+    removeAllInsightToReportTranslations,
+    removeAllWordingTranslationsWithSpecialSuffix,
+} from "../utils";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { ITranslations } from "../../../localization/IntlWrapper";
 
@@ -38,6 +42,23 @@ describe("removeAllInsightToReportTranslations", () => {
         const result = removeAllInsightToReportTranslations({
             ...mockTranslationWithoutExtraWords,
             ...mockTranslation,
+        });
+        expect(result).toMatchObject(mockTranslationWithoutExtraWords);
+    });
+});
+
+describe("removeAllWordingTranslationsWithSpecialSuffix", () => {
+    const mockTranslationWithoutExtraWords: ITranslations = {
+        "mock.translation": "Insight",
+        "mock.translation.metric": "Measure",
+    };
+
+    it("should remove all insight to report words", () => {
+        const result = removeAllWordingTranslationsWithSpecialSuffix({
+            ...mockTranslationWithoutExtraWords,
+            ...mockTranslation,
+            "mock.translation.metric._measure": "Measure",
+            "mock.translation.metric._metric": "Metric",
         });
         expect(result).toMatchObject(mockTranslationWithoutExtraWords);
     });

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/utils.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import memoizeOne from "memoize-one";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 
@@ -95,6 +95,29 @@ export const removeAllInsightToReportTranslations = (
             delete translations[key];
         }
     });
+    return {
+        ...translations,
+    };
+};
+
+/**
+ * The function to remove all translation keys that contain special suffixes "|report", "|insight", "._measure" or "._metric"
+ * @beta
+ */
+export const removeAllWordingTranslationsWithSpecialSuffix = (
+    translations: Record<string, string>,
+): Record<string, string> => {
+    Object.keys(translations).forEach((key) => {
+        if (
+            key.includes("|report") ||
+            key.includes("|insight") ||
+            key.includes("._measure") ||
+            key.includes("._metric")
+        ) {
+            delete translations[key];
+        }
+    });
+
     return {
         ...translations,
     };

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/workspaceSettingsLoader.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/workspaceSettingsLoader.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IAnalyticalBackend, IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import { LRUCache } from "@gooddata/util";
 
@@ -15,7 +15,7 @@ class WorkspaceSettingsLoader {
             settings = backend
                 .workspace(workspace)
                 .settings()
-                .getSettings()
+                .getSettingsForCurrentUser()
                 .catch((error) => {
                     // do not cache errors
                     this.settingsCache.delete(cacheKey);


### PR DESCRIPTION
- enableRenamingMeasureToMetric FF does not work for user level.
- Refactor: removeAllInsightToReportTranslations and removeAllMeasureToMetricTranslations

JIRA: SD-1960

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
