### PR TITLE
RELATED: RAIL-2788 initial support for header based auth on bear

### DIFF
--- a/libs/api-client-bear/src/config.ts
+++ b/libs/api-client-bear/src/config.ts
@@ -1,5 +1,6 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import set from "lodash/set";
+import { IConfigStorage, IOriginPackage } from "./interfaces";
 
 /**
  * Config module holds SDK configuration variables
@@ -33,24 +34,12 @@ export function sanitizeDomain(domain: string | null): string | undefined {
  *
  * @returns config with sanitized domain
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export function sanitizeConfig(config: any): any {
+export function sanitizeConfig(config: IConfigStorage): IConfigStorage {
     const sanitized = { ...config };
     if (config.domain) {
         sanitized.domain = sanitizeDomain(config.domain);
     }
     return sanitized;
-}
-
-export interface IOriginPackage {
-    name: string;
-    version: string;
-}
-
-export interface IConfigStorage {
-    domain?: string;
-    originPackage?: IOriginPackage;
-    xhrSettings?: { headers?: Record<string, string> };
 }
 
 /**

--- a/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
+++ b/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
@@ -6,10 +6,9 @@ import { DashboardModule } from "../dashboard";
 import { XhrModule } from "../../xhr";
 import { ACCEPTED_REQUEST_STATUS, BAD_REQUEST_STATUS, SUCCESS_REQUEST_STATUS } from "../../constants/errors";
 import { mockPollingRequest, mockPollingRequestWithStatus } from "../../tests/utils/polling";
-import { LocalStorageModule } from "../../localStorage";
+import { mockLocalStorageModule } from "../../tests/mockLocalStorageModule";
 
-const dashboardExportModuleMock = () =>
-    new DashboardModule(new XhrModule(fetch, {}, new LocalStorageModule()));
+const dashboardExportModuleMock = () => new DashboardModule(new XhrModule(fetch, {}, mockLocalStorageModule));
 
 describe("exportDashboard", () => {
     const projectId = "testProjectId";

--- a/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
+++ b/libs/api-client-bear/src/dashboard/tests/dashboard.test.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { GdcFilterContext, GdcExport } from "@gooddata/api-model-bear";
@@ -6,8 +6,10 @@ import { DashboardModule } from "../dashboard";
 import { XhrModule } from "../../xhr";
 import { ACCEPTED_REQUEST_STATUS, BAD_REQUEST_STATUS, SUCCESS_REQUEST_STATUS } from "../../constants/errors";
 import { mockPollingRequest, mockPollingRequestWithStatus } from "../../tests/utils/polling";
+import { LocalStorageModule } from "../../localStorage";
 
-const dashboardExportModuleMock = () => new DashboardModule(new XhrModule(fetch, {}));
+const dashboardExportModuleMock = () =>
+    new DashboardModule(new XhrModule(fetch, {}, new LocalStorageModule()));
 
 describe("exportDashboard", () => {
     const projectId = "testProjectId";

--- a/libs/api-client-bear/src/execution/tests/execute-afm.test.ts
+++ b/libs/api-client-bear/src/execution/tests/execute-afm.test.ts
@@ -11,7 +11,7 @@ import {
     replaceLimitAndOffsetInUri,
 } from "../execute-afm";
 import { XhrModule } from "../../xhr";
-import { LocalStorageModule } from "../../localStorage";
+import { mockLocalStorageModule } from "../../tests/mockLocalStorageModule";
 
 const DEFAULT_TEST_LIMIT = 1000;
 
@@ -19,7 +19,7 @@ interface IPagesByOffset {
     [offset: string]: GdcExecution.IExecutionResultWrapper;
 }
 
-const createExecuteAfm = () => new ExecuteAfmModule(new XhrModule(fetch, {}, new LocalStorageModule()));
+const createExecuteAfm = () => new ExecuteAfmModule(new XhrModule(fetch, {}, mockLocalStorageModule));
 
 function createAttributeHeaderItem(name: string): GdcExecution.IResultAttributeHeaderItem {
     return {

--- a/libs/api-client-bear/src/execution/tests/execute-afm.test.ts
+++ b/libs/api-client-bear/src/execution/tests/execute-afm.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import range from "lodash/range";
@@ -11,6 +11,7 @@ import {
     replaceLimitAndOffsetInUri,
 } from "../execute-afm";
 import { XhrModule } from "../../xhr";
+import { LocalStorageModule } from "../../localStorage";
 
 const DEFAULT_TEST_LIMIT = 1000;
 
@@ -18,7 +19,7 @@ interface IPagesByOffset {
     [offset: string]: GdcExecution.IExecutionResultWrapper;
 }
 
-const createExecuteAfm = () => new ExecuteAfmModule(new XhrModule(fetch, {}));
+const createExecuteAfm = () => new ExecuteAfmModule(new XhrModule(fetch, {}, new LocalStorageModule()));
 
 function createAttributeHeaderItem(name: string): GdcExecution.IResultAttributeHeaderItem {
     return {

--- a/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
+++ b/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import range from "lodash/range";
@@ -15,6 +15,7 @@ import sortBy from "lodash/sortBy";
 import levenshtein from "fast-levenshtein";
 import includes from "lodash/includes";
 import find from "lodash/find";
+import { LocalStorageModule } from "../../localStorage";
 
 interface IReportDefinition {
     columns: string[];
@@ -93,7 +94,7 @@ function expectMetricDefinition(expected: IMetricDefinition, reportDefinition: I
 }
 
 function createExecution() {
-    const xhr = new XhrModule(fetch, {});
+    const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
 
     const loaderModule = new AttributesMapLoaderModule(new MetadataModule(xhr));
     return new ExperimentalExecutionsModule(xhr, loaderModule.loadAttributesMap.bind(loaderModule));

--- a/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
+++ b/libs/api-client-bear/src/execution/tests/experimental-executions.test.ts
@@ -15,7 +15,7 @@ import sortBy from "lodash/sortBy";
 import levenshtein from "fast-levenshtein";
 import includes from "lodash/includes";
 import find from "lodash/find";
-import { LocalStorageModule } from "../../localStorage";
+import { mockLocalStorageModule } from "../../tests/mockLocalStorageModule";
 
 interface IReportDefinition {
     columns: string[];
@@ -94,7 +94,7 @@ function expectMetricDefinition(expected: IMetricDefinition, reportDefinition: I
 }
 
 function createExecution() {
-    const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
+    const xhr = new XhrModule(fetch, {}, mockLocalStorageModule);
 
     const loaderModule = new AttributesMapLoaderModule(new MetadataModule(xhr));
     return new ExperimentalExecutionsModule(xhr, loaderModule.loadAttributesMap.bind(loaderModule));

--- a/libs/api-client-bear/src/gooddata.ts
+++ b/libs/api-client-bear/src/gooddata.ts
@@ -14,7 +14,7 @@ import { CatalogueModule } from "./catalogue";
 import { AttributesMapLoaderModule } from "./utils/attributesMapLoader";
 import { LdmModule } from "./ldm";
 import { LocalStorageModule } from "./localStorage";
-import { IConfigStorage } from "./interfaces";
+import { IConfigStorage, ILocalStorageModule } from "./interfaces";
 
 /**
  * This package provides low-level functions for communication with the GoodData platform.
@@ -59,7 +59,7 @@ export class SDK {
         loadAttributesMap: any;
         getAttributesDisplayForms: any;
     };
-    public localStore: LocalStorageModule;
+    public localStore: ILocalStorageModule;
 
     constructor(private fetchMethod: typeof fetch, config = {}) {
         this.configStorage = sanitizeConfig(config); // must be plain object, SDK modules MUST use this storage

--- a/libs/api-client-bear/src/gooddata.ts
+++ b/libs/api-client-bear/src/gooddata.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import cloneDeep from "lodash/cloneDeep";
 import { getAttributesDisplayForms } from "@gooddata/api-model-bear";
 import { XhrModule } from "./xhr";
@@ -9,10 +9,12 @@ import { ExecutionModule } from "./execution";
 import { ProjectModule } from "./project";
 import { ReportModule } from "./report/report";
 import { DashboardModule } from "./dashboard/dashboard";
-import { sanitizeConfig, IConfigStorage, ConfigModule } from "./config";
+import { sanitizeConfig, ConfigModule } from "./config";
 import { CatalogueModule } from "./catalogue";
 import { AttributesMapLoaderModule } from "./utils/attributesMapLoader";
 import { LdmModule } from "./ldm";
+import { LocalStorageModule } from "./localStorage";
+import { IConfigStorage } from "./interfaces";
 
 /**
  * This package provides low-level functions for communication with the GoodData platform.
@@ -57,15 +59,17 @@ export class SDK {
         loadAttributesMap: any;
         getAttributesDisplayForms: any;
     };
+    public localStore: LocalStorageModule;
 
     constructor(private fetchMethod: typeof fetch, config = {}) {
         this.configStorage = sanitizeConfig(config); // must be plain object, SDK modules MUST use this storage
 
         this.config = new ConfigModule(this.configStorage);
-        this.xhr = new XhrModule(fetchMethod, this.configStorage);
-        this.user = new UserModule(this.xhr);
+        this.localStore = new LocalStorageModule();
+        this.xhr = new XhrModule(fetchMethod, this.configStorage, this.localStore);
+        this.user = new UserModule(this.xhr, this.configStorage, this.localStore);
         this.md = new MetadataModule(this.xhr);
-        this.mdExt = new MetadataModuleExt(this.xhr);
+        this.mdExt = new MetadataModuleExt(this.xhr, this.configStorage, this.localStore);
         this.execution = new ExecutionModule(this.xhr, this.md);
         this.project = new ProjectModule(this.xhr);
         this.report = new ReportModule(this.xhr);

--- a/libs/api-client-bear/src/interfaces.ts
+++ b/libs/api-client-bear/src/interfaces.ts
@@ -373,3 +373,11 @@ export interface IConfigStorage {
     xhrSettings?: { headers?: Record<string, string> };
     verificationLevel?: "cookie" | "header";
 }
+
+export interface ILocalStorageModule {
+    storeSST(sst: string): void;
+    storeTT(tt: string): void;
+    getSST(): string | null;
+    getTT(): string | null;
+    clearTokens(): void;
+}

--- a/libs/api-client-bear/src/interfaces.ts
+++ b/libs/api-client-bear/src/interfaces.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { GdcVisualizationObject, GdcExecuteAFM, GdcMetadata, Uri } from "@gooddata/api-model-bear";
 
 export type SortDirection = "asc" | "desc";
@@ -361,3 +361,15 @@ export interface IAdHocItemDescription {
 }
 
 export type ItemDescription = IStoredItemDescription | IAdHocItemDescription;
+
+export interface IOriginPackage {
+    name: string;
+    version: string;
+}
+
+export interface IConfigStorage {
+    domain?: string;
+    originPackage?: IOriginPackage;
+    xhrSettings?: { headers?: Record<string, string> };
+    verificationLevel?: "cookie" | "header";
+}

--- a/libs/api-client-bear/src/localStorage.ts
+++ b/libs/api-client-bear/src/localStorage.ts
@@ -1,0 +1,21 @@
+// (C) 2022 GoodData Corporation
+const SST_STORAGE_KEY = "GoodData_SST";
+const TT_STORAGE_KEY = "GoodData_TT";
+
+export class LocalStorageModule {
+    public storeSST(sst: string): void {
+        window.localStorage.setItem(SST_STORAGE_KEY, sst);
+    }
+
+    public storeTT(tt: string): void {
+        window.localStorage.setItem(TT_STORAGE_KEY, tt);
+    }
+
+    public getSST(): string | null {
+        return window.localStorage.getItem(SST_STORAGE_KEY);
+    }
+
+    public getTT(): string | null {
+        return window.localStorage.getItem(TT_STORAGE_KEY);
+    }
+}

--- a/libs/api-client-bear/src/localStorage.ts
+++ b/libs/api-client-bear/src/localStorage.ts
@@ -1,8 +1,10 @@
 // (C) 2022 GoodData Corporation
+import { ILocalStorageModule } from "./interfaces";
+
 const SST_STORAGE_KEY = "GoodData_SST";
 const TT_STORAGE_KEY = "GoodData_TT";
 
-export class LocalStorageModule {
+export class LocalStorageModule implements ILocalStorageModule {
     public storeSST(sst: string): void {
         window.localStorage.setItem(SST_STORAGE_KEY, sst);
     }
@@ -17,5 +19,10 @@ export class LocalStorageModule {
 
     public getTT(): string | null {
         return window.localStorage.getItem(TT_STORAGE_KEY);
+    }
+
+    public clearTokens(): void {
+        window.localStorage.removeItem(SST_STORAGE_KEY);
+        window.localStorage.removeItem(TT_STORAGE_KEY);
     }
 }

--- a/libs/api-client-bear/src/metadataExt.ts
+++ b/libs/api-client-bear/src/metadataExt.ts
@@ -13,6 +13,7 @@ import {
     GdcMetadata,
     GdcVisualizationObject,
 } from "@gooddata/api-model-bear";
+import { LocalStorageModule } from "./localStorage";
 
 /**
  * Modify how and what should be copied to the cloned dashboard
@@ -111,12 +112,11 @@ export function updateContent(
 export class MetadataModuleExt {
     private metadataModule: MetadataModule;
     private userModule: UserModule;
-    private xhr: XhrModule;
 
-    constructor(xhr: XhrModule) {
+    constructor(private xhr: XhrModule, configStorage: any, localStore: LocalStorageModule) {
         this.xhr = xhr;
         this.metadataModule = new MetadataModule(xhr);
-        this.userModule = new UserModule(xhr);
+        this.userModule = new UserModule(xhr, configStorage, localStore);
     }
 
     /**

--- a/libs/api-client-bear/src/metadataExt.ts
+++ b/libs/api-client-bear/src/metadataExt.ts
@@ -13,7 +13,7 @@ import {
     GdcMetadata,
     GdcVisualizationObject,
 } from "@gooddata/api-model-bear";
-import { LocalStorageModule } from "./localStorage";
+import { IConfigStorage, ILocalStorageModule } from "./interfaces";
 
 /**
  * Modify how and what should be copied to the cloned dashboard
@@ -113,8 +113,7 @@ export class MetadataModuleExt {
     private metadataModule: MetadataModule;
     private userModule: UserModule;
 
-    constructor(private xhr: XhrModule, configStorage: any, localStore: LocalStorageModule) {
-        this.xhr = xhr;
+    constructor(private xhr: XhrModule, configStorage: IConfigStorage, localStore: ILocalStorageModule) {
         this.metadataModule = new MetadataModule(xhr);
         this.userModule = new UserModule(xhr, configStorage, localStore);
     }

--- a/libs/api-client-bear/src/report/tests/report.test.ts
+++ b/libs/api-client-bear/src/report/tests/report.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { ReportModule } from "../report";
@@ -12,8 +12,9 @@ import {
     ERROR_RESTRICTED_MESSAGE,
 } from "../../constants/errors";
 import { GdcExport } from "@gooddata/api-model-bear";
+import { LocalStorageModule } from "../../localStorage";
 
-const mockedReportModule = () => new ReportModule(new XhrModule(fetch, {}));
+const mockedReportModule = () => new ReportModule(new XhrModule(fetch, {}, new LocalStorageModule()));
 
 describe("report", () => {
     const createdReport = "/gdc/exporter/result/12345";

--- a/libs/api-client-bear/src/report/tests/report.test.ts
+++ b/libs/api-client-bear/src/report/tests/report.test.ts
@@ -12,9 +12,9 @@ import {
     ERROR_RESTRICTED_MESSAGE,
 } from "../../constants/errors";
 import { GdcExport } from "@gooddata/api-model-bear";
-import { LocalStorageModule } from "../../localStorage";
+import { mockLocalStorageModule } from "../../tests/mockLocalStorageModule";
 
-const mockedReportModule = () => new ReportModule(new XhrModule(fetch, {}, new LocalStorageModule()));
+const mockedReportModule = () => new ReportModule(new XhrModule(fetch, {}, mockLocalStorageModule));
 
 describe("report", () => {
     const createdReport = "/gdc/exporter/result/12345";

--- a/libs/api-client-bear/src/tests/catalogue.test.ts
+++ b/libs/api-client-bear/src/tests/catalogue.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 
@@ -8,9 +8,10 @@ import { CatalogueModule } from "../catalogue";
 import { XhrModule } from "../xhr";
 import { ExecutionModule } from "../execution";
 import { MetadataModule } from "../metadata";
+import { LocalStorageModule } from "../localStorage";
 
 function createCatalogue() {
-    const xhr = new XhrModule(fetch, {});
+    const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
 
     return new CatalogueModule(xhr, new ExecutionModule(xhr, new MetadataModule(xhr)));
 }

--- a/libs/api-client-bear/src/tests/catalogue.test.ts
+++ b/libs/api-client-bear/src/tests/catalogue.test.ts
@@ -8,10 +8,10 @@ import { CatalogueModule } from "../catalogue";
 import { XhrModule } from "../xhr";
 import { ExecutionModule } from "../execution";
 import { MetadataModule } from "../metadata";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
 function createCatalogue() {
-    const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
+    const xhr = new XhrModule(fetch, {}, mockLocalStorageModule);
 
     return new CatalogueModule(xhr, new ExecutionModule(xhr, new MetadataModule(xhr)));
 }

--- a/libs/api-client-bear/src/tests/config.test.ts
+++ b/libs/api-client-bear/src/tests/config.test.ts
@@ -1,5 +1,6 @@
-// (C) 2007-2014 GoodData Corporation
-import { sanitizeConfig, sanitizeDomain, IConfigStorage, ConfigModule } from "../config";
+// (C) 2007-2022 GoodData Corporation
+import { sanitizeConfig, sanitizeDomain, ConfigModule } from "../config";
+import { IConfigStorage } from "../interfaces";
 
 describe("sanitizeDomain", () => {
     it("should set url if valid", () => {

--- a/libs/api-client-bear/src/tests/metadata.test.ts
+++ b/libs/api-client-bear/src/tests/metadata.test.ts
@@ -10,9 +10,9 @@ import { MetadataModule } from "../metadata";
 import { XhrModule } from "../xhr";
 import * as fixtures from "./metadata.fixtures";
 import { SortDirection } from "../interfaces";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
-const createMd = () => new MetadataModule(new XhrModule(fetch, {}, new LocalStorageModule()));
+const createMd = () => new MetadataModule(new XhrModule(fetch, {}, mockLocalStorageModule));
 
 describe("metadata", () => {
     describe("with fake server", () => {

--- a/libs/api-client-bear/src/tests/metadata.test.ts
+++ b/libs/api-client-bear/src/tests/metadata.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import { GdcMetadata } from "@gooddata/api-model-bear";
 import fetchMock from "fetch-mock";
@@ -10,8 +10,9 @@ import { MetadataModule } from "../metadata";
 import { XhrModule } from "../xhr";
 import * as fixtures from "./metadata.fixtures";
 import { SortDirection } from "../interfaces";
+import { LocalStorageModule } from "../localStorage";
 
-const createMd = () => new MetadataModule(new XhrModule(fetch, {}));
+const createMd = () => new MetadataModule(new XhrModule(fetch, {}, new LocalStorageModule()));
 
 describe("metadata", () => {
     describe("with fake server", () => {

--- a/libs/api-client-bear/src/tests/mockLocalStorageModule.ts
+++ b/libs/api-client-bear/src/tests/mockLocalStorageModule.ts
@@ -1,0 +1,11 @@
+// (C) 2022 GoodData Corporation
+import noop from "lodash/noop";
+import { ILocalStorageModule } from "../interfaces";
+
+export const mockLocalStorageModule: ILocalStorageModule = {
+    clearTokens: noop,
+    getSST: () => "fake-sst",
+    getTT: () => "fake-tt",
+    storeSST: noop,
+    storeTT: noop,
+};

--- a/libs/api-client-bear/src/tests/project.test.ts
+++ b/libs/api-client-bear/src/tests/project.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import noop from "lodash/noop";
@@ -13,8 +13,9 @@ import { ApiError, XhrModule } from "../xhr";
 import { mockPollingRequest } from "./utils/polling";
 import { IColorPalette, IFeatureFlags } from "../interfaces";
 import { IStyleSettingsResponse, IFeatureFlagsResponse } from "../apiResponsesInterfaces";
+import { LocalStorageModule } from "../localStorage";
 
-const createProject = () => new ProjectModule(new XhrModule(fetch, {}));
+const createProject = () => new ProjectModule(new XhrModule(fetch, {}, new LocalStorageModule()));
 
 type ICustomCheck = (options: any) => void;
 

--- a/libs/api-client-bear/src/tests/project.test.ts
+++ b/libs/api-client-bear/src/tests/project.test.ts
@@ -13,9 +13,9 @@ import { ApiError, XhrModule } from "../xhr";
 import { mockPollingRequest } from "./utils/polling";
 import { IColorPalette, IFeatureFlags } from "../interfaces";
 import { IStyleSettingsResponse, IFeatureFlagsResponse } from "../apiResponsesInterfaces";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
-const createProject = () => new ProjectModule(new XhrModule(fetch, {}, new LocalStorageModule()));
+const createProject = () => new ProjectModule(new XhrModule(fetch, {}, mockLocalStorageModule));
 
 type ICustomCheck = (options: any) => void;
 

--- a/libs/api-client-bear/src/tests/user.test.ts
+++ b/libs/api-client-bear/src/tests/user.test.ts
@@ -3,8 +3,10 @@ import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { UserModule } from "../user";
 import { ApiResponse, XhrModule } from "../xhr";
+import { LocalStorageModule } from "../localStorage";
 
-const createUser = () => new UserModule(new XhrModule(fetch, {}));
+const createUser = () =>
+    new UserModule(new XhrModule(fetch, {}, new LocalStorageModule()), {}, new LocalStorageModule());
 
 describe("user", () => {
     describe("with fake server", () => {

--- a/libs/api-client-bear/src/tests/user.test.ts
+++ b/libs/api-client-bear/src/tests/user.test.ts
@@ -3,10 +3,10 @@ import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { UserModule } from "../user";
 import { ApiResponse, XhrModule } from "../xhr";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
 const createUser = () =>
-    new UserModule(new XhrModule(fetch, {}, new LocalStorageModule()), {}, new LocalStorageModule());
+    new UserModule(new XhrModule(fetch, {}, mockLocalStorageModule), {}, mockLocalStorageModule);
 
 describe("user", () => {
     describe("with fake server", () => {
@@ -181,8 +181,7 @@ describe("user", () => {
                 return expect(createUser().logout()).resolves.toEqual(undefined);
             });
 
-            it("should log out user", () => {
-                expect.assertions(1);
+            it("should log out user", async () => {
                 const userId = "USER_ID";
 
                 fetchMock.mock("/gdc/account/token", 200);
@@ -205,11 +204,8 @@ describe("user", () => {
                     200, // should be 204, but see https://github.com/wheresrhys/fetch-mock/issues/36
                 );
 
-                return createUser()
-                    .logout()
-                    .then((r) => {
-                        expect((r as ApiResponse | undefined)?.response.ok).toBeTruthy();
-                    });
+                const result = await createUser().logout();
+                expect((result as ApiResponse | undefined)?.response.ok).toBeTruthy();
             });
         });
 

--- a/libs/api-client-bear/src/tests/util.test.ts
+++ b/libs/api-client-bear/src/tests/util.test.ts
@@ -5,7 +5,7 @@ import { mockPollingRequestWithStatus } from "./utils/polling";
 import { handleHeadPolling, IPollingOptions, queryString, parseSettingItemValue } from "../util";
 import { ApiResponse, XhrModule } from "../xhr";
 import { GdcExport } from "@gooddata/api-model-bear";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
 describe("util", () => {
     describe("queryString", () => {
@@ -42,7 +42,7 @@ describe("util", () => {
         };
 
         const mockedXHR = () => {
-            const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
+            const xhr = new XhrModule(fetch, {}, mockLocalStorageModule);
             return xhr.get.bind(xhr);
         };
 

--- a/libs/api-client-bear/src/tests/util.test.ts
+++ b/libs/api-client-bear/src/tests/util.test.ts
@@ -1,10 +1,11 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 import { mockPollingRequestWithStatus } from "./utils/polling";
 import { handleHeadPolling, IPollingOptions, queryString, parseSettingItemValue } from "../util";
 import { ApiResponse, XhrModule } from "../xhr";
 import { GdcExport } from "@gooddata/api-model-bear";
+import { LocalStorageModule } from "../localStorage";
 
 describe("util", () => {
     describe("queryString", () => {
@@ -41,7 +42,7 @@ describe("util", () => {
         };
 
         const mockedXHR = () => {
-            const xhr = new XhrModule(fetch, {});
+            const xhr = new XhrModule(fetch, {}, new LocalStorageModule());
             return xhr.get.bind(xhr);
         };
 

--- a/libs/api-client-bear/src/tests/xhr.test.ts
+++ b/libs/api-client-bear/src/tests/xhr.test.ts
@@ -5,7 +5,7 @@ import isPlainObject from "lodash/isPlainObject";
 
 import { handlePolling, originPackageHeaders, XhrModule, thisPackage } from "../xhr";
 import { ConfigModule } from "../config";
-import { LocalStorageModule } from "../localStorage";
+import { mockLocalStorageModule } from "./mockLocalStorageModule";
 
 function isHashMap(obj: any): obj is { [t: string]: string } {
     return isPlainObject(obj);
@@ -19,7 +19,7 @@ export function getHeaderValue(request: MockOptions | RequestInit | undefined, n
     throw new Error(`Could not get header ${name}`);
 }
 
-const createXhr = (configStorage = {}) => new XhrModule(fetch, configStorage, new LocalStorageModule());
+const createXhr = (configStorage = {}) => new XhrModule(fetch, configStorage, mockLocalStorageModule);
 
 const dummyBody = '{ "test": "ok" }';
 const parsedDummyBody = { test: "ok" };
@@ -43,7 +43,7 @@ describe("originPackageHeaders", () => {
 describe("createModule", () => {
     it("should use configStorage", () => {
         const configStorage = { xhrSettings: { headers: {} } };
-        const xhr = new XhrModule(fetch, configStorage, new LocalStorageModule());
+        const xhr = new XhrModule(fetch, configStorage, mockLocalStorageModule);
         xhr.ajaxSetup({ someSetting: "Run, Forrest, run tests!" });
 
         expect(configStorage).toEqual({

--- a/libs/api-client-bear/src/tests/xhr.test.ts
+++ b/libs/api-client-bear/src/tests/xhr.test.ts
@@ -5,6 +5,7 @@ import isPlainObject from "lodash/isPlainObject";
 
 import { handlePolling, originPackageHeaders, XhrModule, thisPackage } from "../xhr";
 import { ConfigModule } from "../config";
+import { LocalStorageModule } from "../localStorage";
 
 function isHashMap(obj: any): obj is { [t: string]: string } {
     return isPlainObject(obj);
@@ -18,7 +19,7 @@ export function getHeaderValue(request: MockOptions | RequestInit | undefined, n
     throw new Error(`Could not get header ${name}`);
 }
 
-const createXhr = (configStorage = {}) => new XhrModule(fetch, configStorage);
+const createXhr = (configStorage = {}) => new XhrModule(fetch, configStorage, new LocalStorageModule());
 
 const dummyBody = '{ "test": "ok" }';
 const parsedDummyBody = { test: "ok" };
@@ -42,11 +43,12 @@ describe("originPackageHeaders", () => {
 describe("createModule", () => {
     it("should use configStorage", () => {
         const configStorage = { xhrSettings: { headers: {} } };
-        const xhr = new XhrModule(fetch, configStorage);
+        const xhr = new XhrModule(fetch, configStorage, new LocalStorageModule());
         xhr.ajaxSetup({ someSetting: "Run, Forrest, run tests!" });
 
         expect(configStorage).toEqual({
             xhrSettings: { headers: {}, someSetting: "Run, Forrest, run tests!" },
+            verificationLevel: "cookie",
         });
     });
 });

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -110,9 +110,12 @@ export class UserModule {
                     const sst = headers.get("x-gdc-authsst");
                     const tt = headers.get("x-gdc-authtt");
 
-                    // TODO defaults or throw?
-                    this.localStore.storeSST(sst ?? "");
-                    this.localStore.storeTT(tt ?? "");
+                    if (!(tt && sst)) {
+                        throw new ApiResponseError("Unauthorized", r.response, r.responseBody);
+                    }
+
+                    this.localStore.storeSST(sst);
+                    this.localStore.storeTT(tt);
                 }
                 return r.getData();
             });

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -1,5 +1,6 @@
 // (C) 2007-2022 GoodData Corporation
 import qs from "qs";
+import invariant from "ts-invariant";
 import { XhrModule, ApiResponseError, ApiResponse } from "./xhr";
 import { ProjectModule } from "./project";
 import { GdcUser } from "@gooddata/api-model-bear";
@@ -30,6 +31,22 @@ export class UserModule {
         private configStorage: IConfigStorage,
         private localStore: ILocalStorageModule,
     ) {}
+
+    /**
+     * Set the SST token to use while authenticating.
+     *
+     * @remarks
+     * This is only applicable if "verificationLevel" is set to "header".
+     *
+     * @param sst - the SST to set
+     */
+    public setSST(sst: string): void {
+        invariant(
+            this.configStorage.verificationLevel === "header",
+            `The setSST is not supported for verificationLevel other than "header". Currently set verificationLevel: "${this.configStorage.verificationLevel}"`,
+        );
+        this.localStore.storeSST(sst);
+    }
 
     /**
      * Find out whether a user is logged in

--- a/libs/api-client-bear/src/utils/headers.ts
+++ b/libs/api-client-bear/src/utils/headers.ts
@@ -1,0 +1,26 @@
+// (C) 2022 GoodData Corporation
+import { IConfigStorage, ILocalStorageModule } from "../interfaces";
+
+export function ttHeader(localStore: ILocalStorageModule, configStorage: IConfigStorage): object {
+    if (configStorage.verificationLevel === "header") {
+        const tt = localStore.getTT();
+        if (tt) {
+            return {
+                "X-GDC-AUTHTT": tt,
+            };
+        }
+    }
+    return {};
+}
+
+export function sstHeader(localStore: ILocalStorageModule, configStorage: IConfigStorage): object {
+    if (configStorage.verificationLevel === "header") {
+        const sst = localStore.getSST();
+        if (sst) {
+            return {
+                "X-GDC-AUTHSST": sst,
+            };
+        }
+    }
+    return {};
+}

--- a/libs/api-client-bear/src/utils/tests/attributesMapLoader.test.ts
+++ b/libs/api-client-bear/src/utils/tests/attributesMapLoader.test.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import "isomorphic-fetch";
 import fetchMock from "fetch-mock";
 
@@ -6,9 +6,10 @@ import { AttributesMapLoaderModule, getMissingUrisInAttributesMap } from "../att
 import { XhrModule } from "../../xhr";
 import { MetadataModule } from "../../metadata";
 import * as fixtures from "./attributesMapLoader.fixtures";
+import { LocalStorageModule } from "../../localStorage";
 
 const createAttributesMapLoader = () =>
-    new AttributesMapLoaderModule(new MetadataModule(new XhrModule(fetch, {})));
+    new AttributesMapLoaderModule(new MetadataModule(new XhrModule(fetch, {}, new LocalStorageModule())));
 
 describe("loadAttributesMap", () => {
     const projectId = "mockProject";

--- a/libs/api-client-bear/src/utils/tests/attributesMapLoader.test.ts
+++ b/libs/api-client-bear/src/utils/tests/attributesMapLoader.test.ts
@@ -6,10 +6,10 @@ import { AttributesMapLoaderModule, getMissingUrisInAttributesMap } from "../att
 import { XhrModule } from "../../xhr";
 import { MetadataModule } from "../../metadata";
 import * as fixtures from "./attributesMapLoader.fixtures";
-import { LocalStorageModule } from "../../localStorage";
+import { mockLocalStorageModule } from "../../tests/mockLocalStorageModule";
 
 const createAttributesMapLoader = () =>
-    new AttributesMapLoaderModule(new MetadataModule(new XhrModule(fetch, {}, new LocalStorageModule())));
+    new AttributesMapLoaderModule(new MetadataModule(new XhrModule(fetch, {}, mockLocalStorageModule)));
 
 describe("loadAttributesMap", () => {
     const projectId = "mockProject";

--- a/libs/api-client-bear/src/xhr.ts
+++ b/libs/api-client-bear/src/xhr.ts
@@ -7,8 +7,8 @@ import merge from "lodash/merge";
 import result from "lodash/result";
 import pkgInfo from "../package.json";
 import { stringify } from "./utils/queryString";
-import { LocalStorageModule } from "./localStorage";
-import { IConfigStorage } from "./interfaces";
+import { IConfigStorage, ILocalStorageModule } from "./interfaces";
+import { sstHeader, ttHeader } from "./utils/headers";
 
 const { name: pkgName, version: pkgVersion } = pkgInfo;
 /**
@@ -93,30 +93,6 @@ export function originPackageHeaders({ name, version }: IPackageHeaders): object
     };
 }
 
-function ttHeader(localStore: LocalStorageModule, configStorage: IConfigStorage): object {
-    if (configStorage.verificationLevel === "header") {
-        const tt = localStore.getTT();
-        if (tt) {
-            return {
-                "x-gdc-authtt": tt,
-            };
-        }
-    }
-    return {};
-}
-
-function sstHeader(localStore: LocalStorageModule, configStorage: IConfigStorage): object {
-    if (configStorage.verificationLevel === "header") {
-        const sst = localStore.getSST();
-        if (sst) {
-            return {
-                "x-gdc-authsst": sst,
-            };
-        }
-    }
-    return {};
-}
-
 export class ApiError extends Error {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     constructor(message: string, public cause: any) {
@@ -175,7 +151,7 @@ export class XhrModule {
     constructor(
         private fetch: any,
         private configStorage: IConfigStorage,
-        private localStore: LocalStorageModule,
+        private localStore: ILocalStorageModule,
     ) {
         defaults(configStorage, { xhrSettings: {}, verificationLevel: "cookie" });
     }

--- a/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
+++ b/libs/sdk-backend-bear/api/sdk-backend-bear.api.md
@@ -81,6 +81,7 @@ export abstract class BearAuthProviderBase implements IAuthenticationProvider {
 export type BearBackendConfig = {
     packageName?: string;
     packageVersion?: string;
+    verificationLevel?: "cookie" | "header";
 };
 
 // @public

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -126,6 +126,7 @@ type BearLegacyFunctions = {
     getVisualizationObject?(workspace: string, uri: string): Promise<GdcVisualizationObject.IVisualization>;
     getUISettings?(): Promise<{ settings: GdcUser.IUISettings }>;
     isDomainAdmin?(domainUri: string): Promise<boolean>;
+    setSST?(sst: string): void;
 };
 
 /**
@@ -285,6 +286,10 @@ export class BearBackend implements IAnalyticalBackend {
                                 return true;
                             });
                     });
+                },
+
+                setSST: (sst: string): void => {
+                    this.sdk.user.setSST(sst);
                 },
             };
 

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -87,6 +87,15 @@ export type BearBackendConfig = {
      * Version of the frontend package, this will be recorded by backend as initiator of HTTP requests.
      */
     packageVersion?: string;
