### PR TITLE
RELATED: FET-626 React 17 additional support for overlay handling

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenuButton.tsx
@@ -9,13 +9,9 @@ import { objRefToString, widgetRef } from "@gooddata/sdk-model";
 export const DashboardInsightMenuButton = (props: IDashboardInsightMenuButtonProps): JSX.Element | null => {
     const { isOpen, items, widget, onClick } = props;
 
-    const onMenuButtonClick = useCallback(
-        (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-            e.stopPropagation();
-            onClick();
-        },
-        [onClick],
-    );
+    const onMenuButtonClick = useCallback(() => {
+        onClick();
+    }, [onClick]);
 
     if (!items.length) {
         return null;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyInsightMenu/LegacyInsightMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyInsightMenu/LegacyInsightMenuButton.tsx
@@ -24,13 +24,9 @@ const LegacyInsightMenuButtonCore: React.FC<IDashboardInsightMenuButtonProps & W
     intl,
     isOpen,
 }) => {
-    const onOptionsMenuClick = useCallback(
-        (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-            e.stopPropagation();
-            onClick();
-        },
-        [onClick],
-    );
+    const onOptionsMenuClick = useCallback(() => {
+        onClick();
+    }, [onClick]);
 
     const settings = useDashboardSelector(selectSettings);
     const canExportReport = useDashboardSelector(selectCanExportReport);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/DashboardItemWithKpiAlert.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/DashboardItemWithKpiAlert.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
-import React, { Component, MouseEvent } from "react";
+import React, { Component } from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 import { IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
@@ -259,8 +259,7 @@ export class DashboardItemWithKpiAlert extends Component<
         );
     };
 
-    onAlertDialogOpenClick = (e: MouseEvent): void => {
-        e.stopPropagation();
+    onAlertDialogOpenClick = (): void => {
         this.props.onAlertDialogOpenClick();
     };
 

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -362,7 +362,7 @@ export class EditableLabel extends Component<IEditableLabelProps, IEditableLabel
         autofocus: boolean;
     };
     // (undocumented)
-    edit: (e?: React_2.MouseEvent<HTMLDivElement>) => void;
+    edit: (_e?: React_2.MouseEvent<HTMLDivElement>) => void;
     // (undocumented)
     isClickOutsideTextarea(clickedTarget: EventTarget): boolean;
     // (undocumented)

--- a/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
+++ b/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
@@ -138,12 +138,8 @@ export class EditableLabel extends Component<IEditableLabelProps, IEditableLabel
         });
     };
 
-    edit = (e?: React.MouseEvent<HTMLDivElement>): void => {
+    edit = (_e?: React.MouseEvent<HTMLDivElement>): void => {
         if (!this.state.isEditing) {
-            if (e) {
-                e.stopPropagation();
-            }
-
             this.setState(
                 {
                     isEditing: true,

--- a/libs/sdk-ui-kit/src/Form/InputPure.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputPure.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import NativeListener from "react-native-listener";
@@ -105,10 +105,6 @@ export class InputPure extends React.PureComponent<InputPureProps> implements ID
     };
 
     onClear = (e?: React.ChangeEvent<HTMLInputElement>): void => {
-        if (e) {
-            e.stopPropagation();
-        }
-
         this.props.onChange("", e);
     };
 

--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { createRef } from "react";
 import cx from "classnames";
 import { Portal } from "react-portal";
@@ -48,7 +48,18 @@ function alignExceedsThreshold(firstAlignment: Alignment, secondAlignment: Align
     );
 }
 
-const stopPropagation = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => e.stopPropagation();
+const stopPropagation = (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+    e.stopPropagation();
+    const reactMajorVersion = parseInt(React.version?.split(".")[0], 10);
+    // Propagate events to `document` for react 17
+    // (We need to get them for other overlays to close and the events did not get there due to changes
+    // introduced in https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation)
+    if (reactMajorVersion >= 17) {
+        const evt = new MouseEvent(e.nativeEvent.type, e.nativeEvent);
+        Object.defineProperty(evt, "target", { value: e.nativeEvent.target, enumerable: true });
+        document.dispatchEvent(evt);
+    }
+};
 
 /**
  * @internal

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -41,7 +41,7 @@ import isEqual from "lodash/isEqual";
 import noop from "lodash/noop";
 import debounce from "lodash/debounce";
 import { invariant } from "ts-invariant";
-import { isHeaderResizer, isManualResizing, scrollBarExists } from "./impl/base/agUtils";
+import { isManualResizing, scrollBarExists } from "./impl/base/agUtils";
 import {
     ColumnResizingConfig,
     IMenuAggregationClickConfig,
@@ -668,10 +668,6 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
     };
 
     private onContainerMouseDown = (event: MouseEvent) => {
-        if (event.target && isHeaderResizer(event.target as HTMLElement)) {
-            event.stopPropagation();
-        }
-
         this.internal.isMetaOrCtrlKeyPressed = event.metaKey || event.ctrlKey;
         this.internal.isAltKeyPressed = event.altKey;
     };

--- a/libs/sdk-ui-vis-commons/src/legend/LegendItem.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/LegendItem.tsx
@@ -33,8 +33,7 @@ class LegendItem extends React.Component<ILegendItemProps> {
 
         const style = width ? { width: `${width}px` } : {};
 
-        const onItemClick = (e: React.MouseEvent) => {
-            e.stopPropagation();
+        const onItemClick = () => {
             return this.props.onItemClick(item);
         };
 

--- a/libs/sdk-ui-vis-commons/src/legend/Paging.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/Paging.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
@@ -55,8 +55,7 @@ function renderPagingButton(
         "paging-button",
     );
 
-    const onClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const onClick = () => {
         handler();
     };
 

--- a/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/RowLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/PopUpLegend/RowLegend.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { useState } from "react";
 import { Icon } from "@gooddata/sdk-ui-kit";
 import cx from "classnames";
@@ -42,8 +42,7 @@ export const RowLegendIcoButton: React.FC<IRowLegendIcoButton> = (props) => {
         return null;
     }
 
-    const handleOnClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
+    const handleOnClick = () => {
         onIconClick();
     };
 


### PR DESCRIPTION
* keep stopPropagation in overlays (use Portal) but at the same time re-send the events to the `document` where all overlays listen for events.
* avoid stopPropagation for some events which need to get to parent apps (with possibly another different react root) so that these actions, when triggered, can cause closing of other overlays.
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)