### PR TITLE
RELATED: RAIL-4093 better API for elements specification in attribute elements query

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
@@ -8,7 +8,7 @@ import {
     IElementsQueryAttributeFilter,
     IFilterElementsQuery,
     FilterWithResolvableElements,
-    isElementsQueryOptionsElementsByValue,
+    isValueBasedElementsQueryOptionsElements,
 } from "@gooddata/sdk-backend-spi";
 import {
     filterObjRef,
@@ -135,9 +135,10 @@ class BearWorkspaceElementsQuery implements IElementsQuery {
             );
         }
 
-        if (isElementsQueryOptionsElementsByValue(elements)) {
-            invariant(false, "Specifying elements by value is not supported.");
-        }
+        invariant(
+            !isValueBasedElementsQueryOptionsElements(elements),
+            "Specifying elements by value is not supported.",
+        );
 
         const urisToUse = elements?.uris ?? uris;
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -843,11 +843,20 @@ export interface IElementsQueryFactory {
 // @public
 export interface IElementsQueryOptions {
     complement?: boolean;
+    elements?: IElementsQueryOptionsElements;
     filter?: string;
     includeTotalCountWithoutFilters?: boolean;
     order?: SortDirection;
+    // @deprecated (undocumented)
     prompt?: string;
+    // @deprecated
     uris?: string[];
+}
+
+// @public
+export interface IElementsQueryOptionsElements {
+    type: "primary" | "as_requested";
+    values: string[];
 }
 
 // @public

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -843,7 +843,7 @@ export interface IElementsQueryFactory {
 // @public
 export interface IElementsQueryOptions {
     complement?: boolean;
-    elements?: IElementsQueryOptionsElements;
+    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByUri;
     filter?: string;
     includeTotalCountWithoutFilters?: boolean;
     order?: SortDirection;
@@ -854,8 +854,13 @@ export interface IElementsQueryOptions {
 }
 
 // @public
-export interface IElementsQueryOptionsElements {
-    type: "primary" | "as_requested";
+export interface IElementsQueryOptionsElementsByUri {
+    uris: string[];
+}
+
+// @public
+export interface IElementsQueryOptionsElementsByValue {
+    referenceType: "primary" | "requested";
     values: string[];
 }
 
@@ -1439,6 +1444,9 @@ export interface ISecuritySettingsService {
     isUrlValid(url: string, context: ValidationContext): Promise<boolean>;
     readonly scope: string;
 }
+
+// @public
+export function isElementsQueryOptionsElementsByValue(obj: unknown): obj is IElementsQueryOptionsElementsByValue;
 
 // @public
 export interface ISeparators {

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -843,7 +843,7 @@ export interface IElementsQueryFactory {
 // @public
 export interface IElementsQueryOptions {
     complement?: boolean;
-    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByUri;
+    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByPrimaryDisplayFormValue | IElementsQueryOptionsElementsByUri;
     filter?: string;
     includeTotalCountWithoutFilters?: boolean;
     order?: SortDirection;
@@ -854,13 +854,17 @@ export interface IElementsQueryOptions {
 }
 
 // @public
+export interface IElementsQueryOptionsElementsByPrimaryDisplayFormValue {
+    primaryValues: string[];
+}
+
+// @public
 export interface IElementsQueryOptionsElementsByUri {
     uris: string[];
 }
 
 // @public
 export interface IElementsQueryOptionsElementsByValue {
-    referenceType: "primary" | "requested";
     values: string[];
 }
 
@@ -1446,6 +1450,9 @@ export interface ISecuritySettingsService {
 }
 
 // @public
+export function isElementsQueryOptionsElementsByPrimaryDisplayFormValue(obj: unknown): obj is IElementsQueryOptionsElementsByPrimaryDisplayFormValue;
+
+// @public
 export function isElementsQueryOptionsElementsByValue(obj: unknown): obj is IElementsQueryOptionsElementsByValue;
 
 // @public
@@ -1597,6 +1604,9 @@ export const isUserGroupAccess: (obj: unknown) => obj is IUserGroupAccess;
 
 // @public
 export const isUserGroupAccessGrantee: (obj: unknown) => obj is IUserGroupAccessGrantee;
+
+// @public
+export function isValueBasedElementsQueryOptionsElements(obj: unknown): obj is IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByPrimaryDisplayFormValue;
 
 // @public
 export function isVariableMetadataObject(obj: unknown): obj is IVariableMetadataObject;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -111,7 +111,10 @@ export {
     IElementsQueryAttributeFilter,
     IElementsQueryOptionsElementsByUri,
     IElementsQueryOptionsElementsByValue,
+    IElementsQueryOptionsElementsByPrimaryDisplayFormValue,
     isElementsQueryOptionsElementsByValue,
+    isElementsQueryOptionsElementsByPrimaryDisplayFormValue,
+    isValueBasedElementsQueryOptionsElements,
     IFilterElementsQuery,
     FilterWithResolvableElements,
 } from "./workspace/attributes/elements";

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -109,7 +109,9 @@ export {
     IElementsQuery,
     IElementsQueryOptions,
     IElementsQueryAttributeFilter,
-    IElementsQueryOptionsElements,
+    IElementsQueryOptionsElementsByUri,
+    IElementsQueryOptionsElementsByValue,
+    isElementsQueryOptionsElementsByValue,
     IFilterElementsQuery,
     FilterWithResolvableElements,
 } from "./workspace/attributes/elements";

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -109,6 +109,7 @@ export {
     IElementsQuery,
     IElementsQueryOptions,
     IElementsQueryAttributeFilter,
+    IElementsQueryOptionsElements,
     IFilterElementsQuery,
     FilterWithResolvableElements,
 } from "./workspace/attributes/elements";

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -10,15 +10,6 @@ import { IAttributeElement } from "../../fromModel/ldm/attributeElement";
  */
 export interface IElementsQueryOptionsElementsByValue {
     /**
-     * Type of the element references.
-     *
-     * @remarks
-     * The supported values are "primary" for values of the primary display form related to the requested display form,
-     * and "requested" for the values of the display form actually requested.
-     */
-    referenceType: "primary" | "requested";
-
-    /**
      * The values to request.
      */
     values: string[];
@@ -32,10 +23,44 @@ export interface IElementsQueryOptionsElementsByValue {
 export function isElementsQueryOptionsElementsByValue(
     obj: unknown,
 ): obj is IElementsQueryOptionsElementsByValue {
+    return !!obj && !!(obj as IElementsQueryOptionsElementsByValue).values;
+}
+
+/**
+ * Specification of particular elements to load in {@link IElementsQueryOptions} using the values of the primary
+ * display form related to the attribute the requested display form is from.
+ *
+ * @public
+ */
+export interface IElementsQueryOptionsElementsByPrimaryDisplayFormValue {
+    /**
+     * The values to request.
+     */
+    primaryValues: string[];
+}
+
+/**
+ * Type guard checking whether the object is an instance of {@link IElementsQueryOptionsElementsByPrimaryDisplayFormValue}.
+ *
+ * @public
+ */
+export function isElementsQueryOptionsElementsByPrimaryDisplayFormValue(
+    obj: unknown,
+): obj is IElementsQueryOptionsElementsByPrimaryDisplayFormValue {
+    return !!obj && !!(obj as IElementsQueryOptionsElementsByPrimaryDisplayFormValue).primaryValues;
+}
+
+/**
+ * Type guard checking whether the object is an instance of {@link IElementsQueryOptionsElementsByValue} or {@link IElementsQueryOptionsElementsByPrimaryDisplayFormValue}.
+ *
+ * @public
+ */
+export function isValueBasedElementsQueryOptionsElements(
+    obj: unknown,
+): obj is IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByPrimaryDisplayFormValue {
     return (
-        !!obj &&
-        !!(obj as IElementsQueryOptionsElementsByValue).values &&
-        !!(obj as IElementsQueryOptionsElementsByValue).referenceType
+        isElementsQueryOptionsElementsByValue(obj) ||
+        isElementsQueryOptionsElementsByPrimaryDisplayFormValue(obj)
     );
 }
 
@@ -103,7 +128,10 @@ export interface IElementsQueryOptions {
      * @remarks
      * This is commonly used to preload selected elements in the attribute filter.
      */
-    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByUri;
+    elements?:
+        | IElementsQueryOptionsElementsByValue
+        | IElementsQueryOptionsElementsByPrimaryDisplayFormValue
+        | IElementsQueryOptionsElementsByUri;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -4,22 +4,52 @@ import { IPagedResource } from "../../../common/paging";
 import { IAttributeElement } from "../../fromModel/ldm/attributeElement";
 
 /**
- * Specification of particular elements to load in {@link IElementsQueryOptions}.
+ * Specification of particular elements to load in {@link IElementsQueryOptions} using their values.
  *
  * @public
  */
-export interface IElementsQueryOptionsElements {
+export interface IElementsQueryOptionsElementsByValue {
     /**
-     * Type of the elements
-     * - primary - URIs on backends with the supportsElementUris capability, primary display form values on others
-     * - as_requested - URIs on backends with the supportsElementUris capability, requested display form values on others
+     * Type of the element references
+     * - primary - primary display form values
+     * - requested - requested display form values
      */
-    type: "primary" | "as_requested";
+    referenceType: "primary" | "requested";
 
     /**
      * The values to request.
      */
     values: string[];
+}
+
+/**
+ * Type guard checking whether the object is an instance of {@link IElementsQueryOptionsElementsByValue}.
+ *
+ * @public
+ */
+export function isElementsQueryOptionsElementsByValue(
+    obj: unknown,
+): obj is IElementsQueryOptionsElementsByValue {
+    return (
+        !!obj &&
+        !!(obj as IElementsQueryOptionsElementsByValue).values &&
+        !!(obj as IElementsQueryOptionsElementsByValue).referenceType
+    );
+}
+
+/**
+ * Specification of particular elements to load in {@link IElementsQueryOptions} using their URIs.
+ *
+ * @remarks
+ * This is not supported on backends without the supportsElementUris capability.
+ *
+ * @public
+ */
+export interface IElementsQueryOptionsElementsByUri {
+    /**
+     * The element URIs to request.
+     */
+    uris: string[];
 }
 
 /**
@@ -66,7 +96,7 @@ export interface IElementsQueryOptions {
      * Specify particular elements to load.
      * This is commonly used to preload selected elements in the attribute filter.
      */
-    elements?: IElementsQueryOptionsElements;
+    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByUri;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -4,6 +4,25 @@ import { IPagedResource } from "../../../common/paging";
 import { IAttributeElement } from "../../fromModel/ldm/attributeElement";
 
 /**
+ * Specification of particular elements to load in {@link IElementsQueryOptions}.
+ *
+ * @public
+ */
+export interface IElementsQueryOptionsElements {
+    /**
+     * Type of the elements
+     * - primary - URIs on backends with the supportsElementUris capability, primary display form values on others
+     * - as_requested - URIs on backends with the supportsElementUris capability, requested display form values on others
+     */
+    type: "primary" | "as_requested";
+
+    /**
+     * The values to request.
+     */
+    values: string[];
+}
+
+/**
  * Configuration options for querying attribute elements
  *
  * @public
@@ -20,13 +39,16 @@ export interface IElementsQueryOptions {
     filter?: string;
 
     /**
+     * @privateRemarks
      * TODO what is this doing?
+     * @deprecated do not use.
      */
     prompt?: string;
 
     /**
-     *  With this option you can specify concrete attribute elements uris to load.
-     *  This is commonly used to preload selected elements in the attribute filter
+     * With this option you can specify concrete attribute elements uris to load.
+     * This is commonly used to preload selected elements in the attribute filter.
+     * @deprecated use {@link IElementsQueryOptions.elements} instead
      */
     uris?: string[];
 
@@ -39,6 +61,12 @@ export interface IElementsQueryOptions {
      * Include the total count of all elements in the response (without filters applied)
      */
     includeTotalCountWithoutFilters?: boolean;
+
+    /**
+     * Specify particular elements to load.
+     * This is commonly used to preload selected elements in the attribute filter.
+     */
+    elements?: IElementsQueryOptionsElements;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -10,9 +10,11 @@ import { IAttributeElement } from "../../fromModel/ldm/attributeElement";
  */
 export interface IElementsQueryOptionsElementsByValue {
     /**
-     * Type of the element references
-     * - primary - primary display form values
-     * - requested - requested display form values
+     * Type of the element references.
+     *
+     * @remarks
+     * The supported values are "primary" for values of the primary display form related to the requested display form,
+     * and "requested" for the values of the display form actually requested.
      */
     referenceType: "primary" | "requested";
 
@@ -77,7 +79,10 @@ export interface IElementsQueryOptions {
 
     /**
      * With this option you can specify concrete attribute elements uris to load.
+     *
+     * @remarks
      * This is commonly used to preload selected elements in the attribute filter.
+     *
      * @deprecated use {@link IElementsQueryOptions.elements} instead
      */
     uris?: string[];
@@ -94,6 +99,8 @@ export interface IElementsQueryOptions {
 
     /**
      * Specify particular elements to load.
+     *
+     * @remarks
      * This is commonly used to preload selected elements in the attribute filter.
      */
     elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByUri;

--- a/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/attributes/elements/index.ts
@@ -14,6 +14,7 @@ import {
     IElementsQueryResult,
     IFilterElementsQuery,
     isElementsQueryOptionsElementsByValue,
+    isValueBasedElementsQueryOptionsElements,
     NotSupported,
     UnexpectedError,
 } from "@gooddata/sdk-backend-spi";
@@ -98,19 +99,23 @@ class TigerWorkspaceElementsQuery implements IElementsQuery {
             }
 
             invariant(
-                isElementsQueryOptionsElementsByValue(elements),
+                isValueBasedElementsQueryOptionsElements(elements),
                 "Specifying elements by URIs is not supported. Use specification by value instead.",
             );
 
-            return {
-                exactFilter: elements.values,
-                filterBy: {
-                    labelType:
-                        elements.referenceType === "requested"
-                            ? ElementsRequestFilterByLabelTypeEnum.REQUESTED
-                            : ElementsRequestFilterByLabelTypeEnum.PRIMARY,
-                },
-            };
+            return isElementsQueryOptionsElementsByValue(elements)
+                ? {
+                      exactFilter: elements.values,
+                      filterBy: {
+                          labelType: ElementsRequestFilterByLabelTypeEnum.REQUESTED,
+                      },
+                  }
+                : {
+                      exactFilter: elements.primaryValues,
+                      filterBy: {
+                          labelType: ElementsRequestFilterByLabelTypeEnum.PRIMARY,
+                      },
+                  };
         } else if (uris) {
             return {
                 exactFilter: uris,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getElementTitle.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getElementTitle.ts
@@ -1,4 +1,5 @@
 // (C) 2020-2022 GoodData Corporation
+import { IElementsQueryOptions } from "@gooddata/sdk-backend-spi";
 import { ObjRef } from "@gooddata/sdk-model";
 import { DashboardContext } from "../../types/commonTypes";
 
@@ -8,15 +9,24 @@ export async function getElementTitle(
     attrElementUriOrPrimaryLabel: string,
     ctx: DashboardContext,
 ): Promise<string> {
+    const queryOptions: IElementsQueryOptions = {
+        elements: ctx.backend.capabilities.supportsElementUris
+            ? {
+                  uris: [attrElementUriOrPrimaryLabel],
+              }
+            : {
+                  referenceType: "primary",
+                  values: [attrElementUriOrPrimaryLabel],
+              },
+    };
+
     const validElementsQuery = await ctx.backend
         .workspace(projectId)
         .attributes()
         .elements()
         .forDisplayForm(dfRef)
         .withLimit(1)
-        .withOptions({
-            uris: [attrElementUriOrPrimaryLabel],
-        })
+        .withOptions(queryOptions)
         .query();
 
     return validElementsQuery.items[0].title;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getElementTitle.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/getElementTitle.ts
@@ -15,8 +15,7 @@ export async function getElementTitle(
                   uris: [attrElementUriOrPrimaryLabel],
               }
             : {
-                  referenceType: "primary",
-                  values: [attrElementUriOrPrimaryLabel],
+                  primaryValues: [attrElementUriOrPrimaryLabel],
               },
     };
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useBrokenAlertFiltersMeta.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useBrokenAlertFiltersMeta.ts
@@ -109,8 +109,7 @@ export function useBrokenAlertFiltersMeta({
                                     uris: attributeFilter.attributeElements.uris,
                                 }
                               : {
-                                    referenceType: "primary",
-                                    values: attributeFilter.attributeElements.uris,
+                                    primaryValues: attributeFilter.attributeElements.uris,
                                 },
                           includeTotalCountWithoutFilters: true,
                       };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useBrokenAlertFiltersMeta.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/useBrokenAlertFiltersMeta.ts
@@ -1,10 +1,11 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import {
     AnalyticalBackendError,
     IAnalyticalBackend,
     IDataSetMetadataObject,
     NotSupported,
     ICatalogDateDataset,
+    IElementsQueryOptions,
 } from "@gooddata/sdk-backend-spi";
 import {
     useBackendStrict,
@@ -100,17 +101,26 @@ export function useBrokenAlertFiltersMeta({
 
                       const attributesService = effectiveBackend.workspace(effectiveWorkspace).attributes();
 
+                      const elementsQueryOptions: IElementsQueryOptions = {
+                          elements: attributeFilter.negativeSelection
+                              ? undefined // for negative filters we need to load the items NOT selected, however there is no way of doing that, so we load everything
+                              : effectiveBackend.capabilities.supportsElementUris
+                              ? {
+                                    uris: attributeFilter.attributeElements.uris,
+                                }
+                              : {
+                                    referenceType: "primary",
+                                    values: attributeFilter.attributeElements.uris,
+                                },
+                          includeTotalCountWithoutFilters: true,
+                      };
+
                       const [elements, displayFormData] = await Promise.all([
                           attributesService
                               .elements()
                               .forDisplayForm(displayForm)
                               .withLimit(DEFAULT_ATTRIBUTE_ELEMENT_COUNT)
-                              .withOptions({
-                                  uris: attributeFilter.negativeSelection
-                                      ? undefined // for negative filters we need to load the items NOT selected, however there is no way of doing that, so we load everything
-                                      : attributeFilter.attributeElements.uris,
-                                  includeTotalCountWithoutFilters: true,
-                              })
+                              .withOptions(elementsQueryOptions)
                               .query(),
                           attributesService.getAttributeDisplayForm(displayForm),
                       ]);

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/hooks/useFetchInitialElements.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeFilterButton/hooks/useFetchInitialElements.ts
@@ -42,8 +42,7 @@ const prepareElementsTitleQuery = (
                   uris: elementIdentifiers,
               }
             : {
-                  referenceType: "primary",
-                  values: elementIdentifiers,
+                  primaryValues: elementIdentifiers,
               },
     };
 


### PR DESCRIPTION
Propose a new configuration option to specify attribute elements in attribute elements query.
This allows backends that support it to specify what kind of element value they are sending.

Also deprecate the old way of doing the same thing and deprecate not well documented and seemingly unused prompt config.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
