### PR TITLE
Move ISortConfig interfaces back to the sdk-ui-ext

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -129,7 +129,7 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
             nextProps.referencePoint,
         );
 
-        const propertiesChanged = BaseVisualization.propertiesHasChanged(
+        const propertiesControlsChanged = BaseVisualization.propertiesControlsHasChanged(
             this.props.referencePoint,
             nextProps.referencePoint,
         );
@@ -145,7 +145,8 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
                 // only pass current props if the visualization class is the same (see getExtendedReferencePoint JSDoc)
                 visualizationClassChanged ? undefined : this.props,
             );
-        } else if (propertiesChanged) {
+            // Some of the properties eg. stacking of measures, dual axes influence sorting
+        } else if (propertiesControlsChanged) {
             this.triggerPropertiesChanged(nextProps, this.props);
         }
     }
@@ -290,11 +291,11 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         return !isEqual(omit(currentReferencePoint, "properties"), omit(nextReferencePoint, "properties"));
     }
 
-    private static propertiesHasChanged(
+    private static propertiesControlsHasChanged(
         currentReferencePoint: IReferencePoint,
         nextReferencePoint: IReferencePoint,
     ) {
-        return !isEqual(currentReferencePoint.properties, nextReferencePoint.properties);
+        return !isEqual(currentReferencePoint.properties?.controls, nextReferencePoint.properties?.controls);
     }
 
     private getVisualizationProps(): IVisProps {

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -8,7 +8,6 @@ import {
     visClassUrl,
     IExecutionConfig,
 } from "@gooddata/sdk-model";
-import { ISortConfig } from "@gooddata/sdk-ui-kit";
 import React from "react";
 import { render } from "react-dom";
 import { v4 as uuidv4 } from "uuid";
@@ -38,6 +37,7 @@ import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import noop from "lodash/noop";
 import omit from "lodash/omit";
+import { ISortConfig } from "../interfaces/SortConfig";
 
 export interface IBaseVisualizationProps extends IVisCallbacks {
     backend: IAnalyticalBackend;

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -146,7 +146,7 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
                 visualizationClassChanged ? undefined : this.props,
             );
         } else if (propertiesChanged) {
-            this.triggerPropertiesChanged(nextProps);
+            this.triggerPropertiesChanged(nextProps, this.props);
         }
     }
 
@@ -268,11 +268,18 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         }
     }
 
