### PR TITLE
RELATED: RAIL-4049 Replace options with empty object

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/AttributeFilterButtonUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/AttributeFilterButtonUtils.ts
@@ -208,9 +208,4 @@ export const checkFilterSetupForBackend = (filter: IAttributeFilter, backend: IA
         // eslint-disable-next-line no-console
         console.error("The attribute elements must be defined by URIs for this backend.");
     }
-
-    if (!isSupportElementUris && isElementsByRef) {
-        // eslint-disable-next-line no-console
-        console.error("The current backend does not support attribute elements defined by URIs.");
-    }
 };

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/hooks/useFetchInitialElements.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/hooks/useFetchInitialElements.ts
@@ -39,7 +39,7 @@ const prepareElementsTitleQuery = (
         .attributes()
         .elements()
         .forDisplayForm(getObjRef(currentFilter, identifier))
-        .withOptions(options);
+        .withOptions(options.uris.length > 0 ? options : {});
 };
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/utils/AttributeFilterUtils.ts
@@ -141,7 +141,7 @@ export const getElementTotalCount = async (
         });
 
     // only set the parent filters if needed to avoid errors on backends that do not support this feature
-    if (parentFilters?.length > 0) {
+    if (parentFilters?.length > 0 && isParentFilteringEnabled(backend)) {
         elementsLoader = elementsLoader.withAttributeFilters(parentFilters);
     }
 


### PR DESCRIPTION
If the query options comes with empty uris array, the tiger backend is not able to parse the query. If the uris array is empty, query options are replaced with an empty object.

JIRA: RAIL-4049

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
