### PR TITLE
RELATED: RAIL-4181 Remove POST to /logout

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -22333,7 +22333,6 @@ packages:
       eslint-plugin-prettier: 4.0.0_eslint@8.12.0+prettier@2.5.1
       eslint-plugin-sonarjs: 0.11.0_eslint@8.12.0
       eslint-plugin-tsdoc: 0.2.15
-      http-status-codes: 2.2.0
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
       lodash: 4.17.21

--- a/libs/sdk-backend-tiger/package.json
+++ b/libs/sdk-backend-tiger/package.json
@@ -63,7 +63,6 @@
         "@gooddata/sdk-model": "^8.10.0-alpha.61",
         "axios": "^0.21.4",
         "date-fns": "^2.22.1",
-        "http-status-codes": "^2.1.4",
         "lodash": "^4.17.19",
         "spark-md5": "^3.0.0",
         "ts-invariant": "^0.7.3",

--- a/libs/sdk-backend-tiger/src/auth.ts
+++ b/libs/sdk-backend-tiger/src/auth.ts
@@ -9,8 +9,6 @@ import {
     NotAuthenticatedHandler,
 } from "@gooddata/sdk-backend-spi";
 import { ITigerClient, setAxiosAuthorizationToken } from "@gooddata/api-client-tiger";
-import { AxiosError } from "axios";
-import { StatusCodes as HttpStatusCodes } from "http-status-codes";
 
 import { convertApiError } from "./utils/errorHandling";
 
@@ -29,25 +27,9 @@ export abstract class TigerAuthProviderBase implements IAuthenticationProvider {
 
     public abstract authenticate(context: IAuthenticationContext): Promise<IAuthenticatedPrincipal>;
 
-    public async deauthenticate(context: IAuthenticationContext): Promise<void> {
-        const client = context.client as ITigerClient;
-
+    public deauthenticate(context: IAuthenticationContext): Promise<void> {
         const logoutUrl = createTigerDeauthenticationUrl(context.backend, window.location);
-
-        // TODO: replace with direct call of TigerClient (once methods are generated from OpenAPI)
-        try {
-            await client.axios.post(logoutUrl);
-        } catch (error) {
-            if ((error as AxiosError).response?.status === HttpStatusCodes.METHOD_NOT_ALLOWED) {
-                // this means we are on tiger >= 1.1 -> we must redirect to the /logout resource instead of POSTing to it
-                return window.location.assign(logoutUrl);
-            }
-
-            // eslint-disable-next-line no-console
-            console.debug("Error during logout", error);
-
-            throw convertApiError(error);
-        }
+        return Promise.resolve(window.location.assign(logoutUrl));
     }
 
     public async getCurrentPrincipal(


### PR DESCRIPTION
This was supported only in Tiger < 1.1 which we no longer support
in current versions of SDK so it is safe to remove.

It also removed the last use of the http-status-codes dependedncy
in sdk-backend-tiger so it was removed as a whole as well.

JIRA: RAIL-4181

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
