### PR TITLE
Column, Bar, Area, Combo chart fixes.

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -396,6 +396,9 @@ export class PluggableAreaChart extends PluggableBaseChart {
                             normalSortEnabled: true,
                             areaSortEnabled: true,
                         },
+                        metricSorts: isEmpty(stackBy)
+                            ? measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))
+                            : [],
                     },
                 ],
             };

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -38,6 +38,7 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
+      "metricSorts": Array [],
     },
   ],
   "currentSort": Array [
@@ -128,6 +129,7 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
+      "metricSorts": Array [],
     },
   ],
   "currentSort": Array [
@@ -154,6 +156,28 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
     },
   ],
   "currentSort": Array [
@@ -189,6 +213,28 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
     },
   ],
   "currentSort": Array [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -103,10 +103,9 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const stackBy = getBucketItems(buckets, BucketNames.STACK);
-
         const isStacked = !isEmpty(stackBy) || canSortStackTotalValue;
 
-        if (viewBy.length === 2) {
+        if (viewBy.length === 2 && !isEmpty(measures)) {
             if (measures.length >= 2 && !canSortStackTotalValue) {
                 return {
                     defaultSort: [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -82,9 +82,6 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
                                 normalSortEnabled: true,
                                 areaSortEnabled: true,
                             },
-                            metricSorts: [
-                                ...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                            ],
                         },
                         {
                             itemId: localIdRef(viewBy[1].localIdentifier),
@@ -124,7 +121,7 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
             };
         }
 
-        if (!isEmpty(viewBy) && (!isEmpty(stackBy) || canSortStackTotalValue)) {
+        if (!isEmpty(viewBy) && isStacked) {
             return {
                 defaultSort,
                 availableSorts: [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
@@ -212,7 +212,7 @@ describe("PluggableColumnChart", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
-        it("should provide two attribute normal sorts as default sort, two attribute area and two measure sorts as available sorts for 2M + 2VB", async () => {
+        it("should provide two attribute normal sorts as default sort, two attribute area and one measure sorts as available sorts for 2M + 2VB", async () => {
             const chart = createComponent(defaultProps);
 
             const sortConfig = await chart.getSortConfig(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
@@ -319,7 +319,7 @@ Object {
 }
 `;
 
-exports[`PluggableColumnChart Sort config should provide two attribute normal sorts as default sort, two attribute area and two measure sorts as available sorts for 2M + 2VB 1`] = `
+exports[`PluggableColumnChart Sort config should provide two attribute normal sorts as default sort, two attribute area and one measure sorts as available sorts for 2M + 2VB 1`] = `
 Object {
   "availableSorts": Array [
     Object {
@@ -330,28 +330,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
-      "metricSorts": Array [
-        Object {
-          "locators": Array [
-            Object {
-              "measureLocatorItem": Object {
-                "measureIdentifier": "m1",
-              },
-            },
-          ],
-          "type": "measureSort",
-        },
-        Object {
-          "locators": Array [
-            Object {
-              "measureLocatorItem": Object {
-                "measureIdentifier": "m2",
-              },
-            },
-          ],
-          "type": "measureSort",
-        },
-      ],
     },
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -292,28 +292,13 @@ export class PluggableComboChart extends PluggableBaseChart {
         if (!isEmpty(viewBy) && (!isEmpty(measures) || !isEmpty(secondaryMeasures))) {
             const mergedMeasures = [...measures, ...secondaryMeasures];
 
-            if (canSortStackTotal) {
-                return {
-                    defaultSort,
-                    availableSorts: [
-                        {
-                            itemId: localIdRef(viewBy[0].localIdentifier),
-                            attributeSort: {
-                                areaSortEnabled: true,
-                                normalSortEnabled: true,
-                            },
-                        },
-                    ],
-                };
-            }
-
             return {
                 defaultSort,
                 availableSorts: [
                     {
                         itemId: localIdRef(viewBy[0].localIdentifier),
                         attributeSort: {
-                            areaSortEnabled: mergedMeasures.length > 1,
+                            areaSortEnabled: canSortStackTotal || mergedMeasures.length > 1,
                             normalSortEnabled: true,
                         },
                         metricSorts: mergedMeasures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
@@ -577,7 +577,7 @@ describe("PluggableComboChart", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
-        it("should provide attribute sort as default sort, attribute area as available sorts for 2 primary measures stacked + 1 VB", async () => {
+        it("should provide attribute sort as default sort, attribute area  and two measures sorts as available sorts for 2 primary measures stacked + 1 VB", async () => {
             const chart = createComponent(defaultProps);
 
             const sortConfig = await chart.getSortConfig(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB 1`] = `
+exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area  and two measures sorts as available sorts for 2 primary measures stacked + 1 VB 1`] = `
 Object {
   "availableSorts": Array [
     Object {
@@ -48,7 +48,7 @@ Object {
 }
 `;
 
-exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area as available sorts for 2 primary measures stacked + 1 VB 1`] = `
+exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB 1`] = `
 Object {
   "availableSorts": Array [
     Object {
@@ -59,6 +59,28 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m2",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
     },
   ],
   "currentSort": Array [


### PR DESCRIPTION
JIRA: TNT-520
Fix available sorts for Column Chart.

JIRA: TNT-525
Bar chart sorting is aware of empty measures.


---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
