### PR TITLE
RELATED: RAIL-3485 Create folder for catalog export if not exist

### DIFF
--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -59,7 +59,6 @@ async function loadProjectMetadataFromBackend(config: CatalogExportConfig): Prom
 
 async function checkFolderExists(filePath: string) {
     const directory = path.dirname(filePath);
-    process.stdout.write(`dirname: ${directory}\n`);
     if (!fs.existsSync(directory)) {
         fs.mkdirSync(directory);
     }

--- a/tools/catalog-export/src/index.ts
+++ b/tools/catalog-export/src/index.ts
@@ -15,6 +15,7 @@ import { exportMetadataToTypescript } from "./exports/metaToTypescript";
 import { exportMetadataToJavascript } from "./exports/metaToJavascript";
 import { loadWorkspaceMetadataFromBear } from "./loaders/bear";
 import { loadWorkspaceMetadataFromTiger } from "./loaders/tiger";
+import fs from "fs";
 
 program
     .version(pkg.version)
@@ -56,6 +57,14 @@ async function loadProjectMetadataFromBackend(config: CatalogExportConfig): Prom
     return loadWorkspaceMetadataFromBear(config);
 }
 
+async function checkFolderExists(filePath: string) {
+    const directory = path.dirname(filePath);
+    process.stdout.write(`dirname: ${directory}\n`);
+    if (!fs.existsSync(directory)) {
+        fs.mkdirSync(directory);
+    }
+}
+
 async function run() {
     clearTerminal();
     printHeader(pkg.version);
@@ -75,6 +84,8 @@ async function run() {
     try {
         const filePath = path.resolve(output || (await requestFilePath()));
         const projectMetadata = await loadProjectMetadataFromBackend(mergedConfig);
+
+        await checkFolderExists(filePath);
 
         if (filePath.endsWith(".ts")) {
             await exportMetadataToTypescript(projectMetadata, filePath, backend === "tiger");


### PR DESCRIPTION
- If the folder where catalog export should be saved does not exist, the script will create the folder instead of script failure.

JIRA: RAIL-3485

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
