### PR TITLE
Allow to filter tags with spaces

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/catalog/test/rsqlFilter.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/catalog/test/rsqlFilter.test.ts
@@ -1,0 +1,34 @@
+// (C) 2022 GoodData Corporation
+import { ObjRef } from "@gooddata/sdk-model";
+
+import { tagsToRsqlFilter } from "../rsqlFilter";
+
+describe("tagsToRsqlFilter", () => {
+    it("should parse tags input with correct RSQL format filtering", () => {
+        const includeTagsInput: ObjRef[] = [
+            {
+                identifier: "Products",
+            },
+            {
+                identifier: "Order Lines",
+            },
+        ];
+        const excludeTagsInput: ObjRef[] = [
+            {
+                identifier: "Campaign channels",
+            },
+            {
+                identifier: "Campaign ids",
+            },
+        ];
+
+        const expectedResult = tagsToRsqlFilter({
+            includeTags: includeTagsInput,
+            excludeTags: excludeTagsInput,
+        });
+
+        expect(expectedResult).toEqual(
+            "tags=in=(Products,'Order Lines');tags=out=(\"'Campaign channels','Campaign ids'\")",
+        );
+    });
+});

--- a/libs/util/src/stringUtils.ts
+++ b/libs/util/src/stringUtils.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 
 /**
  * @internal
@@ -71,7 +71,7 @@ export function simplifyText(value: string | number | null): string {
 
 /**
  * Parse string in a form of [foo, bar] to an array of objects.
- * Assume alphanumeric strings in the array; if some is not alphanumeric , return null
+ * Assume alphanumeric strings in the array and spaces; if some is not alphanumeric , return null
  * @param str - input string with the array definition
  * @returns parsed array of strings
  *
@@ -84,7 +84,7 @@ export function parseStringToArray(str: string): string[] | null {
             return [];
         }
 
-        if (str.match(/^\[[a-zA-Z0-9]+(,[a-zA-Z0-9]+)*]$/)) {
+        if (str.match(/^\[[a-zA-Z0-9 ]+(,(?=[^ ])[a-zA-Z0-9 ]+)*]$/)) {
             // [foo], [foo,bar]
             return str.slice(1, -1).split(",");
         }

--- a/libs/util/src/tests/stringUtils.test.ts
+++ b/libs/util/src/tests/stringUtils.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { randomString, shortenText, simplifyText, parseStringToArray, hashCodeString } from "../stringUtils";
 
 describe("randomString", () => {
@@ -45,7 +45,9 @@ describe("parseStringToArray", () => {
         ["[asdf]", ["asdf"]],
         ["[asdf,qwer]", ["asdf", "qwer"]],
         ["[asdf,2]", ["asdf", "2"]],
+        ["[asdf movie,qwer]", ["asdf movie", "qwer"]],
         // invalid
+        ["[asdf tbg, qas tpas]", null],
         ["[asdf", null],
         ["asdf]", null],
         ["[asdf, qwer]", null],


### PR DESCRIPTION
Update 'stringUtils' - 'parseStringToArray' to accept spaces.

With tags allowing spaces in DB, need to pass correct format to RSQL parser arguments to make filtering option work correctly. 

JIRA: TNT-580

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
