### PR TITLE
Fix EditableLabel css styles

### DIFF
--- a/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
+++ b/libs/sdk-ui-kit/src/EditableLabel/EditableLabel.tsx
@@ -264,7 +264,7 @@ export class EditableLabelInner extends Component<IEditableLabelInnerProps, IEdi
 
         return (
             <div ref={this.props.innerRef} className={editableLabelClasses} onClick={this.edit}>
-                <div ref={this.root}>
+                <div className="gd-editable-label-inner" ref={this.root}>
                     {this.state.isEditing ? this.renderEditableLabelEdit() : displayValue}
                 </div>
             </div>

--- a/libs/sdk-ui-kit/styles/scss/editableLabel.scss
+++ b/libs/sdk-ui-kit/styles/scss/editableLabel.scss
@@ -72,6 +72,14 @@ $editable-label-border: #b1c1d1;
     }
 }
 
+.gd-editable-label-inner {
+    width: 100%;
+    height: 100%;
+    line-height: inherit;
+    vertical-align: inherit;
+    min-width: 5em;
+}
+
 .gd-editable-label-overlay {
     textarea {
         @extend %textarea-base;


### PR DESCRIPTION
Introduced with adding an intermediate div during ref forwarding in https://github.com/gooddata/gooddata-ui-sdk/pull/2442

JIRA: TNT-724


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)