### PR TITLE
JoinedAxisName interaction with InsightView

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsForSettings.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/chartOptionsForSettings.ts
@@ -17,8 +17,11 @@ export function updateConfigWithSettings(config: IChartConfig, settings: ISettin
             updatedConfig = { ...updatedConfig, enableCompactSize: true };
         }
 
-        if (settings["enableAxisNameViewByTwoAttributes"] === true) {
-            updatedConfig = { ...updatedConfig, enableJoinedAttributeAxisName: true };
+        if (updatedConfig === undefined || updatedConfig.enableJoinedAttributeAxisName === undefined) {
+            updatedConfig = {
+                ...updatedConfig,
+                enableJoinedAttributeAxisName: settings["enableAxisNameViewByTwoAttributes"],
+            };
         }
     }
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsForSettings.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsForSettings.test.ts
@@ -32,10 +32,23 @@ describe("updateConfigWithSettings", () => {
     });
 
     describe("enableAxisNameViewByTwoAttributes", () => {
-        it("should return correct config from feature flags", async () => {
+        it("should return correct config from feature flags if enableJoinedAttributeAxisName is not provided", async () => {
             const config: IChartConfig = {};
             const settings: ISettings = {
-                enableAxisNameViewByTwoAttributes: true,
+                enableAxisNameViewByTwoAttributes: false,
+            };
+            const expectedConfig = {
+                enableJoinedAttributeAxisName: false,
+            };
+            expect(updateConfigWithSettings(config, settings)).toEqual(expectedConfig);
+        });
+
+        it("should return correct config from feature flags if enableJoinedAttributeAxisName is provided", async () => {
+            const config: IChartConfig = {
+                enableJoinedAttributeAxisName: true,
+            };
+            const settings: ISettings = {
+                enableAxisNameViewByTwoAttributes: false,
             };
             const expectedConfig = {
                 enableJoinedAttributeAxisName: true,

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { useCallback, useEffect, useRef } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { render } from "react-dom";
@@ -214,6 +214,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
         const needsNewSetup =
             !isEqual(this.props.insight, prevProps.insight) ||
             !isEqual(this.props.filters, prevProps.filters) ||
+            !isEqual(this.props.settings, prevProps.settings) ||
             this.props.workspace !== prevProps.workspace;
 
         if (needsNewSetup) {

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React, { useCallback, useMemo, useRef, useState } from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import {


### PR DESCRIPTION
JIRA TNT-507

* **TNT-507:** Previously update config function was not considering the ability to rewrite chart config manually from InsightView property, now it will be prioritising manual input before feature flag’s value.
* **Another discovered issue:** InsightView was finishing its rendering before fetching all the data from backend, which led to incorrect view. I discovered it through feature flags, because InsightView was already rendered before receiving data about them from backend. I added one more condition before starting rendering component. 

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
