### PR TITLE
RELATED: RAIL-4034 Prompt dashboardId in (un)link if needed

### DIFF
--- a/tools/plugin-toolkit/src/_base/terminal/prompts.ts
+++ b/tools/plugin-toolkit/src/_base/terminal/prompts.ts
@@ -65,11 +65,11 @@ export async function promptWorkspaceIdWithoutChoice(): Promise<string> {
     return response.id;
 }
 
-export async function promptDashboardIdWithoutChoice(): Promise<string> {
+export async function promptDashboardIdWithoutChoice(wording: string): Promise<string> {
     const question: DistinctQuestion = {
         type: "input",
         name: "id",
-        message: `Enter identifier of a dashboard to use during plugin development:`,
+        message: wording,
     };
 
     const response = await prompt(question);

--- a/tools/plugin-toolkit/src/initCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/initCmd/actionConfig.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { ActionOptions, SupportedPackageManager, TargetAppLanguage, TargetBackendType } from "../_base/types";
 import {
     createHostnameValidator,
@@ -93,7 +93,11 @@ export async function getInitCmdActionConfig(
     const hostname = hostnameFromOptions ?? (await promptHostname(backend));
     const language = languageFromOptions ?? (await promptLanguage());
     const workspace = workspaceFromOptions ?? (await promptWorkspaceIdWithoutChoice());
-    const dashboard = dashboardFromOptions ?? (await promptDashboardIdWithoutChoice());
+    const dashboard =
+        dashboardFromOptions ??
+        (await promptDashboardIdWithoutChoice(
+            "Enter identifier of a dashboard to use during plugin development:",
+        ));
 
     // validate hostname once again; this is to catch the case when hostname is provided as
     // option but the backend is not and user is prompted for it. the user may select backend

--- a/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/linkPluginCmd/actionConfig.ts
@@ -13,7 +13,7 @@ import {
     InputValidator,
 } from "../_base/inputHandling/validators";
 import isEmpty from "lodash/isEmpty";
-import { promptPluginParameters } from "../_base/terminal/prompts";
+import { promptDashboardIdWithoutChoice, promptPluginParameters } from "../_base/terminal/prompts";
 import { logError } from "../_base/terminal/loggers";
 import { convertToPluginEntrypoint, convertToPluginIdentifier } from "../_base/utils";
 
@@ -129,7 +129,10 @@ export async function getLinkCmdActionConfig(
 ): Promise<LinkCmdActionConfig> {
     const workspaceTargetConfig = await createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials, env, packageJson } = workspaceTargetConfig;
-    const dashboard = getDashboardFromOptions(options) ?? env.DASHBOARD_ID;
+    const dashboard =
+        getDashboardFromOptions(options) ??
+        env.DASHBOARD_ID ??
+        (await promptDashboardIdWithoutChoice("Enter identifier of the dashboard to link the plugin to:"));
 
     const backendInstance = createBackend({
         hostname,

--- a/tools/plugin-toolkit/src/unlinkPluginCmd/actionConfig.ts
+++ b/tools/plugin-toolkit/src/unlinkPluginCmd/actionConfig.ts
@@ -13,6 +13,7 @@ import {
 } from "../_base/inputHandling/validators";
 import isEmpty from "lodash/isEmpty";
 import { convertToPluginEntrypoint, convertToPluginIdentifier } from "../_base/utils";
+import { promptDashboardIdWithoutChoice } from "../_base/terminal/prompts";
 
 export type UnlinkCmdActionConfig = WorkspaceTargetConfig & {
     /**
@@ -95,7 +96,12 @@ export async function getUnlinkCmdActionConfig(
 ): Promise<UnlinkCmdActionConfig> {
     const workspaceTargetConfig = await createWorkspaceTargetConfig(options);
     const { hostname, backend, credentials, env, packageJson } = workspaceTargetConfig;
-    const dashboard = getDashboardFromOptions(options) ?? env.DASHBOARD_ID;
+    const dashboard =
+        getDashboardFromOptions(options) ??
+        env.DASHBOARD_ID ??
+        (await promptDashboardIdWithoutChoice(
+            "Enter identifier of the dashboard to unlink the plugin from:",
+        ));
 
     const backendInstance = createBackend({
         hostname,


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
