### PR TITLE
RELATED: RAIL-3963 Mark useDashboardSelector as public

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5033,7 +5033,7 @@ export type UseDashboardQueryProcessingResult<TQueryCreatorArgs extends any[], T
     run: (...args: TQueryCreatorArgs) => void;
 };
 
-// @alpha (undocumented)
+// @public
 export const useDashboardSelector: TypedUseSelectorHook<DashboardState>;
 
 // @internal

--- a/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
+++ b/libs/sdk-ui-dashboard/src/model/react/DashboardStoreProvider.tsx
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
 import { AnyAction, Dispatch } from "@reduxjs/toolkit";
 import { createDispatchHook, createSelectorHook, Provider, TypedUseSelectorHook } from "react-redux";
@@ -18,7 +18,24 @@ export const ReactDashboardContext: any = React.createContext(null);
 export const useDashboardDispatch: () => Dispatch<AnyAction> = createDispatchHook(ReactDashboardContext);
 
 /**
- * @alpha
+ * Hook for retrieving data from the dashboard state.
+ *
+ * @example
+ * Example how to obtain all insights stored on the dashboard:
+ *
+ * ```tsx
+ * import { useDashboardSelector, selectInsights } from "@gooddata/sdk-ui-dashboard";
+ *
+ * const CustomDashboardWidget = () => {
+ *   const insights = useDashboardSelector(selectInsights);
+ *
+ *   return (
+ *      <pre>{JSON.stringify(insights, null, 2)}</pre>
+ *   );
+ * }
+ * ```
+ *
+ * @public
  */
 export const useDashboardSelector: TypedUseSelectorHook<DashboardState> =
     createSelectorHook(ReactDashboardContext);


### PR DESCRIPTION
We link to it from various places in the docs for public stuff, so it
itself should be public, too.

JIRA: RAIL-3963

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
