### PR TITLE
RELATED: RAIL-4010 make plugin-toolkit runnable outside of plugin folder

### DIFF
--- a/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
+++ b/tools/plugin-toolkit/src/_base/inputHandling/validators.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import url from "url";
 import includes from "lodash/includes";
@@ -159,7 +159,7 @@ export function createPluginUrlValidator(pluginIdentifier: string): AsyncInputVa
                     } else if (status === 403) {
                         return (
                             prefix +
-                            "Host requires authorization to access plugin. Note that in some hosting configuration " +
+                            "Host requires authorization to access plugin. Note that in some hosting configurations " +
                             "this is just a 404 in disguise and the plugin actually does not exist on the host."
                         );
                     }

--- a/tools/plugin-toolkit/src/_base/terminal/prompts.ts
+++ b/tools/plugin-toolkit/src/_base/terminal/prompts.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { DistinctQuestion, prompt } from "inquirer";
 import { TargetAppLanguage, TargetBackendType } from "../types";
 import { createHostnameValidator, pluginNameValidator } from "../inputHandling/validators";
@@ -24,6 +24,17 @@ export async function promptPassword(): Promise<string> {
     const passwordResponse = await prompt(passwordQuestion);
 
     return passwordResponse.password;
+}
+
+export async function promptApiToken(): Promise<string> {
+    const tokenQuestion: DistinctQuestion = {
+        type: "input",
+        name: "token",
+        message: "Enter your API token:",
+    };
+    const tokenResponse = await prompt(tokenQuestion);
+
+    return tokenResponse.token;
 }
 
 export type WorkspaceChoices = {

--- a/tools/plugin-toolkit/src/_base/utils.ts
+++ b/tools/plugin-toolkit/src/_base/utils.ts
@@ -1,8 +1,8 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import path from "path";
 import fse from "fs-extra";
 import snakeCase from "lodash/snakeCase";
-import { InputValidationError, isInputValidationError, TargetBackendType } from "./types";
+import { isInputValidationError, TargetBackendType } from "./types";
 import { logError, logInfo } from "./terminal/loggers";
 import { isNotAuthenticated } from "@gooddata/sdk-backend-spi";
 
@@ -74,12 +74,12 @@ export function convertToPluginEntrypoint(pluginIdentifier: string): string {
 
 /**
  * Given package JSON contents, this function tries to discover the backend type that action should
- * target. The idea is.. if the person develops plugin against particular backend then its likely
+ * target. The idea is: if the person develops plugin against particular backend then its likely
  * that they will also want to deploy it there.
  *
  * @param packageJson - package json object
  */
-export function discoverBackendTypeOrDie(packageJson: Record<string, any>): TargetBackendType {
+export function discoverBackendType(packageJson: Record<string, any>): TargetBackendType | undefined {
     const { peerDependencies = {} } = packageJson;
 
     if (peerDependencies["@gooddata/sdk-backend-bear"] !== undefined) {
@@ -91,12 +91,6 @@ export function discoverBackendTypeOrDie(packageJson: Record<string, any>): Targ
 
         return "tiger";
     }
-
-    throw new InputValidationError(
-        "backend",
-        "?",
-        "Unable to discover target backend type. Please specify --backend option on the command line.",
-    );
 }
 
 export function extractRootCause(error: any): any {

--- a/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
@@ -45,6 +45,16 @@ async function doAsyncValidations(config: AddCmdActionConfig) {
     }
 }
 
+/**
+ * Get the best guess of the original plugin name from ints entry point URL.
+ *
+ * @param url - the URL of the plugin being added
+ */
+function pluginUrlToPluginName(url: string): string {
+    const match = /dp_([^/]+).js$/i.exec(url);
+    return match?.[1] ?? "";
+}
+
 export async function getAddCmdActionConfig(
     pluginUrl: string,
     options: ActionOptions,
@@ -58,11 +68,18 @@ export async function getAddCmdActionConfig(
         credentials,
     });
 
+    /*
+     * In case we are not running this from the original plugin directory, derive a best-guess name from
+     * the plugin URL. This is good enough for most cases and is easier than asking the user to provide
+     * a valid name that would match the URL and pass subsequent validations.
+     */
+    const pluginName = packageJson.name ?? pluginUrlToPluginName(pluginUrl);
+
     const config: AddCmdActionConfig = {
         ...workspaceTargetConfig,
         pluginUrl,
-        pluginIdentifier: convertToPluginIdentifier(packageJson.name),
-        pluginName: packageJson.name,
+        pluginName,
+        pluginIdentifier: convertToPluginIdentifier(pluginName),
         pluginDescription: packageJson.description,
         dryRun: options.commandOpts.dryRun ?? false,
         backendInstance,

--- a/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/actionConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
 import { convertToPluginIdentifier } from "../_base/utils";
 import {
@@ -49,7 +49,7 @@ export async function getAddCmdActionConfig(
     pluginUrl: string,
     options: ActionOptions,
 ): Promise<AddCmdActionConfig> {
-    const workspaceTargetConfig = createWorkspaceTargetConfig(options);
+    const workspaceTargetConfig = await createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials, packageJson } = workspaceTargetConfig;
 
     const backendInstance = createBackend({

--- a/tools/plugin-toolkit/src/addPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/addPluginCmd/index.ts
@@ -1,8 +1,7 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
-import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
+import { logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import { AddCmdActionConfig, getAddCmdActionConfig } from "./actionConfig";
-import fse from "fs-extra";
 import { IDashboardPlugin } from "@gooddata/sdk-backend-spi";
 import { genericErrorReporter } from "../_base/utils";
 import isEmpty from "lodash/isEmpty";
@@ -46,15 +45,6 @@ function createPluginObject(config: AddCmdActionConfig): Promise<IDashboardPlugi
 }
 
 export async function addPluginCmdAction(pluginUrl: string, options: ActionOptions): Promise<void> {
-    if (!fse.existsSync("package.json")) {
-        logError(
-            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
-        );
-
-        process.exit(1);
-        return;
-    }
-
     try {
         const config: AddCmdActionConfig = await getAddCmdActionConfig(pluginUrl, options);
 
@@ -66,7 +56,6 @@ export async function addPluginCmdAction(pluginUrl: string, options: ActionOptio
             );
 
             process.exit(0);
-            return;
         }
 
         const newPluginObject = await createPluginObject(config);

--- a/tools/plugin-toolkit/src/initCmd/index.ts
+++ b/tools/plugin-toolkit/src/initCmd/index.ts
@@ -238,7 +238,6 @@ export async function initCmdAction(pluginName: string | undefined, options: Act
             );
 
             process.exit(1);
-            return;
         }
 
         await prepareProject(target, config);

--- a/tools/plugin-toolkit/src/inspectCmds/actionConfig.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/actionConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { createWorkspaceTargetConfig, WorkspaceTargetConfig } from "../_base/workspaceTargetConfig";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { ActionOptions } from "../_base/types";
@@ -31,7 +31,7 @@ export async function getInspectCmdActionConfig(
     identifier: string,
     options: ActionOptions,
 ): Promise<InspectCmdActionConfig> {
-    const workspaceTargetConfig = createWorkspaceTargetConfig(options);
+    const workspaceTargetConfig = await createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials } = workspaceTargetConfig;
 
     const backendInstance = createBackend({

--- a/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
@@ -1,7 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
-import fse from "fs-extra";
-import { logError, logInfo } from "../_base/terminal/loggers";
+import { logInfo } from "../_base/terminal/loggers";
 import { genericErrorReporter } from "../_base/utils";
 import { getInspectCmdActionConfig, InspectCmdActionConfig } from "./actionConfig";
 import { InspectObjectFn } from "./types";
@@ -31,14 +30,6 @@ export async function inspectCmdAction(
     inspectObjFn: InspectObjectFn,
     options: ActionOptions,
 ): Promise<void> {
-    if (!fse.existsSync("package.json")) {
-        logError(
-            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
-        );
-
-        process.exit(1);
-    }
-
     try {
         const config: InspectCmdActionConfig = await getInspectCmdActionConfig(identifier, options);
 

--- a/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
+++ b/tools/plugin-toolkit/src/inspectCmds/inspectCmdAction.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
 import fse from "fs-extra";
 import { logError, logInfo } from "../_base/terminal/loggers";
@@ -37,7 +37,6 @@ export async function inspectCmdAction(
         );
 
         process.exit(1);
-        return;
     }
 
     try {

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -1,7 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
-import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
-import fse from "fs-extra";
+import { logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import { getLinkCmdActionConfig, LinkCmdActionConfig } from "./actionConfig";
 import { IDashboard, IDashboardDefinition } from "@gooddata/sdk-backend-spi";
 import { idRef } from "@gooddata/sdk-model";
@@ -63,15 +62,6 @@ async function updateDashboardWithPluginLink(config: LinkCmdActionConfig) {
 }
 
 export async function linkPluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {
-    if (!fse.existsSync("package.json")) {
-        logError(
-            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
-        );
-
-        process.exit(1);
-        return;
-    }
-
     try {
         const config: LinkCmdActionConfig = await getLinkCmdActionConfig(identifier, options);
 
@@ -82,8 +72,7 @@ export async function linkPluginCmdAction(identifier: string, options: ActionOpt
                 "Dry run has finished. Dashboard was not updated. Remove '--dry-run' to perform the actual update.",
             );
 
-            process.exit(0);
-            return;
+            return process.exit(0);
         }
 
         const updateProgress = ora({

--- a/tools/plugin-toolkit/src/linkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/index.ts
@@ -72,7 +72,7 @@ export async function linkPluginCmdAction(identifier: string, options: ActionOpt
                 "Dry run has finished. Dashboard was not updated. Remove '--dry-run' to perform the actual update.",
             );
 
-            return process.exit(0);
+            process.exit(0);
         }
 
         const updateProgress = ora({

--- a/tools/plugin-toolkit/src/listCmds/actionConfig.ts
+++ b/tools/plugin-toolkit/src/listCmds/actionConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { createWorkspaceTargetConfig, WorkspaceTargetConfig } from "../_base/workspaceTargetConfig";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { ActionOptions } from "../_base/types";
@@ -27,7 +27,7 @@ async function doAsyncValidations(config: ListCmdActionConfig) {
 }
 
 export async function getListCmdActionConfig(options: ActionOptions): Promise<ListCmdActionConfig> {
-    const workspaceTargetConfig = createWorkspaceTargetConfig(options);
+    const workspaceTargetConfig = await createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials } = workspaceTargetConfig;
 
     const backendInstance = createBackend({

--- a/tools/plugin-toolkit/src/listCmds/listCmdAction.ts
+++ b/tools/plugin-toolkit/src/listCmds/listCmdAction.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
 import fse from "fs-extra";
 import { logError, logInfo, logSuccess } from "../_base/terminal/loggers";
@@ -32,7 +32,6 @@ export async function listCmdAction(listObjFn: ListObjectsFn, options: ActionOpt
         );
 
         process.exit(1);
-        return;
     }
 
     try {

--- a/tools/plugin-toolkit/src/listCmds/listCmdAction.ts
+++ b/tools/plugin-toolkit/src/listCmds/listCmdAction.ts
@@ -1,7 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
-import fse from "fs-extra";
-import { logError, logInfo, logSuccess } from "../_base/terminal/loggers";
+import { logInfo, logSuccess } from "../_base/terminal/loggers";
 import { genericErrorReporter } from "../_base/utils";
 import { getListCmdActionConfig, ListCmdActionConfig } from "./actionConfig";
 import { ListObjectsFn } from "./types";
@@ -26,14 +25,6 @@ function printListConfigSummary(config: ListCmdActionConfig) {
 }
 
 export async function listCmdAction(listObjFn: ListObjectsFn, options: ActionOptions): Promise<void> {
-    if (!fse.existsSync("package.json")) {
-        logError(
-            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
-        );
-
-        process.exit(1);
-    }
-
     try {
         const config: ListCmdActionConfig = await getListCmdActionConfig(options);
 

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
@@ -1,7 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions } from "../_base/types";
-import { logError, logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
-import fse from "fs-extra";
+import { logInfo, logSuccess, logWarn } from "../_base/terminal/loggers";
 import { getUnlinkCmdActionConfig, UnlinkCmdActionConfig } from "./actionConfig";
 import { IDashboardDefinition, IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
 import { areObjRefsEqual, idRef } from "@gooddata/sdk-model";
@@ -71,15 +70,6 @@ async function removeDashboardPluginLink(config: UnlinkCmdActionConfig): Promise
 }
 
 export async function unlinkPluginCmdAction(identifier: string, options: ActionOptions): Promise<void> {
-    if (!fse.existsSync("package.json")) {
-        logError(
-            "Cannot find package.json. Please make sure to run the tool in directory that contains your dashboard plugin project.",
-        );
-
-        process.exit(1);
-        return;
-    }
-
     try {
         const config: UnlinkCmdActionConfig = await getUnlinkCmdActionConfig(identifier, options);
 
@@ -90,8 +80,7 @@ export async function unlinkPluginCmdAction(identifier: string, options: ActionO
                 "Dry run has finished. Dashboard was not updated. Remove '--dry-run' to perform the actual update.",
             );
 
-            process.exit(0);
-            return;
+            return process.exit(0);
         }
 
         const updateProgress = ora({

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/index.ts
@@ -80,7 +80,7 @@ export async function unlinkPluginCmdAction(identifier: string, options: ActionO
                 "Dry run has finished. Dashboard was not updated. Remove '--dry-run' to perform the actual update.",
             );
 
-            return process.exit(0);
+            process.exit(0);
         }
 
         const updateProgress = ora({


### PR DESCRIPTION
Make the plugin-toolkit commands runnable outside of the plugin folder by:
* removing checks for pacakge.json file being present
* prompting missing options instead of failing (except for the arguments, they still fail hard by design)

Also fix some typos and remove unreachable code.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
