### PR TITLE
RELATED: RAIL-3963 Improve filter-related events TSDocs

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/events/filters.ts
+++ b/libs/sdk-ui-dashboard/src/model/events/filters.ts
@@ -10,6 +10,13 @@ import { eventGuard } from "./util";
 
 /**
  * Payload of the {@link DashboardDateFilterSelectionChanged} event.
+ *
+ * @remarks
+ *
+ * See also {@link dashboardDateFilterToDateFilterByWidget} and {@link dashboardDateFilterToDateFilterByDateDataSet} convertors
+ * – those allow you to convert the `filter` object to an {@link @gooddata/sdk-model#IDateFilter} instance you can use
+ * with visualizations, filter UI components and so on.
+ *
  * @public
  */
 export interface DashboardDateFilterSelectionChangedPayload {
@@ -25,6 +32,12 @@ export interface DashboardDateFilterSelectionChangedPayload {
 
 /**
  * This event is emitted after the dashboard's date filter selection is changed.
+ *
+ * @remarks
+ *
+ * See also {@link dashboardDateFilterToDateFilterByWidget} and {@link dashboardDateFilterToDateFilterByDateDataSet} convertors
+ * – those allow you to convert the `filter` in the event payload to an {@link @gooddata/sdk-model#IDateFilter} instance you can use
+ * with visualizations, filter UI components and so on.
  *
  * @public
  */
@@ -254,6 +267,13 @@ export const isDashboardAttributeFilterMoved = eventGuard<DashboardAttributeFilt
 
 /**
  * Payload of the {@link DashboardAttributeFilterSelectionChanged} event.
+ *
+ * @remarks
+ *
+ * See also {@link dashboardAttributeFilterToAttributeFilter} convertor – this allows you to convert the `filter`
+ * object to an {@link @gooddata/sdk-model#IAttributeFilter} instance you can use with visualizations,
+ * filter UI components and so on.
+ *
  * @public
  */
 export interface DashboardAttributeFilterSelectionChangedPayload {
@@ -268,7 +288,11 @@ export interface DashboardAttributeFilterSelectionChangedPayload {
 /**
  * This event is emitted after new elements are selected and applied in an attribute filter.
  *
- * The filter in the payload object must be converted to a {@link @gooddata/sdk-model#IFilter} object before its usage.
+ * @remarks
+ *
+ * See also {@link dashboardAttributeFilterToAttributeFilter} convertor – this allows you to convert the `filter`
+ * in the event payload to an {@link @gooddata/sdk-model#IAttributeFilter} instance you can use with visualizations,
+ * filter UI components and so on.
  *
  * @public
  */
@@ -361,6 +385,13 @@ export const isDashboardAttributeFilterParentChanged = eventGuard<DashboardAttri
 
 /**
  * Payload of the {@link DashboardFilterContextChanged} event.
+ *
+ * @remarks
+ *
+ * See also {@link filterContextToDashboardFiltersByWidget} and {@link filterContextToDashboardFiltersByDateDataSet} convertors
+ * – those allow you to convert the `filterContext` object to array of {@link @gooddata/sdk-model#IFilter} instances you can use
+ * with visualizations, filter UI components and so on.
+ *
  * @public
  */
 export interface DashboardFilterContextChangedPayload {
@@ -376,6 +407,12 @@ export interface DashboardFilterContextChangedPayload {
  *
  * This event is emitted as convenience - more granular events describe all the possible
  * changes to the dashboard filters and can be used to event source the state of filter context.
+ *
+ * @remarks
+ *
+ * See also {@link filterContextToDashboardFiltersByWidget} and {@link filterContextToDashboardFiltersByDateDataSet} convertors
+ * – those allow you to convert the `filterContext` in the event payload to array of {@link @gooddata/sdk-model#IFilter} instances you can use
+ * with visualizations, filter UI components and so on.
  *
  * @public
  */


### PR DESCRIPTION
Add links to the convertors needed to use the filters in other parts
of the SDK such as visualizations or filter UI components.

JRIA: RAIL-3963

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
