### PR TITLE
RELATED: RAIL-4030 Fix getValidDateFilterConfig call

### DIFF
--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-36.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-36.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "Dashboard commands and events related to filter manipulation were made part of the public API.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-38.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-38.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "General Dashboard events (like DashboardSaved) were made part of the public API.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-39.json
+++ b/common/changes/@gooddata/sdk-ui-all/dho-rail-4030-week-filters_2022-02-23-09-39.json
@@ -1,0 +1,10 @@
+{
+    "changes": [
+        {
+            "packageName": "@gooddata/sdk-ui-all",
+            "comment": "The useDispatchDashboardCommnad hook was added to make dispatching Dashboard commands easier.",
+            "type": "none"
+        }
+    ],
+    "packageName": "@gooddata/sdk-ui-all"
+}

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/initializeDashboardHandler/resolveDashboardConfig.ts
@@ -150,7 +150,10 @@ export function* resolveDashboardConfig(
         call(resolveColorPalette, ctx, config),
     ]);
 
-    const [validDateFilterConfig, configValidation] = getValidDateFilterConfig(dateFilterConfig, settings);
+    const [validDateFilterConfig, configValidation] = getValidDateFilterConfig(
+        dateFilterConfig,
+        settings.settings,
+    );
 
     if (configValidation !== "Valid") {
         yield dispatchDashboardEvent(dateFilterValidationFailed(ctx, configValidation, cmd.correlationId));


### PR DESCRIPTION
There was an "unwrap" missing which led to weeks always being broken.

Also add missing changelog entries.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
