### PR TITLE
Fix filter height recalculation in embedded dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -60,7 +60,6 @@ import {
     selectDashboardLoading,
     selectFilterBarExpanded,
     selectFilterBarHeight,
-    selectIsEmbedded,
     selectLocale,
     useDashboardSelector,
     useDispatchDashboardCommand,
@@ -78,17 +77,13 @@ import { DashboardHeader } from "./DashboardHeader/DashboardHeader";
 
 const DashboardMainContent: React.FC<IDashboardProps> = () => {
     const isFilterBarExpanded = useDashboardSelector(selectFilterBarExpanded);
-    const isEmbedded = useDashboardSelector(selectIsEmbedded);
     const filterBarHeight = useDashboardSelector(selectFilterBarHeight);
 
     const onFiltersChange = useDispatchDashboardCommand(changeFilterContextSelection);
 
     const dashSectionStyles = useMemo(
         () => ({
-            marginTop:
-                isFilterBarExpanded && !isEmbedded
-                    ? filterBarHeight - DEFAULT_FILTER_BAR_HEIGHT + "px"
-                    : undefined,
+            marginTop: isFilterBarExpanded ? filterBarHeight - DEFAULT_FILTER_BAR_HEIGHT + "px" : undefined,
             transition: "margin-top 0.2s",
         }),
         [isFilterBarExpanded, filterBarHeight],


### PR DESCRIPTION
It enables calculation of filterBar height and its propagation to the dashboard component that will be rendered below with calculated margin-top (to do not be overlapped by filterBar)

JIRA: TNT-472

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