+
+    /**
+     * Set the verification level of the backend.
+     *
+     * @remarks
+     * Defaults to "cookie". See the {@link https://help.gooddata.com/doc/enterprise/en/expand-your-gooddata-platform/api-reference#tag/login | API Reference } for more details.
+     * @internal
+     */
+    verificationLevel?: "cookie" | "header";
 };
 
 /**
@@ -466,7 +475,8 @@ function newSdkInstance(
     implConfig: BearBackendConfig & FactoryFunction,
     telemetry: TelemetryData,
 ): SDK {
-    const sdk = implConfig.factory ? implConfig.factory() : createSdk();
+    const factoryParams = { verificationLevel: implConfig.verificationLevel };
+    const sdk = implConfig.factory ? implConfig.factory(factoryParams) : createSdk(factoryParams);
 
     if (config.hostname) {
         sdk.config.setCustomDomain(config.hostname);

--- a/libs/sdk-embedding/api/sdk-embedding.api.md
+++ b/libs/sdk-embedding/api/sdk-embedding.api.md
@@ -50,6 +50,8 @@ export namespace EmbeddedAnalyticalDesigner {
         RequestCancellation = "requestCancellation",
         Save = "saveInsight",
         SaveAs = "saveAsInsight",
+        // @internal
+        SetAuth = "setAuth",
         SetFilterContext = "setFilterContext",
         Undo = "undo"
     }
@@ -140,6 +142,8 @@ export namespace EmbeddedAnalyticalDesigner {
     export function isRequestCancellationCommandData(obj: unknown): obj is RequestCancellationCommandData;
     export function isSaveAsInsightCommandData(obj: unknown): obj is SaveAsInsightCommandData;
     export function isSaveInsightCommandData(obj: unknown): obj is SaveInsightCommandData;
+    // @internal (undocumented)
+    export function isSetAuthCommandData(obj: unknown): obj is SetAuthCommandData;
     export function isSetFilterContextCommandData(obj: unknown): obj is SetFilterContextCommandData;
     export function isUndoCommandData(obj: unknown): obj is UndoCommandData;
     export function isUndoFinishedData(obj: unknown): obj is UndoFinishedData;
@@ -162,6 +166,14 @@ export namespace EmbeddedAnalyticalDesigner {
     export type SaveAsInsightCommandData = IGdcAdMessageEnvelope<GdcAdCommandType.SaveAs, ISaveAsInsightCommandBody>;
     export type SaveInsightCommand = IGdcAdMessageEvent<GdcAdCommandType.Save, ISaveCommandBody>;
     export type SaveInsightCommandData = IGdcAdMessageEnvelope<GdcAdCommandType.Save, ISaveCommandBody>;
+    // @internal (undocumented)
+    export type SetAuthCommand = IGdcAdMessageEvent<GdcAdCommandType.RemoveFilterContext, {
+        auth: string;
+    }>;
+    // @internal (undocumented)
+    export type SetAuthCommandData = IGdcAdMessageEnvelope<GdcAdCommandType.SetAuth, {
+        auth: string;
+    }>;
     export type SetFilterContextCommand = IGdcAdMessageEvent<GdcAdCommandType.SetFilterContext, EmbeddedGdc.IFilterContextContent>;
     export type SetFilterContextCommandData = IGdcAdMessageEnvelope<GdcAdCommandType.SetFilterContext, EmbeddedGdc.IFilterContextContent>;
     export type SetFilterContextFinishedData = IGdcAdMessageEnvelope<GdcAdEventType.SetFilterContextFinished, IAvailableCommands>;

--- a/libs/sdk-embedding/src/iframe/ad.ts
+++ b/libs/sdk-embedding/src/iframe/ad.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import isObject from "lodash/isObject";
 import {
     CommandFailed,
@@ -118,6 +118,12 @@ export namespace EmbeddedAnalyticalDesigner {
          * The command to request cancellation
          */
         RequestCancellation = "requestCancellation",