-    private triggerPropertiesChanged(newProps: IBaseVisualizationProps) {
+    private triggerPropertiesChanged(
+        newProps: IBaseVisualizationProps,
+        currentProps?: IBaseVisualizationProps,
+    ) {
         const { referencePoint: newReferencePoint, onSortingChanged } = newProps;
         // Some of the properties eg. stacking of measures, dual axes influence sorting
         if (this.visualization && newReferencePoint && onSortingChanged) {
-            this.visualization.getSortConfig(newReferencePoint).then(onSortingChanged);
+            this.visualization
+                .getExtendedReferencePoint(newReferencePoint, currentProps && currentProps.referencePoint)
+                .then((extendedRefPoint) => {
+                    this.visualization.getSortConfig(extendedRefPoint).then(onSortingChanged);
+                });
         }
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -295,7 +295,10 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         currentReferencePoint: IReferencePoint,
         nextReferencePoint: IReferencePoint,
     ) {
-        return !isEqual(currentReferencePoint.properties?.controls, nextReferencePoint.properties?.controls);
+        return !isEqual(
+            currentReferencePoint?.properties?.controls,
+            nextReferencePoint?.properties?.controls,
+        );
     }
 
     private getVisualizationProps(): IVisProps {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -18,7 +18,6 @@ import {
 import { findDerivedBucketItem, hasDerivedBucketItems, isDerivedBucketItem } from "../../utils/bucketHelper";
 import { IInsight, IInsightDefinition, insightHasDataDefined, insightProperties } from "@gooddata/sdk-model";
 import { IExecutionFactory, IPreparedExecution } from "@gooddata/sdk-backend-spi";
-import { ISortConfig } from "@gooddata/sdk-ui-kit";
 import {
     DefaultLocale,
     GoodDataSdkError,
@@ -33,6 +32,7 @@ import {
 import { IntlShape } from "react-intl";
 import { createInternalIntl } from "../../utils/internalIntlProvider";
 import { getSupportedProperties } from "../../utils/propertiesHelper";
+import { ISortConfig } from "../../interfaces/SortConfig";
 
 export abstract class AbstractPluggableVisualization implements IVisualization {
     protected intl: IntlShape;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -3,14 +3,13 @@ import React from "react";
 import { render } from "react-dom";
 import isEmpty from "lodash/isEmpty";
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
-import { ISortConfig } from "@gooddata/sdk-ui-kit";
 import { IInsightDefinition, localIdRef, newAttributeAreaSort, newMeasureSort } from "@gooddata/sdk-model";
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { IReferencePoint, IVisConstruct } from "../../../interfaces/Visualization";
 import { BAR_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import BarChartConfigurationPanel from "../../configurationPanels/BarChartConfigurationPanel";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
-import { newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
 import { getBucketItems } from "../../../utils/bucketHelper";
 import { canSortStackTotalValue } from "./sortHelpers";
 

--- a/libs/sdk-ui-ext/src/internal/index.ts
+++ b/libs/sdk-ui-ext/src/internal/index.ts
@@ -50,6 +50,8 @@ export { createInternalIntl, InternalIntlWrapper } from "./utils/internalIntlPro
 export { IVisualizationSizeInfo, ISizeInfo } from "./interfaces/VisualizationDescriptor";
 export { IFluidLayoutDescriptor, ILayoutDescriptor, LayoutType } from "./interfaces/LayoutDescriptor";
 
+export { ISortConfig, IAvailableSortsGroup } from "./interfaces/SortConfig";
+
 export { addIntersectionFiltersToInsight } from "./components/pluggableVisualizations/drillDownUtil";
 export * from "./components/pluggableVisualizations/constants";
 

--- a/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
@@ -1,7 +1,20 @@
 // (C) 2019-2022 GoodData Corporation
 
-import { Identifier, IAttributeLocatorItem, newMeasureSort } from "@gooddata/sdk-model";
-import { MeasureSortSuggestion } from "@gooddata/sdk-ui-kit";
+import {
+    Identifier,
+    IAttributeLocatorItem,
+    newMeasureSort,
+    IMeasureSortTarget,
+    LocalIdRef,
+    ISortItem,
+} from "@gooddata/sdk-model";
+
+/**
+ * @internal
+ */
+export type MeasureSortSuggestion = {
+    type: "measureSort";
+} & IMeasureSortTarget;
 
 export function newMeasureSortSuggestion(
     identifier: Identifier,
@@ -14,4 +27,58 @@ export function newMeasureSortSuggestion(
         type: "measureSort",
         locators,
     };
+}
+
+/**
+ * Specifies set of available sorts for given level of hierarchy:
+ * Specific attribute to which sort is related - for eg. multiple ViewBy attributes, each can specify its sorting
+ */
+/**
+ * @internal
+ */
+export interface IAvailableSortsGroup {
+    // bucket item identifier
+    itemId: LocalIdRef;
+    /**
+     * Attribute sorts related to the attribute bucket item referenced by itemId
+     * Attribute sort suggestions can be created later in AD
+     * This structure eliminates the risk, that in one group attributeSortSuggestions for multiple attribute items will be mixed together
+     */
+    attributeSort?: {
+        normalSortEnabled: boolean;
+        areaSortEnabled: boolean;
+    };
+    metricSorts?: MeasureSortSuggestion[];
+    /**
+     * Additional text to available sorts, eg.
+     * when there is single available sort, this can contain explanation of the reason
+     */
+    explanation?: string;
+}
+
+/**
+ * @internal
+ */
+export interface ISortConfig {
+    /**
+     * Current sort - default or chosen from inside of visualization
+     */
+    currentSort: ISortItem[];
+    /**
+     * All available sorts for current buckets
+     * - should contain current sort too
+     */
+    availableSorts: IAvailableSortsGroup[];
+    /**
+     * Whether sorting is supported by viz
+     */
+    supported: boolean;
+    /**
+     * Whether sorting is disabled for current buckets
+     */
+    disabled: boolean;
+    /**
+     * When sorting is disabled, this can contain explanation of reason
+     */
+    disabledExplanation?: string;
 }

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -32,7 +32,7 @@ import {
     SdkErrorType,
     VisualizationEnvironment,
 } from "@gooddata/sdk-ui";
-import { ISortConfig } from "@gooddata/sdk-ui-kit";
+import { ISortConfig } from "./SortConfig";
 
 export type RenderFunction = (component: any, target: Element) => void;
 

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -180,7 +180,11 @@ export class Button extends React_2.Component<IButtonProps> {
 // @internal (undocumented)
 export interface ChartSortingOwnProps {
     // (undocumented)
+    availableSorts: IAvailableSortsGroup[];
+    // (undocumented)
     bucketItemNames: IBucketItemNames;
+    // (undocumented)
+    currentSort: ISortItem[];
     // (undocumented)
     enableRenamingMeasureToMetric?: boolean;
     // (undocumented)
@@ -189,8 +193,6 @@ export interface ChartSortingOwnProps {
     onCancel: () => void;
     // (undocumented)
     onClose?: () => void;
-    // (undocumented)
-    sortConfig: ISortConfig;
 }
 
 // @internal (undocumented)
@@ -697,7 +699,7 @@ export interface IAutoSizeProps {
     children: ({ width, height }: IAutoSizeChildren) => React_2.ReactNode;
 }
 
-// @internal (undocumented)
+// @internal
 export interface IAvailableSortsGroup {
     attributeSort?: {
         normalSortEnabled: boolean;
@@ -2798,15 +2800,6 @@ export interface ISnapPoints {
     child: SnapPoint;
     // (undocumented)
     parent: SnapPoint;
-}
-
-// @internal (undocumented)
-export interface ISortConfig {
-    availableSorts: IAvailableSortsGroup[];
-    currentSort: ISortItem[];
-    disabled: boolean;
-    disabledExplanation?: string;
-    supported: boolean;
 }
 
 // @internal (undocumented)

--- a/libs/sdk-ui-kit/src/ChartSorting/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/AttributeDropdown/AttributeDropdown.tsx
@@ -24,7 +24,6 @@ interface AttributeDropdownProps {
     index: number;
     onSelect: (item: ISortItem) => void;
 
-    disabledExplanationTooltip?: string;
     enableRenamingMeasureToMetric?: boolean;
 }
 
@@ -95,7 +94,6 @@ export const AttributeDropdown: React.FC<AttributeDropdownProps> = ({
     intl,
     index,
     onSelect,
-    disabledExplanationTooltip,
     enableRenamingMeasureToMetric,
 }) => {
     const [width, setWidth] = useState<number>(0);
@@ -190,7 +188,7 @@ export const AttributeDropdown: React.FC<AttributeDropdownProps> = ({
                     availableSorts={availableSorts}
                     bucketItemNames={bucketItemNames}
                     onSelect={measureSelectHandler}
-                    disabledExplanationTooltip={disabledExplanationTooltip}
+                    disabledExplanationTooltip={availableSorts.explanation}
                     enableRenamingMeasureToMetric={enableRenamingMeasureToMetric}
                 />
             )}

--- a/libs/sdk-ui-kit/src/ChartSorting/ChartSorting.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/ChartSorting.tsx
@@ -5,14 +5,16 @@ import { ISortItem } from "@gooddata/sdk-model";
 
 import { ChartSortingDropdownBody } from "./ChartSortingDropdownBody";
 import { ChartSortingDropdown } from "./ChartSortingDropdown";
-import { IBucketItemNames, ISortConfig } from "./types";
+import { IBucketItemNames, IAvailableSortsGroup } from "./types";
 import { Button } from "../Button";
 
 /**
  * @internal
  */
 export interface ChartSortingOwnProps {
-    sortConfig: ISortConfig;
+    currentSort: ISortItem[];
+    // Available Sorts - from which will generate dropdowns
+    availableSorts: IAvailableSortsGroup[];
     bucketItemNames: IBucketItemNames;
     onApply: (sortItems: ISortItem[]) => void;
     onCancel: () => void;
@@ -30,7 +32,8 @@ export type ChartSortingProps = ChartSortingOwnProps & WrappedComponentProps;
  * @internal
  */
 export const ChartSorting: React.FC<ChartSortingProps> = ({
-    sortConfig,
+    currentSort,
+    availableSorts,
     intl,
     bucketItemNames,
     onCancel,
@@ -38,15 +41,11 @@ export const ChartSorting: React.FC<ChartSortingProps> = ({
     onClose,
     enableRenamingMeasureToMetric,
 }) => {
-    const [currentSort, setCurrentSort] = useState<ISortItem[]>(sortConfig.currentSort);
-    const disabledExplanationTooltip = sortConfig.disabledExplanation;
-
-    // Available Sorts - from which will generate dropdowns
-    const availableSorts = sortConfig.availableSorts;
+    const [currentSelectedSort, setCurrentSort] = useState<ISortItem[]>(currentSort);
 
     const handleApply = useCallback(() => {
-        onApply(currentSort);
-    }, [currentSort]);
+        onApply(currentSelectedSort);
+    }, [currentSelectedSort]);
 
     const onSelect = (item: ISortItem[]) => {
         setCurrentSort(item);
@@ -60,10 +59,9 @@ export const ChartSorting: React.FC<ChartSortingProps> = ({
                 </div>
                 <div className="section chart-sorting-body gd-sort-charting-dropdown">
                     <ChartSortingDropdown
-                        currentSort={currentSort}
+                        currentSort={currentSelectedSort}
                         availableSorts={availableSorts}
                         bucketItemNames={bucketItemNames}
-                        disabledExplanationTooltip={disabledExplanationTooltip}
                         intl={intl}
                         onSelect={onSelect}
                         enableRenamingMeasureToMetric={enableRenamingMeasureToMetric}

--- a/libs/sdk-ui-kit/src/ChartSorting/ChartSortingDropdown.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/ChartSortingDropdown.tsx
@@ -13,7 +13,6 @@ interface ChartSortingProps {
     intl: IntlShape;
     onSelect: (item: ISortItem[]) => void;
 
-    disabledExplanationTooltip?: string;
     enableRenamingMeasureToMetric?: boolean;
 }
 
@@ -26,7 +25,6 @@ export const ChartSortingDropdown: React.FC<ChartSortingProps> = ({
     bucketItemNames,
     intl,
     onSelect,
-    disabledExplanationTooltip,
     enableRenamingMeasureToMetric,
 }) => {
     const onSortChanged = useCallback(
@@ -58,7 +56,6 @@ export const ChartSortingDropdown: React.FC<ChartSortingProps> = ({
                                     currentSortItem={currentSortItem}
                                     availableSorts={available}
                                     bucketItemNames={bucketItemNames}
-                                    disabledExplanationTooltip={disabledExplanationTooltip}
                                     intl={intl}
                                     onSelect={(newSort: ISortItem) => {
                                         onSortChanged(newSort, index);

--- a/libs/sdk-ui-kit/src/ChartSorting/index.ts
+++ b/libs/sdk-ui-kit/src/ChartSorting/index.ts
@@ -3,7 +3,6 @@
 export { ChartSortingWithIntl, ChartSortingOwnProps, ChartSortingProps } from "./ChartSorting";
 
 export {
-    ISortConfig,
     IAvailableSortsGroup,
     MeasureSortSuggestion,
     SORT_TARGET_TYPE,

--- a/libs/sdk-ui-kit/src/ChartSorting/test/ChartSorting.test.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/test/ChartSorting.test.tsx
@@ -51,7 +51,7 @@ const messages = pickCorrectWording(messagesMap[DefaultLocale], {
 
 const renderComponent = (props?: Partial<ChartSortingOwnProps>) => {
     const defaultProps: ChartSortingOwnProps = {
-        sortConfig: singleNormalAttributeSortConfig,
+        ...singleNormalAttributeSortConfig,
         bucketItemNames,
         onApply: noop,
         onCancel: noop,
@@ -81,7 +81,9 @@ describe("ChartSorting", () => {
     });
 
     describe("Attribute Area Sort with no metrics", () => {
-        const component = renderComponent({ sortConfig: singleAreaAttributeSortConfig });
+        const component = renderComponent({
+            ...singleAreaAttributeSortConfig,
+        });
 
         it("should render dialog with correct values and measure dropdown disabled", () => {
             expect(findSelector(component, "Sum of all metrics (total)")).toEqual(true);
@@ -105,7 +107,9 @@ describe("ChartSorting", () => {
     });
 
     describe("Attribute Area sort with multiple Metrics", () => {
-        const component = renderComponent({ sortConfig: multipleAttributesSortConfig });
+        const component = renderComponent({
+            ...multipleAttributesSortConfig,
+        });
 
         it("should render dialog with correct values", () => {
             const firstAttribute = component.find(buildAttributeButtonSelector(0)).hostNodes().text();
@@ -146,7 +150,10 @@ describe("ChartSorting", () => {
 
         it("should call onApply for simple normal attribute with correct SortItem payload", () => {
             const onApply = jest.fn();
-            const component = renderComponent({ onApply, sortConfig: singleNormalAttributeSortConfig });
+            const component = renderComponent({
+                onApply,
+                ...singleNormalAttributeSortConfig,
+            });
             component.find(".s-sorting-dropdown-apply").hostNodes().simulate("click");
 
             expect(onApply).toHaveBeenCalledWith([
@@ -161,7 +168,10 @@ describe("ChartSorting", () => {
 
         it("should call onApply for simple area attribute with correct SortItem payload", () => {
             const onApply = jest.fn();
-            const component = renderComponent({ onApply, sortConfig: singleAreaAttributeSortConfig });
+            const component = renderComponent({
+                onApply,
+                ...singleAreaAttributeSortConfig,
+            });
             component.find(".s-sorting-dropdown-apply").hostNodes().simulate("click");
 
             expect(onApply).toHaveBeenCalledWith([
@@ -177,7 +187,10 @@ describe("ChartSorting", () => {
 
         it("should call onApply for multiple attributes with correct SortItem payload", () => {
             const onApply = jest.fn();
-            const component = renderComponent({ onApply, sortConfig: multipleAttributesSortConfig });
+            const component = renderComponent({
+                onApply,
+                ...multipleAttributesSortConfig,
+            });
             component.find(".s-sorting-dropdown-apply").hostNodes().simulate("click");
 
             expect(onApply).toHaveBeenCalledWith([

--- a/libs/sdk-ui-kit/src/ChartSorting/test/mock.ts
+++ b/libs/sdk-ui-kit/src/ChartSorting/test/mock.ts
@@ -1,9 +1,14 @@
 // (C) 2022 GoodData Corporation
 
 import { localIdRef } from "@gooddata/sdk-model";
-import { ISortConfig } from "../types";
+import { ChartSortingOwnProps } from "../ChartSorting";
 
-export const singleNormalAttributeSortConfig: ISortConfig = {
+type SortingPropsMock = {
+    currentSort: ChartSortingOwnProps["currentSort"];
+    availableSorts: ChartSortingOwnProps["availableSorts"];
+};
+
+export const singleNormalAttributeSortConfig: SortingPropsMock = {
     currentSort: [
         {
             attributeSortItem: {
@@ -21,11 +26,9 @@ export const singleNormalAttributeSortConfig: ISortConfig = {
             },
         },
     ],
-    supported: true,
-    disabled: false,
 };
 
-export const singleAreaAttributeSortConfig: ISortConfig = {
+export const singleAreaAttributeSortConfig: SortingPropsMock = {
     currentSort: [
         {
             attributeSortItem: {
@@ -44,11 +47,9 @@ export const singleAreaAttributeSortConfig: ISortConfig = {
             },
         },
     ],
-    supported: true,
-    disabled: false,
 };
 
-export const multipleAttributesSortConfig: ISortConfig = {
+export const multipleAttributesSortConfig: SortingPropsMock = {
     currentSort: [
         {
             measureSortItem: {
@@ -108,6 +109,4 @@ export const multipleAttributesSortConfig: ISortConfig = {
             },
         },
     ],
-    supported: true,
-    disabled: false,
 };

--- a/libs/sdk-ui-kit/src/ChartSorting/types.ts
+++ b/libs/sdk-ui-kit/src/ChartSorting/types.ts
@@ -1,38 +1,16 @@
 // (C) 2022 GoodData Corporation
-import { ISortItem, LocalIdRef, SortDirection, IMeasureSortTarget } from "@gooddata/sdk-model";
+import { IMeasureSortTarget, LocalIdRef, SortDirection } from "@gooddata/sdk-model";
 
 /**
  * @internal
  */
-export interface ISortConfig {
-    /**
-     * Current sort - default or chosen from inside of visualization
-     */
-    currentSort: ISortItem[];
-    /**
-     * All available sorts for current buckets
-     * - should contain current sort too
-     */
-    availableSorts: IAvailableSortsGroup[];
-    /**
-     * Whether sorting is supported by viz
-     */
-    supported: boolean;
-    /**
-     * Whether sorting is disabled for current buckets
-     */
-    disabled: boolean;
-    /**
-     * When sorting is disabled, this can contain explanation of reason
-     */
-    disabledExplanation?: string;
-}
+export type MeasureSortSuggestion = {
+    type: "measureSort";
+} & IMeasureSortTarget;
 
 /**
- * Specifies set of available sorts for given level of hierarchy:
- * Specific attribute to which sort is related - for eg. multiple ViewBy attributes, each can specify its sorting
- */
-/**
+ * For now it is completely the same as IAvailableSortsGroup in sdk-ui-ext
+ *
  * @internal
  */
 export interface IAvailableSortsGroup {
@@ -54,13 +32,6 @@ export interface IAvailableSortsGroup {
      */
     explanation?: string;
 }
-
-/**
- * @internal
- */
-export type MeasureSortSuggestion = {
-    type: "measureSort";
-} & IMeasureSortTarget;
 
 /**
  * @internal

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSorting.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSorting.tsx
@@ -64,7 +64,8 @@ storiesOf(`${UiKit}/ChartSorting`)
                     <InternalIntlWrapper>
                         <ChartSortingWithIntl
                             bucketItemNames={bucketItemNames}
-                            sortConfig={singleAttributeSortConfig}
+                            currentSort={singleAttributeSortConfig.currentSort}
+                            availableSorts={singleAttributeSortConfig.availableSorts}
                             onApply={action("apply")}
                             onCancel={action("cancel")}
                             enableRenamingMeasureToMetric={true}
@@ -83,7 +84,8 @@ storiesOf(`${UiKit}/ChartSorting`)
                     <InternalIntlWrapper>
                         <ChartSortingWithIntl
                             bucketItemNames={bucketItemNames}
-                            sortConfig={singleAttributeWithSingleMetricSortConfig}
+                            currentSort={singleAttributeWithSingleMetricSortConfig.currentSort}
+                            availableSorts={singleAttributeWithSingleMetricSortConfig.availableSorts}
                             onApply={action("apply")}
                             onCancel={action("cancel")}
                             enableRenamingMeasureToMetric={true}
@@ -102,7 +104,8 @@ storiesOf(`${UiKit}/ChartSorting`)
                     <InternalIntlWrapper>
                         <ChartSortingWithIntl
                             bucketItemNames={bucketItemNames}
-                            sortConfig={singleAttributeWithMultipleMetrics}
+                            currentSort={singleAttributeWithMultipleMetrics.currentSort}
+                            availableSorts={singleAttributeWithMultipleMetrics.availableSorts}
                             onApply={action("apply")}
                             onCancel={action("cancel")}
                             enableRenamingMeasureToMetric={true}
@@ -121,7 +124,8 @@ storiesOf(`${UiKit}/ChartSorting`)
                     <InternalIntlWrapper>
                         <ChartSortingWithIntl
                             bucketItemNames={bucketItemNames}
-                            sortConfig={multipleAttributesMultipleMetricsSortConfig}
+                            currentSort={multipleAttributesMultipleMetricsSortConfig.currentSort}
+                            availableSorts={multipleAttributesMultipleMetricsSortConfig.availableSorts}
                             onApply={action("apply")}
                             onCancel={action("cancel")}
                             enableRenamingMeasureToMetric={true}

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSorting.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSorting.tsx
@@ -140,7 +140,8 @@ storiesOf(`${UiKit}/ChartSorting`)
                     <InternalIntlWrapper>
                         <ChartSortingWithIntl
                             bucketItemNames={bucketItemNames}
-                            sortConfig={multipleAttributesMultipleMetricsSortConfig}
+                            currentSort={multipleAttributesMultipleMetricsSortConfig.currentSort}
+                            availableSorts={multipleAttributesMultipleMetricsSortConfig.availableSorts}
                             onApply={action("apply")}
                             onCancel={action("cancel")}
                             enableRenamingMeasureToMetric={true}

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSortingMock.ts
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/ChartSorting/ChartSortingMock.ts
@@ -1,9 +1,14 @@
 // (C) 2022 GoodData Corporation
-import { ISortConfig } from "@gooddata/sdk-ui-kit";
+import { ChartSortingOwnProps } from "@gooddata/sdk-ui-kit";
 import { attributeLocalId, localIdRef, measureLocalId } from "@gooddata/sdk-model";
 import { ExperimentalMd } from "@gooddata/experimental-workspace";
 
-export const singleAttributeSortConfig: ISortConfig = {
+type SortingPropsMock = {
+    currentSort: ChartSortingOwnProps["currentSort"];
+    availableSorts: ChartSortingOwnProps["availableSorts"];
+};
+
+export const singleAttributeSortConfig: SortingPropsMock = {
     currentSort: [
         {
             attributeSortItem: {
@@ -21,11 +26,9 @@ export const singleAttributeSortConfig: ISortConfig = {
             },
         },
     ],
-    supported: true,
-    disabled: false,
 };
 
-export const singleAttributeWithSingleMetricSortConfig: ISortConfig = {
+export const singleAttributeWithSingleMetricSortConfig: SortingPropsMock = {
     currentSort: [
         {
             measureSortItem: {
@@ -61,11 +64,9 @@ export const singleAttributeWithSingleMetricSortConfig: ISortConfig = {
             ],
         },
     ],
-    supported: true,
-    disabled: false,
 };
 
-export const singleAttributeWithMultipleMetrics: ISortConfig = {
+export const singleAttributeWithMultipleMetrics: SortingPropsMock = {
     currentSort: [
         {
             measureSortItem: {
@@ -121,11 +122,9 @@ export const singleAttributeWithMultipleMetrics: ISortConfig = {
             ],
         },
     ],
-    supported: true,
-    disabled: false,
 };
 
-export const multipleAttributesMultipleMetricsSortConfig: ISortConfig = {
+export const multipleAttributesMultipleMetricsSortConfig: SortingPropsMock = {
     currentSort: [
         {
             attributeSortItem: {
@@ -195,6 +194,4 @@ export const multipleAttributesMultipleMetricsSortConfig: ISortConfig = {
             ],
         },
     ],
-    supported: true,
-    disabled: false,
 };


### PR DESCRIPTION
JIRA: TNT-452
Move ISortConfig and related interfaces back to the sdk-ui-ext as these are used mainly for communication between PV and AD
In sdk-ui-kit we keep duplicates for now, but these can evolve as sharing dialog will need extend its props

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
