### PR TITLE
NAS-3405 - Update sdk version in metric editor cause event is not stop propagation

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2795,11 +2795,11 @@ export interface ISingleSelectListItemProps {
     // (undocumented)
     isSelected?: boolean;
     // (undocumented)
-    onClick?: () => void;
+    onClick?: (e: React_2.MouseEvent<HTMLElement>) => void;
     // (undocumented)
-    onMouseOut?: () => void;
+    onMouseOut?: (e: React_2.MouseEvent<HTMLElement>) => void;
     // (undocumented)
-    onMouseOver?: () => void;
+    onMouseOver?: (e: React_2.MouseEvent<HTMLElement>) => void;
     // (undocumented)
     title?: string;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/List/ListItem.tsx
+++ b/libs/sdk-ui-kit/src/List/ListItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component, createRef } from "react";
 import cx from "classnames";
 import { stringUtils } from "@gooddata/util";
@@ -24,9 +24,9 @@ export interface ISingleSelectListItemProps {
 
     isSelected?: boolean;
 
-    onClick?: () => void;
-    onMouseOver?: () => void;
-    onMouseOut?: () => void;
+    onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+    onMouseOver?: (e: React.MouseEvent<HTMLElement>) => void;
+    onMouseOut?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 /**
  * @internal


### PR DESCRIPTION
Add type for events in handlers click, mouseover and mouseout

JIRA: NAS-3405

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
