### PR TITLE
RELATED: RAIL-4046 Add internal barrel to sdk-ui-dashboard

### DIFF
--- a/libs/sdk-ui-dashboard/src/internal.ts
+++ b/libs/sdk-ui-dashboard/src/internal.ts
@@ -1,0 +1,19 @@
+// (C) 2022 GoodData Corporation
+
+/**
+ * This file is used to re-export internal parts of the package that are used in other GoodData applications.
+ * These are not to be used outside of GoodData as they can change or disappear at any time.
+ * Do not add anything new here, instead try to remove as much as possible when you can.
+ */
+
+export * from "./presentation/constants";
+export * from "./presentation/layout/DefaultDashboardLayoutRenderer";
+export * from "./presentation/presentationComponents";
+export * from "./presentation/scheduledEmail";
+export * from "./presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer";
+export * from "./presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts";
+export * from "./presentation/widget/kpi/DefaultDashboardKpi/KpiContent";
+export * from "./presentation/widget/kpi/DefaultDashboardKpi/types";
+export * from "./presentation/widget/kpi/DefaultDashboardKpi/utils/filterUtils";
+export * from "./model/utils/alertsUtils";
+export * from "./_staging/dashboard/fluidLayout/config";

--- a/libs/sdk-ui-dashboard/src/model/utils/alertsUtils.ts
+++ b/libs/sdk-ui-dashboard/src/model/utils/alertsUtils.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import {
     IAttributeDisplayFormMetadataObject,
@@ -123,4 +123,83 @@ function isDateFilterIgnored(widget: IWidgetDefinition, displayForm: ObjRef): bo
     return widget.ignoreDashboardFilters.some(
         (filter) => isDashboardDateFilterReference(filter) && areObjRefsEqual(filter.dataSet, displayForm),
     );
+}
+
+/**
+ * Included only for legacy compatibility reasons, use {@link getBrokenAlertFiltersBasicInfo} instead if possible.
+ *
+ * Gets the information about the so called broken alert filters. These are filters that are set up on the alert,
+ * but the currently applied filters either do not contain them, or the KPI has started ignoring them
+ * since the alert was first set up.
+ *
+ * @param alert - the alert to compute the broken filters for
+ * @param kpi - the KPI widget that the alert is relevant to
+ * @param appliedFilters - all the currently applied filters (including All Time date filters)
+ * @internal
+ * @deprecated use {@link getBrokenAlertFiltersBasicInfo} instead.
+ */
+export function getBrokenAlertFiltersBasicInfoLegacy(
+    alert: IWidgetAlertDefinition | undefined,
+    kpi: IWidgetDefinition,
+    appliedFilters: IFilter[],
+): IBrokenAlertFilterBasicInfo[] {
+    const alertFilters = alert?.filterContext?.filters;
+
+    // no filters -> no filters can be broken, bail early
+    if (!alertFilters) {
+        return [];
+    }
+
+    const result: IBrokenAlertFilterBasicInfo[] = [];
+    const [alertDateFilters, alertAttributeFilters] = partition(alertFilters, isDashboardDateFilter) as [
+        IDashboardDateFilter[],
+        IDashboardAttributeFilter[],
+    ];
+
+    // attribute filters
+    const appliedAttributeFilters = appliedFilters.filter(isAttributeFilter);
+    alertAttributeFilters.forEach((alertFilter) => {
+        // ignored attribute filters are broken even if they are noop
+        const isIgnored = isAttributeFilterIgnored(kpi, alertFilter.attributeFilter.displayForm);
+        if (isIgnored) {
+            result.push({
+                alertFilter,
+                brokenType: "ignored",
+            });
+
+            return;
+        }
+
+        // deleted attribute filters are broken even if they are noop
+        const isInAppliedFilters = appliedAttributeFilters.some((f) =>
+            areObjRefsEqual(filterObjRef(f), alertFilter.attributeFilter.displayForm),
+        );
+
+        const isDeleted = !isInAppliedFilters;
+        if (isDeleted) {
+            result.push({
+                alertFilter,
+                brokenType: "deleted",
+            });
+        }
+    });
+
+    // date filter
+    const alertDateFilter = last(alertDateFilters);
+    if (alertDateFilter) {
+        const isIrrelevantNow = isDateFilterIrrelevant(kpi);
+        if (isIrrelevantNow) {
+            result.push({
+                alertFilter: {
+                    dateFilter: {
+                        ...alertDateFilter.dateFilter,
+                        dataSet: alertDateFilter.dateFilter.dataSet ?? kpi.dateDataSet, // make sure the dataSet is filled
+                    },
+                },
+                brokenType: "ignored",
+            });
+        }
+    }
+
+    return result;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/constants/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/constants/index.ts
@@ -1,5 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 export * from "./zIndex";
 export * from "./layout";
 export * from "./filterBar";
+export * from "./dashboard";

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/SaveAsDialogRenderer.tsx
@@ -1,12 +1,12 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { ConfirmDialog, Input, Message, Typography } from "@gooddata/sdk-ui-kit";
 import compact from "lodash/compact";
 import first from "lodash/first";
-import { IntlWrapper } from "../../localization";
 import noop from "lodash/noop";
-import { DASHBOARD_TITLE_MAX_LENGTH } from "../../constants/dashboard";
+import { IntlWrapper } from "../../localization";
+import { DASHBOARD_TITLE_MAX_LENGTH } from "../../constants";
 
 interface ISaveAsNewDashboardDialogState {
     dashboardTitle: string;

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -35,7 +35,7 @@ import { DateTime } from "./DateTime";
 import { Attachment } from "./Attachment";
 import { RecipientsSelect } from "./RecipientsSelect/RecipientsSelect";
 import { IntlWrapper } from "../../../localization";
-import { DASHBOARD_TITLE_MAX_LENGTH } from "../../../constants/dashboard";
+import { DASHBOARD_TITLE_MAX_LENGTH } from "../../../constants";
 
 const MAX_MESSAGE_LENGTH = 200;
 const MAX_SUBJECT_LENGTH = 200;

--- a/libs/sdk-ui-dashboard/tsconfig.build.json
+++ b/libs/sdk-ui-dashboard/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/typings.d.ts"],
+    "include": ["src/index.ts", "src/internal.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null,


### PR DESCRIPTION
This is the first step towards getting rid of DashboardView:
gdc-dashboards depend on some internals, so we need to
export them from their new locations in sdk-ui-dashboard.

We had to add getBrokenAlertFiltersBasicInfoLegacy because
the new one would be very hard to use in gdc-dashboards as is
and it could potentially break existing stuff there.

JIRA: RAIL-4046

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
