### PR TITLE
Heatmap offers are sort even for single metric

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -201,14 +201,7 @@ export class PluggableHeatmap extends PluggableBaseChart {
         if (!isEmpty(measures) && !isEmpty(stackBy)) {
             return {
                 defaultSort: [newAttributeSort(stackBy[0].localIdentifier, "asc")],
-                availableSorts: [
-                    newAvailableSortsGroup(
-                        stackBy[0].localIdentifier,
-                        [measures[0].localIdentifier],
-                        true,
-                        false,
-                    ),
-                ],
+                availableSorts: [newAvailableSortsGroup(stackBy[0].localIdentifier)],
             };
         }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
@@ -273,7 +273,7 @@ describe("PluggableHeatmap", () => {
             expect(sortConfig).toMatchSnapshot();
         });
 
-        it("should provide attribute normal as default sort, one metric sort as available sorts for 1M + 1SB", async () => {
+        it("should provide attribute normal as default sort, attribute area sort as available sorts for 1M + 1SB", async () => {
             const chart = createComponent(defaultProps);
             const sortConfig = await chart.getSortConfig(referencePointMocks.oneMetricOneStackReferencePoint);
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/__snapshots__/PluggableHeatmap.test.tsx.snap
@@ -42,6 +42,33 @@ Object {
 }
 `;
 
+exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute area sort as available sorts for 1M + 1SB 1`] = `
+Object {
+  "appliedSort": Array [],
+  "availableSorts": Array [
+    Object {
+      "attributeSort": Object {
+        "areaSortEnabled": true,
+        "normalSortEnabled": true,
+      },
+      "itemId": Object {
+        "localIdentifier": "a3",
+      },
+    },
+  ],
+  "defaultSort": Array [
+    Object {
+      "attributeSortItem": Object {
+        "attributeIdentifier": "a3",
+        "direction": "asc",
+      },
+    },
+  ],
+  "disabled": false,
+  "supported": true,
+}
+`;
+
 exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, attribute normal and measuree sorts as available sorts for 1M + 1VB 1`] = `
 Object {
   "appliedSort": Array [],
@@ -73,45 +100,6 @@ Object {
       "attributeSortItem": Object {
         "attributeIdentifier": "a1",
         "direction": "desc",
-      },
-    },
-  ],
-  "disabled": false,
-  "supported": true,
-}
-`;
-
-exports[`PluggableHeatmap Sort config should provide attribute normal as default sort, one metric sort as available sorts for 1M + 1SB 1`] = `
-Object {
-  "appliedSort": Array [],
-  "availableSorts": Array [
-    Object {
-      "attributeSort": Object {
-        "areaSortEnabled": false,
-        "normalSortEnabled": true,
-      },
-      "itemId": Object {
-        "localIdentifier": "a3",
-      },
-      "metricSorts": Array [
-        Object {
-          "locators": Array [
-            Object {
-              "measureLocatorItem": Object {
-                "measureIdentifier": "m1",
-              },
-            },
-          ],
-          "type": "measureSort",
-        },
-      ],
-    },
-  ],
-  "defaultSort": Array [
-    Object {
-      "attributeSortItem": Object {
-        "attributeIdentifier": "a3",
-        "direction": "asc",
       },
     },
   ],


### PR DESCRIPTION
JIRA: TNT-611
Exception for Heatmap, which will offer area sort even for single metric for 1M+1Cols bucket items. Other charts have in such case sorting disabled, but it is UX decision

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
