### PR TITLE
RELATED: RAIL-4091 Productise filter context selectors

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4165,7 +4165,7 @@ export const selectAnalyticalWidgetByRef: (ref: ObjRef | undefined) => OutputSel
 // @public
 export const selectAttributeFilterDisplayForms: OutputSelector<DashboardState, IAttributeDisplayFormMetadataObject[], (res: FilterContextState) => IAttributeDisplayFormMetadataObject[]>;
 
-// @public
+// @internal
 export const selectAttributeFilterDisplayFormsMap: OutputSelector<DashboardState, ObjRefMap<IAttributeDisplayFormMetadataObject>, (res: FilterContextState) => ObjRefMap<IAttributeDisplayFormMetadataObject>>;
 
 // @alpha (undocumented)
@@ -4405,7 +4405,7 @@ export const selectFilterContextDefinition: OutputSelector<DashboardState, IFilt
 // @public
 export const selectFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition) => FilterContextItem[]>;
 
-// @public
+// @internal
 export const selectFilterContextIdentity: OutputSelector<DashboardState, IDashboardObjectIdentity | undefined, (res: FilterContextState) => IDashboardObjectIdentity | undefined>;
 
 // @public

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4162,10 +4162,10 @@ export const selectAllKpiWidgets: OutputSelector<DashboardState, IKpiWidget[], (
 // @alpha
 export const selectAnalyticalWidgetByRef: (ref: ObjRef | undefined) => OutputSelector<DashboardState, IKpiWidget | IInsightWidget | undefined, (res: ObjRefMap<ExtendedDashboardWidget>) => IKpiWidget | IInsightWidget | undefined>;
 
-// @alpha
+// @public
 export const selectAttributeFilterDisplayForms: OutputSelector<DashboardState, IAttributeDisplayFormMetadataObject[], (res: FilterContextState) => IAttributeDisplayFormMetadataObject[]>;
 
-// @alpha
+// @public
 export const selectAttributeFilterDisplayFormsMap: OutputSelector<DashboardState, ObjRefMap<IAttributeDisplayFormMetadataObject>, (res: FilterContextState) => ObjRefMap<IAttributeDisplayFormMetadataObject>>;
 
 // @alpha (undocumented)
@@ -4390,22 +4390,22 @@ export const selectFilterBarExpanded: OutputSelector<DashboardState, boolean, (r
 // @internal (undocumented)
 export const selectFilterBarHeight: OutputSelector<DashboardState, number, (res: UiState) => number>;
 
-// @alpha
+// @public
 export const selectFilterContextAttributeFilterByDisplayForm: (displayForm: ObjRef) => OutputSelector<DashboardState, IDashboardAttributeFilter | undefined, (res1: ObjRefMap<IAttributeDisplayFormMetadataObject>, res2: IDashboardAttributeFilter[]) => IDashboardAttributeFilter | undefined>;
 
-// @alpha
+// @public
 export const selectFilterContextAttributeFilters: OutputSelector<DashboardState, IDashboardAttributeFilter[], (res: FilterContextItem[]) => IDashboardAttributeFilter[]>;
 
-// @alpha
+// @public
 export const selectFilterContextDateFilter: OutputSelector<DashboardState, IDashboardDateFilter | undefined, (res: FilterContextItem[]) => IDashboardDateFilter | undefined>;
 
-// @alpha
+// @public
 export const selectFilterContextDefinition: OutputSelector<DashboardState, IFilterContextDefinition, (res: FilterContextState) => IFilterContextDefinition>;
 
-// @alpha
+// @public
 export const selectFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition) => FilterContextItem[]>;
 
-// @alpha
+// @public
 export const selectFilterContextIdentity: OutputSelector<DashboardState, IDashboardObjectIdentity | undefined, (res: FilterContextState) => IDashboardObjectIdentity | undefined>;
 
 // @public
@@ -4495,10 +4495,10 @@ export const selectMenuButtonItemsVisibility: OutputSelector<DashboardState, IMe
 // @public
 export const selectObjectAvailabilityConfig: OutputSelector<DashboardState, ObjectAvailabilityConfig, (res: ResolvedDashboardConfig) => ObjectAvailabilityConfig>;
 
-// @alpha
+// @public
 export const selectOriginalFilterContextDefinition: OutputSelector<DashboardState, IFilterContextDefinition | undefined, (res: FilterContextState) => IFilterContextDefinition | undefined>;
 
-// @alpha
+// @public
 export const selectOriginalFilterContextFilters: OutputSelector<DashboardState, FilterContextItem[], (res: IFilterContextDefinition | undefined) => FilterContextItem[]>;
 
 // @public

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -40,7 +40,7 @@ export const selectOriginalFilterContextDefinition = createSelector(selectSelf, 
 });
 
 /**
- * This selector returns original (stored) dashboard's filter context definition.
+ * This selector returns original (stored) dashboard's filters.
  *
  * @remarks
  * It is expected that the selector is called only after the filter context state is correctly initialized.
@@ -56,7 +56,7 @@ export const selectOriginalFilterContextFilters = createSelector(
 );
 
 /**
- * This selector returns original (stored) dashboard's filter context filters.
+ * This selector returns current dashboard's filter context definition.
  *
  * @remarks
  * It is expected that the selector is called only after the filter context state is correctly initialized.
@@ -93,7 +93,7 @@ export const selectFilterContextDefinition = createSelector(selectSelf, (filterC
  *
  * @returns a {@link @gooddata/sdk-backend-spi#IDashboardObjectIdentity} or undefined, if the filter context identity is not set.
  *
- * @public
+ * @internal
  */
 export const selectFilterContextIdentity = createSelector(selectSelf, (filterContextState) => {
     // this is intentional; want to fail fast when trying to access an optional identity of filter context \
@@ -133,7 +133,7 @@ export const selectAttributeFilterDisplayForms = createSelector(selectSelf, (fil
  *
  * @returns a {@link ObjRefMap} of {@link @gooddata/sdk-backend-spi#IAttributeDisplayFormMetadataObject}
  *
- * @public
+ * @internal
  */
 export const selectAttributeFilterDisplayFormsMap = createSelector(selectSelf, (filterContextState) => {
     invariant(

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextSelectors.ts
@@ -20,10 +20,15 @@ const selectSelf = createSelector(
 );
 
 /**
- * This selector returns original (stored) dashboard's filter context definition. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns original (stored) dashboard's filter context definition.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns {@link @gooddata/sdk-backend-spi#IFilterContextDefinition} or `undefined` if original filter context definition is not set.
+ *
+ * @public
  */
 export const selectOriginalFilterContextDefinition = createSelector(selectSelf, (filterContextState) => {
     invariant(
@@ -35,10 +40,15 @@ export const selectOriginalFilterContextDefinition = createSelector(selectSelf, 
 });
 
 /**
- * This selector returns original (stored) dashboard's filter context definition. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns original (stored) dashboard's filter context definition.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns an array of {@link @gooddata/sdk-backend-spi#FilterContextItem} or an empty array.
+ *
+ * @public
  */
 export const selectOriginalFilterContextFilters = createSelector(
     selectOriginalFilterContextDefinition,
@@ -46,10 +56,15 @@ export const selectOriginalFilterContextFilters = createSelector(
 );
 
 /**
- * This selector returns original (stored) dashboard's filter context filters. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns original (stored) dashboard's filter context filters.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns a {@link @gooddata/sdk-backend-spi#IFilterContextDefinition}
+ *
+ * @public
  */
 export const selectFilterContextDefinition = createSelector(selectSelf, (filterContextState) => {
     invariant(
@@ -63,16 +78,22 @@ export const selectFilterContextDefinition = createSelector(selectSelf, (filterC
 /**
  * Selects dashboard's filter context identity.
  *
+ * @remarks
  * The identity may be undefined in two circumstances:
  *
  * -  a new, yet unsaved dashboard; the filter context is saved together with the dashboard and after the
  *    save the identity will be known and added
+ *
  * -  export of an existing, saved dashboard; during the export the dashboard receives a temporary
  *    filter context that represents values of filters at the time the export was initiated - which may
  *    be different from what is saved in the filter context itself. that temporary context is not
  *    persistent and lives only for that particular export operation.
  *
- * @alpha
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns a {@link @gooddata/sdk-backend-spi#IDashboardObjectIdentity} or undefined, if the filter context identity is not set.
+ *
+ * @public
  */
 export const selectFilterContextIdentity = createSelector(selectSelf, (filterContextState) => {
     // this is intentional; want to fail fast when trying to access an optional identity of filter context \
@@ -88,7 +109,12 @@ export const selectFilterContextIdentity = createSelector(selectSelf, (filterCon
 /**
  * Selects list of display form metadata objects referenced by attribute filters.
  *
- * @alpha
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns an array of {@link @gooddata/sdk-backend-spi#IAttributeDisplayFormMetadataObject}
+ *
+ * @public
  */
 export const selectAttributeFilterDisplayForms = createSelector(selectSelf, (filterContextState) => {
     invariant(
@@ -102,7 +128,12 @@ export const selectAttributeFilterDisplayForms = createSelector(selectSelf, (fil
 /**
  * Selects map of display form metadata objects referenced by attribute filters.
  *
- * @alpha
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @returns a {@link ObjRefMap} of {@link @gooddata/sdk-backend-spi#IAttributeDisplayFormMetadataObject}
+ *
+ * @public
  */
 export const selectAttributeFilterDisplayFormsMap = createSelector(selectSelf, (filterContextState) => {
     invariant(
@@ -114,10 +145,13 @@ export const selectAttributeFilterDisplayFormsMap = createSelector(selectSelf, (
 });
 
 /**
- * This selector returns dashboard's filter context filters. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns dashboard's filter context filters.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectFilterContextFilters = createSelector(
     selectFilterContextDefinition,
@@ -125,10 +159,13 @@ export const selectFilterContextFilters = createSelector(
 );
 
 /**
- * This selector returns dashboard's filter context attribute filters. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns dashboard's filter context attribute filters.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectFilterContextAttributeFilters = createSelector(
     selectFilterContextFilters,
@@ -136,10 +173,13 @@ export const selectFilterContextAttributeFilters = createSelector(
 );
 
 /**
- * This selector returns dashboard's filter context date filter. It is expected that the selector is called only after the filter
- * context state is correctly initialized. Invocations before initialization lead to invariant errors.
+ * This selector returns dashboard's filter context date filter.
  *
- * @alpha
+ * @remarks
+ * It is expected that the selector is called only after the filter context state is correctly initialized.
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectFilterContextDateFilter = createSelector(
     selectFilterContextFilters,
@@ -149,7 +189,10 @@ export const selectFilterContextDateFilter = createSelector(
 /**
  * Creates a selector for selecting attribute filter by its displayForm {@link @gooddata/sdk-model#ObjRef}.
  *
- * @alpha
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectFilterContextAttributeFilterByDisplayForm = createMemoizedSelector((displayForm: ObjRef) =>
     createSelector(
@@ -167,7 +210,10 @@ export const selectFilterContextAttributeFilterByDisplayForm = createMemoizedSel
 /**
  * Creates a selector for selecting attribute filter by its localId.
  *
- * @alpha
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectFilterContextAttributeFilterByLocalId = createMemoizedSelector((localId: string) =>
     createSelector(selectFilterContextAttributeFilters, (attributeFilters) =>
@@ -178,8 +224,10 @@ export const selectFilterContextAttributeFilterByLocalId = createMemoizedSelecto
 /**
  * Creates a selector for selecting attribute filter index by its localId.
  *
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
  *
- * @alpha
+ * @public
  */
 export const selectFilterContextAttributeFilterIndexByLocalId = createMemoizedSelector((localId: string) =>
     createSelector(selectFilterContextAttributeFilters, (attributeFilters) =>
@@ -190,7 +238,10 @@ export const selectFilterContextAttributeFilterIndexByLocalId = createMemoizedSe
 /**
  * Creates a selector for selecting all descendants of the attribute filter with given localId.
  *
- * @alpha
+ * @remarks
+ * Invocations before initialization lead to invariant errors.
+ *
+ * @public
  */
 export const selectAttributeFilterDescendants = createMemoizedSelector((localId: string) =>
     createSelector(selectFilterContextAttributeFilters, (attributeFilters) => {

--- a/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/filterContext/filterContextState.ts
@@ -21,11 +21,14 @@ export interface FilterContextState {
     originalFilterContextDefinition?: IFilterContextDefinition;
 
     /**
-     * Filter context identity is available for persisted filter contexts. This property may be undefined in
-     * two circumstances:
+     * Filter context identity is available for persisted filter contexts.
+     *
+     * @remarks
+     * This property may be undefined in two circumstances:
      *
      * -  a new, yet unsaved dashboard; the filter context is saved together with the dashboard and after the
      *    save the identity will be known and added
+     *
      * -  export of an existing, saved dashboard; during the export the dashboard receives a temporary
      *    filter context that represents values of filters at the time the export was initiated - which may
      *    be different from what is saved in the filter context itself. that temporary context is not


### PR DESCRIPTION
- make all filterContext related selectors public
- update tsdoc for api reference

JIRA: RAIL-4091

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
