### PR TITLE
RELATED: RAIL-3963 Make the custom widget-related hooks public

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3366,13 +3366,13 @@ export interface ITopBarProps {
     titleProps: ITitleProps;
 }
 
-// @beta
+// @public
 export interface IUseCustomWidgetExecutionDataViewConfig {
     execution?: Exclude<IExecutionConfiguration, "filters">;
     widget: ICustomWidget;
 }
 
-// @beta
+// @public
 export interface IUseCustomWidgetInsightDataViewConfig {
     insight?: IInsightDefinition | ObjRef;
     widget: ICustomWidget;
@@ -4677,11 +4677,11 @@ export interface UpsertExecutionResult extends IDashboardCommand {
     readonly type: "GDC.DASH/CMD.EXECUTION_RESULT.UPSERT";
 }
 
-// @beta
-export const useCustomWidgetExecutionDataView: ({ widget, execution, }: IUseCustomWidgetExecutionDataViewConfig) => UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+// @public
+export function useCustomWidgetExecutionDataView({ widget, execution, }: IUseCustomWidgetExecutionDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
-// @beta
-export const useCustomWidgetInsightDataView: ({ widget, insight, }: IUseCustomWidgetInsightDataViewConfig) => UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
+// @public
+export function useCustomWidgetInsightDataView({ widget, insight, }: IUseCustomWidgetInsightDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>;
 
 // @internal (undocumented)
 export interface UseDashboardAsyncRender {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetExecutionDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetExecutionDataView.ts
@@ -15,7 +15,7 @@ import { useWidgetFilters } from "./useWidgetFilters";
 /**
  * Configuration options for the {@link useCustomWidgetExecutionDataView} hook.
  *
- * @beta
+ * @public
  */
 export interface IUseCustomWidgetExecutionDataViewConfig {
     /**
@@ -34,12 +34,12 @@ export interface IUseCustomWidgetExecutionDataViewConfig {
  * This hook provides an easy way to read a data view from a custom widget. It resolves the appropriate filters
  * for the widget based on the filters currently set on the whole dashboard.
  *
- * @beta
+ * @public
  */
-export const useCustomWidgetExecutionDataView = ({
+export function useCustomWidgetExecutionDataView({
     widget,
     execution,
-}: IUseCustomWidgetExecutionDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> => {
+}: IUseCustomWidgetExecutionDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
     const filterQueryTask = useWidgetFilters(widget);
     const dataViewTask = useExecutionDataView({
         execution: execution
@@ -87,4 +87,4 @@ export const useCustomWidgetExecutionDataView = ({
         result: dataViewTask.result,
         status: "success",
     };
-};
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
@@ -19,7 +19,7 @@ import { useWidgetFilters } from "./useWidgetFilters";
 /**
  * Configuration options for the {@link useCustomWidgetInsightDataView} hook.
  *
- * @beta
+ * @public
  */
 export interface IUseCustomWidgetInsightDataViewConfig {
     /**
@@ -38,12 +38,12 @@ export interface IUseCustomWidgetInsightDataViewConfig {
  * This hook provides an easy way to read a data view for an insight from a custom widget.
  * It resolves the appropriate filters for the widget based on the filters currently set on the whole dashboard.
  *
- * @beta
+ * @public
  */
-export const useCustomWidgetInsightDataView = ({
+export function useCustomWidgetInsightDataView({
     widget,
     insight,
-}: IUseCustomWidgetInsightDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> => {
+}: IUseCustomWidgetInsightDataViewConfig): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
 
@@ -135,4 +135,4 @@ export const useCustomWidgetInsightDataView = ({
         result: dataViewTask.result,
         status: "success",
     };
-};
+}


### PR DESCRIPTION
Also change them to functions to play nicer with api-documenter.

JIRA: RAIL-3963

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
