### PR TITLE
Previous available sorts provided by AD

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -284,7 +284,10 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         currentReferencePoint: IReferencePoint,
         nextReferencePoint: IReferencePoint,
     ) {
-        return !isEqual(omit(currentReferencePoint, "properties"), omit(nextReferencePoint, "properties"));
+        return !isEqual(
+            omit(currentReferencePoint, ["properties", "availableSorts"]),
+            omit(nextReferencePoint, ["properties", "availableSorts"]),
+        );
     }
 
     private static propertiesControlsHasChanged(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -159,12 +159,17 @@ export class PluggableAreaChart extends PluggableBaseChart {
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
-        const { properties } = referencePoint;
+        const { properties, availableSorts: previousAvailableSorts } = referencePoint;
         const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/PluggableBarChart.tsx
@@ -192,7 +192,7 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         };
     }
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets, properties } = referencePoint;
+        const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
 
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(
             referencePoint,
@@ -204,7 +204,12 @@ export class PluggableBarChart extends PluggableColumnBarCharts {
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts: availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -94,7 +94,6 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     protected axis: string;
     protected secondaryAxis: AxisType;
     protected environment: string;
-    protected previousAvailableSorts: IAvailableSortsGroup[];
     protected readonly renderFun: (component: any, target: Element) => void;
 
     constructor(props: IVisConstruct) {
@@ -472,19 +471,13 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
     }
 
     protected reuseCurrentSort(
+        previousAvailableSorts: IAvailableSortsGroup[],
         properties: IVisualizationProperties,
         availableSorts: IAvailableSortsGroup[],
         defaultSort: ISortItem[],
     ) {
-        const currentSort = properties && properties.sortItems;
-        const reusedSort = validateCurrentSort(
-            this.previousAvailableSorts,
-            currentSort,
-            availableSorts,
-            defaultSort,
-        );
-        this.previousAvailableSorts = availableSorts;
-        return reusedSort;
+        const previousSort = properties && properties.sortItems;
+        return validateCurrentSort(previousAvailableSorts, previousSort, availableSorts, defaultSort);
     }
 }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -268,11 +268,16 @@ export class PluggableBulletChart extends PluggableBaseChart {
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
         const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint);
-        const { properties } = referencePoint;
+        const { properties, availableSorts: previousAvailableSorts } = referencePoint;
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/PluggableColumnChart.tsx
@@ -153,7 +153,7 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets, properties } = referencePoint;
+        const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(
             referencePoint,
             canSortStackTotalValue(buckets, properties),
@@ -164,7 +164,12 @@ export class PluggableColumnChart extends PluggableColumnBarCharts {
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -335,7 +335,7 @@ export class PluggableComboChart extends PluggableBaseChart {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets, properties } = referencePoint;
+        const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
 
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(buckets, properties);
         const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
@@ -343,7 +343,12 @@ export class PluggableComboChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -230,7 +230,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets, properties } = referencePoint;
+        const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
         const measures = getMeasureItems(buckets);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const stackBy = getBucketItems(buckets, BucketNames.STACK);
@@ -241,7 +241,12 @@ export class PluggableHeatmap extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -142,11 +142,16 @@ export class PluggableLineChart extends PluggableBaseChart {
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(referencePoint);
         const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
 
-        const { properties } = referencePoint;
+        const { properties, availableSorts: previousAvailableSorts } = referencePoint;
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PluggablePieChart.tsx
@@ -190,7 +190,7 @@ export class PluggablePieChart extends PluggableBaseChart {
     }
 
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
-        const { buckets, properties } = referencePoint;
+        const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
         const measures = getMeasureItems(buckets);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
         const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(measures, viewBy);
@@ -200,7 +200,12 @@ export class PluggablePieChart extends PluggableBaseChart {
         return Promise.resolve({
             supported: true,
             disabled,
-            appliedSort: super.reuseCurrentSort(properties, availableSorts, defaultSort),
+            appliedSort: super.reuseCurrentSort(
+                previousAvailableSorts,
+                properties,
+                availableSorts,
+                defaultSort,
+            ),
             defaultSort,
             availableSorts,
             ...(disabledExplanation && { disabledExplanation }),

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -32,7 +32,7 @@ import {
     SdkErrorType,
     VisualizationEnvironment,
 } from "@gooddata/sdk-ui";
-import { ISortConfig } from "./SortConfig";
+import { IAvailableSortsGroup, ISortConfig } from "./SortConfig";
 
 export type RenderFunction = (component: any, target: Element) => void;
 
@@ -320,6 +320,7 @@ export interface IReferencePoint {
     buckets: IBucketOfFun[];
     filters: IFilters;
     properties?: IVisualizationProperties; // properties are under plugvis creator's control
+    availableSorts?: IAvailableSortsGroup[];
 }
 
 export interface IReferences {


### PR DESCRIPTION
JIRA: TNT-566
Previous available sorts cant be stored in PV, it does not work with AD's Undo/Redo
So the previous available sorts are provided by AD as a part of reference point. But they not trigger changed reference point logic

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
