### PR TITLE
RELATED: RAIL-4066 measures backend spi

### DIFF
--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -548,4 +548,8 @@ class DummyWorkspaceMeasuresService implements IWorkspaceMeasuresService {
     updateMeasure(measure: IMeasureMetadataObject): Promise<IMeasureMetadataObject> {
         return Promise.resolve({ ...measure });
     }
+
+    getMeasures(_measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]> {
+        return Promise.resolve([]);
+    }
 }

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/measures.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/measures.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import {
     IWorkspaceMeasuresService,
@@ -31,6 +31,10 @@ export class RecordedMeasures implements IWorkspaceMeasuresService {
     }
 
     getMeasureReferencingObjects(_: ObjRef): Promise<IMeasureReferencing> {
+        throw new NotSupported("not supported");
+    }
+
+    getMeasures(_measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]> {
         throw new NotSupported("not supported");
     }
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -2189,6 +2189,8 @@ export interface IWorkspaceMeasuresService {
     deleteMeasure(measureRef: ObjRef): Promise<void>;
     getMeasureExpressionTokens(ref: ObjRef): Promise<IMeasureExpressionToken[]>;
     getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
+    // (undocumented)
+    getMeasures(measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]>;
     updateMeasure(measure: IMeasureMetadataObject): Promise<IMeasureMetadataObject>;
 }
 

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -2189,7 +2189,6 @@ export interface IWorkspaceMeasuresService {
     deleteMeasure(measureRef: ObjRef): Promise<void>;
     getMeasureExpressionTokens(ref: ObjRef): Promise<IMeasureExpressionToken[]>;
     getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
-    // (undocumented)
     getMeasures(measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]>;
     updateMeasure(measure: IMeasureMetadataObject): Promise<IMeasureMetadataObject>;
 }

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -54,7 +54,10 @@ export interface IWorkspaceMeasuresService {
     getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
 
     /**
+     * Get all metadata object for given measure references.
      *
+     * @param measureRefs - references of the measures to get.
+     * @returns promise of {@link IMeasureMetadataObject} array.
      */
     getMeasures(measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]>;
 }

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -54,7 +54,7 @@ export interface IWorkspaceMeasuresService {
     getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
 
     /**
-     * Get all metadata object for given measure references.
+     * Get all metadata objects for given measure references.
      *
      * @param measureRefs - references of the measures to get.
      * @returns promise of {@link IMeasureMetadataObject} array.

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { ObjRef } from "@gooddata/sdk-model";
 import { IMeasureExpressionToken } from "../fromModel/ldm/measure";
 import {
@@ -52,4 +52,9 @@ export interface IWorkspaceMeasuresService {
      * @returns promise of references
      */
     getMeasureReferencingObjects(measureRef: ObjRef): Promise<IMeasureReferencing>;
+
+    /**
+     *
+     */
+    getMeasures(measureRefs: ObjRef[]): Promise<IMeasureMetadataObject[]>;
 }

--- a/libs/sdk-backend-spi/src/workspace/measures/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/measures/index.ts
@@ -56,6 +56,13 @@ export interface IWorkspaceMeasuresService {
     /**
      * Get all metadata objects for given measure references.
      *
+     * @remarks
+     * If the array of the given references is too large, the function must load all the measures
+     * available for the current workspace as there is only limited length of the query parameter.
+     *
+     * Consider if you need to fetch all required measures at once or if you could fetch them
+     * separately for better performance results.
+     *
      * @param measureRefs - references of the measures to get.
      * @returns promise of {@link IMeasureMetadataObject} array.
      */

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -26,6 +26,7 @@ import { tokenizeExpression, IExpressionToken } from "./measureExpressionTokens"
 import { v4 as uuidv4 } from "uuid";
 import { visualizationObjectsItemToInsight } from "../../../convertors/fromBackend/InsightConverter";
 
+const MAX_FILTER_LENGTH = 800;
 export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
     constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}
 
@@ -229,7 +230,7 @@ function loadMetrics(
 
     return MetadataUtilities.getAllPagesOf(client, client.entities.getAllEntitiesMetrics, {
         workspaceId,
-        filter,
+        filter: filter.length < MAX_FILTER_LENGTH ? filter : undefined,
     })
         .then(MetadataUtilities.mergeEntitiesResults)
         .then((measures) => measures.data.map(convertMetricFromBackend));

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -26,6 +26,11 @@ import { tokenizeExpression, IExpressionToken } from "./measureExpressionTokens"
 import { v4 as uuidv4 } from "uuid";
 import { visualizationObjectsItemToInsight } from "../../../convertors/fromBackend/InsightConverter";
 
+/**
+ * Max filter length is calculated from the maximal length of the URL (2048 characters) and
+ * its query parameters (1024 characters). As we can expect there are others query params,
+ * filter parameter length specified as below.
+ */
 const MAX_FILTER_LENGTH = 800;
 export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
     constructor(private readonly authCall: TigerAuthenticatedCallGuard, public readonly workspace: string) {}


### PR DESCRIPTION
- add getMeasures() into workspace measure service to be able to acquire limited measure objects only

JIRA: RAIL-4066
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
