### PR TITLE
RELATED: RAIL-4065 revert fixes related to Tiger composite ids

### DIFF
--- a/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
+++ b/examples/sdk-examples/src/examples/dashboardComponent/DashboardComponentWithLocalPluginSrc.tsx
@@ -129,7 +129,7 @@ class LocalPlugin extends DashboardPluginV1 {
                         newCustomWidget("myWidget1", "myCustomWidget", {
                             // specify which date data set to used when applying the date filter to this widget
                             // if not specified, the date filter is ignored
-                            dateDataSet: Md.DateDatasets.Date.ref,
+                            dateDataSet: Md.DateDatasets.Date,
                             // specify which attribute filters to ignore for this widget
                             // if empty or not specified, all attribute filters are used
                             ignoreDashboardFilters: [

--- a/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
+++ b/libs/sdk-ui/src/base/headerMatching/HeaderPredicateFactory.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { IHeaderPredicate, IHeaderPredicateContext } from "./HeaderPredicate";
 import {
     getMappingHeaderIdentifier,
@@ -111,28 +111,9 @@ function matchHeaderUri(uri: string, header: IMappingHeader): boolean {
     return headerUri ? headerUri === uri : false;
 }
 
-function matchHeaderIdentifierWithCompositeSupport(
-    identifier: string,
-    header: IMappingHeader,
-    currentWorkspace: string,
-): boolean {
+function matchHeaderIdentifier(identifier: string, header: IMappingHeader): boolean {
     const headerIdentifier = getMappingHeaderIdentifier(header);
-    if (!headerIdentifier) {
-        return false;
-    }
-
-    if (headerIdentifier === identifier) {
-        return true;
-    }
-
-    // also try stripping current workspace prefix in case we are in a workspace with composite ids
-    const compositeIdFromCurrentWorkspaceRegex = new RegExp(`^${currentWorkspace}:`);
-    const isCompositeIdFromCurrentWorkspace = compositeIdFromCurrentWorkspaceRegex.test(identifier);
-
-    return (
-        isCompositeIdFromCurrentWorkspace &&
-        headerIdentifier === identifier.replace(compositeIdFromCurrentWorkspaceRegex, "")
-    );
+    return headerIdentifier ? headerIdentifier === identifier : false;
 }
 
 function matchUri(uri: string, measure: IMeasure): boolean {
@@ -140,28 +121,9 @@ function matchUri(uri: string, measure: IMeasure): boolean {
     return simpleMeasureUri ? simpleMeasureUri === uri : false;
 }
 
-function matchMeasureIdentifierWithCompositeSupport(
-    identifier: string,
-    measure: IMeasure,
-    currentWorkspace: string,
-): boolean {
+function matchMeasureIdentifier(identifier: string, measure: IMeasure): boolean {
     const simpleMeasureIdentifier = measureIdentifier(measure);
-    if (!simpleMeasureIdentifier) {
-        return false;
-    }
-
-    if (simpleMeasureIdentifier === identifier) {
-        return true;
-    }
-
-    // also try stripping current workspace prefix in case we are in a workspace with composite ids
-    const compositeIdFromCurrentWorkspaceRegex = new RegExp(`^${currentWorkspace}:`);
-    const isCompositeIdFromCurrentWorkspace = compositeIdFromCurrentWorkspaceRegex.test(identifier);
-
-    return (
-        isCompositeIdFromCurrentWorkspace &&
-        simpleMeasureIdentifier === identifier.replace(compositeIdFromCurrentWorkspaceRegex, "")
-    );
+    return simpleMeasureIdentifier ? simpleMeasureIdentifier === identifier : false;
 }
 
 function matchDerivedMeasureByMasterUri(
@@ -201,13 +163,13 @@ function matchDerivedMeasureByMasterIdentifier(
 
     const masterMeasureHeader = dv.meta().measureDescriptor(masterMeasureLocalIdentifier)!;
 
-    if (matchHeaderIdentifierWithCompositeSupport(identifier, masterMeasureHeader, dv.definition.workspace)) {
+    if (matchHeaderIdentifier(identifier, masterMeasureHeader)) {
         return true;
     }
 
     const masterMeasure = dv.def().measure(masterMeasureLocalIdentifier)!;
 
-    return matchMeasureIdentifierWithCompositeSupport(identifier, masterMeasure, dv.definition.workspace);
+    return matchMeasureIdentifier(identifier, masterMeasure);
 }
 
 /**
@@ -262,7 +224,7 @@ export function identifierMatch(identifier: string): IHeaderPredicate {
             return false;
         }
 
-        if (matchHeaderIdentifierWithCompositeSupport(identifier, header, dv.definition.workspace)) {
+        if (matchHeaderIdentifier(identifier, header)) {
             return true;
         }
 
@@ -276,7 +238,7 @@ export function identifierMatch(identifier: string): IHeaderPredicate {
             return false;
         }
 
-        if (matchMeasureIdentifierWithCompositeSupport(identifier, measure, dv.definition.workspace)) {
+        if (matchMeasureIdentifier(identifier, measure)) {
             return true;
         }
 

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
@@ -4,13 +4,7 @@ import { barChartForDrillTests } from "../../../../__mocks__/fixtures";
 import { IAttributeDescriptor, IMeasureDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
 import { uriRef } from "@gooddata/sdk-model";
 
-export const context: IHeaderPredicateContext = {
-    dv: barChartForDrillTests,
-};
-
-export const workspace = context.dv.definition.workspace;
-
-export const measureDescriptors: Record<string, IMeasureDescriptor> = {
+export const measureDescriptors: { [key: string]: IMeasureDescriptor } = {
     uriBasedMeasure: {
         measureHeaderItem: {
             uri: "/uriBasedMeasureUri",
@@ -26,15 +20,6 @@ export const measureDescriptors: Record<string, IMeasureDescriptor> = {
             localIdentifier: "identifierBasedMeasureLocalIdentifier",
             identifier: "identifierBasedMeasureIdentifier",
             name: "identifierBasedMeasureName",
-            format: "#,##0.00",
-        },
-    },
-    compositeIdentifierBasedMeasure: {
-        measureHeaderItem: {
-            uri: "compositeIdentifierUri",
-            localIdentifier: "compositeIdentifierLocalId",
-            identifier: `${workspace}:compositeIdentifierId`,
-            name: "compositeIdentifierBasedMeasure",
             format: "#,##0.00",
         },
     },
@@ -72,14 +57,14 @@ export const measureDescriptors: Record<string, IMeasureDescriptor> = {
     uriBasedPPMeasure: {
         measureHeaderItem: {
             localIdentifier: "uriBasedPPMeasureLocalIdentifier",
-            name: "uriBasedPPMeasureName",
+            name: "uriBasedSPMeasureName",
             format: "#,##0.00",
         },
     },
     identifierBasedPPMeasure: {
         measureHeaderItem: {
             localIdentifier: "identifierBasedPPMeasureLocalIdentifier",
-            name: "uriBasedPPMeasureName",
+            name: "uriBasedSPMeasureName",
             format: "#,##0.00",
         },
     },
@@ -191,25 +176,15 @@ export const attributeDescriptor: IAttributeDescriptor = {
     },
 };
 
-export const compositeAttributeDescriptor: IAttributeDescriptor = {
-    attributeHeader: {
-        uri: "/attributeUri",
-        identifier: `${workspace}:attributeIdentifier`,
-        localIdentifier: "attributeLocalIdentifier",
-        name: "attributeName",
-        ref: uriRef("/attributeUri"),
-        formOf: {
-            uri: "/attributeElementUri",
-            identifier: "attributeElementIdentifier",
-            name: "attributeElementName",
-            ref: uriRef("/attributeElementUri"),
-        },
-    },
-};
-
 export const attributeHeaderItem: IResultAttributeHeader = {
     attributeHeaderItem: {
         uri: "/attributeItemUri",
         name: "attributeItemName",
     },
 };
+
+export const context: IHeaderPredicateContext = {
+    dv: barChartForDrillTests,
+};
+
+export const workspace = context.dv.definition.workspace;

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.fixtures.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2020 GoodData Corporation
 import { IHeaderPredicateContext } from "../HeaderPredicate";
 import { barChartForDrillTests } from "../../../../__mocks__/fixtures";
 import { IAttributeDescriptor, IMeasureDescriptor, IResultAttributeHeader } from "@gooddata/sdk-backend-spi";
@@ -186,5 +186,3 @@ export const attributeHeaderItem: IResultAttributeHeader = {
 export const context: IHeaderPredicateContext = {
     dv: barChartForDrillTests,
 };
-
-export const workspace = context.dv.definition.workspace;

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -1,4 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
+import { IHeaderPredicate } from "../HeaderPredicate";
 import * as headerPredicateFactory from "../HeaderPredicateFactory";
 import {
     measureDescriptors,
@@ -6,38 +7,37 @@ import {
     attributeHeaderItem,
     attributeDescriptor,
     workspace,
-    compositeAttributeDescriptor,
 } from "./HeaderPredicateFactory.fixtures";
 import { attributeDisplayFormRef, measureItem, newAttribute, newMeasure, uriRef } from "@gooddata/sdk-model";
-import { IAttributeDescriptor, IMeasureDescriptor } from "@gooddata/sdk-backend-spi";
 
 describe("uriMatch", () => {
     describe("measure headers", () => {
         describe("simple measure headers", () => {
             it("should match when uri-based measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(true);
             });
             it("should match when identifier-based measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
             });
 
             it("should NOT match when measure uri does not match header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/someOtherUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/someOtherUri");
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
             });
             it("should NOT match when measure uri is null", () => {
                 // @ts-expect-error Testing possible inputs not allowed by types but possible if used from JavaScript
-                const predicate = headerPredicateFactory.uriMatch(null);
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(null);
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
             });
             it("should NOT match when measure uri is empty", () => {
-                const predicate = headerPredicateFactory.uriMatch("");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("");
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
             });
@@ -45,13 +45,16 @@ describe("uriMatch", () => {
 
         describe("show in % ad-hoc measure headers", () => {
             it("should match when show in % ad-hoc measure matches uri used to define measure in afm", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedRatioMeasure, context)).toBe(true);
             });
 
             it("should NOT match when show in % ad-hoc measure since identifier was used to define measure in afm and ad-hoc headers does not contain identifiers", () => {
-                const predicate = headerPredicateFactory.uriMatch("/identifierBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(
+                    "/identifierBasedRatioMeasureUri",
+                );
 
                 expect(predicate(measureDescriptors.identifierBasedRatioMeasure, context)).toBe(false);
             });
@@ -59,13 +62,13 @@ describe("uriMatch", () => {
 
         describe("ad-hoc measure headers", () => {
             it("should NOT match when ad-hoc measure is created from identifier-based attribute matching uri since uri of attribute not available in execution response or afm", () => {
-                const predicate = headerPredicateFactory.uriMatch("/attributeUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/attributeUri");
 
                 expect(predicate(measureDescriptors.identifierBasedAdhocMeasure, context)).toBe(false);
             });
 
             it("should match when ad-hoc measure is created from uri-based attribute matching uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/attributeUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/attributeUri");
 
                 expect(predicate(measureDescriptors.uriBasedAdhocMeasure, context)).toBe(true);
             });
@@ -73,23 +76,25 @@ describe("uriMatch", () => {
 
         describe("derived measure headers", () => {
             it("should match when uri-based PP derived measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedPPMeasure, context)).toBe(true);
             });
             it("should match when identifier-based PP derived measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.identifierBasedPPMeasure, context)).toBe(true);
             });
 
             it("should match when uri-based SP derived measure uri matches header identifier", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedSPMeasure, context)).toBe(true);
             });
             it("should match when identifier-based SP derived measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
             });
@@ -97,25 +102,31 @@ describe("uriMatch", () => {
 
         describe("derived show in % measure headers", () => {
             it("should match when uri-based PP derived ratio measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedPPRatioMeasure, context)).toBe(true);
             });
 
             it("should NOT match when identifier-based PP derived ratio measure uri matches header uri since measure was defined using identifier in afm and ratio measure headers does not contain uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/identifierBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(
+                    "/identifierBasedRatioMeasureUri",
+                );
 
                 expect(predicate(measureDescriptors.identifierBasedPPRatioMeasure, context)).toBe(false);
             });
 
             it("should match when uri-based SP derived ratio measure uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("/uriBasedRatioMeasureUri");
 
                 expect(predicate(measureDescriptors.uriBasedSPRatioMeasure, context)).toBe(true);
             });
 
             it("should NOT match when identifier-based SP derived ratio measure uri matches header uri since measure was defined using identifier in afm and ration measure headers does not contain uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/identifierBasedRatioMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch(
+                    "/identifierBasedRatioMeasureUri",
+                );
 
                 expect(predicate(measureDescriptors.identifierBasedSPRatioMeasure, context)).toBe(false);
             });
@@ -123,12 +134,13 @@ describe("uriMatch", () => {
 
         describe("AM headers", () => {
             it("should NOT match when AM uri-based operand uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
+                const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/uriBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
             });
             it("should NOT match when AM identifier-based operand uri matches header uri", () => {
-                const predicate = headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.uriMatch("identifierBasedMeasureUri");
 
                 expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
             });
@@ -137,12 +149,12 @@ describe("uriMatch", () => {
 
     describe("attribute headers", () => {
         it("should match when measure item uri matches", () => {
-            const predicate = headerPredicateFactory.uriMatch("/attributeUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/attributeUri");
 
             expect(predicate(attributeDescriptor, context)).toBe(true);
         });
         it("should NOT match when measure item uri does not match", () => {
-            const predicate = headerPredicateFactory.uriMatch("/someOtherUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/someOtherUri");
 
             expect(predicate(attributeDescriptor, context)).toBe(false);
         });
@@ -150,12 +162,12 @@ describe("uriMatch", () => {
 
     describe("attribute item header", () => {
         it("should match when attributeHeaderItem matches uri", () => {
-            const predicate = headerPredicateFactory.uriMatch("/attributeItemUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/attributeItemUri");
 
             expect(predicate(attributeHeaderItem, context)).toBe(true);
         });
         it("should NOT match when attributeHeaderItem does not match uri", () => {
-            const predicate = headerPredicateFactory.uriMatch("/someOtherUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.uriMatch("/someOtherUri");
 
             expect(predicate(attributeHeaderItem, context)).toBe(false);
         });
@@ -165,74 +177,63 @@ describe("uriMatch", () => {
 describe("identifierMatch", () => {
     describe("measure headers", () => {
         describe("simple measure headers", () => {
-            const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-                [
-                    "uri-based measure identifier matches header identifier",
-                    "uriBasedMeasureIdentifier",
-                    measureDescriptors.uriBasedMeasure,
-                ],
-                [
-                    "identifier-based measure identifier matches header identifier",
+            it("should match when uri-based measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
+
+                expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     "identifierBasedMeasureIdentifier",
-                    measureDescriptors.identifierBasedMeasure,
-                ],
-                [
-                    "identifier-based measure identifier matches header composite identifier",
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based measure identifier matches header composite identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     `${workspace}:identifierBasedMeasureIdentifier`,
-                    measureDescriptors.identifierBasedMeasure,
-                ],
-                [
-                    "composite-identifier-based measure identifier matches header identifier",
-                    "compositeIdentifierId",
-                    measureDescriptors.compositeIdentifierBasedMeasure,
-                ],
-                [
-                    "composite-identifier-based measure identifier matches header composite identifier",
-                    `${workspace}:compositeIdentifierId`,
-                    measureDescriptors.compositeIdentifierBasedMeasure,
-                ],
-            ];
+                );
 
-            it.each(positiveScenarios)("should match when %s", (_, identifier, descriptor) => {
-                const predicate = headerPredicateFactory.identifierMatch(identifier);
-                expect(predicate(descriptor, context)).toBe(true);
+                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
             });
 
-            const negativeScenarios: [string, string, IMeasureDescriptor][] = [
-                [
-                    "measure identifier does not match header identifier",
-                    "someOtherId",
-                    measureDescriptors.uriBasedMeasure,
-                ],
-                ["measure identifier is empty", "", measureDescriptors.uriBasedMeasure],
-                [
-                    "identifier-based measure identifier matches header composite identifier but it is not the current workspace",
-                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
-                    measureDescriptors.identifierBasedMeasure,
-                ],
-            ];
+            it("should NOT match when measure identifier does not match header identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherId");
 
-            it.each(negativeScenarios)("should NOT match when %s", (_, identifier, descriptor) => {
-                const predicate = headerPredicateFactory.identifierMatch(identifier);
-                expect(predicate(descriptor, context)).toBe(false);
+                expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
             });
-
             it("should NOT match when measure identifier is null", () => {
                 // @ts-expect-error Testing possible inputs not allowed by types but possible if used from JavaScript
-                const predicate = headerPredicateFactory.identifierMatch(null);
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(null);
+
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
+            });
+            it("should NOT match when measure identifier is empty", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("");
+
+                expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
+            });
+            it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(false);
             });
         });
 
         describe("show in % ad-hoc measure headers", () => {
             it("should NOT match when show in % ad-hoc measure since uri was used to define measure in afm and ad-hoc headers does not contain uris", () => {
-                const predicate = headerPredicateFactory.identifierMatch("uriBasedRatioMeasureIdentifier");
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "uriBasedRatioMeasureIdentifier",
+                );
 
                 expect(predicate(measureDescriptors.uriBasedRatioMeasure, context)).toBe(false);
             });
 
             it("should match when show in % ad-hoc measure matches identifier used to define measure in afm", () => {
-                const predicate = headerPredicateFactory.identifierMatch(
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     "identifierBasedRatioMeasureIdentifier",
                 );
 
@@ -242,59 +243,57 @@ describe("identifierMatch", () => {
 
         describe("ad-hoc measure headers", () => {
             it("should NOT match when ad-hoc measure is created from uri-based attribute matching identifier since identifier of attribute not available in execution response or afm", () => {
-                const predicate = headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
 
                 expect(predicate(measureDescriptors.uriBasedAdhocMeasure, context)).toBe(false);
             });
 
             it("should match when ad-hoc measure is created from identifier-based attribute matching identifier", () => {
-                const predicate = headerPredicateFactory.identifierMatch("attributeIdentifier");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("attributeIdentifier");
 
                 expect(predicate(measureDescriptors.identifierBasedAdhocMeasure, context)).toBe(true);
             });
         });
 
         describe("derived measure headers", () => {
-            const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-                [
-                    "uri-based PP derived measure identifier matches header identifier",
-                    "uriBasedMeasureIdentifier",
-                    measureDescriptors.uriBasedPPMeasure,
-                ],
-                [
-                    "identifier-based PP derived measure identifier matches header identifier",
-                    "identifierBasedMeasureIdentifier",
-                    measureDescriptors.identifierBasedPPMeasure,
-                ],
-                [
-                    "identifier-based PP derived measure identifier matches header composite identifier",
-                    `${workspace}:identifierBasedMeasureIdentifier`,
-                    measureDescriptors.identifierBasedPPMeasure,
-                ],
-                [
-                    "uri-based SP derived measure identifier matches header identifier",
-                    "uriBasedMeasureIdentifier",
-                    measureDescriptors.uriBasedSPMeasure,
-                ],
-                [
-                    "identifier-based SP derived measure identifier matches header identifier",
-                    "identifierBasedMeasureIdentifier",
-                    measureDescriptors.identifierBasedSPMeasure,
-                ],
-                [
-                    "identifier-based SP derived measure identifier matches header composite identifier",
-                    `${workspace}:identifierBasedMeasureIdentifier`,
-                    measureDescriptors.identifierBasedSPMeasure,
-                ],
-            ];
+            it("should match when uri-based PP derived measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
 
-            it.each(positiveScenarios)("should match when %s", (_, identifier, descriptor) => {
-                const predicate = headerPredicateFactory.identifierMatch(identifier);
-                expect(predicate(descriptor, context)).toBe(true);
+                expect(predicate(measureDescriptors.uriBasedPPMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based PP derived measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "identifierBasedMeasureIdentifier",
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedPPMeasure, context)).toBe(true);
             });
 
-            it("should NOT match when identifier-based SP derived measure identifier matches header composite identifier but it is not the current workspace", () => {
-                const predicate = headerPredicateFactory.identifierMatch(
+            it("should match when uri-based SP derived measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
+
+                expect(predicate(measureDescriptors.uriBasedSPMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based SP derived measure identifier matches header identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "identifierBasedMeasureIdentifier",
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based SP derived measure identifier matches header composite identifier", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    `${workspace}:identifierBasedMeasureIdentifier`,
+                );
+
+                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
+            });
+            it("should match when identifier-based SP derived measure identifier matches header composite identifier but it is not the current workspace", () => {
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     `some_other_${workspace}:identifierBasedMeasureIdentifier`,
                 );
 
@@ -304,13 +303,15 @@ describe("identifierMatch", () => {
 
         describe("derived show in % measure headers", () => {
             it("should NOT match when uri-based PP derived ratio measure identifier matches header identifier since measure was defined using uri in afm and ratio measure headers does not contain identifier", () => {
-                const predicate = headerPredicateFactory.identifierMatch("uriBasedRatioMeasureIdentifier");
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "uriBasedRatioMeasureIdentifier",
+                );
 
                 expect(predicate(measureDescriptors.uriBasedPPRatioMeasure, context)).toBe(false);
             });
 
             it("should match when identifier-based PP derived ratio measure identifier matches header identifier", () => {
-                const predicate = headerPredicateFactory.identifierMatch(
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     "identifierBasedRatioMeasureIdentifier",
                 );
 
@@ -318,13 +319,15 @@ describe("identifierMatch", () => {
             });
 
             it("should NOT match when uri-based SP derived ratio measure identifier matches header identifier since measure was defined using uri in afm and ratio measure headers does not contain identifier", () => {
-                const predicate = headerPredicateFactory.identifierMatch("uriBasedRatioMeasureIdentifier");
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "uriBasedRatioMeasureIdentifier",
+                );
 
                 expect(predicate(measureDescriptors.uriBasedSPRatioMeasure, context)).toBe(false);
             });
 
             it("should match when identifier-based SP derived ratio measure identifier matches header identifier", () => {
-                const predicate = headerPredicateFactory.identifierMatch(
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                     "identifierBasedRatioMeasureIdentifier",
                 );
 
@@ -334,13 +337,16 @@ describe("identifierMatch", () => {
 
         describe("AM headers", () => {
             it("should NOT match when AM uri-based operand identifier matches header identifier since AMs are not supported", () => {
-                const predicate = headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
+                const predicate: IHeaderPredicate =
+                    headerPredicateFactory.identifierMatch("uriBasedMeasureIdentifier");
 
                 expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
             });
 
             it("should NOT match when AM identifier-based operand identifier matches header identifier since AMs are not supported", () => {
-                const predicate = headerPredicateFactory.identifierMatch("identifierBasedMeasureIdentifier");
+                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                    "identifierBasedMeasureIdentifier",
+                );
 
                 expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
             });
@@ -348,36 +354,25 @@ describe("identifierMatch", () => {
     });
 
     describe("attribute headers", () => {
-        const positiveScenarios: [string, string, IAttributeDescriptor][] = [
-            ["measure item identifier matches", "attributeIdentifier", attributeDescriptor],
-            [
-                "identifier-based measure identifier matches header composite identifier",
-                `${workspace}:attributeIdentifier`,
-                attributeDescriptor,
-            ],
-            [
-                "composite-identifier-based measure item identifier matches",
-                "attributeIdentifier",
-                compositeAttributeDescriptor,
-            ],
-            [
-                "composite-identifier-based measure identifier matches header composite identifier",
-                `${workspace}:attributeIdentifier`,
-                compositeAttributeDescriptor,
-            ],
-        ];
+        it("should match when measure item identifier matches", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("attributeIdentifier");
 
-        it.each(positiveScenarios)("should match when %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.identifierMatch(identifier);
-            expect(predicate(descriptor, context)).toBe(true);
+            expect(predicate(attributeDescriptor, context)).toBe(true);
         });
+        it("should match when identifier-based measure identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
+                `${workspace}:attributeIdentifier`,
+            );
 
+            expect(predicate(attributeDescriptor, context)).toBe(true);
+        });
         it("should NOT match when measure item identifier does not match", () => {
-            const predicate = headerPredicateFactory.identifierMatch("someOtherIdentifier");
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherIdentifier");
+
             expect(predicate(attributeDescriptor, context)).toBe(false);
         });
         it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate = headerPredicateFactory.identifierMatch(
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
                 `some_other_${workspace}:attributeIdentifier`,
             );
 
@@ -388,7 +383,7 @@ describe("identifierMatch", () => {
     describe("attribute item headers", () => {
         it("should NOT match since attributeHeaderItem does not have identifier", () => {
             // @ts-expect-error Testing possible inputs not allowed by types but possible if used from JavaScript
-            const predicate = headerPredicateFactory.identifierMatch(null);
+            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(null);
 
             expect(predicate(attributeHeaderItem, context)).toBe(false);
         });
@@ -398,12 +393,13 @@ describe("identifierMatch", () => {
 describe("composedFromUri", () => {
     describe("simple measure headers (not supported)", () => {
         it("should NOT match when uri-based measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
 
             expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
         });
         it("should NOT match when identifier-based measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
 
@@ -413,13 +409,13 @@ describe("composedFromUri", () => {
 
     describe("ad-hoc measure headers (not supported)", () => {
         it("should NOT match when ad-hoc measure is created from identifier-based attribute matching uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/attributeUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/attributeUri");
 
             expect(predicate(measureDescriptors.identifierBasedAdhocMeasure, context)).toBe(false);
         });
 
         it("should NOT match when ad-hoc measure is created from uri-based attribute matching uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/attributeUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/attributeUri");
 
             expect(predicate(measureDescriptors.uriBasedAdhocMeasure, context)).toBe(false);
         });
@@ -427,12 +423,13 @@ describe("composedFromUri", () => {
 
     describe("derived measure headers (not supported)", () => {
         it("should NOT match when uri-based PP derived measure uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedPPMeasure");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedPPMeasure");
 
             expect(predicate(measureDescriptors.uriBasedPPMeasure, context)).toBe(false);
         });
         it("should NOT match when identifier-based PP derived measure uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/identifierBasedPPMeasure");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromUri("/identifierBasedPPMeasure");
 
             expect(predicate(measureDescriptors.identifierBasedPPMeasure, context)).toBe(false);
         });
@@ -440,17 +437,18 @@ describe("composedFromUri", () => {
 
     describe("AM headers", () => {
         it("should match when AM uri-based operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
         });
         it("should match when AM identifier-based operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
         });
         it("should NOT match when AM uri-based operand uri does not match header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/someUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/someUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
         });
@@ -458,18 +456,19 @@ describe("composedFromUri", () => {
 
     describe("2nd order AM headers", () => {
         it("should match when 2nd order AM uri-based operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
         });
 
         it("should match when 2nd order AM identifier-based operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
         });
         it("should NOT match when 2nd order AM uri-based operand uri does not match header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/someOtherUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/someOtherUri");
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
         });
@@ -477,12 +476,13 @@ describe("composedFromUri", () => {
 
     describe("derived AM headers", () => {
         it("should match when AM uri-based PP+SP derived operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
 
             expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
         });
         it("should match when AM identifier-based PP+SP derived operand uri matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromUri("identifierBasedMeasureUri");
 
             expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
         });
@@ -490,25 +490,25 @@ describe("composedFromUri", () => {
 
     describe("derived from AM", () => {
         it("should match when derived PP from AM matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
 
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
         });
 
         it("should not match when derived PP from AM doesn't match header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/someOtherUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/someOtherUri");
 
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
         });
 
         it("should match when derived SP from AM matches header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/uriBasedMeasureUri");
 
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
         });
 
         it("should not match when derived SP from AM doesn't match header uri", () => {
-            const predicate = headerPredicateFactory.composedFromUri("/someOtherUri");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromUri("/someOtherUri");
 
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
         });
@@ -518,12 +518,13 @@ describe("composedFromUri", () => {
 describe("composedFromIdentifier", () => {
     describe("simple measure headers (not supported)", () => {
         it("should NOT match when uri-based measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
 
             expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
         });
         it("should NOT match when identifier-based measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
 
@@ -533,13 +534,15 @@ describe("composedFromIdentifier", () => {
 
     describe("ad-hoc measure headers (not supported)", () => {
         it("should NOT match when ad-hoc measure is created from uri-based attribute matching identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("uriBasedIdentifier");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedIdentifier");
 
             expect(predicate(measureDescriptors.uriBasedAdhocMeasure, context)).toBe(false);
         });
 
         it("should NOT match when ad-hoc measure is created from identifier-based attribute matching identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("attributeIdentifier");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("attributeIdentifier");
 
             expect(predicate(measureDescriptors.identifierBasedAdhocMeasure, context)).toBe(false);
         });
@@ -547,12 +550,14 @@ describe("composedFromIdentifier", () => {
 
     describe("derived measure headers (not supported)", () => {
         it("should NOT match when uri-based PP derived measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("uriBasedPPMeasureIdentifier");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                "uriBasedPPMeasureIdentifier",
+            );
 
             expect(predicate(measureDescriptors.uriBasedPPMeasure, context)).toBe(false);
         });
         it("should NOT match when identifier-based PP derived measure identifier matches header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedPPMeasureIdentifier",
             );
 
@@ -561,36 +566,34 @@ describe("composedFromIdentifier", () => {
     });
 
     describe("AM headers", () => {
-        const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-            [
-                "uri-based operand identifier matches header identifier",
-                "uriBasedMeasureIdentifier",
-                measureDescriptors.arithmeticMeasure,
-            ],
-            [
-                "identifier-based operand identifier matches header identifier",
-                "identifierBasedMeasureIdentifier",
-                measureDescriptors.arithmeticMeasure,
-            ],
-            [
-                "identifier-based operand identifier matches header composite identifier",
-                `${workspace}:identifierBasedMeasureIdentifier`,
-                measureDescriptors.arithmeticMeasure,
-            ],
-        ];
+        it("should match when AM uri-based operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
 
-        it.each(positiveScenarios)("should match when AM %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(identifier);
-            expect(predicate(descriptor, context)).toBe(true);
+            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
         });
+        it("should match when AM identifier-based operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                "identifierBasedMeasureIdentifier",
+            );
 
+            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
+        });
+        it("should match when AM identifier-based operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
+        });
         it("should NOT match when AM uri-based operand identifier does not match header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("someIdentifier");
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("someIdentifier");
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
         });
         it("should NOT match when AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 `some_other_${workspace}:identifierBasedMeasureIdentifier`,
             );
 
@@ -599,36 +602,34 @@ describe("composedFromIdentifier", () => {
     });
 
     describe("2nd order AM headers", () => {
-        const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-            [
-                "uri-based operand identifier matches header identifier",
-                "uriBasedMeasureIdentifier",
-                measureDescriptors.arithmeticMeasureOf2ndOrder,
-            ],
-            [
-                "identifier-based operand identifier matches header identifier",
-                "identifierBasedMeasureIdentifier",
-                measureDescriptors.arithmeticMeasureOf2ndOrder,
-            ],
-            [
-                "identifier-based operand identifier matches header composite identifier",
-                `${workspace}:identifierBasedMeasureIdentifier`,
-                measureDescriptors.arithmeticMeasureOf2ndOrder,
-            ],
-        ];
+        it("should match when 2nd order AM uri-based operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
 
-        it.each(positiveScenarios)("should match when 2nd order AM %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(identifier);
-            expect(predicate(descriptor, context)).toBe(true);
+            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
         });
 
+        it("should match when 2nd order AM identifier-based operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                "identifierBasedMeasureIdentifier",
+            );
+
+            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
+        });
+        it("should match when 2nd order AM identifier-based operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
+        });
         it("should NOT match when 2nd order AM uri-based operand identifier does not match header identifier", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier("someOtherId");
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier("someOtherId");
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
         });
         it("should NOT match when 2nd order AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 `some_other_${workspace}:identifierBasedMeasureIdentifier`,
             );
 
@@ -637,90 +638,96 @@ describe("composedFromIdentifier", () => {
     });
 
     describe("derived AM headers", () => {
-        const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-            [
-                "uri-based PP+SP derived operand identifier matches header identifier",
-                "uriBasedMeasureIdentifier",
-                measureDescriptors.uriBasedCompareArithmeticMeasure,
-            ],
-            [
-                "uri-based PP+SP derived operand identifier matches header composite identifier",
-                `${workspace}:uriBasedMeasureIdentifier`,
-                measureDescriptors.uriBasedCompareArithmeticMeasure,
-            ],
-            [
-                "identifier-based PP+SP derived operand identifier matches header identifier",
-                "identifierBasedMeasureIdentifier",
-                measureDescriptors.identifierBasedCompareArithmeticMeasure,
-            ],
-            [
-                "identifier-based PP+SP derived operand identifier matches header composite identifier",
-                `${workspace}:identifierBasedMeasureIdentifier`,
-                measureDescriptors.identifierBasedCompareArithmeticMeasure,
-            ],
-        ];
+        it("should match when AM uri-based PP+SP derived operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("uriBasedMeasureIdentifier");
 
-        it.each(positiveScenarios)("should match when AM %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(identifier);
-            expect(predicate(descriptor, context)).toBe(true);
+            expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
+        });
+        it("should match when AM uri-based PP+SP derived operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:uriBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
+        });
+        it("should match when AM identifier-based PP+SP derived operand identifier matches header identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                "identifierBasedMeasureIdentifier",
+            );
+
+            expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
+        });
+        it("should match when AM identifier-based PP+SP derived operand identifier matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
         });
     });
 
     describe("derived from AM", () => {
-        const positiveScenarios: [string, string, IMeasureDescriptor][] = [
-            [
-                "PP from AM matches header identifier",
+        it("should match when derived PP from AM matches header identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
-                measureDescriptors.derivedPPFromArithmeticMeasure,
-            ],
-            [
-                "PP from AM matches header composite identifier",
-                `${workspace}:identifierBasedMeasureIdentifier`,
-                measureDescriptors.derivedPPFromArithmeticMeasure,
-            ],
-            [
-                "SP from AM matches header identifier",
-                "identifierBasedMeasureIdentifier",
-                measureDescriptors.derivedSPFromArithmeticMeasure,
-            ],
-            [
-                "SP from AM matches header composite identifier",
-                `${workspace}:identifierBasedMeasureIdentifier`,
-                measureDescriptors.derivedSPFromArithmeticMeasure,
-            ],
-        ];
+            );
 
-        it.each(positiveScenarios)("should match when derived %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(identifier);
-            expect(predicate(descriptor, context)).toBe(true);
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
         });
 
-        const negativeScenarios: [string, string, IMeasureDescriptor][] = [
-            [
-                "PP from AM doesn't match header identifier",
-                "someOtherIdentifier",
-                measureDescriptors.derivedPPFromArithmeticMeasure,
-            ],
-            [
-                "PP from AM doesn't match header composite identifier",
-                `${workspace}:someOtherIdentifier`,
-                measureDescriptors.derivedPPFromArithmeticMeasure,
-            ],
-            [
-                "SP from AM doesn't match header identifier",
-                "someOtherIdentifier",
-                measureDescriptors.derivedSPFromArithmeticMeasure,
-            ],
-            [
-                "SP from AM doesn't match header composite identifier",
-                `${workspace}:someOtherIdentifier`,
-                measureDescriptors.derivedSPFromArithmeticMeasure,
-            ],
-        ];
+        it("should match when derived PP from AM matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
 
-        it.each(negativeScenarios)("should NOT match when derived %s", (_, identifier, descriptor) => {
-            const predicate = headerPredicateFactory.composedFromIdentifier(identifier);
-            expect(predicate(descriptor, context)).toBe(false);
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
+        });
+
+        it("should not match when derived PP from AM doesn't match header identifier", () => {
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
+
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
+        });
+
+        it("should not match when derived PP from AM doesn't match header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:someOtherIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
+        });
+
+        it("should match when derived SP from AM matches header identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                "identifierBasedMeasureIdentifier",
+            );
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
+        });
+
+        it("should match when derived SP from AM matches header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:identifierBasedMeasureIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
+        });
+
+        it("should not match when derived SP from AM doesn't match header identifier", () => {
+            const predicate: IHeaderPredicate =
+                headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
+        });
+
+        it("should not match when derived SP from AM doesn't match header composite identifier", () => {
+            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
+                `${workspace}:someOtherIdentifier`,
+            );
+
+            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
         });
     });
 });

--- a/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
+++ b/libs/sdk-ui/src/base/headerMatching/tests/HeaderPredicateFactory.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { IHeaderPredicate } from "../HeaderPredicate";
 import * as headerPredicateFactory from "../HeaderPredicateFactory";
 import {
@@ -6,7 +6,6 @@ import {
     context,
     attributeHeaderItem,
     attributeDescriptor,
-    workspace,
 } from "./HeaderPredicateFactory.fixtures";
 import { attributeDisplayFormRef, measureItem, newAttribute, newMeasure, uriRef } from "@gooddata/sdk-model";
 
@@ -190,13 +189,6 @@ describe("identifierMatch", () => {
 
                 expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
             });
-            it("should match when identifier-based measure identifier matches header composite identifier", () => {
-                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                    `${workspace}:identifierBasedMeasureIdentifier`,
-                );
-
-                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(true);
-            });
 
             it("should NOT match when measure identifier does not match header identifier", () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherId");
@@ -213,13 +205,6 @@ describe("identifierMatch", () => {
                 const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("");
 
                 expect(predicate(measureDescriptors.uriBasedMeasure, context)).toBe(false);
-            });
-            it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
-                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
-                );
-
-                expect(predicate(measureDescriptors.identifierBasedMeasure, context)).toBe(false);
             });
         });
 
@@ -285,20 +270,6 @@ describe("identifierMatch", () => {
 
                 expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
             });
-            it("should match when identifier-based SP derived measure identifier matches header composite identifier", () => {
-                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                    `${workspace}:identifierBasedMeasureIdentifier`,
-                );
-
-                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(true);
-            });
-            it("should match when identifier-based SP derived measure identifier matches header composite identifier but it is not the current workspace", () => {
-                const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                    `some_other_${workspace}:identifierBasedMeasureIdentifier`,
-                );
-
-                expect(predicate(measureDescriptors.identifierBasedSPMeasure, context)).toBe(false);
-            });
         });
 
         describe("derived show in % measure headers", () => {
@@ -359,22 +330,8 @@ describe("identifierMatch", () => {
 
             expect(predicate(attributeDescriptor, context)).toBe(true);
         });
-        it("should match when identifier-based measure identifier matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                `${workspace}:attributeIdentifier`,
-            );
-
-            expect(predicate(attributeDescriptor, context)).toBe(true);
-        });
         it("should NOT match when measure item identifier does not match", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch("someOtherIdentifier");
-
-            expect(predicate(attributeDescriptor, context)).toBe(false);
-        });
-        it("should NOT match when identifier-based measure identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.identifierMatch(
-                `some_other_${workspace}:attributeIdentifier`,
-            );
 
             expect(predicate(attributeDescriptor, context)).toBe(false);
         });
@@ -579,23 +536,9 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
         });
-        it("should match when AM identifier-based operand identifier matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:identifierBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(true);
-        });
         it("should NOT match when AM uri-based operand identifier does not match header identifier", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someIdentifier");
-
-            expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
-        });
-        it("should NOT match when AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `some_other_${workspace}:identifierBasedMeasureIdentifier`,
-            );
 
             expect(predicate(measureDescriptors.arithmeticMeasure, context)).toBe(false);
         });
@@ -616,22 +559,8 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
         });
-        it("should match when 2nd order AM identifier-based operand identifier matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:identifierBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(true);
-        });
         it("should NOT match when 2nd order AM uri-based operand identifier does not match header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier("someOtherId");
-
-            expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
-        });
-        it("should NOT match when 2nd order AM identifier-based operand identifier matches header composite identifier but it is not the current workspace", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `some_other_${workspace}:identifierBasedMeasureIdentifier`,
-            );
 
             expect(predicate(measureDescriptors.arithmeticMeasureOf2ndOrder, context)).toBe(false);
         });
@@ -644,13 +573,6 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
         });
-        it("should match when AM uri-based PP+SP derived operand identifier matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:uriBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.uriBasedCompareArithmeticMeasure, context)).toBe(true);
-        });
         it("should match when AM identifier-based PP+SP derived operand identifier matches header identifier", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
@@ -658,17 +580,10 @@ describe("composedFromIdentifier", () => {
 
             expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
         });
-        it("should match when AM identifier-based PP+SP derived operand identifier matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:identifierBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.identifierBasedCompareArithmeticMeasure, context)).toBe(true);
-        });
     });
 
     describe("derived from AM", () => {
-        it("should match when derived PP from AM matches header identifier", () => {
+        it("should match when derived PP from AM matches header uri", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
@@ -676,30 +591,14 @@ describe("composedFromIdentifier", () => {
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
         });
 
-        it("should match when derived PP from AM matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:identifierBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(true);
-        });
-
-        it("should not match when derived PP from AM doesn't match header identifier", () => {
+        it("should not match when derived PP from AM doesn't match header uri", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
 
             expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
         });
 
-        it("should not match when derived PP from AM doesn't match header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:someOtherIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.derivedPPFromArithmeticMeasure, context)).toEqual(false);
-        });
-
-        it("should match when derived SP from AM matches header identifier", () => {
+        it("should match when derived SP from AM matches header uri", () => {
             const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
                 "identifierBasedMeasureIdentifier",
             );
@@ -707,25 +606,9 @@ describe("composedFromIdentifier", () => {
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
         });
 
-        it("should match when derived SP from AM matches header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:identifierBasedMeasureIdentifier`,
-            );
-
-            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(true);
-        });
-
-        it("should not match when derived SP from AM doesn't match header identifier", () => {
+        it("should not match when derived SP from AM doesn't match header uri", () => {
             const predicate: IHeaderPredicate =
                 headerPredicateFactory.composedFromIdentifier("someOtherIdentifier");
-
-            expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
-        });
-
-        it("should not match when derived SP from AM doesn't match header composite identifier", () => {
-            const predicate: IHeaderPredicate = headerPredicateFactory.composedFromIdentifier(
-                `${workspace}:someOtherIdentifier`,
-            );
 
             expect(predicate(measureDescriptors.derivedSPFromArithmeticMeasure, context)).toEqual(false);
         });
@@ -885,14 +768,6 @@ describe("objRefMatch tests", () => {
         expect(predicate(attributeDescriptor, context)).toBe(true);
     });
 
-    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match scenario", () => {
-        const attributeObjRef = attributeDisplayFormRef(newAttribute(`${workspace}:attributeIdentifier`));
-
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
-
-        expect(predicate(attributeDescriptor, context)).toBe(true);
-    });
-
     it("objRefMatch - should match predicate when attribute objRef matches - uri match scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute(uriRef("/attributeUri")));
 
@@ -903,26 +778,6 @@ describe("objRefMatch tests", () => {
 
     it("objRefMatch - should match predicate when attribute objRef matches - identifier match negative scenario", () => {
         const attributeObjRef = attributeDisplayFormRef(newAttribute("otherAttributeIdentifier"));
-
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
-
-        expect(predicate(attributeDescriptor, context)).toBe(false);
-    });
-
-    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match negative scenario", () => {
-        const attributeObjRef = attributeDisplayFormRef(
-            newAttribute(`${workspace}:otherAttributeIdentifier`),
-        );
-
-        const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
-
-        expect(predicate(attributeDescriptor, context)).toBe(false);
-    });
-
-    it("objRefMatch - should match predicate when attribute objRef matches - composite identifier match negative scenario (workspace mismatch)", () => {
-        const attributeObjRef = attributeDisplayFormRef(
-            newAttribute(`some_other_${workspace}:attributeIdentifier`),
-        );
 
         const predicate = headerPredicateFactory.objRefMatch(attributeObjRef);
 

--- a/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerAnalyticalDashboards.ts
@@ -2,7 +2,6 @@
 
 import { ObjectMeta } from "../../base/types";
 import { ITigerClient, MetadataUtilities } from "@gooddata/api-client-tiger";
-import { toFullyQualifiedId } from "./tigerCommon";
 
 /**
  * Load analytical dashboards that are stored in workspace metadata so that their links can be included
@@ -28,7 +27,7 @@ export async function loadAnalyticalDashboards(
     return result.data.map((dashboard) => {
         return {
             title: dashboard.attributes?.title ?? dashboard.id,
-            identifier: toFullyQualifiedId(dashboard.id, workspaceId),
+            identifier: dashboard.id,
             tags: dashboard.attributes?.tags?.join(",") ?? "",
         };
     });

--- a/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCatalog.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { Attribute, Catalog, Fact, Metric } from "../../base/types";
 import {
     JsonApiAttributeOutList,
@@ -8,14 +8,14 @@ import {
     MetadataUtilities,
     ValidateRelationsHeader,
 } from "@gooddata/api-client-tiger";
-import { convertAttribute, createLabelMap, toFullyQualifiedId } from "./tigerCommon";
+import { convertAttribute, createLabelMap } from "./tigerCommon";
 
-function convertMetrics(metrics: JsonApiMetricOutList, workspaceId: string): Metric[] {
+function convertMetrics(metrics: JsonApiMetricOutList): Metric[] {
     return metrics.data.map((metric) => {
         return {
             metric: {
                 meta: {
-                    identifier: toFullyQualifiedId(metric.id, workspaceId),
+                    identifier: metric.id,
                     title: metric.attributes?.title ?? metric.id,
                     tags: metric.attributes?.tags?.join(",") ?? "",
                 },
@@ -24,12 +24,12 @@ function convertMetrics(metrics: JsonApiMetricOutList, workspaceId: string): Met
     });
 }
 
-function convertFacts(facts: JsonApiFactOutList, workspaceId: string): Fact[] {
+function convertFacts(facts: JsonApiFactOutList): Fact[] {
     return facts.data.map((fact) => {
         return {
             fact: {
                 meta: {
-                    identifier: toFullyQualifiedId(fact.id, workspaceId),
+                    identifier: fact.id,
                     title: fact.attributes?.title ?? fact.id,
                     tags: fact.attributes?.tags?.join(",") ?? "",
                 },
@@ -38,7 +38,7 @@ function convertFacts(facts: JsonApiFactOutList, workspaceId: string): Fact[] {
     });
 }
 
-function convertAttributes(attributes: JsonApiAttributeOutList, workspaceId: string): Attribute[] {
+function convertAttributes(attributes: JsonApiAttributeOutList): Attribute[] {
     const labels = createLabelMap(attributes.included);
 
     /*
@@ -49,7 +49,7 @@ function convertAttributes(attributes: JsonApiAttributeOutList, workspaceId: str
 
     return attributes.data
         .filter((attribute) => attribute.attributes?.granularity === undefined)
-        .map((attribute) => convertAttribute(attribute, labels, workspaceId))
+        .map((attribute) => convertAttribute(attribute, labels))
         .filter((a): a is Attribute => a !== undefined);
 }
 
@@ -78,8 +78,8 @@ export async function loadCatalog(client: ITigerClient, workspaceId: string): Pr
     ]);
 
     return {
-        metrics: convertMetrics(metricsResult, workspaceId),
-        facts: convertFacts(factsResult, workspaceId),
-        attributes: convertAttributes(attributesResult, workspaceId),
+        metrics: convertMetrics(metricsResult),
+        facts: convertFacts(factsResult),
+        attributes: convertAttributes(attributesResult),
     };
 }

--- a/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerCommon.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import {
     JsonApiDatasetOut,
     JsonApiLabelOut,
@@ -68,11 +68,7 @@ export function getReferencedDataset(
     return datasetsMap[datasetsRef.id];
 }
 
-export function convertLabels(
-    attribute: JsonApiAttributeOutWithLinks,
-    labelsMap: LabelMap,
-    workspaceId: string,
-): DisplayForm[] {
+export function convertLabels(attribute: JsonApiAttributeOutWithLinks, labelsMap: LabelMap): DisplayForm[] {
     const labelsRefs = attribute.relationships?.labels?.data as JsonApiLabelLinkage[];
     return labelsRefs
         .map((ref) => {
@@ -84,7 +80,7 @@ export function convertLabels(
 
             return {
                 meta: {
-                    identifier: toFullyQualifiedId(ref.id, workspaceId),
+                    identifier: ref.id,
                     title: label.attributes?.title ?? ref.id,
                     tags: label.attributes?.tags?.join(",") ?? "",
                 },
@@ -96,35 +92,17 @@ export function convertLabels(
 export function convertAttribute(
     attribute: JsonApiAttributeOutWithLinks,
     labels: LabelMap,
-    workspaceId: string,
 ): Attribute | undefined {
     return {
         attribute: {
             content: {
-                displayForms: convertLabels(attribute, labels, workspaceId),
+                displayForms: convertLabels(attribute, labels),
             },
             meta: {
-                identifier: toFullyQualifiedId(attribute.id, workspaceId),
+                identifier: attribute.id,
                 title: attribute.attributes?.title ?? attribute.id,
                 tags: attribute.attributes?.tags?.join(",") ?? "",
             },
         },
     };
-}
-
-const WORKSPACE_PREFIX_SEPARATOR = ":";
-
-/**
- * To make sure ids are as portable as possible, prefix every non-prefixed id with the current workspace.
- * This makes sure that things created in that workspace will keep working even in child workspaces
- * (e.g. dashboard plugins created for a parent workspace should keep working in child workspaces as well
- * and for that to happen, all the ids must be prefixed with the parent workspace id).
- *
- * @param id - the id to convert
- * @param workspaceId - the id of the workspace the catalog is being exported for
- * @internal
- */
-export function toFullyQualifiedId(id: string, workspaceId: string): string {
-    const isAlreadyPrefixed = id.includes(WORKSPACE_PREFIX_SEPARATOR);
-    return isAlreadyPrefixed ? id : [workspaceId, id].join(WORKSPACE_PREFIX_SEPARATOR);
 }

--- a/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerDateDatasets.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 
 import { Attribute, DateDataSet } from "../../base/types";
 import {
@@ -57,7 +57,6 @@ function findDateDatasetsWithAttributes(
 function convertToExportableFormat(
     dateDatasets: DatasetWithAttributes[],
     labelsMap: LabelMap,
-    workspaceId: string,
 ): DateDataSet[] {
     return dateDatasets.map(({ dataset, attributes }) => {
         return {
@@ -69,7 +68,7 @@ function convertToExportableFormat(
                 },
                 content: {
                     attributes: attributes
-                        .map((attribute) => convertAttribute(attribute, labelsMap, workspaceId))
+                        .map((attribute) => convertAttribute(attribute, labelsMap))
                         .filter((a): a is Attribute => a !== undefined),
                 },
             },
@@ -88,5 +87,5 @@ export async function loadDateDataSets(client: ITigerClient, workspaceId: string
 
     const dateDatasets = findDateDatasetsWithAttributes(result, datasetsMap);
 
-    return convertToExportableFormat(dateDatasets, labelsMap, workspaceId);
+    return convertToExportableFormat(dateDatasets, labelsMap);
 }

--- a/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerInsights.ts
@@ -1,8 +1,7 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 
 import { ObjectMeta } from "../../base/types";
 import { ITigerClient, MetadataUtilities, ValidateRelationsHeader } from "@gooddata/api-client-tiger";
-import { toFullyQualifiedId } from "./tigerCommon";
 
 /**
  * Load insights that are stored in workspace metadata so that their links can be included
@@ -24,7 +23,7 @@ export async function loadInsights(client: ITigerClient, workspaceId: string): P
     return result.data.map((vis) => {
         return {
             title: vis.attributes?.title ?? vis.id,
-            identifier: toFullyQualifiedId(vis.id, workspaceId),
+            identifier: vis.id,
             tags: vis.attributes?.tags?.join(",") ?? "",
         };
     });

--- a/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
+++ b/tools/catalog-export/src/loaders/tiger/tigerLoad.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2022 GoodData Corporation
+// (C) 2007-2021 GoodData Corporation
 import { CatalogExportError, WorkspaceMetadata } from "../../base/types";
 import { ITigerClient } from "@gooddata/api-client-tiger";
 import ora from "ora";
@@ -35,7 +35,7 @@ export async function tigerLoad(client: ITigerClient, workspaceId: string): Prom
             insights,
             analyticalDashboards,
         };
-    } catch (err: any) {
+    } catch (err) {
         spinner.fail();
         if (err?.response?.status === 404) {
             // handle known error more gracefully to avoid general-type error messages


### PR DESCRIPTION
These were only partial fixes and caused more problems than they solved. For consistency sake, we revert them for 8.9.0 and will revisit this later in a future release.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