+
+        /**
+         * Set auth data
+         * @internal
+         */
+        SetAuth = "setAuth",
     }
 
     /**
@@ -793,6 +799,23 @@ export namespace EmbeddedAnalyticalDesigner {
      */
     export function isRemoveFilterContextCommandData(obj: unknown): obj is RemoveFilterContextCommandData {
         return isObject(obj) && getEventType(obj) === GdcAdCommandType.RemoveFilterContext;
+    }
+
+    /**
+     * @internal
+     */
+    export type SetAuthCommandData = IGdcAdMessageEnvelope<GdcAdCommandType.SetAuth, { auth: string }>;
+
+    /**
+     * @internal
+     */
+    export type SetAuthCommand = IGdcAdMessageEvent<GdcAdCommandType.RemoveFilterContext, { auth: string }>;
+
+    /**
+     * @internal
+     */
+    export function isSetAuthCommandData(obj: unknown): obj is SetAuthCommandData {
+        return isObject(obj) && getEventType(obj) === GdcAdCommandType.SetAuth;
     }
 
     //


### PR DESCRIPTION
This exposes the `verify_level` parameter of the Bear login method. If used, no cookies will be set, instead the tokens will be passed along to the backend via HTTP headers. This can help avoiding issues caused by some browsers blocking third party cookies.

### Caveats/future improvements
* this only works for username/password auth, SSO is not supported yet

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
