### PR TITLE
RELATED: RAIL-4069 Improve colorMapping codegen

### DIFF
--- a/libs/sdk-ui-all/api/sdk-ui-all.api.md
+++ b/libs/sdk-ui-all/api/sdk-ui-all.api.md
@@ -4,8 +4,11 @@
 
 ```ts
 
+import { getColorMappingPredicate } from '@gooddata/sdk-ui-charts';
 import { IUser } from '@gooddata/sdk-model';
 import { userFullName } from '@gooddata/sdk-model';
+
+export { getColorMappingPredicate }
 
 export { IUser }
 

--- a/libs/sdk-ui-all/src/index.ts
+++ b/libs/sdk-ui-all/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 /**
  * This is an all-in-one package that has all GoodData.UI packages as dependencies and re-exports their public API.
  *
@@ -17,7 +17,9 @@ export * from "@gooddata/sdk-model";
 // eslint-disable-next-line import/export
 export * from "@gooddata/sdk-backend-spi";
 export * from "@gooddata/sdk-ui";
+// eslint-disable-next-line import/export
 export * from "@gooddata/sdk-ui-charts";
+// eslint-disable-next-line import/export
 export * from "@gooddata/sdk-ui-geo";
 export * from "@gooddata/sdk-ui-pivot";
 export * from "@gooddata/sdk-ui-filters";
@@ -27,3 +29,8 @@ export * from "@gooddata/sdk-ui-ext";
 import { IUser, userFullName } from "@gooddata/sdk-model";
 // eslint-disable-next-line import/export
 export { IUser, userFullName };
+
+// override getColorMappingPredicate, it is exported by both charts and geo, so use the chart version
+import { getColorMappingPredicate } from "@gooddata/sdk-ui-charts";
+// eslint-disable-next-line import/export
+export { getColorMappingPredicate };

--- a/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
+++ b/libs/sdk-ui-charts/api/sdk-ui-charts.api.md
@@ -13,6 +13,7 @@ import { AttributesOrPlaceholders } from '@gooddata/sdk-ui';
 import { ChartType } from '@gooddata/sdk-ui';
 import { ColorUtils } from '@gooddata/sdk-ui-vis-commons';
 import { FiltersOrPlaceholders } from '@gooddata/sdk-ui';
+import { getColorMappingPredicate } from '@gooddata/sdk-ui-vis-commons';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IColorMapping } from '@gooddata/sdk-ui-vis-commons';
 import { IColorPalette } from '@gooddata/sdk-model';
@@ -75,6 +76,8 @@ export const DonutChart: (props: IDonutChartProps) => JSX.Element;
 
 // @public
 export const FunnelChart: (props: IFunnelChartProps) => JSX.Element;
+
+export { getColorMappingPredicate }
 
 // @public
 export const Headline: (props: IHeadlineProps) => JSX.Element;

--- a/libs/sdk-ui-charts/src/index.ts
+++ b/libs/sdk-ui-charts/src/index.ts
@@ -32,3 +32,6 @@ export {
     isTreemap,
     updateConfigWithSettings,
 } from "./highcharts";
+
+// export the getColorMappingPredicate so that users can import it directly without having to explicitly install vis-commons
+export { getColorMappingPredicate } from "@gooddata/sdk-ui-vis-commons";

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
@@ -54,7 +54,7 @@ export class AreaChartDescriptor extends BigChartDescriptor implements IVisualiz
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
@@ -57,7 +57,7 @@ export class BarChartDescriptor extends BaseChartDescriptor implements IVisualiz
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private adjustIntersectionForColumnBar(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/BubbleChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/BubbleChartDescriptor.ts
@@ -38,6 +38,6 @@ export class BubbleChartDescriptor extends BigChartDescriptor implements IVisual
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
@@ -57,7 +57,7 @@ export class BulletChartDescriptor extends BaseChartDescriptor implements IVisua
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private addFiltersForBullet(insight: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
@@ -69,22 +69,28 @@ export function chartConfigFromInsight(
     )(withValuesFromContext);
 }
 
-export const chartAdditionalFactories: IAdditionalFactoryDefinition[] = [
-    {
-        importInfo: {
-            importType: "named",
-            name: "getColorMappingPredicate",
-            package: "@gooddata/sdk-ui-vis-commons",
+export function chartAdditionalFactories(options?: {
+    getColorMappingPredicatePackage?: string;
+}): IAdditionalFactoryDefinition[] {
+    const { getColorMappingPredicatePackage = "@gooddata/sdk-ui-charts" } = options ?? {};
+
+    return [
+        {
+            importInfo: {
+                importType: "named",
+                name: "getColorMappingPredicate",
+                package: getColorMappingPredicatePackage,
+            },
+            transformation: (obj) => {
+                return isColorMappingItem(obj)
+                    ? `{predicate: getColorMappingPredicate("${obj.id}"), color: ${factoryNotationFor(
+                          obj.color,
+                      )}}`
+                    : undefined;
+            },
         },
-        transformation: (obj) => {
-            return isColorMappingItem(obj)
-                ? `{predicate: getColorMappingPredicate("${obj.id}"), color: ${factoryNotationFor(
-                      obj.color,
-                  )}}`
-                : undefined;
-        },
-    },
-];
+    ];
+}
 
 const chartConfigPropMeta: PropMeta = {
     typeImport: {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
@@ -57,7 +57,7 @@ export class ColumnChartDescriptor extends BaseChartDescriptor implements IVisua
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private adjustIntersectionForColumnBar(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/ComboChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/ComboChartDescriptor.ts
@@ -40,6 +40,6 @@ export class ComboChartDescriptor extends BigChartDescriptor implements IVisuali
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/DonutChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/DonutChartDescriptor.ts
@@ -36,6 +36,6 @@ export class DonutChartDescriptor extends BaseChartDescriptor implements IVisual
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/FunnelChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/FunnelChartDescriptor.ts
@@ -36,6 +36,6 @@ export class FunnelChartDescriptor extends BaseChartDescriptor implements IVisua
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/GeoPushpinChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/GeoPushpinChartDescriptor.ts
@@ -75,7 +75,9 @@ export class GeoPushpinChartDescriptor extends BaseChartDescriptor implements IV
                 geoConfigFromInsight,
             ),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories({
+            getColorMappingPredicatePackage: "@gooddata/sdk-ui-geo",
+        }),
     });
 
     protected getMinHeight(enableCustomHeight: boolean): number {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
@@ -50,7 +50,7 @@ export class HeatmapDescriptor extends BigChartDescriptor implements IVisualizat
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
@@ -49,7 +49,7 @@ export class LineChartDescriptor extends BaseChartDescriptor implements IVisuali
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PieChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PieChartDescriptor.ts
@@ -36,6 +36,6 @@ export class PieChartDescriptor extends BaseChartDescriptor implements IVisualiz
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/ScatterPlotDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/ScatterPlotDescriptor.ts
@@ -34,6 +34,6 @@ export class ScatterPlotDescriptor extends BigChartDescriptor {
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
@@ -44,7 +44,7 @@ export class TreemapDescriptor extends BigChartDescriptor {
             filters: filtersInsightConversion("filters"),
             config: chartConfigInsightConversion("config"),
         }),
-        additionalFactories: chartAdditionalFactories,
+        additionalFactories: chartAdditionalFactories(),
     });
 
     private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -6957,8 +6957,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for BarChart - assign color to attribute element stack 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { BarChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { BarChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -6996,8 +6995,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for BarChart - assign color to master measure impacts derived PoP 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure, newPopMeasure } from \\"@gooddata/sdk-model\\";
-import { BarChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { BarChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -7034,8 +7032,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for BarChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { BarChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { BarChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -10512,8 +10509,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for BubbleChart - assign color to attribute bubbles 1`] = `
 "import React from \\"react\\";
 import { IAttribute, idRef, IMeasure, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { BubbleChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { BubbleChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const xAxisMeasure: IMeasure = newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"));
 const yAxisMeasure: IMeasure = newMeasure(idRef(\\"abZgFKGPaGYM\\", \\"measure\\"), m => m.localId(\\"m_abZgFKGPaGYM\\"));
@@ -13267,8 +13263,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for BulletChart - assign color to attribute bubbles 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newArithmeticMeasure, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { BulletChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { BulletChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const primaryMeasure: IAttributeOrMeasure = newMeasure(idRef(\\"acugFHNJgsBy\\", \\"measure\\"), m => m.localId(\\"m_acugFHNJgsBy\\"));
 const targetMeasure: IAttributeOrMeasure = newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"));
@@ -16197,8 +16192,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for ColumnChart - assign color to attribute element stack 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { ColumnChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { ColumnChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -16236,8 +16230,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for ColumnChart - assign color to master measure impacts derived PoP 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure, newPopMeasure } from \\"@gooddata/sdk-model\\";
-import { ColumnChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { ColumnChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -16274,8 +16267,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for ColumnChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { ColumnChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { ColumnChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -20097,8 +20089,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for ComboChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, idRef, IMeasure, newArithmeticMeasure, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { ComboChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { ComboChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const primaryMeasures: IMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -24820,8 +24811,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for DonutChart - assign color to attributes 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { DonutChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { DonutChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -24855,8 +24845,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for DonutChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttributeOrMeasure, idRef, newMeasure } from \\"@gooddata/sdk-model\\";
-import { DonutChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { DonutChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -25694,8 +25683,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for FunnelChart - assign color to attributes 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { FunnelChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { FunnelChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -25729,8 +25717,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for FunnelChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttributeOrMeasure, idRef, newArithmeticMeasure, newMeasure } from \\"@gooddata/sdk-model\\";
-import { FunnelChart, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { FunnelChart, getColorMappingPredicate, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -26461,8 +26448,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for Heatmap - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, ISortItem, newAttribute, newAttributeSort, newMeasure } from \\"@gooddata/sdk-model\\";
-import { Heatmap, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, Heatmap, IChartConfig } from \\"@gooddata/sdk-ui-charts\\";
 
 const measure: IAttributeOrMeasure = newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"));
 const rows: IAttribute = newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"));
@@ -29283,8 +29269,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for LineChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IChartConfig, LineChart } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, IChartConfig, LineChart } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -32062,8 +32047,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PieChart - assign color to attributes 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IChartConfig, PieChart } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, IChartConfig, PieChart } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -32097,8 +32081,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PieChart - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttributeOrMeasure, idRef, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IChartConfig, PieChart } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, IChartConfig, PieChart } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -35667,8 +35650,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for ScatterPlot - assign color to measures 1`] = `
 "import React from \\"react\\";
 import { IAttribute, idRef, IMeasure, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IChartConfig, ScatterPlot } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, IChartConfig, ScatterPlot } from \\"@gooddata/sdk-ui-charts\\";
 
 const xAxisMeasure: IMeasure = newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"));
 const yAxisMeasure: IMeasure = newMeasure(idRef(\\"abZgFKGPaGYM\\", \\"measure\\"), m => m.localId(\\"m_abZgFKGPaGYM\\"));
@@ -37689,8 +37671,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for Treemap - assign color to attributes 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IChartConfig, Treemap } from \\"@gooddata/sdk-ui-charts\\";
-import { getColorMappingPredicate } from \\"@gooddata/sdk-ui-vis-commons\\";
+import { getColorMappingPredicate, IChartConfig, Treemap } from \\"@gooddata/sdk-ui-charts\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))

--- a/libs/sdk-ui-geo/api/sdk-ui-geo.api.md
+++ b/libs/sdk-ui-geo/api/sdk-ui-geo.api.md
@@ -10,6 +10,7 @@
 import { AttributeMeasureOrPlaceholder } from '@gooddata/sdk-ui';
 import { AttributeOrPlaceholder } from '@gooddata/sdk-ui';
 import { ContentRect } from 'react-measure';
+import { getColorMappingPredicate } from '@gooddata/sdk-ui-vis-commons';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
 import { IAttribute } from '@gooddata/sdk-model';
 import { IColorMapping } from '@gooddata/sdk-ui-vis-commons';
@@ -42,6 +43,8 @@ export const CoreGeoChart: React_2.FC<ICoreGeoChartProps & WrappedComponentProps
 
 // @public (undocumented)
 export const GeoPushpinChart: (props: IGeoPushpinChartProps) => JSX.Element;
+
+export { getColorMappingPredicate }
 
 // @internal (undocumented)
 export function getGeoChartDimensions(def: IExecutionDefinition): IDimension[];

--- a/libs/sdk-ui-geo/src/index.ts
+++ b/libs/sdk-ui-geo/src/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 /**
  * This package provides the components that you can use to visualize location-based data.
@@ -38,3 +38,6 @@ export {
     IGeoChartLegendRendererProps,
     IGeoChartRendererProps,
 } from "./core/geoChart/GeoChartInner";
+
+// export the getColorMappingPredicate so that users can import it directly without having to explicitly install vis-commons
+export { getColorMappingPredicate } from "@gooddata/sdk-ui-vis-commons";


### PR DESCRIPTION
Make the predicate available in charts and geo.
This makes it easier for the end users as they no longer need to install
sdk-ui-vis-commons explicitly to use the generated mapping code.

JIRA: RAIL-4069

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
