### PR TITLE
Bullet chart custom sorting

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import noop from "lodash/noop";
 import cloneDeep from "lodash/cloneDeep";
 import { PluggableBulletChart } from "../PluggableBulletChart";
@@ -798,5 +798,27 @@ describe("PluggableBulletChart", () => {
                 expect(result).toEqual(expectedInsight);
             },
         );
+    });
+
+    describe("Sort config", () => {
+        const scenarios: Array<[string, IReferencePoint]> = [
+            ["0 M + 0 VB", referencePointMocks.emptyReferencePoint],
+            ["1 M + 0 VB", referencePointMocks.oneMetricNoCategoriesReferencePoint],
+            ["0 M + 1 VB", referencePointMocks.justViewByReferencePoint],
+            ["1 M + 1 VB", referencePointMocks.onePrimaryMetricAndOneViewByRefPoint],
+            ["1 M + 2 VB", referencePointMocks.oneMetricAndTwoCategoriesReferencePoint],
+            ["2 M + 1 VB", referencePointMocks.twoMetricsAndOneViewByRefPoint],
+            ["2 M + 2 VB", referencePointMocks.twoMeasuresBucketsTwoViewByReferencePoint],
+            ["3 M + 1 VB", referencePointMocks.threeMeasuresBucketsReferencePoint],
+            ["3 M + 2 VB", referencePointMocks.threeMeasuresTwoViewByReferencePoint],
+        ];
+
+        it.each(scenarios)("should return expected sort config for %s", async (_name, referencePointMock) => {
+            const chart = createComponent(defaultProps);
+
+            const sortConfig = await chart.getSortConfig(referencePointMock);
+
+            expect(sortConfig).toMatchSnapshot();
+        });
     });
 });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -1,0 +1,379 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
+Object {
+  "availableSorts": Array [],
+  "currentSort": Array [],
+  "disabled": true,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": false,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+      "metricSorts": Array [],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": true,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
+Object {
+  "availableSorts": Array [],
+  "currentSort": Array [],
+  "disabled": true,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 1 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": false,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 2 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+    },
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": false,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a2",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a2",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 2 M + 1 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+    },
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a2",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a2",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 3 M + 1 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m3",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableBulletChart Sort config should return expected sort config for 3 M + 2 VB 1`] = `
+Object {
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+    },
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a2",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m3",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "currentSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a2",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
@@ -26,7 +26,7 @@ Object {
           "locators": Array [
             Object {
               "measureLocatorItem": Object {
-                "measureIdentifier": "m1",
+                "measureIdentifier": "m2",
               },
             },
           ],

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -2326,7 +2326,7 @@ export const twoMetricsAndOneViewByRefPoint: IReferencePoint = {
         },
         {
             localIdentifier: "secondary_measures",
-            items: masterMeasureItems.slice(0, 1),
+            items: masterMeasureItems.slice(1, 2),
         },
         {
             localIdentifier: "view",
@@ -2854,6 +2854,31 @@ export const bulletChartWithMeasureInSecondaryBucket: IReferencePoint = {
     },
 };
 
+export const twoMeasuresBucketsTwoViewByReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "secondary_measures",
+            items: masterMeasureItems.slice(1, 2),
+        },
+        {
+            localIdentifier: "tertiary_measures",
+            items: [],
+        },
+        {
+            localIdentifier: "view",
+            items: attributeItems.slice(0, 2),
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
 export const threeMeasuresBucketsReferencePoint: IReferencePoint = {
     buckets: [
         {
@@ -2871,6 +2896,31 @@ export const threeMeasuresBucketsReferencePoint: IReferencePoint = {
         {
             localIdentifier: "view",
             items: attributeItems.slice(0, 1),
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+};
+
+export const threeMeasuresTwoViewByReferencePoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "secondary_measures",
+            items: masterMeasureItems.slice(1, 2),
+        },
+        {
+            localIdentifier: "tertiary_measures",
+            items: masterMeasureItems.slice(2, 3),
+        },
+        {
+            localIdentifier: "view",
+            items: attributeItems.slice(0, 2),
         },
     ],
     filters: {


### PR DESCRIPTION
JIRA: TNT-457
Bullet chart supports custom sorting, reports its default and available sorts for every bucket combination

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
