### PR TITLE
RELATED: RAIL-4117 Fix the version specs in webpack config

### DIFF
--- a/tools/dashboard-plugin-template/webpack.config.js
+++ b/tools/dashboard-plugin-template/webpack.config.js
@@ -19,12 +19,12 @@ const DEFAULT_BACKEND_URL = "https://live-examples-proxy.herokuapp.com";
 // add all the gooddata packages that absolutely need to be shared and singletons because of contexts
 // allow sharing @gooddata/sdk-ui-dashboard here so that multiple plugins can share it among themselves
 // this makes redux related contexts work for example
-const gooddataSharePackagesEntries = [...Object.keys(deps), ...Object.keys(peerDeps)]
-    .filter((pkg) => pkg.startsWith("@gooddata"))
-    .reduce((acc, curr) => {
-        acc[curr] = {
+const gooddataSharePackagesEntries = [...Object.entries(deps), ...Object.entries(peerDeps)]
+    .filter(([pkgName]) => pkgName.startsWith("@gooddata"))
+    .reduce((acc, [pkgName, version]) => {
+        acc[pkgName] = {
             singleton: true,
-            requiredVersion: deps[curr],
+            requiredVersion: version,
         };
         return acc;
     }, {});


### PR DESCRIPTION
The old variant did not specify versions for peerDeps properly.
That was not intentional, so fix it appropriately.

Note that this does not fix the related issue, it just prevents
uncertainty in the future.

JIRA: RAIL-4117

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
