### PR TITLE
Add shortcut for scheduling widget export

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -2305,8 +2305,11 @@ export type FluidLayoutCustomizationFn = (layout: IDashboardLayout<ExtendedDashb
 export function getDefaultInsightMenuItems(intl: IntlShape, config: {
     exportXLSXDisabled: boolean;
     exportCSVDisabled: boolean;
+    scheduleExportDisabled: boolean;
     onExportXLSX: () => void;
     onExportCSV: () => void;
+    onScheduleExport: () => void;
+    isScheduleExportVisible: boolean;
     tooltipMessage: string;
 }): IInsightMenuItem[];
 
@@ -4523,6 +4526,9 @@ export const selectPersistedDashboard: OutputSelector<DashboardState, IDashboard
 // @public
 export const selectPlatformEdition: OutputSelector<DashboardState, PlatformEdition, (res: ResolvedDashboardConfig) => PlatformEdition>;
 
+// @alpha (undocumented)
+export const selectScheduleEmailDialogDefaultAttachment: OutputSelector<DashboardState, UriRef | IdentifierRef | undefined, (res: UiState) => UriRef | IdentifierRef | undefined>;
+
 // @public
 export const selectSeparators: OutputSelector<DashboardState, ISeparators, (res: ResolvedDashboardConfig) => ISeparators>;
 
@@ -4632,6 +4638,11 @@ export interface TriggerEventPayload {
 export const uiActions: CaseReducerActions<    {
 openScheduleEmailDialog: CaseReducer<UiState, AnyAction>;
 closeScheduleEmailDialog: CaseReducer<UiState, AnyAction>;
+setScheduleEmailDialogDefaultAttachment: CaseReducer<UiState, {
+payload: ObjRef;
+type: string;
+}>;
+resetScheduleEmailDialogDefaultAttachment: CaseReducer<UiState, AnyAction>;
 openScheduleEmailManagementDialog: CaseReducer<UiState, AnyAction>;
 closeScheduleEmailManagementDialog: CaseReducer<UiState, AnyAction>;
 openSaveAsDialog: CaseReducer<UiState, AnyAction>;
@@ -4684,6 +4695,7 @@ export interface UiState {
     // (undocumented)
     scheduleEmailDialog: {
         open: boolean;
+        defaultAttachmentRef: ObjRef | undefined;
     };
     // (undocumented)
     scheduleEmailManagementDialog: {
@@ -5105,6 +5117,24 @@ export const useDashboardQueryProcessing: <TQuery extends DashboardQueries, TQue
 // @internal (undocumented)
 export type UseDashboardQueryProcessingResult<TQueryCreatorArgs extends any[], TQueryResult> = QueryProcessingState<TQueryResult> & {
     run: (...args: TQueryCreatorArgs) => void;
+};
+
+// @alpha
+export const useDashboardScheduledEmails: () => {
+    isScheduledEmailingVisible: boolean;
+    enableInsightExportScheduling: boolean;
+    defaultOnScheduleEmailing: () => void;
+    isScheduleEmailingDialogOpen: boolean;
+    isScheduleEmailingManagementDialogOpen: boolean;
+    onScheduleEmailingOpen: (attachmentRef?: UriRef | IdentifierRef | undefined) => void;
+    onScheduleEmailingCancel: () => void;
+    onScheduleEmailingError: () => void;
+    onScheduleEmailingSuccess: () => void;
+    onScheduleEmailingManagementAdd: () => void;
+    onScheduleEmailingManagementClose: () => void;
+    onScheduleEmailingManagementLoadingError: () => void;
+    onScheduleEmailingManagementDeleteSuccess: () => void;
+    onScheduleEmailingManagementDeleteError: () => void;
 };
 
 // @public

--- a/libs/sdk-ui-dashboard/src/model/react/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/index.ts
@@ -24,3 +24,4 @@ export { useDashboardAsyncRender, UseDashboardAsyncRender } from "./useDashboard
 export { IDashboardStoreProviderProps } from "./types";
 export { useDispatchDashboardCommand } from "./useDispatchDashboardCommand";
 export { useWidgetExecutionsHandler } from "./useWidgetExecutionsHandler";
+export { useDashboardScheduledEmails } from "./useDashboardScheduledEmails";

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
@@ -1,0 +1,135 @@
+// (C) 2022 GoodData Corporation
+
+import { useCallback } from "react";
+import { useToastMessage } from "@gooddata/sdk-ui-kit";
+import { ObjRef } from "@gooddata/sdk-model";
+import {
+    selectCanCreateScheduledMail,
+    selectDashboardRef,
+    selectEnableInsightExportScheduling,
+    selectEnableKPIDashboardSchedule,
+    selectIsReadOnly,
+    selectIsScheduleEmailDialogOpen,
+    selectIsScheduleEmailManagementDialogOpen,
+    selectMenuButtonItemsVisibility,
+    uiActions,
+} from "../store";
+import { useDashboardDispatch, useDashboardSelector } from "./DashboardStoreProvider";
+
+/**
+ * Hook that handles schedule emailing dialogs.
+ *
+ * @alpha
+ */
+export const useDashboardScheduledEmails = () => {
+    const { addSuccess, addError } = useToastMessage();
+    const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
+    const isScheduleEmailingManagementDialogOpen = useDashboardSelector(
+        selectIsScheduleEmailManagementDialogOpen,
+    );
+    const dispatch = useDashboardDispatch();
+    const dashboardRef = useDashboardSelector(selectDashboardRef);
+    const enableInsightExportScheduling = useDashboardSelector(selectEnableInsightExportScheduling);
+    const isReadOnly = useDashboardSelector(selectIsReadOnly);
+    const canCreateScheduledMail = useDashboardSelector(selectCanCreateScheduledMail);
+    const isScheduledEmailingEnabled = !!useDashboardSelector(selectEnableKPIDashboardSchedule);
+    const menuButtonItemsVisibility = useDashboardSelector(selectMenuButtonItemsVisibility);
+
+    const openScheduleEmailingDialog = () => dispatch(uiActions.openScheduleEmailDialog());
+    const closeScheduleEmailingDialog = () => dispatch(uiActions.closeScheduleEmailDialog());
+    const openScheduleEmailingManagementDialog = () =>
+        enableInsightExportScheduling && dispatch(uiActions.openScheduleEmailManagementDialog());
+    const closeScheduleEmailingManagementDialog = () =>
+        enableInsightExportScheduling && dispatch(uiActions.closeScheduleEmailManagementDialog());
+    const setScheduledEmailDefaultAttachment = (attachmentRef: ObjRef) =>
+        enableInsightExportScheduling &&
+        dispatch(uiActions.setScheduleEmailDialogDefaultAttachment(attachmentRef));
+    const resetScheduledEmailDefaultAttachment = () =>
+        enableInsightExportScheduling && dispatch(uiActions.resetScheduleEmailDialogDefaultAttachment());
+
+    const isScheduledEmailingVisible =
+        !isReadOnly &&
+        canCreateScheduledMail &&
+        isScheduledEmailingEnabled &&
+        (menuButtonItemsVisibility.scheduleEmailButton ?? true);
+
+    /*
+     * exports and scheduling are not available when rendering a dashboard that is not persisted.
+     * this can happen when a new dashboard is created and is being edited.
+     *
+     * the setup of menu items available in the menu needs to reflect this.
+     */
+    const defaultOnScheduleEmailing = useCallback(() => {
+        if (!dashboardRef) {
+            return;
+        }
+
+        if (enableInsightExportScheduling) {
+            openScheduleEmailingManagementDialog();
+        } else {
+            openScheduleEmailingDialog();
+        }
+    }, [dashboardRef, enableInsightExportScheduling]);
+
+    const onScheduleEmailingOpen = useCallback((attachmentRef?: ObjRef) => {
+        openScheduleEmailingDialog();
+        attachmentRef && setScheduledEmailDefaultAttachment(attachmentRef);
+    }, []);
+
+    const onScheduleEmailingError = useCallback(() => {
+        closeScheduleEmailingDialog();
+        addError({ id: "dialogs.schedule.email.submit.error" });
+    }, []);
+
+    const onScheduleEmailingSuccess = useCallback(() => {
+        closeScheduleEmailingDialog();
+        addSuccess({ id: "dialogs.schedule.email.submit.success" });
+        resetScheduledEmailDefaultAttachment();
+    }, []);
+
+    const onScheduleEmailingCancel = useCallback(() => {
+        closeScheduleEmailingDialog();
+        openScheduleEmailingManagementDialog();
+        resetScheduledEmailDefaultAttachment();
+    }, []);
+
+    const onScheduleEmailingManagementDeleteSuccess = useCallback(() => {
+        addSuccess({ id: "dialogs.schedule.email.delete.success" });
+    }, []);
+
+    const onScheduleEmailingManagementAdd = useCallback(() => {
+        closeScheduleEmailingManagementDialog();
+        openScheduleEmailingDialog();
+    }, []);
+
+    const onScheduleEmailingManagementClose = useCallback(() => {
+        closeScheduleEmailingManagementDialog();
+    }, []);
+
+    const onScheduleEmailingManagementLoadingError = useCallback(() => {
+        closeScheduleEmailingManagementDialog();
+        addError({ id: "dialogs.schedule.management.load.error" });
+    }, []);
+
+    const onScheduleEmailingManagementDeleteError = useCallback(() => {
+        closeScheduleEmailingManagementDialog();
+        addError({ id: "dialogs.schedule.management.delete.error" });
+    }, []);
+
+    return {
+        isScheduledEmailingVisible,
+        enableInsightExportScheduling,
+        defaultOnScheduleEmailing,
+        isScheduleEmailingDialogOpen,
+        isScheduleEmailingManagementDialogOpen,
+        onScheduleEmailingOpen,
+        onScheduleEmailingCancel,
+        onScheduleEmailingError,
+        onScheduleEmailingSuccess,
+        onScheduleEmailingManagementAdd,
+        onScheduleEmailingManagementClose,
+        onScheduleEmailingManagementLoadingError,
+        onScheduleEmailingManagementDeleteSuccess,
+        onScheduleEmailingManagementDeleteError,
+    };
+};

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -179,6 +179,7 @@ export {
     selectIsKpiAlertOpenedByWidgetRef,
     selectIsKpiAlertHighlightedByWidgetRef,
     selectMenuButtonItemsVisibility,
+    selectScheduleEmailDialogDefaultAttachment,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -14,6 +14,14 @@ const closeScheduleEmailDialog: UiReducer = (state) => {
     state.scheduleEmailDialog.open = false;
 };
 
+const setScheduleEmailDialogDefaultAttachment: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
+    state.scheduleEmailDialog.defaultAttachmentRef = action.payload;
+};
+
+const resetScheduleEmailDialogDefaultAttachment: UiReducer = (state) => {
+    state.scheduleEmailDialog.defaultAttachmentRef = undefined;
+};
+
 const openScheduleEmailManagementDialog: UiReducer = (state) => {
     state.scheduleEmailManagementDialog.open = true;
 };
@@ -68,6 +76,8 @@ const setMenuButtonItemsVisibility: UiReducer<PayloadAction<IMenuButtonItemsVisi
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
+    setScheduleEmailDialogDefaultAttachment,
+    resetScheduleEmailDialogDefaultAttachment,
     openScheduleEmailManagementDialog,
     closeScheduleEmailManagementDialog,
     openSaveAsDialog,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -22,6 +22,14 @@ export const selectIsScheduleEmailDialogOpen = createSelector(
 /**
  * @alpha
  */
+export const selectScheduleEmailDialogDefaultAttachment = createSelector(
+    selectSelf,
+    (state) => state.scheduleEmailDialog.defaultAttachmentRef,
+);
+
+/**
+ * @alpha
+ */
 export const selectIsScheduleEmailManagementDialogOpen = createSelector(
     selectSelf,
     (state) => state.scheduleEmailManagementDialog.open,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -12,6 +12,7 @@ export interface UiState {
     };
     scheduleEmailDialog: {
         open: boolean;
+        defaultAttachmentRef: ObjRef | undefined;
     };
     saveAsDialog: {
         open: boolean;
@@ -38,6 +39,7 @@ export const uiInitialState: UiState = {
     },
     scheduleEmailDialog: {
         open: false,
+        defaultAttachmentRef: undefined,
     },
     saveAsDialog: {
         open: false,

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -16,13 +16,11 @@ import {
     exportDashboardToPdf,
     renameDashboard,
     selectCanCreateAnalyticalDashboard,
-    selectCanCreateScheduledMail,
     selectCanExportReport,
     selectDashboardRef,
     selectDashboardShareInfo,
     selectDashboardTitle,
     selectEnableKPIDashboardExportPDF,
-    selectEnableKPIDashboardSchedule,
     selectFilterContextFilters,
     selectIsLayoutEmpty,
     selectIsReadOnly,
@@ -33,6 +31,7 @@ import {
     useDashboardCommandProcessing,
     useDashboardDispatch,
     useDashboardSelector,
+    useDashboardScheduledEmails,
 } from "../../../model";
 
 import { ExportDialogProvider } from "../../dialogs";
@@ -42,10 +41,7 @@ import { DefaultButtonBar, DefaultMenuButton, DefaultTopBar, IMenuButtonItem, To
 import { SaveAsDialog } from "../../saveAs";
 import { DefaultFilterBar, FilterBar } from "../../filterBar";
 import { ShareDialogDashboardHeader } from "./ShareDialogDashboardHeader";
-import {
-    ScheduledEmailDialogProvider,
-    useScheduledEmailDialogProvider,
-} from "./ScheduledEmailDialogProvider";
+import { ScheduledEmailDialogProvider } from "./ScheduledEmailDialogProvider";
 
 const useFilterBar = (): {
     filters: FilterContextItem[];
@@ -116,7 +112,7 @@ export const DashboardHeader = (): JSX.Element => {
     const { filters, onAttributeFilterChanged, onDateFilterChanged } = useFilterBar();
     const { title, onTitleChanged, onShareButtonClick, shareInfo } = useTopBar();
     const { addSuccess, addError, addProgress, removeMessage } = useToastMessage();
-    const { defaultOnScheduleEmailing } = useScheduledEmailDialogProvider();
+    const { isScheduledEmailingVisible, defaultOnScheduleEmailing } = useDashboardScheduledEmails();
 
     const dispatch = useDashboardDispatch();
     const isSaveAsDialogOpen = useDashboardSelector(selectIsSaveAsDialogOpen);
@@ -178,8 +174,6 @@ export const DashboardHeader = (): JSX.Element => {
     const canExportReport = useDashboardSelector(selectCanExportReport);
     const isKPIDashboardExportPDFEnabled = !!useDashboardSelector(selectEnableKPIDashboardExportPDF);
 
-    const canCreateScheduledMail = useDashboardSelector(selectCanCreateScheduledMail);
-    const isScheduledEmailingEnabled = !!useDashboardSelector(selectEnableKPIDashboardSchedule);
     const menuButtonItemsVisibility = useDashboardSelector(selectMenuButtonItemsVisibility);
 
     const defaultMenuItems = useMemo<IMenuButtonItem[]>(() => {
@@ -194,12 +188,6 @@ export const DashboardHeader = (): JSX.Element => {
             canExportReport &&
             isKPIDashboardExportPDFEnabled &&
             (menuButtonItemsVisibility.pdfExportButton ?? true);
-
-        const isScheduledEmailingVisible =
-            !isReadOnly &&
-            canCreateScheduledMail &&
-            isScheduledEmailingEnabled &&
-            (menuButtonItemsVisibility.scheduleEmailButton ?? true);
 
         return [
             {
@@ -238,8 +226,7 @@ export const DashboardHeader = (): JSX.Element => {
         menuButtonItemsVisibility,
         canExportReport,
         isKPIDashboardExportPDFEnabled,
-        canCreateScheduledMail,
-        isScheduledEmailingEnabled,
+        isScheduledEmailingVisible,
     ]);
 
     const onSaveAsError = useCallback(() => {

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/ScheduledEmailDialogProvider.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/ScheduledEmailDialogProvider.tsx
@@ -1,107 +1,22 @@
 // (C) 2022 GoodData Corporation
 
-import React, { useCallback } from "react";
-import { useToastMessage } from "@gooddata/sdk-ui-kit";
-import {
-    selectDashboardRef,
-    selectEnableInsightExportScheduling,
-    selectIsScheduleEmailDialogOpen,
-    selectIsScheduleEmailManagementDialogOpen,
-    uiActions,
-    useDashboardDispatch,
-    useDashboardSelector,
-} from "../../../model";
+import React from "react";
 import { ScheduledEmailDialog, ScheduledEmailManagementDialog } from "../../scheduledEmail";
-
-export const useScheduledEmailDialogProvider = () => {
-    const dispatch = useDashboardDispatch();
-    const dashboardRef = useDashboardSelector(selectDashboardRef);
-    const isInsightExportSchedulingEnabled = useDashboardSelector(selectEnableInsightExportScheduling);
-
-    const openScheduleEmailingDialog = () => dispatch(uiActions.openScheduleEmailDialog());
-    const closeScheduleEmailingDialog = () => dispatch(uiActions.closeScheduleEmailDialog());
-    const openScheduleEmailingManagementDialog = () =>
-        isInsightExportSchedulingEnabled && dispatch(uiActions.openScheduleEmailManagementDialog());
-    const closeScheduleEmailingManagementDialog = () =>
-        isInsightExportSchedulingEnabled && dispatch(uiActions.closeScheduleEmailManagementDialog());
-
-    /*
-     * exports and scheduling are not available when rendering a dashboard that is not persisted.
-     * this can happen when a new dashboard is created and is being edited.
-     *
-     * the setup of menu items available in the menu needs to reflect this.
-     */
-    const defaultOnScheduleEmailing = useCallback(() => {
-        if (!dashboardRef) {
-            return;
-        }
-
-        if (isInsightExportSchedulingEnabled) {
-            openScheduleEmailingManagementDialog();
-        } else {
-            openScheduleEmailingDialog();
-        }
-    }, [dashboardRef, isInsightExportSchedulingEnabled]);
-
-    return {
-        defaultOnScheduleEmailing,
-        openScheduleEmailingDialog,
-        closeScheduleEmailingDialog,
-        openScheduleEmailingManagementDialog,
-        closeScheduleEmailingManagementDialog,
-    };
-};
+import { useDashboardScheduledEmails } from "../../../model";
 
 export const ScheduledEmailDialogProvider = () => {
     const {
-        openScheduleEmailingDialog,
-        closeScheduleEmailingDialog,
-        openScheduleEmailingManagementDialog,
-        closeScheduleEmailingManagementDialog,
-    } = useScheduledEmailDialogProvider();
-    const { addSuccess, addError } = useToastMessage();
-    const isScheduleEmailingDialogOpen = useDashboardSelector(selectIsScheduleEmailDialogOpen);
-    const isScheduleEmailingManagementDialogOpen = useDashboardSelector(
-        selectIsScheduleEmailManagementDialogOpen,
-    );
-
-    const onScheduleEmailingError = useCallback(() => {
-        closeScheduleEmailingDialog();
-        addError({ id: "dialogs.schedule.email.submit.error" });
-    }, []);
-
-    const onScheduleEmailingSuccess = useCallback(() => {
-        closeScheduleEmailingDialog();
-        addSuccess({ id: "dialogs.schedule.email.submit.success" });
-    }, []);
-
-    const onScheduleEmailingCancel = useCallback(() => {
-        closeScheduleEmailingDialog();
-        openScheduleEmailingManagementDialog();
-    }, []);
-
-    const onScheduleEmailingManagementDelete = useCallback(() => {
-        addSuccess({ id: "dialogs.schedule.email.delete.success" });
-    }, []);
-
-    const onScheduleEmailingManagementAdd = useCallback(() => {
-        closeScheduleEmailingManagementDialog();
-        openScheduleEmailingDialog();
-    }, []);
-
-    const onScheduleEmailingManagementClose = useCallback(() => {
-        closeScheduleEmailingManagementDialog();
-    }, []);
-
-    const onScheduleEmailingManagementLoadingError = useCallback(() => {
-        closeScheduleEmailingManagementDialog();
-        addError({ id: "dialogs.schedule.management.load.error" });
-    }, []);
-
-    const onScheduleEmailingManagementDeleteError = useCallback(() => {
-        closeScheduleEmailingManagementDialog();
-        addError({ id: "dialogs.schedule.management.delete.error" });
-    }, []);
+        isScheduleEmailingDialogOpen,
+        isScheduleEmailingManagementDialogOpen,
+        onScheduleEmailingCancel,
+        onScheduleEmailingError,
+        onScheduleEmailingSuccess,
+        onScheduleEmailingManagementAdd,
+        onScheduleEmailingManagementClose,
+        onScheduleEmailingManagementLoadingError,
+        onScheduleEmailingManagementDeleteSuccess,
+        onScheduleEmailingManagementDeleteError,
+    } = useDashboardScheduledEmails();
 
     return (
         <>
@@ -110,7 +25,7 @@ export const ScheduledEmailDialogProvider = () => {
                     isVisible={isScheduleEmailingManagementDialogOpen}
                     onAdd={onScheduleEmailingManagementAdd}
                     onClose={onScheduleEmailingManagementClose}
-                    onDeleteSuccess={onScheduleEmailingManagementDelete}
+                    onDeleteSuccess={onScheduleEmailingManagementDeleteSuccess}
                     onLoadError={onScheduleEmailingManagementLoadingError}
                     onDeleteError={onScheduleEmailingManagementDeleteError}
                 />

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -867,6 +867,11 @@
         "comment": "Export to file with XLSX extension.",
         "limit": 0
     },
+    "widget.options.menu.scheduleExport": {
+        "value": "Schedule export",
+        "comment": "",
+        "limit": 0
+    },
     "share.button.text": {
         "value": "Share",
         "comment": "Text of button that opens share dialog",

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/test/ScheduledMailDialogRenderer.test.tsx
@@ -13,6 +13,7 @@ import { DateTime } from "../DateTime";
 import { getUserTimezone, ITimezone } from "../../utils/timezone";
 import { useWorkspaceUsers } from "../../useWorkspaceUsers";
 import { IntlWrapper } from "../../../../localization/IntlWrapper";
+import { newInsightWidget } from "@gooddata/sdk-backend-base";
 
 jest.mock("../../useWorkspaceUsers", () => ({
     useWorkspaceUsers: (): ReturnType<typeof useWorkspaceUsers> => ({
@@ -185,5 +186,57 @@ describe("ScheduledMailDialogRenderer", () => {
         const subjectInput = wrapper.find(".s-gd-schedule-email-dialog-subject input");
         const valueInput = subjectInput.prop("placeholder");
         expect(valueInput?.length).toBe(255);
+    });
+
+    describe("default attachment", () => {
+        const widgetUri1 = "/widget/uri1";
+        const widgetUri2 = "/widget/uri2";
+        const widgetRef1 = uriRef(widgetUri1);
+        const widgetRef2 = uriRef(widgetUri2);
+        const insightWidget1 = newInsightWidget(uriRef("/insight/uri1"), (w) =>
+            w.title("Widget 1").ref(widgetRef1).uri(widgetUri1),
+        );
+        const insightWidget2 = newInsightWidget(uriRef("/insight/uri2"), (w) =>
+            w.title("Widget 2").ref(widgetRef2).uri(widgetUri2),
+        );
+
+        it("should not render default csv attachment selected when FF is false", () => {
+            const wrapper = renderComponent({
+                enableWidgetExportScheduling: false,
+                defaultAttachment: widgetRef2,
+                dashboardInsightWidgets: [insightWidget1, insightWidget2],
+            });
+
+            expect(wrapper.find(".s-gd-dashboard-attachment")).not.toExist();
+        });
+
+        it("should not render default csv attachment selected when default attachment is not provided", () => {
+            const wrapper = renderComponent({
+                enableWidgetExportScheduling: true,
+                dashboardInsightWidgets: [insightWidget1, insightWidget2],
+            });
+
+            expect(wrapper.find(".s-gd-dashboard-attachment").text()).toEqual("pdfDashboard title");
+        });
+
+        it("should not render default csv attachment selected when default attachment is not valid", () => {
+            const wrapper = renderComponent({
+                enableWidgetExportScheduling: true,
+                defaultAttachment: uriRef("invalidWidgetUri"),
+                dashboardInsightWidgets: [insightWidget1, insightWidget2],
+            });
+
+            expect(wrapper.find(".s-gd-dashboard-attachment").text()).toEqual("pdfDashboard title");
+        });
+
+        it("should render default csv attachment selected when provided", () => {
+            const wrapper = renderComponent({
+                enableWidgetExportScheduling: true,
+                defaultAttachment: widgetRef2,
+                dashboardInsightWidgets: [insightWidget1, insightWidget2],
+            });
+
+            expect(wrapper.find(".s-gd-dashboard-attachment").text()).toEqual("csvWidget 2");
+        });
     });
 });

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/index.tsx
@@ -26,6 +26,7 @@ export const DefaultScheduledEmailDialog = (props: IScheduledEmailDialogProps): 
         enableKPIDashboardSchedule,
         enableKPIDashboardScheduleRecipients,
         enableWidgetExportScheduling,
+        defaultAttachment,
     } = useScheduledEmail({ onSubmit, onSubmitSuccess: onSuccess, onSubmitError: onError });
 
     // trigger the invariant only if the user tries to open the dialog
@@ -56,6 +57,7 @@ export const DefaultScheduledEmailDialog = (props: IScheduledEmailDialogProps): 
             onSubmit={handleCreateScheduledEmail}
             onCancel={onCancel}
             onError={onError}
+            defaultAttachment={defaultAttachment}
         />
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/useScheduledEmail.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/useScheduledEmail.ts
@@ -8,7 +8,7 @@ import {
     IInsightWidget,
 } from "@gooddata/sdk-backend-spi";
 import { GoodDataSdkError, ILocale } from "@gooddata/sdk-ui";
-import { UriRef, IUser } from "@gooddata/sdk-model";
+import { UriRef, IUser, ObjRef } from "@gooddata/sdk-model";
 import isEqual from "lodash/isEqual";
 
 import {
@@ -28,6 +28,7 @@ import {
     selectWidgets,
     isCustomWidget,
     selectCanExportReport,
+    selectScheduleEmailDialogDefaultAttachment,
 } from "../../../model";
 
 import { useCreateScheduledEmail } from "./useCreateScheduledEmail";
@@ -111,6 +112,11 @@ interface UseScheduledEmailResult {
      * Status of the scheduled email creation -
      */
     scheduledEmailCreationStatus?: CommandProcessingStatus;
+
+    /**
+     * Attachment to be selected by default.
+     */
+    defaultAttachment?: ObjRef;
 }
 
 /**
@@ -160,6 +166,7 @@ export const useScheduledEmail = (props: UseScheduledEmailProps): UseScheduledEm
     const canExportReport = useDashboardSelector(selectCanExportReport);
     const enableKPIDashboardSchedule = useDashboardSelector(selectEnableKPIDashboardSchedule);
     const enableWidgetExportScheduling = useDashboardSelector(selectEnableInsightExportScheduling);
+    const defaultAttachment = useDashboardSelector(selectScheduleEmailDialogDefaultAttachment);
 
     const scheduledEmailCreator = useCreateScheduledEmail({
         onSuccess: onSubmitSuccess,
@@ -196,5 +203,6 @@ export const useScheduledEmail = (props: UseScheduledEmailProps): UseScheduledEm
         locale,
         handleCreateScheduledEmail,
         scheduledEmailCreationStatus,
+        defaultAttachment,
     };
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/getDefaultInsightMenuItems.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/getDefaultInsightMenuItems.ts
@@ -1,5 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { IntlShape } from "react-intl";
+import compact from "lodash/compact";
 
 import { IInsightMenuItem } from "../types";
 
@@ -11,14 +12,26 @@ export function getDefaultInsightMenuItems(
     config: {
         exportXLSXDisabled: boolean;
         exportCSVDisabled: boolean;
+        scheduleExportDisabled: boolean;
         onExportXLSX: () => void;
         onExportCSV: () => void;
+        onScheduleExport: () => void;
+        isScheduleExportVisible: boolean;
         tooltipMessage: string;
     },
 ): IInsightMenuItem[] {
-    const { exportCSVDisabled, exportXLSXDisabled, onExportCSV, onExportXLSX, tooltipMessage } = config;
+    const {
+        exportCSVDisabled,
+        exportXLSXDisabled,
+        scheduleExportDisabled,
+        onExportCSV,
+        onExportXLSX,
+        onScheduleExport,
+        isScheduleExportVisible,
+        tooltipMessage,
+    } = config;
 
-    return [
+    return compact([
         {
             type: "button",
             itemId: "ExportXLSXBubble",
@@ -39,5 +52,15 @@ export function getDefaultInsightMenuItems(
             icon: "gd-icon-download",
             className: "s-options-menu-export-csv",
         },
-    ];
+        isScheduleExportVisible && {
+            type: "button",
+            itemId: "ScheduleExport",
+            itemName: intl.formatMessage({ id: "widget.options.menu.scheduleExport" }),
+            onClick: onScheduleExport,
+            disabled: scheduleExportDisabled,
+            tooltip: tooltipMessage,
+            icon: "gd-icon-clock",
+            className: "s-options-menu-schedule-export",
+        },
+    ]);
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -1,12 +1,17 @@
 // (C) 2020-2022 GoodData Corporation
-import React, { useMemo } from "react";
+import React, { useMemo, useCallback } from "react";
 import cx from "classnames";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IInsight, insightVisualizationUrl } from "@gooddata/sdk-model";
 import { IInsightWidget, ScreenSize, widgetTitle } from "@gooddata/sdk-backend-spi";
 import { OnError, OnExportReady, OnLoadingChanged, VisType } from "@gooddata/sdk-ui";
 
-import { useDashboardSelector, selectInsightsMap } from "../../../model";
+import {
+    useDashboardSelector,
+    selectInsightsMap,
+    isCustomWidget,
+    useDashboardScheduledEmails,
+} from "../../../model";
 import {
     DashboardItem,
     DashboardItemHeadline,
@@ -77,20 +82,31 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     index,
 }) => {
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
+    const { ref: widgetRef } = widget;
 
     const { exportCSVEnabled, exportXLSXEnabled, onExportCSV, onExportXLSX } = useInsightExport({
-        widgetRef: widget.ref,
+        widgetRef,
         title: widgetTitle(widget) || intl.formatMessage({ id: "export.defaultTitle" }),
         insight,
     });
+
+    const { isScheduledEmailingVisible, enableInsightExportScheduling, onScheduleEmailingOpen } =
+        useDashboardScheduledEmails();
+    const onScheduleExport = useCallback(() => {
+        onScheduleEmailingOpen(widgetRef);
+    }, [widgetRef]);
+    const scheduleExportEnabled = !isCustomWidget(widget);
 
     const { closeMenu, isMenuOpen, menuItems, openMenu } = useInsightMenu({
         insight,
         widget,
         exportCSVEnabled,
         exportXLSXEnabled,
+        scheduleExportEnabled,
         onExportCSV,
         onExportXLSX,
+        onScheduleExport,
+        isScheduleExportVisible: isScheduledEmailingVisible && enableInsightExportScheduling,
     });
 
     const {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { useCallback, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
@@ -20,10 +20,23 @@ export const useInsightMenu = (config: {
     widget: IInsightWidget;
     exportCSVEnabled: boolean;
     exportXLSXEnabled: boolean;
+    scheduleExportEnabled: boolean;
     onExportCSV: () => void;
     onExportXLSX: () => void;
+    onScheduleExport: () => void;
+    isScheduleExportVisible: boolean;
 }): { menuItems: IInsightMenuItem[]; isMenuOpen: boolean; openMenu: () => void; closeMenu: () => void } => {
-    const { exportCSVEnabled, exportXLSXEnabled, insight, onExportCSV, onExportXLSX, widget } = config;
+    const {
+        exportCSVEnabled,
+        exportXLSXEnabled,
+        scheduleExportEnabled,
+        insight,
+        onExportCSV,
+        onExportXLSX,
+        onScheduleExport,
+        isScheduleExportVisible,
+        widget,
+    } = config;
 
     const intl = useIntl();
 
@@ -49,6 +62,7 @@ export const useInsightMenu = (config: {
         return defaultMenuItemsGetter(intl, {
             exportCSVDisabled: !exportCSVEnabled,
             exportXLSXDisabled: !exportXLSXEnabled,
+            scheduleExportDisabled: !scheduleExportEnabled,
             onExportCSV: () => {
                 setIsMenuOpen(false);
                 onExportCSV();
@@ -57,6 +71,11 @@ export const useInsightMenu = (config: {
                 setIsMenuOpen(false);
                 onExportXLSX();
             },
+            onScheduleExport: () => {
+                setIsMenuOpen(false);
+                onScheduleExport();
+            },
+            isScheduleExportVisible,
             tooltipMessage: intl.formatMessage({ id: bubbleMessageKey }),
         });
     }, [
@@ -64,8 +83,11 @@ export const useInsightMenu = (config: {
         execution,
         exportCSVEnabled,
         exportXLSXEnabled,
+        scheduleExportEnabled,
         onExportCSV,
         onExportXLSX,
+        onScheduleExport,
+        isScheduleExportVisible,
         intl,
     ]);
 


### PR DESCRIPTION
Show schedule export option in insight widget menu which opens scheduling dialog with particular widget attachment set up.

JIRA: TNT-652

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
