### PR TITLE
Fix availableSorts in moment of disabled sort

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -100,6 +100,13 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
+        if (this.isSortDisabled(referencePoint).disabled) {
+            return {
+                defaultSort: [],
+                availableSorts: [],
+            };
+        }
+
         const { buckets } = referencePoint;
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
@@ -173,11 +180,11 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
             availableSorts: [],
         };
     }
-    private isSortDisabled(referencePoint: IReferencePoint, availableSorts: ISortConfig["availableSorts"]) {
+    private isSortDisabled(referencePoint: IReferencePoint) {
         const { buckets } = referencePoint;
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const measures = getBucketItems(buckets, BucketNames.MEASURES);
-        const disabled = viewBy.length < 1 || measures.length < 1 || availableSorts.length === 0;
+        const disabled = viewBy.length < 1 || measures.length < 1;
         const disabledExplanation = getCustomSortDisabledExplanation(measures, viewBy, this.intl);
         return {
             disabled,
@@ -192,7 +199,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
             canSortStackTotalValue(buckets, properties),
         );
 
-        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
+        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint);
 
         return Promise.resolve({
             supported: true,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -205,13 +205,13 @@ export class PluggableBulletChart extends PluggableBaseChart {
         return true;
     }
 
-    private isSortDisabled(referencePoint: IReferencePoint, availableSorts: ISortConfig["availableSorts"]) {
+    private isSortDisabled(referencePoint: IReferencePoint) {
         const { buckets } = referencePoint;
         const primaryMeasures = getBucketItems(buckets, BucketNames.MEASURES);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const disabledExplanation = getCustomSortDisabledExplanation(primaryMeasures, viewBy, this.intl);
         return {
-            disabled: viewBy.length < 1 || primaryMeasures.length < 1 || availableSorts.length === 0,
+            disabled: viewBy.length < 1 || primaryMeasures.length < 1,
             disabledExplanation,
         };
     }
@@ -220,6 +220,12 @@ export class PluggableBulletChart extends PluggableBaseChart {
         defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
+        if (this.isSortDisabled(referencePoint).disabled) {
+            return {
+                defaultSort: [],
+                availableSorts: [],
+            };
+        }
         const { buckets } = referencePoint;
         const measures = getAllItemsByType(buckets, [METRIC]);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
@@ -261,7 +267,7 @@ export class PluggableBulletChart extends PluggableBaseChart {
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
-        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
+        const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint);
         const { properties } = referencePoint;
         return Promise.resolve({
             supported: true,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/__snapshots__/PluggableBulletChart.test.tsx.snap
@@ -14,25 +14,8 @@ Object {
 exports[`PluggableBulletChart Sort config should return expected sort config for 0 M + 1 VB 1`] = `
 Object {
   "appliedSort": Array [],
-  "availableSorts": Array [
-    Object {
-      "attributeSort": Object {
-        "areaSortEnabled": false,
-        "normalSortEnabled": true,
-      },
-      "itemId": Object {
-        "localIdentifier": "a1",
-      },
-    },
-  ],
-  "defaultSort": Array [
-    Object {
-      "attributeSortItem": Object {
-        "attributeIdentifier": "a1",
-        "direction": "asc",
-      },
-    },
-  ],
+  "availableSorts": Array [],
+  "defaultSort": Array [],
   "disabled": true,
   "supported": true,
 }


### PR DESCRIPTION
JIRA: TNT-548

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description            |
| ------------------------ | ---------------------- |
| `ok to test`             | Re-run standard checks |
| `extended test`          | BackstopJS tests       |
| `extended check sonar`   | SonarQube tests        |
| `extended check cypress` | Cypress E2E tests      |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
