### PR TITLE
RELATED: RAIL-4050, RAIL-4054 fix composite id matching

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -129,7 +129,7 @@ class LocalPlugin extends DashboardPluginV1 {
                         newCustomWidget("myWidget1", "myCustomWidget", {
                             // specify which date data set to used when applying the date filter to this widget
                             // if not specified, the date filter is ignored
-                            dateDataSet: Md.DateDatasets.Date,
+                            dateDataSet: Md.DateDatasets.Date.ref,
                             // specify which attribute filters to ignore for this widget
                             // if empty or not specified, all attribute filters are used
                             ignoreDashboardFilters: [

--- a/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/queryWidgetFilters.ts
@@ -48,12 +48,43 @@ import { ExtendedDashboardWidget, ICustomWidget } from "../types/layoutTypes";
 
 export const QueryWidgetFiltersService = createQueryService("GDC.DASH/QUERY.WIDGET.FILTERS", queryService);
 
-function refMatchesMdObject(ref: ObjRef, mdObject: IMetadataObject, type?: ObjectType): boolean {
-    return (
-        areObjRefsEqual(ref, mdObject.ref) ||
-        areObjRefsEqual(ref, idRef(mdObject.id, type)) ||
-        areObjRefsEqual(ref, uriRef(mdObject.uri))
-    );
+function matchRef(ref: ObjRef, mdObject: IMetadataObject): boolean {
+    return areObjRefsEqual(ref, mdObject.ref);
+}
+
+function matchUri(ref: ObjRef, mdObject: IMetadataObject): boolean {
+    return areObjRefsEqual(ref, uriRef(mdObject.uri));
+}
+
+function matchId(ref: ObjRef, mdObject: IMetadataObject, type: ObjectType): boolean {
+    return areObjRefsEqual(ref, idRef(mdObject.id, type));
+}
+
+function matchCompositeId(
+    ref: ObjRef,
+    mdObject: IMetadataObject,
+    type: ObjectType,
+    workspace: string,
+): boolean {
+    // try adding a workspace prefix for backends with support for composite identifiers
+    if (!mdObject.id.includes(":")) {
+        return areObjRefsEqual(ref, idRef(`${workspace}:${mdObject.id}`, type));
+    }
+    return false;
+}
+
+function refMatchesMdObject(
+    ref: ObjRef,
+    mdObject: IMetadataObject,
+    type: ObjectType,
+    workspace: string,
+): boolean {
+    return [
+        matchRef(ref, mdObject),
+        matchId(ref, mdObject, type),
+        matchUri(ref, mdObject),
+        matchCompositeId(ref, mdObject, type, workspace),
+    ].some(Boolean);
 }
 
 interface IFilterDisplayFormPair {
@@ -132,6 +163,7 @@ function* getResolvedAttributeFilters(
 
     const attributeFilterDisplayFormPairsWithIgnoreResolved = resolveWidgetFilterIgnore(
         widget,
+        ctx.workspace,
         attributeFilterDisplayFormPairs,
     );
 
@@ -140,6 +172,7 @@ function* getResolvedAttributeFilters(
 
 function resolveWidgetFilterIgnore(
     widget: ExtendedDashboardWidget,
+    workspace: string,
     dashboardNonDateFilterDisplayFormPairs: IFilterDisplayFormPair[],
 ): IFilterDisplayFormPair[] {
     return dashboardNonDateFilterDisplayFormPairs.filter(({ displayForm }) => {
@@ -147,7 +180,9 @@ function resolveWidgetFilterIgnore(
             displayForm &&
             widget.ignoreDashboardFilters
                 ?.filter(isDashboardAttributeFilterReference)
-                .some((ignored) => refMatchesMdObject(ignored.displayForm, displayForm, "displayForm"));
+                .some((ignored) =>
+                    refMatchesMdObject(ignored.displayForm, displayForm, "displayForm", workspace),
+                );
 
         return !matches;
     });
@@ -167,6 +202,7 @@ export function isDashboardDateFilterIgnoredForInsight(insight: IInsightDefiniti
 
 function selectResolvedInsightDateFilters(
     state: DashboardState,
+    workspace: string,
     insight: IInsightDefinition,
     dashboardDateFilters: IDateFilter[],
     insightDateFilters: IDateFilter[],
@@ -175,22 +211,29 @@ function selectResolvedInsightDateFilters(
         return insightDateFilters;
     }
 
-    return selectResolvedDateFilters(state, [...insightDateFilters, ...dashboardDateFilters]);
+    return selectResolvedDateFilters(state, workspace, [...insightDateFilters, ...dashboardDateFilters]);
 }
 
-function selectResolvedDateFilters(state: DashboardState, dateFilters: IDateFilter[]): IDateFilter[] {
+function selectResolvedDateFilters(
+    state: DashboardState,
+    workspace: string,
+    dateFilters: IDateFilter[],
+): IDateFilter[] {
     const allDateFilterDateDatasetPairs = selectDateDatasetsForDateFilters(state, dateFilters);
-    return resolveDateFilters(allDateFilterDateDatasetPairs);
+    return resolveDateFilters(allDateFilterDateDatasetPairs, workspace);
 }
 
-function resolveDateFilters(allDateFilterDateDatasetPairs: IFilterDateDatasetPair[]): IDateFilter[] {
+function resolveDateFilters(
+    allDateFilterDateDatasetPairs: IFilterDateDatasetPair[],
+    workspace: string,
+): IDateFilter[] {
     // go through the filters in reverse order using the first filter for a given dimension encountered
     // and strip useless all time filters at the end
     return allDateFilterDateDatasetPairs
         .filter((item) => !!item.dateDataset)
         .reduceRight((acc: IDateFilter[], curr) => {
             const alreadyPresent = acc.some((item) =>
-                refMatchesMdObject(filterObjRef(item), curr.dateDataset!.dataSet, "dataSet"),
+                refMatchesMdObject(filterObjRef(item), curr.dateDataset!.dataSet, "dataSet", workspace),
             );
 
             if (!alreadyPresent) {
@@ -224,6 +267,7 @@ function* queryWithInsight(
     const [dateFilters, attributeFilters] = yield all([
         select(
             selectResolvedInsightDateFilters,
+            ctx.workspace,
             insight,
             widgetAwareDashboardFilters.filter(isDateFilter),
             effectiveInsightFilters.filter(isDateFilter),
@@ -265,7 +309,7 @@ function* queryWithoutInsight(
     );
 
     const [dateFilters, attributeFilters] = yield all([
-        select(selectResolvedDateFilters, widgetAwareDashboardFilters.filter(isDateFilter)),
+        select(selectResolvedDateFilters, ctx.workspace, widgetAwareDashboardFilters.filter(isDateFilter)),
         call(getResolvedAttributeFilters, ctx, widget, widgetAwareDashboardFilters.filter(isAttributeFilter)),
     ]);
 

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IHeaderPredicateContext } from "../HeaderPredicate";
 import { barChartForDrillTests } from "../../../../__mocks__/fixtures";
 import { IAttributeDescriptor, IMeasureDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
@@ -186,3 +186,5 @@ export const attributeHeaderItem: IResultAttributeHeader = {
 export const context: IHeaderPredicateContext = {
     dv: barChartForDrillTests,
 };
+
+export const workspace = context.dv.definition.workspace;

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IHeaderPredicate } from "../HeaderPredicate";
 import * as headerPredicateFactory from "../HeaderPredicateFactory";
 import {
@@ -6,6 +6,7 @@ import {
     context,
     attributeHeaderItem,
     attributeDescriptor,
+    workspace,
 } from "./HeaderPredicateFactory.fixtures";
 import { attributeDisplayFormRef, measureItem, newAttribute, newMeasure, uriRef } from "@gooddata/sdk-model";
 
@@ -189,6 +190,13 @@ describe("identifierMatch", () => {
 
                 expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
             });
+            it("should match when identifier-based measure identifier matches header composite identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
+            });
 
             it("should NOT match when measure identifier does not match header identifier", () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherId");
@@ -205,6 +213,13 @@ describe("identifierMatch", () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("");
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
+            });
+            it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(false);
             });
         });
 
@@ -270,6 +285,20 @@ describe("identifierMatch", () => {
 
                 expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
             });
+            it("should match when identifier-based SP derived measure identifier matches header composite identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based SP derived measure identifier matches header composite identifier but it is not the current workspace", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(false);
+            });
         });
 
         describe("derived show in % measure headers", () => {
@@ -330,8 +359,22 @@ describe("identifierMatch", () => {
 
             expect(predicate(attributeDescriptor, context)).toBe(true);
         });
+        it("should match when identifier-based measure identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                `${workspace}:attributeIdentifier`,
+            );
+
+            expect(predicate(attributeDescriptor, context)).toBe(true);
+        });
         it("should NOT match when measure item identifier does not match", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherIdentifier");
+
+            expect(predicate(attributeDescriptor, context)).toBe(false);
+        });
+        it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                `some_other_${workspace}:attributeIdentifier`,
+            );
 
             expect(predicate(attributeDescriptor, context)).toBe(false);
         });
@@ -536,9 +579,23 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
         });
+        it("should match when AM identifier-based operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
+        });
         it("should NOT match when AM uri-based operand identifier does not match header identifier", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someIdentifier");
+
+            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
+        });
+        it("should NOT match when AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `some_other_${workspace}:identifierBasedMeasureIdentifier`,
+            );
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
         });
@@ -559,8 +616,22 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
         });
+        it("should match when 2nd order AM identifier-based operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
+        });
         it("should NOT match when 2nd order AM uri-based operand identifier does not match header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier("someOtherId");
+
+            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
+        });
+        it("should NOT match when 2nd order AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `some_other_${workspace}:identifierBasedMeasureIdentifier`,
+            );
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
         });
