### PR TITLE
Reuse existing custom sort

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -897,6 +897,9 @@ export function isAttributeFilter(obj: unknown): obj is IAttributeFilter;
 export function isAttributeLocator(obj: unknown): obj is IAttributeLocatorItem;
 
 // @public
+export function isAttributeSimpleSort(obj: unknown): obj is IAttributeSortItem;
+
+// @public
 export function isAttributeSort(obj: unknown): obj is IAttributeSortItem;
 
 // @public

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1257,7 +1257,7 @@ export function newMeasure(measure: ObjRef | Identifier, modifications?: Measure
 export function newMeasureSort(measureOrId: IMeasure | string, sortDirection?: SortDirection, attributeLocators?: IAttributeLocatorItem[]): IMeasureSortItem;
 
 // @public
-export function newMeasureSortFromParts(locators: ILocatorItem[], sortDirection?: SortDirection): IMeasureSortItem;
+export function newMeasureSortFromLocators(locators: ILocatorItem[], sortDirection?: SortDirection): IMeasureSortItem;
 
 // @public
 export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1257,6 +1257,9 @@ export function newMeasure(measure: ObjRef | Identifier, modifications?: Measure
 export function newMeasureSort(measureOrId: IMeasure | string, sortDirection?: SortDirection, attributeLocators?: IAttributeLocatorItem[]): IMeasureSortItem;
 
 // @public
+export function newMeasureSortFromParts(locators: ILocatorItem[], sortDirection?: SortDirection): IMeasureSortItem;
+
+// @public
 export function newMeasureValueFilter(measureOrRef: IMeasure | ObjRefInScope | string, operator: ComparisonConditionOperator, value: number, treatNullValuesAs?: number): IMeasureValueFilter;
 
 // @public

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -897,10 +897,10 @@ export function isAttributeFilter(obj: unknown): obj is IAttributeFilter;
 export function isAttributeLocator(obj: unknown): obj is IAttributeLocatorItem;
 
 // @public
-export function isAttributeSimpleSort(obj: unknown): obj is IAttributeSortItem;
+export function isAttributeSort(obj: unknown): obj is IAttributeSortItem;
 
 // @public
-export function isAttributeSort(obj: unknown): obj is IAttributeSortItem;
+export function isAttributeValueSort(obj: unknown): obj is IAttributeSortItem;
 
 // @public
 export function isBucket(obj: unknown): obj is IBucket;

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -388,6 +388,27 @@ export function newMeasureSort(
 }
 
 /**
+ * Creates a new measure sort - sorting the result by values of the provided measure. New measure sort is created from provided parts. Helpful eg. for just switching the direction of existing sort
+ *
+ * @param locators - complete locators
+ * @param sortDirection - asc or desc, defaults to "asc"
+ * @returns new sort item
+ * @public
+ */
+export function newMeasureSortFromParts(
+    locators: ILocatorItem[],
+    sortDirection: SortDirection = "asc",
+): IMeasureSortItem {
+    invariant(locators.length !== 0, "locators must be specified");
+    return {
+        measureSortItem: {
+            direction: sortDirection,
+            locators,
+        },
+    };
+}
+
+/**
  * Creates a new attribute locator for an attribute element.
  *
  * @param attributeOrId - attribute, can be specified by either the attribute object or its local identifier

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -152,6 +152,15 @@ export function isAttributeAreaSort(obj: unknown): obj is IAttributeSortItem {
 }
 
 /**
+ * Type guard checking whether an object is a simple attribute sort item, not the area one.
+ *
+ * @public
+ */
+export function isAttributeSimpleSort(obj: unknown): obj is IAttributeSortItem {
+    return isAttributeSort(obj) && !isAttributeAreaSort(obj);
+}
+
+/**
  * Type guard checking whether an object is a measure sort item.
  *
  * @public

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -395,7 +395,7 @@ export function newMeasureSort(
  * @returns new sort item
  * @public
  */
-export function newMeasureSortFromParts(
+export function newMeasureSortFromLocators(
     locators: ILocatorItem[],
     sortDirection: SortDirection = "asc",
 ): IMeasureSortItem {

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -152,11 +152,11 @@ export function isAttributeAreaSort(obj: unknown): obj is IAttributeSortItem {
 }
 
 /**
- * Type guard checking whether an object is a simple attribute sort item, not the area one.
+ * Type guard checking whether an object is a normal attribute value sort item, not the area one.
  *
  * @public
  */
-export function isAttributeSimpleSort(obj: unknown): obj is IAttributeSortItem {
+export function isAttributeValueSort(obj: unknown): obj is IAttributeSortItem {
     return isAttributeSort(obj) && !isAttributeAreaSort(obj);
 }
 

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -89,7 +89,7 @@ export {
     isMeasureSort,
     isAttributeSort,
     isAttributeAreaSort,
-    isAttributeSimpleSort,
+    isAttributeValueSort,
     newMeasureSort,
     newAttributeSort,
     newAttributeAreaSort,

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -89,6 +89,7 @@ export {
     isMeasureSort,
     isAttributeSort,
     isAttributeAreaSort,
+    isAttributeSimpleSort,
     newMeasureSort,
     newAttributeSort,
     newAttributeAreaSort,

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -91,7 +91,7 @@ export {
     isAttributeAreaSort,
     isAttributeValueSort,
     newMeasureSort,
-    newMeasureSortFromParts,
+    newMeasureSortFromLocators,
     newAttributeSort,
     newAttributeAreaSort,
     newAttributeLocator,

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -91,6 +91,7 @@ export {
     isAttributeAreaSort,
     isAttributeValueSort,
     newMeasureSort,
+    newMeasureSortFromParts,
     newAttributeSort,
     newAttributeAreaSort,
     newAttributeLocator,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -318,7 +318,7 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      */
     public getSortConfig(_referencePoint: IReferencePoint): Promise<ISortConfig> {
         return Promise.resolve({
-            currentSort: [],
+            defaultSort: [],
             availableSorts: [],
             supported: false,
             disabled: false,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -147,7 +147,9 @@ export class PluggableAreaChart extends PluggableBaseChart {
             newReferencePoint,
             this.supportedPropertiesList,
         );
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
@@ -162,7 +164,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }
@@ -328,7 +330,7 @@ export class PluggableAreaChart extends PluggableBaseChart {
     }
 
     private getDefaultAndAvailableSort(referencePoint: IReferencePoint): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const { buckets, properties } = referencePoint;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -160,10 +160,12 @@ export class PluggableAreaChart extends PluggableBaseChart {
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
+        const { properties } = referencePoint;
         const disabled = this.isSortDisabled(referencePoint, availableSorts);
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluggableAreaChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -12,7 +12,7 @@ Object {
 exports[`PluggableAreaChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -21,7 +21,7 @@ Object {
 exports[`PluggableAreaChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -41,7 +41,7 @@ Object {
       "metricSorts": Array [],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -79,7 +79,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -105,7 +105,7 @@ Object {
       },
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -132,7 +132,7 @@ Object {
       "metricSorts": Array [],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -180,7 +180,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -196,7 +196,7 @@ Object {
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -237,7 +237,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -253,7 +253,7 @@ Object {
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 stacked M + 2 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/__snapshots__/PluggableAreaChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -11,6 +12,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -20,6 +22,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -29,6 +32,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 1 M + 1 VB + 1 ST 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -56,6 +60,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 1 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -94,6 +99,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 1 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -120,6 +126,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 M + 1 VB + 1 ST 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -147,6 +154,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -195,6 +203,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -204,6 +213,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 stacked M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -252,6 +262,7 @@ Object {
 
 exports[`PluggableAreaChart Sort config should return expected sort config for 2 stacked M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -4,13 +4,13 @@ import { render } from "react-dom";
 import isEmpty from "lodash/isEmpty";
 
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
-import { IInsightDefinition, localIdRef, newAttributeAreaSort, newMeasureSort } from "@gooddata/sdk-model";
+import { IInsightDefinition, newAttributeAreaSort, newMeasureSort } from "@gooddata/sdk-model";
 import { PluggableColumnBarCharts } from "../PluggableColumnBarCharts";
 import { IReferencePoint, IVisConstruct } from "../../../interfaces/Visualization";
 import { BAR_CHART_SUPPORTED_PROPERTIES } from "../../../constants/supportedProperties";
 import BarChartConfigurationPanel from "../../configurationPanels/BarChartConfigurationPanel";
 import { AXIS, AXIS_NAME } from "../../../constants/axis";
-import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
+import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 import { getBucketItems } from "../../../utils/bucketHelper";
 import { canSortStackTotalValue } from "./sortHelpers";
 import { validateCurrentSort } from "../../../utils/sort";
@@ -114,23 +114,10 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                         newMeasureSort(measures[0].localIdentifier, "desc"),
                     ],
                     availableSorts: [
-                        {
-                            itemId: localIdRef(viewBy[0].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: true,
-                            },
-                        },
-                        {
-                            itemId: localIdRef(viewBy[1].localIdentifier),
-                            attributeSort: {
-                                normalSortEnabled: true,
-                                areaSortEnabled: true,
-                            },
-                            metricSorts: [
-                                ...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier)),
-                            ],
-                        },
+                        newAvailableSortsGroup(viewBy[0].localIdentifier),
+                        newAvailableSortsGroup(viewBy[1].localIdentifier, [
+                            ...measures.map((m) => m.localIdentifier),
+                        ]),
                     ],
                 };
             }
@@ -143,23 +130,13 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
                         : newMeasureSort(measures[0].localIdentifier, "desc"),
                 ],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                    },
-                    {
-                        itemId: localIdRef(viewBy[1].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: isStacked || measures.length > 1,
-                        },
-                        metricSorts: isEmpty(stackBy)
-                            ? [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))]
-                            : [],
-                    },
+                    newAvailableSortsGroup(viewBy[0].localIdentifier),
+                    newAvailableSortsGroup(
+                        viewBy[1].localIdentifier,
+                        isEmpty(stackBy) ? [...measures.map((m) => m.localIdentifier)] : [],
+                        true,
+                        isStacked || measures.length > 1,
+                    ),
                 ],
             };
         }
@@ -168,16 +145,10 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
             return {
                 defaultSort: [newAttributeAreaSort(viewBy[0].localIdentifier, "desc")],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: true,
-                        },
-                        metricSorts: isEmpty(stackBy)
-                            ? [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))]
-                            : [],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        isEmpty(stackBy) ? [...measures.map((m) => m.localIdentifier)] : [],
+                    ),
                 ],
             };
         }
@@ -186,14 +157,12 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
             return {
                 defaultSort: [newMeasureSort(measures[0].localIdentifier, "desc")],
                 availableSorts: [
-                    {
-                        itemId: localIdRef(viewBy[0].localIdentifier),
-                        attributeSort: {
-                            normalSortEnabled: true,
-                            areaSortEnabled: measures.length > 1,
-                        },
-                        metricSorts: [...measures.map((m) => newMeasureSortSuggestion(m.localIdentifier))],
-                    },
+                    newAvailableSortsGroup(
+                        viewBy[0].localIdentifier,
+                        [...measures.map((m) => m.localIdentifier)],
+                        true,
+                        measures.length > 1,
+                    ),
                 ],
             };
         }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -13,7 +13,6 @@ import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { ISortConfig, newAvailableSortsGroup } from "../../../interfaces/SortConfig";
 import { getBucketItems } from "../../../utils/bucketHelper";
 import { canSortStackTotalValue } from "./sortHelpers";
-import { validateCurrentSort } from "../../../utils/sort";
 
 /**
  * PluggableBarChart
@@ -174,19 +173,17 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
     }
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { buckets, properties } = referencePoint;
-        const currentSort = properties && properties.sortItems;
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(
             referencePoint,
             canSortStackTotalValue(buckets, properties),
         );
-        const keptCurrentSort = validateCurrentSort(currentSort, availableSorts, defaultSort);
         const disabled = viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0;
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: currentSort && currentSort.length ? keptCurrentSort : [],
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts: availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -13,6 +13,7 @@ import { AXIS, AXIS_NAME } from "../../../constants/axis";
 import { ISortConfig, newMeasureSortSuggestion } from "../../../interfaces/SortConfig";
 import { getBucketItems } from "../../../utils/bucketHelper";
 import { canSortStackTotalValue } from "./sortHelpers";
+import { validateCurrentSort } from "../../../utils/sort";
 
 /**
  * PluggableBarChart
@@ -96,7 +97,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         referencePoint: IReferencePoint,
         canSortStackTotalValue: boolean,
     ): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const { buckets } = referencePoint;
@@ -204,17 +205,20 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
     }
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { buckets, properties } = referencePoint;
+        const currentSort = properties && properties.sortItems;
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(
             referencePoint,
             canSortStackTotalValue(buckets, properties),
         );
+        const keptCurrentSort = validateCurrentSort(currentSort, availableSorts, defaultSort);
         const disabled = viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0;
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            appliedSort: currentSort && currentSort.length ? keptCurrentSort : [],
+            defaultSort,
             availableSorts: availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/PluggableBarChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/PluggableBarChart.test.tsx
@@ -178,7 +178,7 @@ describe("PluggableBarChart", () => {
 
             const sortConfig = await chart.getSortConfig(referencePointMocks.oneMetricOneCategory);
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide attribute area sort and measureSort as default sort for 1M + 2 VB", async () => {
@@ -188,7 +188,7 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.oneMetricAndTwoCategoriesReferencePoint,
             );
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide two attribute area sorts as default sort for 1M + 2 VB + 1SB", async () => {
@@ -198,7 +198,7 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.oneMetricAndManyCategoriesAndOneStackRefPoint,
             );
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide measureSort by first measure as default sort for 2M + 1 VB", async () => {
@@ -206,7 +206,7 @@ describe("PluggableBarChart", () => {
 
             const sortConfig = await chart.getSortConfig(referencePointMocks.twoMetricAndOneCategoryRefPoint);
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide attribute area sort as default sort for 2 stacked M + 1 VB", async () => {
@@ -216,7 +216,7 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.twoStackedMetricAndOneCategoryRefPoint,
             );
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide areaSort+measureSort by first measure as default sort for 2M + 2 VB", async () => {
@@ -226,7 +226,7 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.twoMetricAndTwoCategoriesRefPoint,
             );
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         it("should provide two areaSorts as default sort for 2 stacked M + 2 VB", async () => {
@@ -236,7 +236,7 @@ describe("PluggableBarChart", () => {
                 referencePointMocks.twoStackedMetricAndTwoCategoriesRefPoint,
             );
 
-            expect(sortConfig.currentSort).toMatchSnapshot();
+            expect(sortConfig.defaultSort).toMatchSnapshot();
         });
 
         const Scenarios: Array<[string, IReferencePoint]> = [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/__snapshots__/PluggableBarChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/tests/__snapshots__/PluggableBarChart.test.tsx.snap
@@ -142,7 +142,6 @@ Array [
     "itemId": Object {
       "localIdentifier": "a1",
     },
-    "metricSorts": Array [],
   },
 ]
 `;
@@ -192,7 +191,6 @@ Array [
     "itemId": Object {
       "localIdentifier": "a2",
     },
-    "metricSorts": Array [],
   },
 ]
 `;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -9,6 +9,7 @@ import {
     insightBuckets,
     insightHasMeasures,
     insightMeasures,
+    ISortItem,
 } from "@gooddata/sdk-model";
 import { BucketNames, ChartType, VisualizationTypes } from "@gooddata/sdk-ui";
 import {
@@ -40,6 +41,7 @@ import {
     IVisProps,
     IVisualizationProperties,
 } from "../../../interfaces/Visualization";
+import { IAvailableSortsGroup } from "../../../interfaces/SortConfig";
 import { configureOverTimeComparison, configurePercent } from "../../../utils/bucketConfig";
 
 import {
@@ -63,7 +65,7 @@ import {
     hasColorMapping,
     isEmptyObject,
 } from "../../../utils/propertiesHelper";
-import { createSorts, removeSort } from "../../../utils/sort";
+import { createSorts, removeSort, validateCurrentSort } from "../../../utils/sort";
 import { getTranslation } from "../../../utils/translations";
 
 import {
@@ -461,6 +463,15 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     protected isMultipleDatesEnabled(): boolean {
         //this is development FF and will be removed in the end of dev cycle
         return !!this.featureFlags["enableMultipleDates"];
+    }
+
+    protected reuseCurrentSort(
+        properties: IVisualizationProperties,
+        availableSorts: IAvailableSortsGroup[],
+        defaultSort: ISortItem[],
+    ) {
+        const currentSort = properties && properties.sortItems;
+        return validateCurrentSort(currentSort, availableSorts, defaultSort);
     }
 }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -141,7 +141,9 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
             this.supportedPropertiesList,
         );
         newReferencePoint = setBaseChartUiConfig(newReferencePoint, this.intl, this.type);
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -124,7 +124,9 @@ export class PluggableBulletChart extends PluggableBaseChart {
             newReferencePoint,
             this.supportedPropertiesList,
         );
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
@@ -212,7 +214,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
     }
 
     private getDefaultAndAvailableSort(referencePoint: IReferencePoint): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const { buckets } = referencePoint;
@@ -270,7 +272,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -269,9 +269,11 @@ export class PluggableBulletChart extends PluggableBaseChart {
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
         const disabled = this.isSortDisabled(referencePoint, availableSorts);
+        const { properties } = referencePoint;
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -23,7 +23,7 @@ Object {
       "metricSorts": Array [],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -39,7 +39,7 @@ Object {
 exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -70,7 +70,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -117,7 +117,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -171,7 +171,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -228,7 +228,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -292,7 +292,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -359,7 +359,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -11,6 +12,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -38,6 +40,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -47,6 +50,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -85,6 +89,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 1 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -138,6 +143,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 2 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -186,6 +192,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -249,6 +256,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 3 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -307,6 +315,7 @@ Object {
 
 exports[`PluggableBulletChart Sort config should return expected sort config for 3 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -65,7 +65,7 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
         stackBy: IBucketItem[],
         canSortStackTotalValue: boolean,
     ): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const defaultSort = viewBy.map((vb) => newAttributeSort(vb.localIdentifier, "asc"));
@@ -176,7 +176,7 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -176,6 +176,7 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/PluggableColumnChart.test.tsx
@@ -180,7 +180,9 @@ describe("PluggableColumnChart", () => {
         it("should provide attribute normal sort as default sort, attribute normal and attribute area available sorts for 1M + 1VB + 1SB", async () => {
             const chart = createComponent(defaultProps);
 
-            const sortConfig = await chart.getSortConfig(referencePointMocks.simpleStackedReferencePoint);
+            const sortConfig = await chart.getSortConfig(
+                referencePointMocks.simpleStackedWithoutPropertiesReferencePoint,
+            );
 
             expect(sortConfig).toMatchSnapshot();
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
@@ -35,7 +35,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -62,7 +62,7 @@ Object {
       "metricSorts": Array [],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -98,7 +98,7 @@ Object {
       "metricSorts": Array [],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -142,7 +142,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -190,7 +190,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -237,7 +237,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -300,7 +300,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -363,7 +363,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/tests/__snapshots__/PluggableColumnChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sort as default sort, attribute area and measure sort as available sorts for 2M + 1VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -50,6 +51,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sort as default sort, attribute normal and attribute area available sorts for 1M + 1VB + 1SB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -77,6 +79,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sort as default sort, attribute normal and attribute area available sorts for 1M + 2VB + 1SB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -119,6 +122,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sort as default sort, attribute normal and measure sort as available sorts for 1M + 1VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -157,6 +161,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sort as default sort, one attribute area and two measure sorts as available sorts for 2 stacked M + 1VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -205,6 +210,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide attribute normal sorts as default sort, two attribute normal, one area sort and one measure sort as available sort for 1M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -258,6 +264,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide two attribute normal sorts as default sort, two attribute area and one measure sorts as available sorts for 2 stacked M + 2VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -321,6 +328,7 @@ Object {
 
 exports[`PluggableColumnChart Sort config should provide two attribute normal sorts as default sort, two attribute area and one measure sorts as available sorts for 2M + 2VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -157,7 +157,9 @@ export class PluggableComboChart extends PluggableBaseChart {
             this.supportedPropertiesList,
         );
         newReferencePoint = applyUiConfig(newReferencePoint);
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
@@ -279,7 +281,7 @@ export class PluggableComboChart extends PluggableBaseChart {
         buckets: IBucketOfFun[],
         properties: IVisualizationProperties,
     ): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const measures = getBucketItemsByType(buckets, BucketNames.MEASURES, [METRIC]);
@@ -338,7 +340,7 @@ export class PluggableComboChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -340,6 +340,7 @@ export class PluggableComboChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
@@ -35,7 +35,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -83,7 +83,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -121,7 +121,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -159,7 +159,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area  and two measures sorts as available sorts for 2 primary measures stacked + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -50,6 +51,7 @@ Object {
 
 exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -98,6 +100,7 @@ Object {
 
 exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute normal and measue sort as available sorts for 1 seconday measure + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -136,6 +139,7 @@ Object {
 
 exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute normal and measure sort as available sorts for 1 primary measure + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/PluggableFunnelChart.tsx
@@ -7,6 +7,7 @@ import { PluggablePieChart } from "../pieChart/PluggablePieChart";
 import { setFunnelChartUiConfig } from "../../../utils/uiConfigHelpers/funnelChartUiConfigHelper";
 import UnsupportedConfigurationPanel from "../../configurationPanels/UnsupportedConfigurationPanel";
 import { VisualizationTypes } from "@gooddata/sdk-ui";
+import { ISortConfig } from "../../../interfaces/SortConfig";
 
 /**
  * PluggableFunnelChart
@@ -60,5 +61,14 @@ export class PluggableFunnelChart extends PluggablePieChart {
                 document.querySelector(this.configPanelElement),
             );
         }
+    }
+
+    public getSortConfig(_referencePoint: IReferencePoint): Promise<ISortConfig> {
+        return Promise.resolve({
+            defaultSort: [],
+            availableSorts: [],
+            supported: false,
+            disabled: false,
+        });
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -234,7 +234,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets } = referencePoint;
+        const { buckets, properties } = referencePoint;
         const measures = getMeasureItems(buckets);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const stackBy = getBucketItems(buckets, BucketNames.STACK);
@@ -245,6 +245,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -143,7 +143,9 @@ export class PluggableHeatmap extends PluggableBaseChart {
             newReferencePoint,
             this.supportedPropertiesList,
         );
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
@@ -168,7 +170,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         viewBy: IBucketItem[],
         stackBy: IBucketItem[],
     ): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         if (!isEmpty(viewBy) && !isEmpty(stackBy) && !isEmpty(measures)) {
@@ -243,7 +245,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -22,7 +22,7 @@ Object {
       },
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -54,7 +54,7 @@ Object {
       },
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a3",
@@ -92,7 +92,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute are sorts as available sorts for 1M + 1VB + 1SB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -43,6 +44,7 @@ Object {
 
 exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute area sorts as available sorts for 1M + 1SB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -69,6 +71,7 @@ Object {
 
 exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute normal and measuree sorts as available sorts for 1M + 1VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -126,7 +126,9 @@ export class PluggableLineChart extends PluggableBaseChart {
             newReferencePoint,
             this.supportedPropertiesList,
         );
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
@@ -142,7 +144,7 @@ export class PluggableLineChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }
@@ -280,7 +282,7 @@ export class PluggableLineChart extends PluggableBaseChart {
     }
 
     private getDefaultAndAvailableSort(referencePoint: IReferencePoint): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const { buckets } = referencePoint;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -141,9 +141,11 @@ export class PluggableLineChart extends PluggableBaseChart {
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
         const disabled = this.isSortDisabled(referencePoint, availableSorts);
+        const { properties } = referencePoint;
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PluggableLineChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -12,7 +12,7 @@ Object {
 exports[`PluggableLineChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -21,7 +21,7 @@ Object {
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -40,7 +40,7 @@ Object {
       },
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -78,7 +78,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -94,7 +94,7 @@ Object {
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 2 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -113,7 +113,7 @@ Object {
       },
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -161,7 +161,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -177,7 +177,7 @@ Object {
 exports[`PluggableLineChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }
@@ -218,7 +218,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
@@ -234,7 +234,7 @@ Object {
 exports[`PluggableLineChart Sort config should return expected sort config for 2 stacked M + 2 VB 1`] = `
 Object {
   "availableSorts": Array [],
-  "currentSort": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/__snapshots__/PluggableLineChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggableLineChart Sort config should return expected sort config for 0 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -11,6 +12,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -20,6 +22,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 0 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -29,6 +32,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 1 VB + 1 SEG 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -55,6 +59,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -93,6 +98,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 1 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -102,6 +108,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 2 M + 1 VB + 1 SEG 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -128,6 +135,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 2 M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -176,6 +184,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 2 M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,
@@ -185,6 +194,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 2 stacked M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {
@@ -233,6 +243,7 @@ Object {
 
 exports[`PluggableLineChart Sort config should return expected sort config for 2 stacked M + 2 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [],
   "defaultSort": Array [],
   "disabled": true,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -143,7 +143,9 @@ export class PluggablePieChart extends PluggableBaseChart {
             newReferencePoint,
             this.supportedPropertiesList,
         );
-        newReferencePoint = removeSort(newReferencePoint);
+        if (!this.featureFlags.enableChartsSorting) {
+            newReferencePoint = removeSort(newReferencePoint);
+        }
 
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
@@ -152,7 +154,7 @@ export class PluggablePieChart extends PluggableBaseChart {
         measures: IBucketItem[],
         viewBy: IBucketItem[],
     ): {
-        defaultSort: ISortConfig["currentSort"];
+        defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         if (!isEmpty(measures) && !isEmpty(viewBy)) {
@@ -187,7 +189,7 @@ export class PluggablePieChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            currentSort: defaultSort,
+            defaultSort,
             availableSorts,
         });
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -180,7 +180,7 @@ export class PluggablePieChart extends PluggableBaseChart {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets } = referencePoint;
+        const { buckets, properties } = referencePoint;
         const measures = getMeasureItems(buckets);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(measures, viewBy);
@@ -189,6 +189,7 @@ export class PluggablePieChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
+            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
             defaultSort,
             availableSorts,
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/PluggablePieChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/PluggablePieChart.test.tsx
@@ -253,7 +253,9 @@ describe("PluggablePieChart", () => {
         it("should provide measure sort as default sort, measure sort as available sorts for 1M + 1 VB", async () => {
             const chart = createComponent(defaultProps);
 
-            const sortConfig = await chart.getSortConfig(referencePointMocks.simpleStackedReferencePoint);
+            const sortConfig = await chart.getSortConfig(
+                referencePointMocks.simpleStackedWithoutPropertiesReferencePoint,
+            );
 
             expect(sortConfig).toMatchSnapshot();
         });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PluggablePieChart Sort config should provide measure sort as default sort, measure sort as available sorts for 1M + 1 VB 1`] = `
 Object {
+  "appliedSort": Array [],
   "availableSorts": Array [
     Object {
       "attributeSort": Object {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/tests/__snapshots__/PluggablePieChart.test.tsx.snap
@@ -25,7 +25,7 @@ Object {
       ],
     },
   ],
-  "currentSort": Array [
+  "defaultSort": Array [
     Object {
       "measureSortItem": Object {
         "direction": "desc",

--- a/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/tests/BaseVisualization.test.tsx
@@ -386,7 +386,7 @@ describe("BaseVisualization", () => {
                 }),
                 expect.objectContaining({
                     availableSorts: [],
-                    currentSort: [],
+                    defaultSort: [],
                     disabled: false,
                     supported: false,
                 }),

--- a/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
@@ -7,6 +7,7 @@ import {
     IMeasureSortTarget,
     LocalIdRef,
     ISortItem,
+    localIdRef,
 } from "@gooddata/sdk-model";
 
 /**
@@ -55,6 +56,39 @@ export interface IAvailableSortsGroup {
      */
     explanation?: string;
 }
+
+/**
+ * @internal
+ */
+export const newAvailableSortsGroup = (
+    attributeId: string,
+    measureIds: string[] = [],
+    normalSortEnabled: boolean = true,
+    areaSortEnabled: boolean = true,
+    explanation?: string,
+): IAvailableSortsGroup => {
+    const metricSortsProp = measureIds.length
+        ? {
+              metricSorts: [
+                  ...measureIds.map((localIdentifier) => newMeasureSortSuggestion(localIdentifier)),
+              ],
+          }
+        : {};
+    const explanationProp = explanation
+        ? {
+              explanation,
+          }
+        : {};
+    return {
+        itemId: localIdRef(attributeId),
+        attributeSort: {
+            normalSortEnabled,
+            areaSortEnabled,
+        },
+        ...metricSortsProp,
+        ...explanationProp,
+    };
+};
 
 /**
  * @internal

--- a/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/SortConfig.ts
@@ -61,9 +61,14 @@ export interface IAvailableSortsGroup {
  */
 export interface ISortConfig {
     /**
-     * Current sort - default or chosen from inside of visualization
+     * Applied sort - when custom sort was provided, it is validated in current context of visualization and can be fully or partially applied.
+     * When defined it has priority over defaultSort
      */
-    currentSort: ISortItem[];
+    appliedSort?: ISortItem[];
+    /**
+     * Default sort - default or chosen from inside of visualization
+     */
+    defaultSort: ISortItem[];
     /**
      * All available sorts for current buckets
      * - should contain current sort too

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -727,6 +727,11 @@ export const simpleStackedReferencePoint: IReferencePoint = {
     },
 };
 
+export const simpleStackedWithoutPropertiesReferencePoint: IReferencePoint = {
+    ...simpleStackedReferencePoint,
+    properties: {},
+};
+
 export const oneMetricReferencePoint: IReferencePoint = {
     buckets: [
         {

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -19,7 +19,7 @@ import {
     newAttributeAreaSort,
     ILocatorItem,
     isAttributeAreaSort,
-    isAttributeSimpleSort,
+    isAttributeValueSort,
     isMeasureSort,
     sortMeasureLocators,
     IMeasureSortItem,
@@ -192,7 +192,7 @@ function isValidateAreaSort(areaSort: ISortItem, availableSort: IAvailableSortsG
 
 function isValidAttributeSort(attributeSort: ISortItem, availableSort: IAvailableSortsGroup) {
     return (
-        isAttributeSimpleSort(attributeSort) &&
+        isAttributeValueSort(attributeSort) &&
         availableSort &&
         attributeSort.attributeSortItem.attributeIdentifier === availableSort.itemId.localIdentifier &&
         availableSort.attributeSort?.normalSortEnabled
@@ -267,7 +267,7 @@ export function validateCurrentSort(
             if (currentSortItem) {
                 const currentSortDirection = sortDirection(currentSortItem);
                 if (
-                    isAttributeSimpleSort(currentSortItem) &&
+                    isAttributeValueSort(currentSortItem) &&
                     availableSortGroup.attributeSort.normalSortEnabled
                 ) {
                     return newAttributeSort(availableSortGroup.itemId.localIdentifier, currentSortDirection);

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -14,7 +14,7 @@ import {
     insightSorts,
     newAttributeSort,
     newMeasureSort,
-    newMeasureSortFromParts,
+    newMeasureSortFromLocators,
     SortDirection,
     ISortItem,
     newAttributeAreaSort,
@@ -182,7 +182,7 @@ export function removeSort(referencePoint: Readonly<IExtendedReferencePoint>): I
     return referencePoint;
 }
 
-function isValidateAreaSort(areaSort: ISortItem, availableSort: IAvailableSortsGroup) {
+function isValidAreaSort(areaSort: ISortItem, availableSort: IAvailableSortsGroup) {
     return (
         isAttributeAreaSort(areaSort) &&
         availableSort &&
@@ -222,12 +222,12 @@ function findReusableSort(
     currentSort: ISortItem[],
     availableSortGroup: IAvailableSortsGroup,
     groupIndex: number,
-    attributeValidationFce: (attributeSort: ISortItem, availableSort: IAvailableSortsGroup) => boolean,
+    attributeValidationPredicate: (attributeSort: ISortItem, availableSort: IAvailableSortsGroup) => boolean,
 ) {
     const modifiedSorts = [...currentSort];
 
     const attributeSortIndex = currentSort.findIndex((sortItem) =>
-        attributeValidationFce(sortItem, availableSortGroup),
+        attributeValidationPredicate(sortItem, availableSortGroup),
     );
     if (attributeSortIndex !== -1) {
         const reusedItem = currentSort[attributeSortIndex];
@@ -255,7 +255,7 @@ function handleDifferentOrder(
         }
     }
     if (availableSortGroup.attributeSort.areaSortEnabled) {
-        const found = findReusableSort(currentSort, availableSortGroup, groupIndex, isValidateAreaSort);
+        const found = findReusableSort(currentSort, availableSortGroup, groupIndex, isValidAreaSort);
         if (found) {
             return found;
         }
@@ -275,7 +275,7 @@ function reuseSortItemType(currentSortItem: ISortItem, availableSortGroup: IAvai
             }
             const availableMetricSort = availableSortGroup.metricSorts && availableSortGroup.metricSorts[0];
             if (availableMetricSort) {
-                return newMeasureSortFromParts(availableMetricSort.locators, currentSortDirection);
+                return newMeasureSortFromLocators(availableMetricSort.locators, currentSortDirection);
             }
         }
         if (isMeasureSort(currentSortItem)) {
@@ -284,7 +284,7 @@ function reuseSortItemType(currentSortItem: ISortItem, availableSortGroup: IAvai
             }
             const availableMetricSort = availableSortGroup.metricSorts && availableSortGroup.metricSorts[0];
             if (availableMetricSort) {
-                return newMeasureSortFromParts(availableMetricSort.locators, currentSortDirection);
+                return newMeasureSortFromLocators(availableMetricSort.locators, currentSortDirection);
             }
             if (availableSortGroup.attributeSort.areaSortEnabled) {
                 return newAttributeAreaSort(availableSortGroup.itemId.localIdentifier, currentSortDirection);

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -274,7 +274,7 @@ export function validateCurrentSort(
                 }
                 if (isAttributeAreaSort(currentSortItem)) {
                     if (availableSortGroup.attributeSort.areaSortEnabled) {
-                        return newAttributeSort(
+                        return newAttributeAreaSort(
                             availableSortGroup.itemId.localIdentifier,
                             currentSortDirection,
                         );

--- a/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
@@ -5,6 +5,7 @@ import {
     getAttributeSortItem,
     getBucketItemIdentifiers,
     getDefaultTreemapSortFromBuckets,
+    validateCurrentSort,
 } from "../sort";
 import { IExtendedReferencePoint } from "../../interfaces/Visualization";
 import * as referencePointMocks from "../../tests/mocks/referencePointMocks";
@@ -22,9 +23,13 @@ import {
     IMeasureSortItem,
     ISortItem,
     newAttribute,
+    newAttributeAreaSort,
+    newAttributeSort,
     newBucket,
     newMeasure,
+    newMeasureSort,
 } from "@gooddata/sdk-model";
+import { newAvailableSortsGroup } from "../../interfaces/SortConfig";
 
 const attributeSort: IAttributeSortItem = {
     attributeSortItem: {
@@ -234,5 +239,23 @@ describe("getDefaultTreemapSortFromBuckets", () => {
                 },
             },
         ]);
+    });
+});
+
+describe("validateCurrentSort", () => {
+    it("should handle empty currentSort", () => {
+        expect(
+            validateCurrentSort([], [newAvailableSortsGroup("a1")], [newAttributeSort("a1", "asc")]),
+        ).toEqual([]);
+    });
+
+    it("should reuse attribute sort which changed only the order", () => {
+        expect(
+            validateCurrentSort(
+                [newMeasureSort("m1", "desc"), newAttributeSort("a1", "asc")],
+                [newAvailableSortsGroup("a1"), newAvailableSortsGroup("a2", ["m1"])],
+                [newAttributeAreaSort("a1", "asc"), newMeasureSort("m1", "desc")],
+            ),
+        ).toEqual([newAttributeSort("a1", "asc"), newMeasureSort("m1", "desc")]);
     });
 });

--- a/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/tests/sort.test.ts
@@ -258,4 +258,74 @@ describe("validateCurrentSort", () => {
             ),
         ).toEqual([newAttributeSort("a1", "asc"), newMeasureSort("m1", "desc")]);
     });
+
+    it("should reuse both numeric sorts when attributes changed the order", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc"), newMeasureSort("m1", "desc")],
+                [newAvailableSortsGroup("a2"), newAvailableSortsGroup("a1", ["m1", "m2"])],
+                [newAttributeAreaSort("a2", "asc"), newMeasureSort("m1", "desc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a2", "desc"), newAttributeAreaSort("a1", "desc")]);
+    });
+
+    it("should keep second attribute sort when first attribute removed", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeSort("a1", "asc"), newAttributeSort("a2", "desc")],
+                [newAvailableSortsGroup("a2", ["m1", "m2"])],
+                [newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeSort("a2", "desc")]);
+    });
+
+    it("should keep type of numeric sort from first item when first attribute removed", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc"), newMeasureSort("m1", "desc")],
+                [newAvailableSortsGroup("a2", ["m1", "m2"])],
+                [newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a2", "desc")]);
+    });
+
+    it("should keep whole sort when first attribute replaced", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc"), newMeasureSort("m1", "desc")],
+                [newAvailableSortsGroup("a3"), newAvailableSortsGroup("a2", ["m1", "m2"])],
+                [newAttributeSort("a3", "asc"), newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a3", "desc"), newMeasureSort("m1", "desc")]);
+    });
+
+    it("should keep first sort when second attribute removed", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc"), newMeasureSort("m1", "desc")],
+                [newAvailableSortsGroup("a1", ["m1", "m2"])],
+                [newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a1", "desc")]);
+    });
+
+    it("should still apply second numeric sort when only one of measures removed and some still remain", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc"), newMeasureSort("m1", "desc")],
+                [newAvailableSortsGroup("a1", []), newAvailableSortsGroup("a2", ["m2"])],
+                [newAttributeSort("a1", "asc"), newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a1", "desc"), newMeasureSort("m2", "desc")]);
+    });
+
+    it("should apply default sort to newly added second attribute", () => {
+        expect(
+            validateCurrentSort(
+                [newAttributeAreaSort("a1", "desc")],
+                [newAvailableSortsGroup("a1", []), newAvailableSortsGroup("a2", ["m1", "m2"])],
+                [newAttributeSort("a1", "asc"), newAttributeSort("a2", "asc")],
+            ),
+        ).toEqual([newAttributeAreaSort("a1", "desc"), newAttributeSort("a2", "asc")]);
+    });
 });

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -198,8 +198,6 @@ export interface ChartSortingOwnProps {
     onApply: (sortItems: ISortItem[]) => void;
     // (undocumented)
     onCancel: () => void;
-    // (undocumented)
-    onClose?: () => void;
 }
 
 // @internal (undocumented)
@@ -792,9 +790,19 @@ export interface IBubbleTriggerState {
 }
 
 // @internal (undocumented)
+export interface IBucketItemDescriptor {
+    // (undocumented)
+    name: string;
+    // (undocumented)
+    sequenceNumber?: string;
+    // (undocumented)
+    type: "attribute" | "chronologicalDate" | "genericDate" | "measure";
+}
+
+// @internal (undocumented)
 export interface IBucketItemDescriptors {
     // (undocumented)
-    [localIdentifier: string]: IIBucketItemDescriptor;
+    [localIdentifier: string]: IBucketItemDescriptor;
 }
 
 // @internal (undocumented)
@@ -1555,16 +1563,6 @@ export interface IHubspotConversionTouchPointDialogBaseProps {
 export interface IHubspotFormValue {
     // (undocumented)
     [key: string]: string | number | boolean;
-}
-
-// @internal (undocumented)
-export interface IIBucketItemDescriptor {
-    // (undocumented)
-    name: string;
-    // (undocumented)
-    sequenceNumber?: string;
-    // (undocumented)
-    type: "attribute" | "chronologicalDate" | "genericDate" | "measure";
 }
 
 // @internal (undocumented)

--- a/libs/sdk-ui-kit/src/ChartSorting/ChartSorting.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/ChartSorting.tsx
@@ -19,7 +19,6 @@ export interface ChartSortingOwnProps {
     bucketItems: IBucketItemDescriptors;
     onApply: (sortItems: ISortItem[]) => void;
     onCancel: () => void;
-    onClose?: () => void;
     buttonNode?: HTMLElement | string;
     locale?: string;
     enableRenamingMeasureToMetric?: boolean;

--- a/libs/sdk-ui-kit/src/ChartSorting/index.ts
+++ b/libs/sdk-ui-kit/src/ChartSorting/index.ts
@@ -12,6 +12,6 @@ export {
     MeasureSortSuggestion,
     SORT_TARGET_TYPE,
     ISortTypeItem,
-    IIBucketItemDescriptor,
+    IBucketItemDescriptor,
     IBucketItemDescriptors,
 } from "./types";

--- a/libs/sdk-ui-kit/src/ChartSorting/types.ts
+++ b/libs/sdk-ui-kit/src/ChartSorting/types.ts
@@ -69,7 +69,7 @@ export interface IMeasureDropdownValue {
 /**
  * @internal
  */
-export interface IIBucketItemDescriptor {
+export interface IBucketItemDescriptor {
     type: "attribute" | "chronologicalDate" | "genericDate" | "measure";
     name: string;
     sequenceNumber?: string;
@@ -79,7 +79,7 @@ export interface IIBucketItemDescriptor {
  * @internal
  */
 export interface IBucketItemDescriptors {
-    [localIdentifier: string]: IIBucketItemDescriptor;
+    [localIdentifier: string]: IBucketItemDescriptor;
 }
 
 /**


### PR DESCRIPTION
JIRA: TNT-463
Reuse existing custom sort whenever it is possible

JIRA: TNT-546 
Turn off custom sorting for funnel chart

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
