### PR TITLE
RELATED: FET-626 Register handlers with capture

### DIFF
--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { createRef } from "react";
 import cx from "classnames";
 import { Portal } from "react-portal";
@@ -18,16 +18,16 @@ import { IOverlayProps, IOverlayState } from "./typings";
 import { Alignment, OverlayPositionType, SameAsTargetPosition } from "../typings/overlay";
 
 const events = [
-    { name: "click", handler: "closeOnOutsideClick", target: document },
+    { name: "click", handler: "closeOnOutsideClick", target: document, capture: true },
     {
         name: "mousedown",
         handler: "onDocumentMouseDown",
         target: document,
         requiredProp: "closeOnOutsideClick",
     },
-    { name: "goodstrap.scrolled", handler: "closeOnParentScroll" },
-    { name: "goodstrap.drag", handler: "closeOnMouseDrag" },
-    { name: "keydown", handler: "closeOnEscape" },
+    { name: "goodstrap.scrolled", handler: "closeOnParentScroll", capture: true },
+    { name: "goodstrap.drag", handler: "closeOnMouseDrag", capture: true },
+    { name: "keydown", handler: "closeOnEscape", capture: true },
 ];
 
 const eventProps = events.map((event) => event.handler);
@@ -370,7 +370,9 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
             if (props[event.handler] || props[event.requiredProp]) {
                 const handler = this[event.handler];
                 if (handler) {
-                    (event.target || window)[`${method}EventListener`](event.name, handler);
+                    (event.target || window)[`${method}EventListener`](event.name, handler, {
+                        capture: event.capture || false,
+                    });
                 }
             }
         });


### PR DESCRIPTION
When used from react 17, these events are not triggered
Example: repeat dropdown in schedule email dialog cannot be closed on
outside click.

React 17 no longer attaches event handlers at the document level,
instead it attaches them to the root node where the React tree is rendered
[https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation]

JIRA: FET-626


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)