@@ -573,6 +644,13 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
         });
+        it("should match when AM uri-based PP+SP derived operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:uriBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
+        });
         it("should match when AM identifier-based PP+SP derived operand identifier matches header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
@@ -580,10 +658,17 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
         });
+        it("should match when AM identifier-based PP+SP derived operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
+        });
     });
 
     describe("derived from AM", () => {
-        it("should match when derived PP from AM matches header uri", () => {
+        it("should match when derived PP from AM matches header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
@@ -591,14 +676,30 @@ describe("composedFromIdentifier", () => {
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
         });
 
-        it("should not match when derived PP from AM doesn't match header uri", () => {
+        it("should match when derived PP from AM matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
+        });
+
+        it("should not match when derived PP from AM doesn't match header identifier", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
 
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
         });
 
-        it("should match when derived SP from AM matches header uri", () => {
+        it("should not match when derived PP from AM doesn't match header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:someOtherIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
+        });
+
+        it("should match when derived SP from AM matches header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
@@ -606,9 +707,25 @@ describe("composedFromIdentifier", () => {
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
         });
 
-        it("should not match when derived SP from AM doesn't match header uri", () => {
+        it("should match when derived SP from AM matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
+        });
+
+        it("should not match when derived SP from AM doesn't match header identifier", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
+        });
+
+        it("should not match when derived SP from AM doesn't match header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:someOtherIdentifier`,
+            );
 
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
         });
@@ -768,6 +885,14 @@ describe("objRefMatch tests", () => {
         expect(predicate(attributeDescriptor, context)).toBe(true);
     });
 
+    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(newAttribute(`${workspace}:attributeIdentifier`));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(true);
+    });
+
     it("objRefMatch - should match predicate when attribute objRef matches - uri match scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/attributeUri")));
 
@@ -778,6 +903,26 @@ describe("objRefMatch tests", () => {
 
     it("objRefMatch - should match predicate when attribute objRef matches - identifier match negative scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute("otherAttributeIdentifier"));
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match negative scenario", () => {
+        const attributeObjRef = attributeDisplayFormRef(
+            newAttribute(`${workspace}:otherAttributeIdentifier`),
+        );
+
+        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
+
+        expect(predicate(attributeDescriptor, context)).toBe(false);
+    });
+
+    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match negative scenario (workspace mismatch)", () => {
+        const attributeObjRef = attributeDisplayFormRef(
+            newAttribute(`some_other_${workspace}:attributeIdentifier`),
+        );
 
         const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
 


### PR DESCRIPTION
Since Tiger supports two types of ids
* short, e.g. `product`
* composite, e.g. `demo_workspace:product`

and they can both link to the same object, we need to handle this in case this resolution is done only on client (because server handles this automatically). These cases are

* attribute filter ignores in query widget filters
* drilling header predicates

Unfortunately, wihout any significant breaking changes we cannot really access the backend instance in the HeaderPredicates so we try to do this match even if the backend does not support it. To be consistent we also do this in the query widget filters service. 

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
