### PR TITLE
Chart Sorting disabled tooltips

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -57,7 +57,7 @@ import {
     getReferencePointWithSupportedProperties,
     removeImmutableOptionalStackingProperties,
 } from "../../../utils/propertiesHelper";
-import { removeSort } from "../../../utils/sort";
+import { removeSort, getCustomSortDisabledExplanation } from "../../../utils/sort";
 import { setAreaChartUiConfig } from "../../../utils/uiConfigHelpers/areaChartUiConfigHelper";
 import LineChartBasedConfigurationPanel from "../../configurationPanels/LineChartBasedConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
@@ -161,13 +161,14 @@ export class PluggableAreaChart extends PluggableBaseChart {
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
         const { properties } = referencePoint;
-        const disabled = this.isSortDisabled(referencePoint, availableSorts);
+        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
         return Promise.resolve({
             supported: true,
             disabled,
             appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
+            ...(disabledExplanation && { disabledExplanation }),
         });
     }
 
@@ -417,6 +418,10 @@ export class PluggableAreaChart extends PluggableBaseChart {
         const { buckets } = referencePoint;
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
-        return viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0;
+        const disabledExplanation = getCustomSortDisabledExplanation(measures, viewBy, this.intl);
+        return {
+            disabled: viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0,
+            disabledExplanation,
+        };
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -5,7 +5,6 @@ import {
     IInsightDefinition,
     insightBuckets,
     newAttributeSort,
-    localIdRef,
 } from "@gooddata/sdk-model";
 import { BucketNames, IDrillEvent, VisualizationTypes } from "@gooddata/sdk-ui";
 import React from "react";
@@ -66,7 +65,7 @@ import {
     modifyBucketsAttributesForDrillDown,
     reverseAndTrimIntersection,
 } from "../drillDownUtil";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 /**
  * PluggableAreaChart
@@ -349,14 +348,10 @@ export class PluggableAreaChart extends PluggableBaseChart {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                        metricSorts: measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        measures.map((m) => m.localIdentifier),
+                    ),
                 ],
             };
         }
@@ -364,29 +359,19 @@ export class PluggableAreaChart extends PluggableBaseChart {
             if (viewBy.length >= 2) {
                 return {
                     defaultSort,
-                    availableSorts: [
-                        {
-                            itemId: localIdRef(viewBy[0].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: true,
-                            },
-                        },
-                    ],
+                    availableSorts: [newAvailableSortsGroup(viewBy[0].localIdentifier)],
                 };
             }
             if (viewBy.length === 1) {
                 return {
                     defaultSort,
                     availableSorts: [
-                        {
-                            itemId: localIdRef(viewBy[0].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: false,
-                            },
-                            metricSorts: measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                        },
+                        newAvailableSortsGroup(
+                            viewBy[0].localIdentifier,
+                            measures.map((m) => m.localIdentifier),
+                            true,
+                            false,
+                        ),
                     ],
                 };
             }
@@ -395,16 +380,10 @@ export class PluggableAreaChart extends PluggableBaseChart {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                        metricSorts: isEmpty(stackBy)
-                            ? measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))
-                            : [],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        isEmpty(stackBy) ? measures.map((m) => m.localIdentifier) : [],
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -6,6 +6,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;
@@ -26,6 +27,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -44,7 +44,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
-      "metricSorts": Array [],
     },
   ],
   "defaultSort": Array [
@@ -138,7 +137,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
-      "metricSorts": Array [],
     },
   ],
   "defaultSort": Array [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -115,9 +115,10 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                     ],
                     availableSorts: [
                         newAvailableSortsGroup(viewBy[0].localIdentifier),
-                        newAvailableSortsGroup(viewBy[1].localIdentifier, [
-                            ...measures.map((m) => m.localIdentifier),
-                        ]),
+                        newAvailableSortsGroup(
+                            viewBy[1].localIdentifier,
+                            measures.map((m) => m.localIdentifier),
+                        ),
                     ],
                 };
             }
@@ -133,7 +134,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                     newAvailableSortsGroup(viewBy[0].localIdentifier),
                     newAvailableSortsGroup(
                         viewBy[1].localIdentifier,
-                        isEmpty(stackBy) ? [...measures.map((m) => m.localIdentifier)] : [],
+                        isEmpty(stackBy) ? measures.map((m) => m.localIdentifier) : [],
                         true,
                         isStacked || measures.length > 1,
                     ),
@@ -147,7 +148,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                 availableSorts: [
                     newAvailableSortsGroup(
                         viewBy[0].localIdentifier,
-                        isEmpty(stackBy) ? [...measures.map((m) => m.localIdentifier)] : [],
+                        isEmpty(stackBy) ? measures.map((m) => m.localIdentifier) : [],
                     ),
                 ],
             };
@@ -159,7 +160,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                 availableSorts: [
                     newAvailableSortsGroup(
                         viewBy[0].localIdentifier,
-                        [...measures.map((m) => m.localIdentifier)],
+                        measures.map((m) => m.localIdentifier),
                         true,
                         measures.length > 1,
                     ),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -40,13 +40,12 @@ import {
     IInsight,
     IInsightDefinition,
     insightBucket,
-    localIdRef,
     newAttributeSort,
 } from "@gooddata/sdk-model";
 import { transformBuckets } from "./bucketHelper";
 import { modifyBucketsAttributesForDrillDown, addIntersectionFiltersToInsight } from "../drillDownUtil";
 import { drillDownFromAttributeLocalId } from "../../../utils/ImplicitDrillDownHelper";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 /**
  * PluggableBulletChart
@@ -231,21 +230,13 @@ export class PluggableBulletChart extends PluggableBaseChart {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                    {
-                        itemId: localIdRef(viewBy[1].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: measures.length > 1,
-                        },
-                        metricSorts: measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                    },
+                    newAvailableSortsGroup(viewBy[0].localIdentifier),
+                    newAvailableSortsGroup(
+                        viewBy[1].localIdentifier,
+                        measures.map((m) => m.localIdentifier),
+                        true,
+                        measures.length > 1,
+                    ),
                 ],
             };
         }
@@ -253,14 +244,12 @@ export class PluggableBulletChart extends PluggableBaseChart {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: measures.length > 1,
-                        },
-                        metricSorts: measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        measures.map((m) => m.localIdentifier),
+                        true,
+                        measures.length > 1,
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -28,7 +28,7 @@ import {
 } from "../../../utils/bucketHelper";
 
 import { BUCKETS, METRIC } from "../../../constants/bucket";
-import { removeSort } from "../../../utils/sort";
+import { removeSort, getCustomSortDisabledExplanation } from "../../../utils/sort";
 import { getBulletChartUiConfig } from "../../../utils/uiConfigHelpers/bulletChartUiConfigHelper";
 import { BULLET_CHART_CONFIG_MULTIPLE_DATES, DEFAULT_BULLET_CHART_CONFIG } from "../../../constants/uiConfig";
 import { BULLET_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
@@ -210,7 +210,11 @@ export class PluggableBulletChart extends PluggableBaseChart {
         const { buckets } = referencePoint;
         const primaryMeasures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
-        return viewBy.length < 1 || primaryMeasures.length < 1 || availableSorts.length === 0;
+        const disabledExplanation = getCustomSortDisabledExplanation(primaryMeasures, viewBy, this.intl);
+        return {
+            disabled: viewBy.length < 1 || primaryMeasures.length < 1 || availableSorts.length === 0,
+            disabledExplanation,
+        };
     }
 
     private getDefaultAndAvailableSort(referencePoint: IReferencePoint): {
@@ -268,7 +272,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
-        const disabled = this.isSortDisabled(referencePoint, availableSorts);
+        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
         const { properties } = referencePoint;
         return Promise.resolve({
             supported: true,
@@ -276,6 +280,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
             appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
+            ...(disabledExplanation && { disabledExplanation }),
         });
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -6,6 +6,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;
@@ -44,6 +45,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -23,7 +23,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
-      "metricSorts": Array [],
     },
   ],
   "defaultSort": Array [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -1,14 +1,14 @@
 // (C) 2019-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { VisualizationTypes, BucketNames } from "@gooddata/sdk-ui";
-import { localIdRef, newAttributeSort } from "@gooddata/sdk-model";
+import { newAttributeSort } from "@gooddata/sdk-model";
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { COLUMN_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import { IVisConstruct, IReferencePoint, IBucketItem } from "../../../interfaces/Visualization";
 import { getBucketItems } from "../../../utils/bucketHelper";
 import { canSortStackTotalValue } from "../barChart/sortHelpers";
-import { newMeasureSortSuggestion, ISortConfig } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 import { getCustomSortDisabledExplanation } from "../../../utils/sort";
 
 /**
@@ -77,23 +77,11 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
                 return {
                     defaultSort,
                     availableSorts: [
-                        {
-                            itemId: localIdRef(viewBy[0].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: true,
-                            },
-                        },
-                        {
-                            itemId: localIdRef(viewBy[1].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: true,
-                            },
-                            metricSorts: [
-                                ...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                            ],
-                        },
+                        newAvailableSortsGroup(viewBy[0].localIdentifier),
+                        newAvailableSortsGroup(
+                            viewBy[1].localIdentifier,
+                            measures.map((m) => m.localIdentifier),
+                        ),
                     ],
                 };
             }
@@ -101,23 +89,13 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                    {
-                        itemId: localIdRef(viewBy[1].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: isStacked || measures.length > 1,
-                        },
-                        metricSorts: isEmpty(stackBy)
-                            ? [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))]
-                            : [],
-                    },
+                    newAvailableSortsGroup(viewBy[0].localIdentifier),
+                    newAvailableSortsGroup(
+                        viewBy[1].localIdentifier,
+                        isEmpty(stackBy) ? measures.map((m) => m.localIdentifier) : [],
+                        true,
+                        isStacked || measures.length > 1,
+                    ),
                 ],
             };
         }
@@ -126,16 +104,10 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                        metricSorts: isEmpty(stackBy)
-                            ? [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))]
-                            : [],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        isEmpty(stackBy) ? measures.map((m) => m.localIdentifier) : [],
+                    ),
                 ],
             };
         }
@@ -144,14 +116,12 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: measures.length > 1,
-                        },
-                        metricSorts: [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        measures.map((m) => m.localIdentifier),
+                        true,
+                        measures.length > 1,
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
@@ -1,10 +1,12 @@
 // (C) 2019-2022 GoodData Corporation
 import noop from "lodash/noop";
+import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
+import { OverTimeComparisonTypes } from "@gooddata/sdk-ui";
+
 import { PluggableColumnChart } from "../PluggableColumnChart";
+
 import * as referencePointMocks from "../../../../tests/mocks/referencePointMocks";
 import { AXIS } from "../../../../constants/axis";
-import { OverTimeComparisonTypes } from "@gooddata/sdk-ui";
-import { dummyBackend } from "@gooddata/sdk-backend-mockingbird";
 
 describe("PluggableColumnChart", () => {
     const defaultProps = {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
@@ -61,7 +61,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a1",
       },
-      "metricSorts": Array [],
     },
   ],
   "defaultSort": Array [
@@ -98,7 +97,6 @@ Object {
       "itemId": Object {
         "localIdentifier": "a2",
       },
-      "metricSorts": Array [],
     },
   ],
   "defaultSort": Array [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -7,13 +7,7 @@ import without from "lodash/without";
 import isEmpty from "lodash/isEmpty";
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import { isAreaChart, isLineChart } from "@gooddata/sdk-ui-charts";
-import {
-    insightBuckets,
-    bucketsIsEmpty,
-    IInsightDefinition,
-    localIdRef,
-    newAttributeSort,
-} from "@gooddata/sdk-model";
+import { insightBuckets, bucketsIsEmpty, IInsightDefinition, newAttributeSort } from "@gooddata/sdk-model";
 
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 
@@ -32,7 +26,7 @@ import {
     IVisualizationProperties,
     IBucketOfFun,
 } from "../../../interfaces/Visualization";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 import { removeSort, getCustomSortDisabledExplanation } from "../../../utils/sort";
@@ -297,14 +291,12 @@ export class PluggableComboChart extends PluggableBaseChart {
             return {
                 defaultSort,
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            areaSortEnabled: canSortStackTotal || mergedMeasures.length > 1,
-                            normalSortEnabled: true,
-                        },
-                        metricSorts: mergedMeasures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        mergedMeasures.map((m) => m.localIdentifier),
+                        true,
+                        canSortStackTotal || mergedMeasures.length > 1,
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -12,7 +12,7 @@ import {
     isDrillIntersectionAttributeItem,
     VisualizationTypes,
 } from "@gooddata/sdk-ui";
-import { IInsight, IInsightDefinition, newAttributeSort, localIdRef } from "@gooddata/sdk-model";
+import { IInsight, IInsightDefinition, newAttributeSort } from "@gooddata/sdk-model";
 
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import { addIntersectionFiltersToInsight, modifyBucketsAttributesForDrillDown } from "../drillDownUtil";
@@ -31,7 +31,7 @@ import {
     IDrillDownDefinition,
     IBucketItem,
 } from "../../../interfaces/Visualization";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 import {
@@ -180,20 +180,8 @@ export class PluggableHeatmap extends PluggableBaseChart {
                     newAttributeSort(stackBy[0].localIdentifier, "desc"),
                 ],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                    {
-                        itemId: localIdRef(stackBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
+                    newAvailableSortsGroup(viewBy[0].localIdentifier),
+                    newAvailableSortsGroup(stackBy[0].localIdentifier),
                 ],
             };
         }
@@ -201,29 +189,19 @@ export class PluggableHeatmap extends PluggableBaseChart {
             return {
                 defaultSort: [newAttributeSort(viewBy[0].localIdentifier, "desc")],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: false,
-                        },
-                        metricSorts: [newMeasureSortSuggestion(measures[0].localIdentifier)],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        [measures[0].localIdentifier],
+                        true,
+                        false,
+                    ),
                 ],
             };
         }
         if (!isEmpty(measures) && !isEmpty(stackBy)) {
             return {
                 defaultSort: [newAttributeSort(stackBy[0].localIdentifier, "desc")],
-                availableSorts: [
-                    {
-                        itemId: localIdRef(stackBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                ],
+                availableSorts: [newAvailableSortsGroup(stackBy[0].localIdentifier)],
             };
         }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -38,7 +38,7 @@ import {
     getReferencePointWithSupportedProperties,
     setSecondaryMeasures,
 } from "../../../utils/propertiesHelper";
-import { removeSort } from "../../../utils/sort";
+import { removeSort, getCustomSortDisabledExplanation } from "../../../utils/sort";
 import { setLineChartUiConfig } from "../../../utils/uiConfigHelpers/lineChartUiConfigHelper";
 import LineChartBasedConfigurationPanel from "../../configurationPanels/LineChartBasedConfigurationPanel";
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
@@ -140,7 +140,8 @@ export class PluggableLineChart extends PluggableBaseChart {
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
-        const disabled = this.isSortDisabled(referencePoint, availableSorts);
+        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
+
         const { properties } = referencePoint;
         return Promise.resolve({
             supported: true,
@@ -148,6 +149,7 @@ export class PluggableLineChart extends PluggableBaseChart {
             appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
+            ...(disabledExplanation && { disabledExplanation }),
         });
     }
 
@@ -333,6 +335,10 @@ export class PluggableLineChart extends PluggableBaseChart {
         const { buckets } = referencePoint;
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.TREND);
-        return viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0;
+        const disabledExplanation = getCustomSortDisabledExplanation(measures, viewBy, this.intl);
+        return {
+            disabled: viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0,
+            disabledExplanation,
+        };
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -5,7 +5,7 @@ import { render } from "react-dom";
 import isEmpty from "lodash/isEmpty";
 import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
-import { IInsight, IInsightDefinition, newAttributeSort, localIdRef } from "@gooddata/sdk-model";
+import { IInsight, IInsightDefinition, newAttributeSort } from "@gooddata/sdk-model";
 
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { ATTRIBUTE, BUCKETS, DATE } from "../../../constants/bucket";
@@ -47,7 +47,7 @@ import {
     modifyBucketsAttributesForDrillDown,
     reverseAndTrimIntersection,
 } from "../drillDownUtil";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 /**
  * PluggableLineChart
@@ -301,28 +301,18 @@ export class PluggableLineChart extends PluggableBaseChart {
                 return {
                     defaultSort,
                     availableSorts: [
-                        {
-                            itemId: localIdRef(trendBy[0].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: measures.length > 1,
-                            },
-                            metricSorts: measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                        },
+                        newAvailableSortsGroup(
+                            trendBy[0].localIdentifier,
+                            measures.map((m) => m.localIdentifier),
+                            true,
+                            measures.length > 1,
+                        ),
                     ],
                 };
             }
             return {
                 defaultSort,
-                availableSorts: [
-                    {
-                        itemId: localIdRef(trendBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                ],
+                availableSorts: [newAvailableSortsGroup(trendBy[0].localIdentifier)],
             };
         }
         return {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
@@ -6,6 +6,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;
@@ -26,6 +27,7 @@ Object {
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
+  "disabledExplanation": "Sorting is not possible for this insight configuration.",
   "supported": true,
 }
 `;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -6,7 +6,7 @@ import cloneDeep from "lodash/cloneDeep";
 import set from "lodash/set";
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import { IChartConfig, TOP } from "@gooddata/sdk-ui-charts";
-import { IInsightDefinition, newMeasureSort, localIdRef } from "@gooddata/sdk-model";
+import { IInsightDefinition, newMeasureSort } from "@gooddata/sdk-model";
 
 import { PluggableBaseChart } from "../baseChart/PluggableBaseChart";
 import PieChartConfigurationPanel from "../../configurationPanels/PieChartConfigurationPanel";
@@ -29,7 +29,7 @@ import {
     IVisualizationProperties,
     IBucketItem,
 } from "../../../interfaces/Visualization";
-import { newMeasureSortSuggestion, ISortConfig } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 import {
@@ -161,14 +161,12 @@ export class PluggablePieChart extends PluggableBaseChart {
             return {
                 defaultSort: [newMeasureSort(measures[0].localIdentifier, "desc")],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: false,
-                        },
-                        metricSorts: [newMeasureSortSuggestion(measures[0].localIdentifier)],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        [measures[0].localIdentifier],
+                        true,
+                        false,
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
@@ -17,7 +17,7 @@ export type MeasureSortSuggestion = {
     type: "measureSort";
 } & IMeasureSortTarget;
 
-export function newMeasureSortSuggestion(
+function newMeasureSortSuggestion(
     identifier: Identifier,
     attributeLocators: IAttributeLocatorItem[] = [],
 ): MeasureSortSuggestion {

--- a/libs/sdk-ui-ext/src/internal/translations/en-US.json
+++ b/libs/sdk-ui-ext/src/internal/translations/en-US.json
@@ -1566,5 +1566,35 @@
         "value": "Use two fingers to move the map",
         "comment": "This message will appear when moving map on GeoChart is disabled by one finger and available only with two.",
         "limit": 0
+    },
+    "sorting.disabled.explanation.attribute|insight": {
+        "value": "Sorting is not possible for this insight configuration.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.attribute|report": {
+        "value": "Sorting is not possible for this report configuration.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._measure|insight": {
+        "value": "You must add at least one attribute to sort the insight. You can also adjust the position of items in the Measures section to change their position in the insight.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._measure|report": {
+        "value": "You must add at least one attribute to sort the report. You can also adjust the position of items in the Measures section to change their position in the report.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._metric|insight": {
+        "value": "You must add at least one attribute to sort the insight. You can also adjust the position of items in the Metrics section to change their position in the insight.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
+    },
+    "sorting.disabled.explanation.measure._metric|report": {
+        "value": "You must add at least one attribute to sort the report. You can also adjust the position of items in the Metrics section to change their position in the report.",
+        "comment": "Explains why sort button is disabled. Shown as tooltip",
+        "limit": 0
     }
 }

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -1,9 +1,9 @@
 // (C) 2019-2022 GoodData Corporation
+import { IntlShape } from "react-intl";
 import isEmpty from "lodash/isEmpty";
 import isNil from "lodash/isNil";
 import omitBy from "lodash/omitBy";
 import isEqual from "lodash/isEqual";
-
 import {
     bucketAttributes,
     IBucket,
@@ -26,8 +26,10 @@ import {
     IMeasureSortItem,
     sortDirection,
 } from "@gooddata/sdk-model";
-
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
+
+import { getTranslation } from "./translations";
+
 import { SORT_DIR_DESC } from "../constants/sort";
 import { IBucketItem, IBucketOfFun, IExtendedReferencePoint } from "../interfaces/Visualization";
 import { IAvailableSortsGroup } from "../interfaces/SortConfig";
@@ -331,4 +333,18 @@ export function validateCurrentSort(
             return reuseSortItemType(currentSortItem, availableSortGroup) ?? defaultSort[index];
         })
         .filter(Boolean);
+}
+
+export function getCustomSortDisabledExplanation(
+    relevantMeasures: IBucketItem[],
+    relevantAttributes: IBucketItem[],
+    intl: IntlShape,
+): string {
+    if (relevantAttributes.length === 0 && relevantMeasures.length >= 2) {
+        return getTranslation("sorting.disabled.explanation.measure", intl);
+    }
+
+    if (relevantAttributes.length === 0) {
+        return getTranslation("sorting.disabled.explanation.attribute", intl);
+    }
 }


### PR DESCRIPTION
JIRA: TNT-466
PVs now explain why the sorting is disabled via tooltip text
Code unification cross all sortable PVs 

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
