### PR TITLE
RELATED: RAIL-4085 Fix for lcm workspace loading issue

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -1,331 +1,37 @@
 // (C) 2021-2022 GoodData Corporation
-import React, { useCallback, useMemo } from "react";
-import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
-import { ToastMessageContextProvider } from "@gooddata/sdk-ui-kit";
+import React from "react";
 import {
-    BackendProvider,
-    ErrorComponent as DefaultError,
     LoadingComponent as DefaultLoading,
-    useBackendStrict,
-    useWorkspaceStrict,
-    WorkspaceProvider,
+    useClientWorkspaceStatus,
+    useClientWorkspaceIdentifiers,
+    useClientWorkspaceInitialized,
 } from "@gooddata/sdk-ui";
-import { ThemeProvider, useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
-
-import {
-    AttributeFilterComponentProvider,
-    InsightComponentProvider,
-    InsightMenuButtonComponentProvider,
-    InsightMenuComponentProvider,
-    KpiComponentProvider,
-    WidgetComponentProvider,
-    DashboardComponentsProvider,
-    DashboardConfigProvider,
-    DashboardCustomizationsProvider,
-    ExportDialogContextProvider,
-    useDashboardComponentsContext,
-} from "../dashboardContexts";
-import {
-    CustomDashboardAttributeFilterComponent,
-    DefaultDashboardAttributeFilter,
-    DefaultDashboardDateFilter,
-    DefaultFilterBar,
-} from "../filterBar";
-import {
-    CustomDashboardInsightComponent,
-    CustomDashboardInsightMenuButtonComponent,
-    CustomDashboardInsightMenuComponent,
-    CustomDashboardKpiComponent,
-    CustomDashboardWidgetComponent,
-    DefaultDashboardInsight,
-    DefaultDashboardInsightMenu,
-    DefaultDashboardInsightMenuButton,
-    DefaultDashboardKpi,
-    DefaultDashboardWidget,
-    LegacyDashboardInsightMenu,
-    LegacyDashboardInsightMenuButton,
-} from "../widget";
-import { DashboardLayout, DefaultDashboardLayout } from "../layout";
-import { IntlWrapper } from "../localization";
-import {
-    changeFilterContextSelection,
-    DashboardStoreProvider,
-    ExtendedDashboardWidget,
-    selectDashboardLoading,
-    selectFilterBarExpanded,
-    selectFilterBarHeight,
-    selectLocale,
-    useDashboardSelector,
-    useDispatchDashboardCommand,
-} from "../../model";
-import { DefaultScheduledEmailDialog, DefaultScheduledEmailManagementDialog } from "../scheduledEmail";
-import { DefaultButtonBar, DefaultMenuButton, DefaultTitle, DefaultTopBar } from "../topBar";
-
-import { defaultDashboardThemeModifier } from "./defaultDashboardThemeModifier";
 import { IDashboardProps } from "./types";
-import { DefaultSaveAsDialog } from "../saveAs";
-import {
-    IdentifierRef,
-    idRef,
-    IInsight,
-    UriRef,
-    IDashboardAttributeFilter,
-    IKpiWidget,
-    IInsightWidget,
-    IKpi,
-} from "@gooddata/sdk-model";
-import { DEFAULT_FILTER_BAR_HEIGHT } from "../constants";
-import { DefaultShareDialog } from "../shareDialog";
-import { DashboardHeader } from "./DashboardHeader/DashboardHeader";
-
-const DashboardMainContent: React.FC<IDashboardProps> = () => {
-    const isFilterBarExpanded = useDashboardSelector(selectFilterBarExpanded);
-    const filterBarHeight = useDashboardSelector(selectFilterBarHeight);
-
-    const onFiltersChange = useDispatchDashboardCommand(changeFilterContextSelection);
-
-    const dashSectionStyles = useMemo(
-        () => ({
-            marginTop: isFilterBarExpanded ? filterBarHeight - DEFAULT_FILTER_BAR_HEIGHT + "px" : undefined,
-            transition: "margin-top 0.2s",
-        }),
-        [isFilterBarExpanded, filterBarHeight],
-    );
-
-    return (
-        <div className="gd-flex-item-stretch dash-section dash-section-kpis" style={dashSectionStyles}>
-            <div className="gd-flex-container root-flex-maincontent">
-                <DashboardLayout onFiltersChange={onFiltersChange} />
-            </div>
-        </div>
-    );
-};
-
-const DashboardInner: React.FC<IDashboardProps> = () => {
-    const locale = useDashboardSelector(selectLocale);
-
-    return (
-        <IntlWrapper locale={locale}>
-            <div className="gd-dashboards-root">
-                <div className="gd-dash-header-wrapper">
-                    <DashboardHeader />
-                </div>
-                <DashboardMainContent />
-            </div>
-        </IntlWrapper>
-    );
-};
-
-const DashboardLoading: React.FC<IDashboardProps> = (props: IDashboardProps) => {
-    const { loading, error, result } = useDashboardSelector(selectDashboardLoading);
-    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
-
-    if (error) {
-        return <ErrorComponent message={error.message} />;
-    }
-
-    if (loading || !result) {
-        return <LoadingComponent />;
-    }
-
-    return <DashboardInner {...props} />;
-};
-
-interface IUseDashboardResult {
-    backend: IAnalyticalBackend;
-    workspace: string;
-    dashboardOrRef: UriRef | IdentifierRef | undefined;
-    hasThemeProvider: boolean;
-    attributeFilterProvider: AttributeFilterComponentProvider;
-    widgetProvider: WidgetComponentProvider;
-    insightProvider: InsightComponentProvider;
-    insightMenuButtonProvider: InsightMenuButtonComponentProvider;
-    insightMenuProvider: InsightMenuComponentProvider;
-    kpiProvider: KpiComponentProvider;
-}
-
-const useDashboard = (props: IDashboardProps): IUseDashboardResult => {
-    const {
-        dashboard,
-        DashboardAttributeFilterComponentProvider,
-        WidgetComponentProvider,
-        InsightComponentProvider,
-        InsightMenuButtonComponentProvider,
-        insightMenuItemsProvider,
-        InsightMenuComponentProvider,
-        KpiComponentProvider,
-    } = props;
-
-    const backend = useBackendStrict(props.backend);
-    const workspace = useWorkspaceStrict(props.workspace);
-
-    const attributeFilterProvider = useCallback(
-        (filter: IDashboardAttributeFilter): CustomDashboardAttributeFilterComponent => {
-            const userSpecified = DashboardAttributeFilterComponentProvider?.(filter);
-            return userSpecified ?? DefaultDashboardAttributeFilter;
-        },
-        [DashboardAttributeFilterComponentProvider],
-    );
-
-    const widgetProvider = useCallback(
-        (widget: ExtendedDashboardWidget): CustomDashboardWidgetComponent => {
-            const userSpecified = WidgetComponentProvider?.(widget);
-            return userSpecified ?? DefaultDashboardWidget;
-        },
-        [WidgetComponentProvider],
-    );
-
-    const insightProvider = useCallback(
-        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightComponent => {
-            const userSpecified = InsightComponentProvider?.(insight, widget);
-            return userSpecified ?? DefaultDashboardInsight;
-        },
-        [InsightComponentProvider],
-    );
-
-    const insightMenuButtonProvider = useCallback(
-        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightMenuButtonComponent => {
-            const userSpecified = InsightMenuButtonComponentProvider?.(insight, widget);
-            // if user customizes the items, always use the "new" default menu button
-            const FallbackDashboardInsightMenuButtonInner = insightMenuItemsProvider
-                ? DefaultDashboardInsightMenuButton
-                : LegacyDashboardInsightMenuButton;
-            return userSpecified ?? FallbackDashboardInsightMenuButtonInner;
-        },
-        [InsightMenuButtonComponentProvider],
-    );
-
-    const insightMenuProvider = useCallback(
-        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightMenuComponent => {
-            const userSpecified = InsightMenuComponentProvider?.(insight, widget);
-            // if user customizes the items, always use the "new" default menu
-            const FallbackDashboardInsightMenuInner = insightMenuItemsProvider
-                ? DefaultDashboardInsightMenu
-                : LegacyDashboardInsightMenu;
-            return userSpecified ?? FallbackDashboardInsightMenuInner;
-        },
-        [InsightMenuComponentProvider],
-    );
-
-    const kpiProvider = useCallback(
-        (kpi: IKpi, widget: IKpiWidget): CustomDashboardKpiComponent => {
-            const userSpecified = KpiComponentProvider?.(kpi, widget);
-            return userSpecified ?? DefaultDashboardKpi;
-        },
-        [KpiComponentProvider],
-    );
-
-    const dashboardOrRef = useMemo(() => {
-        return typeof dashboard === "string" ? idRef(dashboard) : dashboard;
-    }, [dashboard]);
-
-    const isThemeLoading = useThemeIsLoading();
-    const hasThemeProvider = isThemeLoading !== undefined;
-
-    return {
-        backend,
-        workspace,
-        hasThemeProvider,
-        dashboardOrRef,
-        attributeFilterProvider,
-        widgetProvider,
-        insightProvider,
-        insightMenuButtonProvider,
-        insightMenuProvider,
-        kpiProvider,
-    };
-};
+import { DashboardRenderer } from "./components/DashboardRenderer";
 
 /**
  * @internal
  */
 export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => {
-    const {
-        backend,
-        workspace,
-        hasThemeProvider,
-        dashboardOrRef,
-        attributeFilterProvider,
-        widgetProvider,
-        insightProvider,
-        insightMenuButtonProvider,
-        insightMenuProvider,
-        kpiProvider,
-    } = useDashboard(props);
+    const workspaceStatus = useClientWorkspaceStatus();
+    const clientWsIdentifiers = useClientWorkspaceIdentifiers();
+    const isClientWorkspaceInitialized = useClientWorkspaceInitialized();
 
-    const dashboardRender = (
-        <BackendProvider backend={backend}>
-            <WorkspaceProvider workspace={workspace}>
-                <DashboardStoreProvider
-                    backend={props.backend}
-                    workspace={props.workspace}
-                    dashboard={dashboardOrRef}
-                    filterContextRef={props.filterContextRef}
-                    eventHandlers={props.eventHandlers}
-                    config={props.config}
-                    permissions={props.permissions}
-                    onStateChange={props.onStateChange}
-                    onEventingInitialized={props.onEventingInitialized}
-                    additionalReduxContext={props.additionalReduxContext}
-                    customizationFns={props.customizationFns}
-                >
-                    <ToastMessageContextProvider>
-                        <ExportDialogContextProvider>
-                            <DashboardCustomizationsProvider
-                                insightMenuItemsProvider={props.insightMenuItemsProvider}
-                            >
-                                <DashboardComponentsProvider
-                                    ErrorComponent={props.ErrorComponent ?? DefaultError}
-                                    LoadingComponent={props.LoadingComponent ?? DefaultLoading}
-                                    LayoutComponent={props.LayoutComponent ?? DefaultDashboardLayout}
-                                    InsightComponentProvider={insightProvider}
-                                    InsightMenuButtonComponentProvider={insightMenuButtonProvider}
-                                    InsightMenuComponentProvider={insightMenuProvider}
-                                    KpiComponentProvider={kpiProvider}
-                                    WidgetComponentProvider={widgetProvider}
-                                    ButtonBarComponent={props.ButtonBarComponent ?? DefaultButtonBar}
-                                    MenuButtonComponent={props.MenuButtonComponent ?? DefaultMenuButton}
-                                    TopBarComponent={props.TopBarComponent ?? DefaultTopBar}
-                                    TitleComponent={props.TitleComponent ?? DefaultTitle}
-                                    ScheduledEmailDialogComponent={
-                                        props.ScheduledEmailDialogComponent ?? DefaultScheduledEmailDialog
-                                    }
-                                    ScheduledEmailManagementDialogComponent={
-                                        props.ScheduledEmailManagementDialogComponent ??
-                                        DefaultScheduledEmailManagementDialog
-                                    }
-                                    ShareDialogComponent={props.ShareDialogComponent ?? DefaultShareDialog}
-                                    SaveAsDialogComponent={props.SaveAsDialogComponent ?? DefaultSaveAsDialog}
-                                    DashboardAttributeFilterComponentProvider={attributeFilterProvider}
-                                    DashboardDateFilterComponent={
-                                        props.DashboardDateFilterComponent ?? DefaultDashboardDateFilter
-                                    }
-                                    FilterBarComponent={props.FilterBarComponent ?? DefaultFilterBar}
-                                >
-                                    <DashboardConfigProvider menuButtonConfig={props.menuButtonConfig}>
-                                        <DashboardLoading {...props} />
-                                    </DashboardConfigProvider>
-                                </DashboardComponentsProvider>
-                            </DashboardCustomizationsProvider>
-                        </ExportDialogContextProvider>
-                    </ToastMessageContextProvider>
-                </DashboardStoreProvider>
-            </WorkspaceProvider>
-        </BackendProvider>
-    );
-
-    if (props.theme || (!hasThemeProvider && !props.disableThemeLoading)) {
-        return (
-            <ThemeProvider
-                theme={props.theme}
-                modifier={props.themeModifier ?? defaultDashboardThemeModifier}
-                backend={backend}
-                workspace={workspace}
-            >
-                {dashboardRender}
-            </ThemeProvider>
-        );
+    if (!isClientWorkspaceInitialized) {
+        return <DashboardRenderer {...props} />;
     }
 
-    return dashboardRender;
+    const LoadingComponent = props.LoadingComponent ?? DefaultLoading;
+
+    /**
+     * Show loading indicator if the client workspace is loading and the workspace
+     * is not defined.
+     */
+    if (workspaceStatus !== "success") {
+        return <LoadingComponent />;
+    }
+
+    console.log("client WS identifiers", clientWsIdentifiers);
+
+    return <DashboardRenderer workspace={clientWsIdentifiers.workspace} {...props} />;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/Dashboard.tsx
@@ -31,7 +31,5 @@ export const Dashboard: React.FC<IDashboardProps> = (props: IDashboardProps) => 
         return <LoadingComponent />;
     }
 
-    console.log("client WS identifiers", clientWsIdentifiers);
-
     return <DashboardRenderer workspace={clientWsIdentifiers.workspace} {...props} />;
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -1,0 +1,22 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { IntlWrapper } from "../../localization";
+import { useDashboardSelector, selectLocale } from "../../../model";
+import { DashboardHeader } from "../DashboardHeader/DashboardHeader";
+import { IDashboardProps } from "../types";
+import { DashboardMainContent } from "./DashboardMainContent";
+
+export const DashboardInner: React.FC<IDashboardProps> = () => {
+    const locale = useDashboardSelector(selectLocale);
+
+    return (
+        <IntlWrapper locale={locale}>
+            <div className="gd-dashboards-root">
+                <div className="gd-dash-header-wrapper">
+                    <DashboardHeader />
+                </div>
+                <DashboardMainContent />
+            </div>
+        </IntlWrapper>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardLoading.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardLoading.tsx
@@ -1,0 +1,21 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { useDashboardSelector, selectDashboardLoading } from "../../../model";
+import { useDashboardComponentsContext } from "../../dashboardContexts";
+import { IDashboardProps } from "../types";
+import { DashboardInner } from "./DashboardInner";
+
+export const DashboardLoading: React.FC<IDashboardProps> = (props: IDashboardProps) => {
+    const { loading, error, result } = useDashboardSelector(selectDashboardLoading);
+    const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
+
+    if (error) {
+        return <ErrorComponent message={error.message} />;
+    }
+
+    if (loading || !result) {
+        return <LoadingComponent />;
+    }
+
+    return <DashboardInner {...props} />;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardMainContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardMainContent.tsx
@@ -1,0 +1,35 @@
+// (C) 2022 GoodData Corporation
+import React, { useMemo } from "react";
+import {
+    useDashboardSelector,
+    selectFilterBarExpanded,
+    selectFilterBarHeight,
+    useDispatchDashboardCommand,
+    changeFilterContextSelection,
+} from "../../../model";
+import { DEFAULT_FILTER_BAR_HEIGHT } from "../../constants";
+import { DashboardLayout } from "../../layout";
+import { IDashboardProps } from "../types";
+
+export const DashboardMainContent: React.FC<IDashboardProps> = () => {
+    const isFilterBarExpanded = useDashboardSelector(selectFilterBarExpanded);
+    const filterBarHeight = useDashboardSelector(selectFilterBarHeight);
+
+    const onFiltersChange = useDispatchDashboardCommand(changeFilterContextSelection);
+
+    const dashSectionStyles = useMemo(
+        () => ({
+            marginTop: isFilterBarExpanded ? filterBarHeight - DEFAULT_FILTER_BAR_HEIGHT + "px" : undefined,
+            transition: "margin-top 0.2s",
+        }),
+        [isFilterBarExpanded, filterBarHeight],
+    );
+
+    return (
+        <div className="gd-flex-item-stretch dash-section dash-section-kpis" style={dashSectionStyles}>
+            <div className="gd-flex-container root-flex-maincontent">
+                <DashboardLayout onFiltersChange={onFiltersChange} />
+            </div>
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardRenderer.tsx
@@ -1,0 +1,121 @@
+// (C) 2022 GoodData Corporation
+import {
+    BackendProvider,
+    WorkspaceProvider,
+    ErrorComponent as DefaultError,
+    LoadingComponent as DefaultLoading,
+} from "@gooddata/sdk-ui";
+import { ToastMessageContextProvider } from "@gooddata/sdk-ui-kit";
+import { ThemeProvider } from "@gooddata/sdk-ui-theme-provider";
+import React from "react";
+import { DashboardStoreProvider } from "../../../model";
+import {
+    ExportDialogContextProvider,
+    DashboardCustomizationsProvider,
+    DashboardComponentsProvider,
+    DashboardConfigProvider,
+} from "../../dashboardContexts";
+import { DefaultDashboardDateFilter, DefaultFilterBar } from "../../filterBar";
+import { DefaultDashboardLayout } from "../../layout";
+import { DefaultSaveAsDialog } from "../../saveAs";
+import { DefaultScheduledEmailDialog, DefaultScheduledEmailManagementDialog } from "../../scheduledEmail";
+import { DefaultShareDialog } from "../../shareDialog";
+import { DefaultButtonBar, DefaultMenuButton, DefaultTopBar, DefaultTitle } from "../../topBar";
+import { defaultDashboardThemeModifier } from "../defaultDashboardThemeModifier";
+import { useDashboard } from "../hooks/useDashboard";
+import { IDashboardProps } from "../types";
+import { DashboardLoading } from "./DashboardLoading";
+
+/**
+ * @internal
+ */
+export const DashboardRenderer: React.FC<IDashboardProps> = (props: IDashboardProps) => {
+    const {
+        backend,
+        workspace,
+        hasThemeProvider,
+        dashboardOrRef,
+        attributeFilterProvider,
+        widgetProvider,
+        insightProvider,
+        insightMenuButtonProvider,
+        insightMenuProvider,
+        kpiProvider,
+    } = useDashboard(props);
+
+    const dashboardRender = (
+        <BackendProvider backend={backend}>
+            <WorkspaceProvider workspace={workspace}>
+                <DashboardStoreProvider
+                    backend={props.backend}
+                    workspace={props.workspace}
+                    dashboard={dashboardOrRef}
+                    filterContextRef={props.filterContextRef}
+                    eventHandlers={props.eventHandlers}
+                    config={props.config}
+                    permissions={props.permissions}
+                    onStateChange={props.onStateChange}
+                    onEventingInitialized={props.onEventingInitialized}
+                    additionalReduxContext={props.additionalReduxContext}
+                    customizationFns={props.customizationFns}
+                >
+                    <ToastMessageContextProvider>
+                        <ExportDialogContextProvider>
+                            <DashboardCustomizationsProvider
+                                insightMenuItemsProvider={props.insightMenuItemsProvider}
+                            >
+                                <DashboardComponentsProvider
+                                    ErrorComponent={props.ErrorComponent ?? DefaultError}
+                                    LoadingComponent={props.LoadingComponent ?? DefaultLoading}
+                                    LayoutComponent={props.LayoutComponent ?? DefaultDashboardLayout}
+                                    InsightComponentProvider={insightProvider}
+                                    InsightMenuButtonComponentProvider={insightMenuButtonProvider}
+                                    InsightMenuComponentProvider={insightMenuProvider}
+                                    KpiComponentProvider={kpiProvider}
+                                    WidgetComponentProvider={widgetProvider}
+                                    ButtonBarComponent={props.ButtonBarComponent ?? DefaultButtonBar}
+                                    MenuButtonComponent={props.MenuButtonComponent ?? DefaultMenuButton}
+                                    TopBarComponent={props.TopBarComponent ?? DefaultTopBar}
+                                    TitleComponent={props.TitleComponent ?? DefaultTitle}
+                                    ScheduledEmailDialogComponent={
+                                        props.ScheduledEmailDialogComponent ?? DefaultScheduledEmailDialog
+                                    }
+                                    ScheduledEmailManagementDialogComponent={
+                                        props.ScheduledEmailManagementDialogComponent ??
+                                        DefaultScheduledEmailManagementDialog
+                                    }
+                                    ShareDialogComponent={props.ShareDialogComponent ?? DefaultShareDialog}
+                                    SaveAsDialogComponent={props.SaveAsDialogComponent ?? DefaultSaveAsDialog}
+                                    DashboardAttributeFilterComponentProvider={attributeFilterProvider}
+                                    DashboardDateFilterComponent={
+                                        props.DashboardDateFilterComponent ?? DefaultDashboardDateFilter
+                                    }
+                                    FilterBarComponent={props.FilterBarComponent ?? DefaultFilterBar}
+                                >
+                                    <DashboardConfigProvider menuButtonConfig={props.menuButtonConfig}>
+                                        <DashboardLoading {...props} />
+                                    </DashboardConfigProvider>
+                                </DashboardComponentsProvider>
+                            </DashboardCustomizationsProvider>
+                        </ExportDialogContextProvider>
+                    </ToastMessageContextProvider>
+                </DashboardStoreProvider>
+            </WorkspaceProvider>
+        </BackendProvider>
+    );
+
+    if (props.theme || (!hasThemeProvider && !props.disableThemeLoading)) {
+        return (
+            <ThemeProvider
+                theme={props.theme}
+                modifier={props.themeModifier ?? defaultDashboardThemeModifier}
+                backend={backend}
+                workspace={workspace}
+            >
+                {dashboardRender}
+            </ThemeProvider>
+        );
+    }
+
+    return dashboardRender;
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/hooks/useDashboard.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/hooks/useDashboard.ts
@@ -1,0 +1,145 @@
+// (C) 2022 GoodData Corporation
+import { useCallback, useMemo } from "react";
+import {
+    IDashboardAttributeFilter,
+    IInsight,
+    IInsightWidget,
+    IKpi,
+    IKpiWidget,
+    idRef,
+    IdentifierRef,
+    UriRef,
+} from "@gooddata/sdk-model";
+import { useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
+import { useThemeIsLoading } from "@gooddata/sdk-ui-theme-provider";
+import { ExtendedDashboardWidget } from "../../../model";
+import { CustomDashboardAttributeFilterComponent, DefaultDashboardAttributeFilter } from "../../filterBar";
+import {
+    CustomDashboardWidgetComponent,
+    DefaultDashboardWidget,
+    CustomDashboardInsightComponent,
+    DefaultDashboardInsight,
+    CustomDashboardInsightMenuButtonComponent,
+    DefaultDashboardInsightMenuButton,
+    LegacyDashboardInsightMenuButton,
+    CustomDashboardInsightMenuComponent,
+    DefaultDashboardInsightMenu,
+    LegacyDashboardInsightMenu,
+    CustomDashboardKpiComponent,
+    DefaultDashboardKpi,
+} from "../../widget";
+import { IDashboardProps } from "../types";
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import {
+    AttributeFilterComponentProvider,
+    WidgetComponentProvider,
+    InsightComponentProvider,
+    InsightMenuButtonComponentProvider,
+    InsightMenuComponentProvider,
+    KpiComponentProvider,
+} from "../../dashboardContexts";
+
+interface IUseDashboardResult {
+    backend: IAnalyticalBackend;
+    workspace: string;
+    dashboardOrRef: UriRef | IdentifierRef | undefined;
+    hasThemeProvider: boolean;
+    attributeFilterProvider: AttributeFilterComponentProvider;
+    widgetProvider: WidgetComponentProvider;
+    insightProvider: InsightComponentProvider;
+    insightMenuButtonProvider: InsightMenuButtonComponentProvider;
+    insightMenuProvider: InsightMenuComponentProvider;
+    kpiProvider: KpiComponentProvider;
+}
+
+export const useDashboard = (props: IDashboardProps): IUseDashboardResult => {
+    const {
+        dashboard,
+        DashboardAttributeFilterComponentProvider,
+        WidgetComponentProvider,
+        InsightComponentProvider,
+        InsightMenuButtonComponentProvider,
+        insightMenuItemsProvider,
+        InsightMenuComponentProvider,
+        KpiComponentProvider,
+    } = props;
+
+    const backend = useBackendStrict(props.backend);
+    const workspace = useWorkspaceStrict(props.workspace);
+
+    const attributeFilterProvider = useCallback(
+        (filter: IDashboardAttributeFilter): CustomDashboardAttributeFilterComponent => {
+            const userSpecified = DashboardAttributeFilterComponentProvider?.(filter);
+            return userSpecified ?? DefaultDashboardAttributeFilter;
+        },
+        [DashboardAttributeFilterComponentProvider],
+    );
+
+    const widgetProvider = useCallback(
+        (widget: ExtendedDashboardWidget): CustomDashboardWidgetComponent => {
+            const userSpecified = WidgetComponentProvider?.(widget);
+            return userSpecified ?? DefaultDashboardWidget;
+        },
+        [WidgetComponentProvider],
+    );
+
+    const insightProvider = useCallback(
+        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightComponent => {
+            const userSpecified = InsightComponentProvider?.(insight, widget);
+            return userSpecified ?? DefaultDashboardInsight;
+        },
+        [InsightComponentProvider],
+    );
+
+    const insightMenuButtonProvider = useCallback(
+        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightMenuButtonComponent => {
+            const userSpecified = InsightMenuButtonComponentProvider?.(insight, widget);
+            // if user customizes the items, always use the "new" default menu button
+            const FallbackDashboardInsightMenuButtonInner = insightMenuItemsProvider
+                ? DefaultDashboardInsightMenuButton
+                : LegacyDashboardInsightMenuButton;
+            return userSpecified ?? FallbackDashboardInsightMenuButtonInner;
+        },
+        [InsightMenuButtonComponentProvider],
+    );
+
+    const insightMenuProvider = useCallback(
+        (insight: IInsight, widget: IInsightWidget): CustomDashboardInsightMenuComponent => {
+            const userSpecified = InsightMenuComponentProvider?.(insight, widget);
+            // if user customizes the items, always use the "new" default menu
+            const FallbackDashboardInsightMenuInner = insightMenuItemsProvider
+                ? DefaultDashboardInsightMenu
+                : LegacyDashboardInsightMenu;
+            return userSpecified ?? FallbackDashboardInsightMenuInner;
+        },
+        [InsightMenuComponentProvider],
+    );
+
+    const kpiProvider = useCallback(
+        (kpi: IKpi, widget: IKpiWidget): CustomDashboardKpiComponent => {
+            const userSpecified = KpiComponentProvider?.(kpi, widget);
+            return userSpecified ?? DefaultDashboardKpi;
+        },
+        [KpiComponentProvider],
+    );
+
+    const dashboardOrRef = useMemo(() => {
+        return typeof dashboard === "string" ? idRef(dashboard) : dashboard;
+    }, [dashboard]);
+
+    const isThemeLoading = useThemeIsLoading();
+    const hasThemeProvider = isThemeLoading !== undefined;
+
+    return {
+        backend,
+        workspace,
+        hasThemeProvider,
+        dashboardOrRef,
+        attributeFilterProvider,
+        widgetProvider,
+        insightProvider,
+        insightMenuButtonProvider,
+        insightMenuProvider,
+        kpiProvider,
+    };
+};

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -603,6 +603,12 @@ export interface IClientWorkspaceProviderWithWorkspaceProps extends IClientWorks
 }
 
 // @internal (undocumented)
+export interface IClientWorkspaceStatus {
+    // (undocumented)
+    isInitialized: boolean;
+}
+
+// @internal (undocumented)
 export interface IColorAssignment {
     // (undocumented)
     color: IColor;
@@ -1672,6 +1678,9 @@ export const useClientWorkspaceError: () => GoodDataSdkError | undefined;
 
 // @alpha
 export const useClientWorkspaceIdentifiers: () => IClientWorkspaceIdentifiers;
+
+// @alpha
+export const useClientWorkspaceInitialized: () => boolean;
 
 // @alpha
 export const useClientWorkspaceStatus: () => UseCancelablePromiseStatus;

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -153,8 +153,12 @@ export {
     useClientWorkspaceIdentifiers,
     useClientWorkspaceStatus,
     useClientWorkspaceError,
+    useClientWorkspaceInitialized,
 } from "./react/ClientWorkspaceContext/ClientWorkspaceContext";
-export { IClientWorkspaceIdentifiers } from "./react/ClientWorkspaceContext/interfaces";
+export {
+    IClientWorkspaceIdentifiers,
+    IClientWorkspaceStatus,
+} from "./react/ClientWorkspaceContext/interfaces";
 export { resolveLCMWorkspaceIdentifiers } from "./react/ClientWorkspaceContext/resolveLCMWorkspaceIdentifiers";
 export { usePrevious } from "./react/usePrevious";
 /*

--- a/libs/sdk-ui/src/base/react/ClientWorkspaceContext/ClientWorkspaceContext.tsx
+++ b/libs/sdk-ui/src/base/react/ClientWorkspaceContext/ClientWorkspaceContext.tsx
@@ -10,7 +10,7 @@ import {
 import { GoodDataSdkError } from "../../errors/GoodDataSdkError";
 import isEmpty from "lodash/isEmpty";
 import { resolveLCMWorkspaceIdentifiers } from "./resolveLCMWorkspaceIdentifiers";
-import { IClientWorkspaceIdentifiers } from "./interfaces";
+import { IClientWorkspaceIdentifiers, IClientWorkspaceStatus } from "./interfaces";
 import { useWorkspace, WorkspaceProvider } from "../WorkspaceContext";
 import invariant from "ts-invariant";
 
@@ -20,12 +20,14 @@ import invariant from "ts-invariant";
 export type IClientWorkspaceContext = UseCancelablePromiseState<
     IClientWorkspaceIdentifiers,
     GoodDataSdkError
->;
+> &
+    IClientWorkspaceStatus;
 
 const ClientWorkspaceContext = React.createContext<IClientWorkspaceContext>({
     status: "pending",
     error: undefined,
     result: undefined,
+    isInitialized: false,
 });
 ClientWorkspaceContext.displayName = "ClientWorkspace";
 
@@ -124,7 +126,7 @@ export const ClientWorkspaceProvider: React.FC<IClientWorkspaceProviderProps> = 
     const ws = lcmIdentifiers.result?.workspace;
 
     return (
-        <ClientWorkspaceContext.Provider value={lcmIdentifiers}>
+        <ClientWorkspaceContext.Provider value={{ ...lcmIdentifiers, isInitialized: true }}>
             <WorkspaceProvider workspace={ws!}>{children}</WorkspaceProvider>
         </ClientWorkspaceContext.Provider>
     );
@@ -152,6 +154,7 @@ export const ResolvedClientWorkspaceProvider: React.FC<IClientWorkspaceIdentifie
         status: "success",
         result: props,
         error: undefined,
+        isInitialized: true,
     };
 
     return (
@@ -186,6 +189,16 @@ export const useClientWorkspaceError = (): GoodDataSdkError | undefined => {
 export const useClientWorkspaceIdentifiers = (): IClientWorkspaceIdentifiers => {
     const context = React.useContext(ClientWorkspaceContext);
     return context.result ?? {};
+};
+
+/**
+ * Hook to check if client workspace is initialized.
+ *
+ * @alpha
+ */
+export const useClientWorkspaceInitialized = (): boolean => {
+    const context = React.useContext(ClientWorkspaceContext);
+    return context.isInitialized;
 };
 
 //

--- a/libs/sdk-ui/src/base/react/ClientWorkspaceContext/interfaces.ts
+++ b/libs/sdk-ui/src/base/react/ClientWorkspaceContext/interfaces.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 /**
  * Resolved LCM identifiers of the workspace.
@@ -25,4 +25,11 @@ export interface IClientWorkspaceIdentifiers {
      * Workspace identifier.
      */
     workspace?: string;
+}
+
+/**
+ * @internal
+ */
+export interface IClientWorkspaceStatus {
+    isInitialized: boolean;
 }


### PR DESCRIPTION
- added check if the clientWorkspaceContext is initialized
- if clientWorkspaceContext is initialized, Dashboard component is going to wait until workspace id is resolved

JIRA: RAIL-4085

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
