### PR TITLE
RELATED: TNT-629 Correctly handle token api error

### DIFF
--- a/libs/api-client-bear/src/tests/xhr.test.ts
+++ b/libs/api-client-bear/src/tests/xhr.test.ts
@@ -206,6 +206,17 @@ describe("fetch", () => {
                 });
         });
 
+        it("should fail if token renewal fails with error", () => {
+            fetchMock.get("/some/url", 401);
+            fetchMock.get("/gdc/account/token", 503);
+
+            return createXhr()
+                .ajax("/some/url")
+                .then(null, (err) => {
+                    expect(err.response.status).toBe(503);
+                });
+        });
+
         it("should correctly handle multiple requests with token request in progress", () => {
             const firstFailedMatcher = () => {
                 if (fetchMock.calls("/some/url/1").length === 1) {

--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -386,6 +386,11 @@ export class XhrModule {
             throw new ApiResponseError("Unauthorized", response, responseBody);
         }
 
+        if (!response.ok) {
+            // other non-2xx errors
+            throw new ApiResponseError(response.statusText, response, responseBody);
+        }
+
         return this.ajax(originalUrl, originalSettings);
     }
 


### PR DESCRIPTION
Fail when /gdc/account/token api returns error


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)