### PR TITLE
RELATED: FET-626 No more default stopPropagation

### DIFF
--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { createRef } from "react";
 import cx from "classnames";
 import { Portal } from "react-portal";
@@ -48,8 +48,6 @@ function alignExceedsThreshold(firstAlignment: Alignment, secondAlignment: Align
     );
 }
 
-const stopPropagation = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => e.stopPropagation();
-
 /**
  * @internal
  */
@@ -67,9 +65,9 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
 
         shouldCloseOnClick: () => true,
 
-        onClick: stopPropagation,
-        onMouseOver: stopPropagation,
-        onMouseUp: stopPropagation,
+        onClick: noop,
+        onMouseOver: noop,
+        onMouseUp: noop,
         onAlign: noop,
         onClose: noop,
     };


### PR DESCRIPTION
Necessary when used from React17
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)