### PR TITLE
View by two attributes axis name visible with ff

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -1381,6 +1381,7 @@ export interface ISettings {
     enableApproxCount?: boolean;
     enableAxisLabelFormat?: boolean;
     enableAxisNameConfiguration?: boolean;
+    enableAxisNameViewByTwoAttributes?: boolean;
     enableBulletChart?: boolean;
     enableChartsSorting?: boolean;
     enableClickableAttributeURL?: boolean;

--- a/libs/sdk-backend-spi/src/common/settings.ts
+++ b/libs/sdk-backend-spi/src/common/settings.ts
@@ -201,6 +201,11 @@ export interface ISettings {
      */
     enableChartsSorting?: boolean;
 
+    /**
+     * Enable axis name for the column, bar and bullet charts with view by two attributes.
+     */
+    enableAxisNameViewByTwoAttributes?: boolean;
+
     [key: string]: number | boolean | string | object | undefined;
 }
 

--- a/libs/sdk-backend-tiger/src/backend/uiSettings.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiSettings.ts
@@ -75,6 +75,7 @@ export const DefaultUiSettings: ISettings = {
     enableAxisLabelFormat: true,
 
     enableChartsSorting: false,
+    enableAxisNameViewByTwoAttributes: false,
 };
 
 /**

--- a/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
+++ b/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
@@ -191,6 +191,7 @@ export interface IChartConfig {
     disableDrillUnderline?: boolean;
     dualAxis?: boolean;
     enableCompactSize?: boolean;
+    enableJoinedAttributeAxisName?: boolean;
     forceDisableDrillOnAxes?: boolean;
     grid?: IGridConfig;
     legend?: ILegendConfig;

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -30,6 +30,7 @@ import {
     isOneOfTypes,
     isRotationInRange,
     isScatterPlot,
+    isSupportingJoinedAttributeAxisName,
     percentFormatter,
 } from "../_util/common";
 import {
@@ -1176,7 +1177,10 @@ const getXAxisConfiguration = (
                 ? MIN_RANGE
                 : undefined;
 
-        const titleTextProp = visible && !isViewByTwoAttributes ? {} : { text: null }; // new way how to hide title instead of deprecated 'enabled'
+        const joinedAttributeAxisName: boolean =
+            chartConfig?.enableJoinedAttributeAxisName && isSupportingJoinedAttributeAxisName(type);
+        const titleTextProp =
+            visible && (!isViewByTwoAttributes || joinedAttributeAxisName) ? {} : { text: null }; // new way how to hide title instead of deprecated 'enabled'
 
         // for bar chart take y axis options
         return {
@@ -1204,7 +1208,6 @@ const getXAxisConfiguration = (
                 useHTML: !isInvertedChart && isViewByTwoAttributes,
             },
             title: {
-                // should disable X axis title when 'View By 2 attributes'
                 ...titleTextProp,
                 margin: 10,
                 style: {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
@@ -482,6 +482,21 @@ describe("getCustomizedConfiguration", () => {
             expect(result.xAxis[0].lineWidth).toEqual(0);
             expect(result.yAxis[0].lineWidth).toEqual(0);
         });
+
+        it("should set attribute axis title when chart config 'enableJoinedAttributeAxisName' is true", () => {
+            const result = getCustomizedConfiguration(
+                {
+                    ...chartOptions,
+                    type: VisualizationTypes.BAR,
+                    isViewByTwoAttributes: true,
+                },
+                {
+                    enableJoinedAttributeAxisName: true,
+                },
+            );
+
+            expect(result.xAxis[0].title.text).toEqual(chartOptions.xAxes[0].label);
+        });
     });
 
     describe("gridline configuration", () => {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsBuilder.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IDataView, IMeasureDescriptor, IMeasureGroupDescriptor, ITheme } from "@gooddata/sdk-backend-spi";
 import invariant from "ts-invariant";
 
@@ -355,7 +355,7 @@ export function getChartOptions(
     const gridEnabled = config?.grid?.enabled ?? true;
     const stacking = getStackingConfig(stackByAttribute, config);
     const measureGroup = findMeasureGroupInDimensions(dimensions);
-    const xAxes = getXAxes(dv, config, measureGroup, viewByAttribute);
+    const xAxes = getXAxes(dv, config, measureGroup, viewByAttribute, viewByParentAttribute);
     const yAxes = getYAxes(dv, config, measureGroup, stackByAttribute);
 
     const seriesWithoutDrillability = getSeries(

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsForSettings.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsForSettings.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 import { ISettings } from "@gooddata/sdk-backend-spi";
 import { IChartConfig } from "../../../interfaces";
@@ -15,6 +15,10 @@ export function updateConfigWithSettings(config: IChartConfig, settings: ISettin
 
         if (settings["enableKDWidgetCustomHeight"] === true) {
             updatedConfig = { ...updatedConfig, enableCompactSize: true };
+        }
+
+        if (settings["enableAxisNameViewByTwoAttributes"] === true) {
+            updatedConfig = { ...updatedConfig, enableJoinedAttributeAxisName: true };
         }
     }
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import range from "lodash/range";
 import set from "lodash/set";
 import isNil from "lodash/isNil";
@@ -3068,6 +3068,23 @@ describe("chartOptionsBuilder", () => {
                     {
                         label: "_Snapshot [EOP-2]",
                         format: "#,##0.00",
+                    },
+                ];
+
+                expect(chartOptions.xAxes).toEqual(expectedAxes);
+            });
+
+            it("should generate joined label when chart config 'enableJoinedAttributeAxisName' is true", () => {
+                const chartOptions = generateChartOptions(
+                    fixtures.barChartWith4MetricsAndViewByTwoAttributes,
+                    {
+                        type: "bar",
+                        enableJoinedAttributeAxisName: true,
+                    },
+                );
+                const expectedAxes = [
+                    {
+                        label: "Department \u203a Region",
                     },
                 ];
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsForSettings.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsForSettings.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 import { ISettings } from "@gooddata/sdk-backend-spi";
 import { IChartConfig } from "../../../../interfaces";
@@ -26,6 +26,19 @@ describe("updateConfigWithSettings", () => {
             };
             const expectedConfig = {
                 enableCompactSize: true,
+            };
+            expect(updateConfigWithSettings(config, settings)).toEqual(expectedConfig);
+        });
+    });
+
+    describe("enableAxisNameViewByTwoAttributes", () => {
+        it("should return correct config from feature flags", async () => {
+            const config: IChartConfig = {};
+            const settings: ISettings = {
+                enableAxisNameViewByTwoAttributes: true,
+            };
+            const expectedConfig = {
+                enableJoinedAttributeAxisName: true,
             };
             expect(updateConfigWithSettings(config, settings)).toEqual(expectedConfig);
         });

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import clone from "lodash/clone";
 import includes from "lodash/includes";
 import isNil from "lodash/isNil";
@@ -97,6 +97,12 @@ export const isTreemap = isEqual(VisualizationTypes.TREEMAP);
  * @internal
  */
 export const isHeatmap = isEqual(VisualizationTypes.HEATMAP);
+
+/**
+ * @internal
+ */
+export const isSupportingJoinedAttributeAxisName = (type: string): boolean =>
+    isBarChart(type) || isColumnChart(type) || isBulletChart(type);
 
 /**
  * @internal

--- a/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
+++ b/libs/sdk-ui-charts/src/interfaces/chartConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import { ISeparators } from "@gooddata/numberjs";
 import { IColorPalette, Identifier } from "@gooddata/sdk-model";
 import { VisType } from "@gooddata/sdk-ui";
@@ -177,6 +177,11 @@ export interface IChartConfig {
      *
      */
     enableCompactSize?: boolean;
+
+    /**
+     * Enable attribute axis name for the column, bar and bullet charts when view by many attributes.
+     */
+    enableJoinedAttributeAxisName?: boolean;
 
     //
     //

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BarChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BarChartConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import BaseChartConfigurationPanel from "./BaseChartConfigurationPanel";
 import { BAR_CHART_AXIS_CONFIG } from "../../constants/axis";
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BaseChartConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import includes from "lodash/includes";
@@ -123,10 +123,13 @@ export default class BaseChartConfigurationPanel<
         const itemsOnAxes = countItemsOnAxes(type, controls, insight);
         const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
         const isAxisLabelsFormatEnabled: boolean = featureFlags.enableAxisLabelFormat as boolean;
+        const isAxisNameViewByTwoAttributesEnabled: boolean =
+            featureFlags.enableAxisNameViewByTwoAttributes as boolean;
 
         return axes.map((axis: IAxisProperties) => {
             const disabled = controlsDisabled || (!axis.primary && !isViewedBy);
-            const hasMoreThanOneItem = itemsOnAxes[axis.name] > 1;
+            const nameSubsectionDisabled: boolean =
+                (axis.primary || !isAxisNameViewByTwoAttributesEnabled) && itemsOnAxes[axis.name] > 1;
             const { name, title, subtitle, visible } = axis;
 
             return (
@@ -145,7 +148,7 @@ export default class BaseChartConfigurationPanel<
                 >
                     {isNameSubsectionVisible && (
                         <NameSubsection
-                            disabled={disabled || hasMoreThanOneItem}
+                            disabled={disabled || nameSubsectionDisabled}
                             configPanelDisabled={controlsDisabled}
                             axis={axis.name}
                             properties={properties}

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/BulletChartConfigurationPanel.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/BulletChartConfigurationPanel.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { Bubble, BubbleHoverTrigger } from "@gooddata/sdk-ui-kit";
@@ -34,6 +34,11 @@ export default class BulletChartConfigurationPanel extends ConfigurationPanelCon
         const xAxisNameSectionDisabled = controlsDisabled || itemsOnXAxis !== 1;
         const isNameSubsectionVisible: boolean = featureFlags.enableAxisNameConfiguration as boolean;
         const isAxisLabelsFormatEnabled: boolean = featureFlags.enableAxisLabelFormat as boolean;
+        const isAxisNameViewByTwoAttributesEnabled: boolean =
+            featureFlags.enableAxisNameViewByTwoAttributes as boolean;
+        const yAxisNameSubsectionDisabled = isAxisNameViewByTwoAttributesEnabled
+            ? controlsDisabled || itemsOnYAxis === 0
+            : controlsDisabled || itemsOnYAxis !== 1;
 
         return (
             <BubbleHoverTrigger showDelay={SHOW_DELAY_DEFAULT} hideDelay={HIDE_DELAY_DEFAULT}>
@@ -82,7 +87,7 @@ export default class BulletChartConfigurationPanel extends ConfigurationPanelCon
                     >
                         {isNameSubsectionVisible && (
                             <NameSubsection
-                                disabled={controlsDisabled || itemsOnYAxis !== 1}
+                                disabled={yAxisNameSubsectionDisabled}
                                 configPanelDisabled={controlsDisabled}
                                 axis={"yaxis"}
                                 properties={properties}

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BulletChartConfigurationPanel.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/tests/BulletChartConfigurationPanel.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { shallow } from "enzyme";
 import BulletChartConfigurationPanel from "../BulletChartConfigurationPanel";
@@ -338,6 +338,31 @@ describe("BulletChartConfigurationPanel", () => {
 
             const yAxisSection = wrapper.find(NameSubsection).at(1);
             expect(yAxisSection.props().disabled).toEqual(true);
+        });
+
+        it("should render name configuration panel enabled if there are two attributes and feature flag 'enableAxisNameViewByTwoAttributes' is true", () => {
+            const insight = testInsight([
+                {
+                    localIdentifier: "measures",
+                    items: [testMeasure],
+                },
+                {
+                    localIdentifier: "view",
+                    items: [attributeItemA1, attributeItemA2],
+                },
+            ]);
+
+            const wrapper = createComponent({
+                ...defaultProps,
+                featureFlags: {
+                    ...defaultProps.featureFlags,
+                    enableAxisNameViewByTwoAttributes: true,
+                },
+                insight,
+            });
+
+            const yAxisSection = wrapper.find(NameSubsection).at(1);
+            expect(yAxisSection.props().disabled).toEqual(false);
         });
     });
 });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { COLUMN_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";


### PR DESCRIPTION
JIRA TNT-188

* enableAxisNameViewByTwoAttributes - feature flag
* enableJoinedAttributeAxisName - chart config property, which propagates FF above

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
