### PR TITLE
Custom Sort - sanitize insight config, update heatmap default order

### DIFF
--- a/libs/sdk-ui-charts/src/charts/_commons/sanitizeStacking.ts
+++ b/libs/sdk-ui-charts/src/charts/_commons/sanitizeStacking.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import {
     IAttributeOrMeasure,
@@ -49,16 +49,25 @@ export function getSanitizedStackingConfig(
     executionDef: IExecutionDefinition,
     chartConfig: IChartConfig,
 ): IChartConfig {
+    let updatedChartConfig = chartConfig;
+
+    // In case enableChartSorting is set to true and sort was not specified,
+    // we need to change its value, so visualization is able to take default sort
+    if (executionDef.sortBy.length === 0 && chartConfig.enableChartSorting) {
+        updatedChartConfig = { ...updatedChartConfig, enableChartSorting: false };
+    }
+
     if (executionDef.measures.length === 1) {
         const { stackMeasures, stackMeasuresToPercent } = chartConfig;
         const singleMeasure = executionDef.measures[0];
         const isComputeRatio = measureDoesComputeRatio(singleMeasure);
 
         return {
-            ...chartConfig,
+            ...updatedChartConfig,
             stackMeasures: stackMeasures && !isComputeRatio,
             stackMeasuresToPercent: stackMeasuresToPercent && !isComputeRatio,
         };
     }
-    return chartConfig;
+
+    return updatedChartConfig;
 }

--- a/libs/sdk-ui-charts/src/charts/donutChart/DonutChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/donutChart/DonutChart.tsx
@@ -113,12 +113,6 @@ export const DonutChart = (props: IDonutChartProps) => {
         props.placeholdersResolutionContext,
     );
 
-    // In case enableChartSorting is set to true and sort was not specified,
-    // we need to change its value, so visualization is able to take default sort
-    if (props.config && props.config.enableChartSorting && !sortBy) {
-        props.config.enableChartSorting = false;
-    }
-
     return (
         <WrappedDonutChart
             {...props}

--- a/libs/sdk-ui-charts/src/charts/pieChart/PieChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/pieChart/PieChart.tsx
@@ -103,12 +103,6 @@ export const PieChart = (props: IPieChartProps) => {
         props.placeholdersResolutionContext,
     );
 
-    // In case enableChartSorting is set to true and sort was not specified,
-    // we need to change its value, so visualization is able to take default sort
-    if (props.config && props.config.enableChartSorting && !sortBy) {
-        props.config.enableChartSorting = false;
-    }
-
     return (
         <WrappedPieChart
             {...props}

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -174,8 +174,8 @@ export class PluggableHeatmap extends PluggableBaseChart {
         if (!isEmpty(viewBy) && !isEmpty(stackBy) && !isEmpty(measures)) {
             return {
                 defaultSort: [
-                    newAttributeSort(viewBy[0].localIdentifier, "asc"),
-                    newAttributeSort(stackBy[0].localIdentifier, "asc"),
+                    newAttributeSort(viewBy[0].localIdentifier, "desc"),
+                    newAttributeSort(stackBy[0].localIdentifier, "desc"),
                 ],
                 availableSorts: [
                     {
@@ -197,7 +197,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         }
         if (!isEmpty(measures) && !isEmpty(viewBy)) {
             return {
-                defaultSort: [newAttributeSort(viewBy[0].localIdentifier, "asc")],
+                defaultSort: [newAttributeSort(viewBy[0].localIdentifier, "desc")],
                 availableSorts: [
                     {
                         itemId: localIdRef(viewBy[0].localIdentifier),
@@ -212,7 +212,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         }
         if (!isEmpty(measures) && !isEmpty(stackBy)) {
             return {
-                defaultSort: [newAttributeSort(stackBy[0].localIdentifier, "asc")],
+                defaultSort: [newAttributeSort(stackBy[0].localIdentifier, "desc")],
                 availableSorts: [
                     {
                         itemId: localIdRef(stackBy[0].localIdentifier),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
@@ -250,7 +250,6 @@ describe("PluggableHeatmap", () => {
     describe("Sort config", () => {
         it("should create sort config with sorting supported but disabled when there is no view by attribute", async () => {
             const chart = createComponent(defaultProps);
-
             const sortConfig = await chart.getSortConfig(
                 referencePointMocks.oneMetricNoCategoriesReferencePoint,
             );
@@ -261,7 +260,6 @@ describe("PluggableHeatmap", () => {
 
         it("should create sort config with sorting disabled when there is no measure", async () => {
             const chart = createComponent(defaultProps);
-
             const sortConfig = await chart.getSortConfig(referencePointMocks.justViewByReferencePoint);
 
             expect(sortConfig.supported).toBeTruthy();
@@ -270,7 +268,6 @@ describe("PluggableHeatmap", () => {
 
         it("should provide attribute normal as default sort, attribute normal and measuree sorts as available sorts for 1M + 1VB", async () => {
             const chart = createComponent(defaultProps);
-
             const sortConfig = await chart.getSortConfig(referencePointMocks.oneMetricOneCategory);
 
             expect(sortConfig).toMatchSnapshot();
@@ -278,7 +275,6 @@ describe("PluggableHeatmap", () => {
 
         it("should provide attribute normal as default sort, attribute area sorts as available sorts for 1M + 1SB", async () => {
             const chart = createComponent(defaultProps);
-
             const sortConfig = await chart.getSortConfig(referencePointMocks.oneMetricOneStackReferencePoint);
 
             expect(sortConfig).toMatchSnapshot();
@@ -286,7 +282,6 @@ describe("PluggableHeatmap", () => {
 
         it("should provide attribute normal as default sort, attribute are sorts as available sorts for 1M + 1VB + 1SB", async () => {
             const chart = createComponent(defaultProps);
-
             const sortConfig = await chart.getSortConfig(
                 referencePointMocks.oneMetricAndCategoryAndStackReferencePoint,
             );

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -26,13 +26,13 @@ Object {
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
-        "direction": "asc",
+        "direction": "desc",
       },
     },
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a2",
-        "direction": "asc",
+        "direction": "desc",
       },
     },
   ],
@@ -58,7 +58,7 @@ Object {
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a3",
-        "direction": "asc",
+        "direction": "desc",
       },
     },
   ],
@@ -96,7 +96,7 @@ Object {
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
-        "direction": "asc",
+        "direction": "desc",
       },
     },
   ],


### PR DESCRIPTION
- TNT-544:  In case `enableChartSorting` is set to true and no `sortBy` was specified by user, need to make sure that insight is aware that it should get sort by default.
- TNT-543: Update custom sort order for Heatmap chart, so it matches old sort behaviour.

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
