### PR TITLE
Dont offer area sort when there is only single measure

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChart.tsx
@@ -271,18 +271,14 @@ export class PluggableComboChart extends PluggableBaseChart {
         );
     }
 
-    protected getDefaultAndAvailableSort(
-        buckets: IBucketOfFun[],
-        properties: IVisualizationProperties,
-    ): {
+    protected getDefaultAndAvailableSort(buckets: IBucketOfFun[]): {
         defaultSort: ISortConfig["defaultSort"];
         availableSorts: ISortConfig["availableSorts"];
     } {
         const measures = getBucketItemsByType(buckets, BucketNames.MEASURES, [METRIC]);
         const secondaryMeasures = getBucketItemsByType(buckets, BucketNames.SECONDARY_MEASURES, [METRIC]);
         const viewBy = getBucketItems(buckets, BucketNames.VIEW);
-        const canSortStackTotal =
-            properties?.controls?.stackMeasures ?? this.getUiConfig().optionalStacking.stackMeasures;
+
         const defaultSort = viewBy.map((vb) => newAttributeSort(vb.localIdentifier, "asc"));
 
         if (!isEmpty(viewBy) && (!isEmpty(measures) || !isEmpty(secondaryMeasures))) {
@@ -295,7 +291,7 @@ export class PluggableComboChart extends PluggableBaseChart {
                         viewBy[0].localIdentifier,
                         mergedMeasures.map((m) => m.localIdentifier),
                         true,
-                        canSortStackTotal || mergedMeasures.length > 1,
+                        mergedMeasures.length > 1,
                     ),
                 ],
             };
@@ -337,7 +333,7 @@ export class PluggableComboChart extends PluggableBaseChart {
     public getSortConfig(referencePoint: IReferencePoint): Promise<ISortConfig> {
         const { buckets, properties, availableSorts: previousAvailableSorts } = referencePoint;
 
-        const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(buckets, properties);
+        const { defaultSort, availableSorts } = this.getDefaultAndAvailableSort(buckets);
         const { disabled, disabledExplanation } = this.isSortDisabled(referencePoint, availableSorts);
 
         return Promise.resolve({

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/PluggableComboChart.test.tsx
@@ -569,6 +569,16 @@ describe("PluggableComboChart", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
+        it("should not offer area sort as available, when primary type is area but there is only singe measure", async () => {
+            const chart = createComponent(defaultProps);
+
+            const sortConfig = await chart.getSortConfig(
+                referencePointMocks.oneSecondaryMetricAndOneViewByAreaChartComboRefPoint,
+            );
+
+            expect(sortConfig).toMatchSnapshot();
+        });
+
         it("should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB", async () => {
             const chart = createComponent(defaultProps);
 
@@ -577,7 +587,7 @@ describe("PluggableComboChart", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
-        it("should provide attribute sort as default sort, attribute area  and two measures sorts as available sorts for 2 primary measures stacked + 1 VB", async () => {
+        it("should provide attribute sort as default sort, attribute area and two measures sorts as available sorts for 2 primary measures stacked + 1 VB", async () => {
             const chart = createComponent(defaultProps);
 
             const sortConfig = await chart.getSortConfig(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/tests/__snapshots__/PluggableComboChart.test.tsx.snap
@@ -1,6 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area  and two measures sorts as available sorts for 2 primary measures stacked + 1 VB 1`] = `
+exports[`PluggableComboChart Sort config should not offer area sort as available, when primary type is area but there is only singe measure 1`] = `
+Object {
+  "appliedSort": Array [],
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": false,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a1",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "defaultSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a1",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB 1`] = `
 Object {
   "appliedSort": Array [],
   "availableSorts": Array [
@@ -49,7 +88,7 @@ Object {
 }
 `;
 
-exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measure sorts as available sorts for 2M + 1 VB 1`] = `
+exports[`PluggableComboChart Sort config should provide attribute sort as default sort, attribute area and two measures sorts as available sorts for 2 primary measures stacked + 1 VB 1`] = `
 Object {
   "appliedSort": Array [],
   "availableSorts": Array [

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -201,7 +201,14 @@ export class PluggableHeatmap extends PluggableBaseChart {
         if (!isEmpty(measures) && !isEmpty(stackBy)) {
             return {
                 defaultSort: [newAttributeSort(stackBy[0].localIdentifier, "asc")],
-                availableSorts: [newAvailableSortsGroup(stackBy[0].localIdentifier)],
+                availableSorts: [
+                    newAvailableSortsGroup(
+                        stackBy[0].localIdentifier,
+                        [measures[0].localIdentifier],
+                        true,
+                        false,
+                    ),
+                ],
             };
         }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
@@ -273,7 +273,7 @@ describe("PluggableHeatmap", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
-        it("should provide attribute normal as default sort, attribute area sorts as available sorts for 1M + 1SB", async () => {
+        it("should provide attribute normal as default sort, one metric sort as available sorts for 1M + 1SB", async () => {
             const chart = createComponent(defaultProps);
             const sortConfig = await chart.getSortConfig(referencePointMocks.oneMetricOneStackReferencePoint);
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -42,33 +42,6 @@ Object {
 }
 `;
 
-exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute area sorts as available sorts for 1M + 1SB 1`] = `
-Object {
-  "appliedSort": Array [],
-  "availableSorts": Array [
-    Object {
-      "attributeSort": Object {
-        "areaSortEnabled": true,
-        "normalSortEnabled": true,
-      },
-      "itemId": Object {
-        "localIdentifier": "a3",
-      },
-    },
-  ],
-  "defaultSort": Array [
-    Object {
-      "attributeSortItem": Object {
-        "attributeIdentifier": "a3",
-        "direction": "asc",
-      },
-    },
-  ],
-  "disabled": false,
-  "supported": true,
-}
-`;
-
 exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute normal and measuree sorts as available sorts for 1M + 1VB 1`] = `
 Object {
   "appliedSort": Array [],
@@ -100,6 +73,45 @@ Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
         "direction": "desc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
+exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, one metric sort as available sorts for 1M + 1SB 1`] = `
+Object {
+  "appliedSort": Array [],
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": false,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a3",
+      },
+      "metricSorts": Array [
+        Object {
+          "locators": Array [
+            Object {
+              "measureLocatorItem": Object {
+                "measureIdentifier": "m1",
+              },
+            },
+          ],
+          "type": "measureSort",
+        },
+      ],
+    },
+  ],
+  "defaultSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a3",
+        "direction": "asc",
       },
     },
   ],

--- a/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
+++ b/libs/sdk-ui-ext/src/internal/tests/mocks/referencePointMocks.ts
@@ -10,7 +10,7 @@ import {
     DATE_DATASET_ATTRIBUTE,
     IRankingFilter,
 } from "../../interfaces/Visualization";
-import { OverTimeComparisonTypes } from "@gooddata/sdk-ui";
+import { OverTimeComparisonTypes, VisualizationTypes } from "@gooddata/sdk-ui";
 import { ColumnWidthItem } from "@gooddata/sdk-ui-pivot";
 import { ObjRef, uriRef, idRef, ISortItem } from "@gooddata/sdk-model";
 
@@ -2294,6 +2294,32 @@ export const oneSecondaryMetricAndOneViewByRefPoint: IReferencePoint = {
     filters: {
         localIdentifier: "filters",
         items: [],
+    },
+};
+
+export const oneSecondaryMetricAndOneViewByAreaChartComboRefPoint: IReferencePoint = {
+    buckets: [
+        {
+            localIdentifier: "measures",
+            items: [],
+        },
+        {
+            localIdentifier: "secondary_measures",
+            items: masterMeasureItems.slice(0, 1),
+        },
+        {
+            localIdentifier: "view",
+            items: attributeItems.slice(0, 1),
+        },
+    ],
+    filters: {
+        localIdentifier: "filters",
+        items: [],
+    },
+    properties: {
+        controls: {
+            primaryChartType: VisualizationTypes.AREA,
+        },
     },
 };
 


### PR DESCRIPTION
JIRA: TNT-611
Dont offer sort by total in Combo and Heatmap when there is only single measure to keep it consistent with other charts

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
