### PR TITLE
RELATED: RAIL-4157 Properly fill X-GDC-JS-PACKAGE{,-VERSION}

### DIFF
--- a/libs/api-client-tiger/src/axios.ts
+++ b/libs/api-client-tiger/src/axios.ts
@@ -2,6 +2,7 @@
 import a, { AxiosInstance, AxiosRequestConfig } from "axios";
 import cloneDeep from "lodash/cloneDeep";
 import merge from "lodash/merge";
+import packageJson from "../package.json";
 
 /**
  * Default config from axios sets request headers:
@@ -21,6 +22,8 @@ const _CONFIG: AxiosRequestConfig = {
     headers: {
         common: {
             "X-Requested-With": "XMLHttpRequest",
+            "X-GDC-JS-PACKAGE": packageJson.name,
+            "X-GDC-JS-PACKAGE-VERSION": packageJson.version,
         },
         post: {
             "Content-Type": "application/json;charset=utf8",

--- a/libs/api-client-tiger/src/typings.d.ts
+++ b/libs/api-client-tiger/src/typings.d.ts
@@ -1,0 +1,6 @@
+// (C) 2022 GoodData Corporation
+// declare package json so that we can import it even without resolveJsonModule which breaks outputs
+declare module "*/package.json" {
+    export const name: string;
+    export const version: string;
+}

--- a/libs/api-client-tiger/tsconfig.build.json
+++ b/libs/api-client-tiger/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null,

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -41,6 +41,7 @@ import {
 } from "@gooddata/sdk-backend-base";
 import { IDrillableItemsCommandBody } from "@gooddata/sdk-embedding";
 import { BearOrganization, BearOrganizations } from "./organization";
+import packageJson from "../../package.json";
 
 const CAPABILITIES: IBackendCapabilities = {
     canCalculateGrandTotals: true,
@@ -473,6 +474,8 @@ function newSdkInstance(
 
     if (implConfig.packageName && implConfig.packageVersion) {
         sdk.config.setJsPackage(implConfig.packageName, implConfig.packageVersion);
+    } else {
+        sdk.config.setJsPackage(packageJson.name, packageJson.version);
     }
 
     if (telemetry.componentName) {

--- a/libs/sdk-backend-bear/src/typings.d.ts
+++ b/libs/sdk-backend-bear/src/typings.d.ts
@@ -1,0 +1,6 @@
+// (C) 2022 GoodData Corporation
+// declare package json so that we can import it even without resolveJsonModule which breaks outputs
+declare module "*/package.json" {
+    export const name: string;
+    export const version: string;
+}

--- a/libs/sdk-backend-bear/tsconfig.build.json
+++ b/libs/sdk-backend-bear/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null,

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -40,6 +40,7 @@ import {
 import { DateFormatter } from "../convertors/fromBackend/dateFormatting/types";
 import { createDefaultDateFormatter } from "../convertors/fromBackend/dateFormatting/defaultDateFormatter";
 import { TigerOrganization, TigerOrganizations } from "./organization";
+import packageJson from "../../package.json";
 
 const CAPABILITIES: IBackendCapabilities = {
     hasTypeScopedIdentifiers: true,
@@ -359,7 +360,10 @@ function interceptBackendErrorsToConsole(client: AxiosInstance): AxiosInstance {
 }
 
 function createHeaders(implConfig: TigerBackendConfig, telemetry: TelemetryData): { [name: string]: string } {
-    const headers: { [name: string]: string } = {};
+    const headers: { [name: string]: string } = {
+        "X-GDC-JS-PACKAGE": packageJson.name,
+        "X-GDC-JS-PACKAGE-VERSION": packageJson.version,
+    };
 
     if (telemetry.componentName) {
         headers["X-GDC-JS-SDK-COMP"] = telemetry.componentName;

--- a/libs/sdk-backend-tiger/src/typings.d.ts
+++ b/libs/sdk-backend-tiger/src/typings.d.ts
@@ -1,0 +1,6 @@
+// (C) 2022 GoodData Corporation
+// declare package json so that we can import it even without resolveJsonModule which breaks outputs
+declare module "*/package.json" {
+    export const name: string;
+    export const version: string;
+}

--- a/libs/sdk-backend-tiger/tsconfig.build.json
+++ b/libs/sdk-backend-tiger/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts"],
+    "include": ["src/index.ts", "src/typings.d.ts"],
     "compilerOptions": {
         "baseUrl": null,
         "paths": null,

--- a/libs/sdk-ui-pivot/src/PivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/PivotTable.tsx
@@ -49,6 +49,7 @@ function prepareExecution(props: IPivotTableProps): IPreparedExecution {
     const { backend, workspace, filters, sortBy = [], execConfig = {} } = props;
 
     return backend!
+        .withTelemetry("PivotTable", props)
         .workspace(workspace!)
         .execution()
         .forBuckets(getBuckets(props), filters as INullableFilter[])


### PR DESCRIPTION
This aligns the behavior between bear and tiger and enables us
to determine how the SDK is used.

Also fix PivotTable telemetry, now it behaves like other charts.

JIRA: RAIL-4157

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
