### PR TITLE
Fix issue in chart sort dialog when current sort does not match available sorts length

### DIFF
--- a/libs/sdk-ui-kit/src/ChartSorting/ChartSortingDropdown.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/ChartSortingDropdown.tsx
@@ -37,32 +37,34 @@ export const ChartSortingDropdown: React.FC<ChartSortingProps> = ({
 
     return (
         <div className="gd-sort-attribute-section">
-            {currentSort &&
-                currentSort.map((currentSortItem: ISortItem, index: number) => {
-                    // Obtain available items with the same id as current index
-                    const available: IAvailableSortsGroup = availableSorts[index];
+            {availableSorts?.map((availableSort: IAvailableSortsGroup, index: number) => {
+                // Obtain current sort item with the same id as current index
+                const currentSortItem: ISortItem = currentSort[index];
 
-                    return (
-                        <div key={index} className={`gd-sort-attribute-item s-sort-attribute-item-${index}`}>
-                            {currentSort.length > 1 && (
-                                <div className="attribute-sorting-title">
-                                    {getAttributeName(bucketItems, available)}
-                                </div>
-                            )}
-                            <AttributeDropdown
-                                index={index}
-                                currentSortItem={currentSortItem}
-                                availableSorts={available}
-                                bucketItems={bucketItems}
-                                intl={intl}
-                                onSelect={(newSort: ISortItem) => {
-                                    onSortChanged(newSort, index);
-                                }}
-                                enableRenamingMeasureToMetric={enableRenamingMeasureToMetric}
-                            />
-                        </div>
-                    );
-                })}
+                if (!currentSortItem) {
+                    return null;
+                }
+                return (
+                    <div key={index} className={`gd-sort-attribute-item s-sort-attribute-item-${index}`}>
+                        {availableSorts.length > 1 && (
+                            <div className="attribute-sorting-title">
+                                {getAttributeName(bucketItems, availableSort)}
+                            </div>
+                        )}
+                        <AttributeDropdown
+                            index={index}
+                            currentSortItem={currentSortItem}
+                            availableSorts={availableSort}
+                            bucketItems={bucketItems}
+                            intl={intl}
+                            onSelect={(newSort: ISortItem) => {
+                                onSortChanged(newSort, index);
+                            }}
+                            enableRenamingMeasureToMetric={enableRenamingMeasureToMetric}
+                        />
+                    </div>
+                );
+            })}
         </div>
     );
 };

--- a/libs/sdk-ui-kit/src/ChartSorting/test/ChartSorting.test.tsx
+++ b/libs/sdk-ui-kit/src/ChartSorting/test/ChartSorting.test.tsx
@@ -283,5 +283,13 @@ describe("ChartSorting", () => {
                 },
             ]);
         });
+
+        it("should render when current sort does not match available sorts length", () => {
+            const component = renderComponent({
+                availableSorts: multipleAttributesSortConfig.availableSorts,
+                currentSort: singleNormalAttributeSortConfig.currentSort,
+            });
+            expect(component.find(".s-attribute-dropdown-button").hostNodes().length).toBe(1);
+        });
     });
 });


### PR DESCRIPTION
Additionally, the logic of generating available sort controls in UI was changed to be generated from available sorts array instead of current sorts array to make the code more understandable.

JIRA: TNT-514

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
