### PR TITLE
RELATED: RAIL-4190 Fix default project settings in plugin template

### DIFF
--- a/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
+++ b/tools/dashboard-plugin-template/src/harness/PluginLoader.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { idRef } from "@gooddata/sdk-model";
 import { DashboardStub, IEmbeddedPlugin } from "@gooddata/sdk-ui-loaders";
@@ -14,7 +14,7 @@ const Config: DashboardConfig = {
 export const PluginLoader = (): JSX.Element => {
     return (
         <DashboardStub
-            dashboard={idRef(process.env.DASHBOARD_ID ?? DEFAULT_DASHBOARD_ID)}
+            dashboard={idRef(process.env.DASHBOARD_ID || DEFAULT_DASHBOARD_ID)}
             loadingMode="staticOnly"
             config={Config}
             extraPlugins={Plugins}

--- a/tools/dashboard-plugin-template/src/harness/Root.tsx
+++ b/tools/dashboard-plugin-template/src/harness/Root.tsx
@@ -1,13 +1,13 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { BackendProvider, WorkspaceProvider } from "@gooddata/sdk-ui";
 
-import { backend, hasCredentialsSetup } from "./backend";
+import { backend, hasCredentialsSetup, needsAuthentication } from "./backend";
 import { App } from "./App";
 import { DEFAULT_WORKSPACE } from "./constants";
 
 export const Root: React.FC = () => {
-    if (!hasCredentialsSetup()) {
+    if (!hasCredentialsSetup() && needsAuthentication()) {
         return (
             <div>
                 The environment is not setup with credentials to use for authentication to Analytical Backend.
@@ -19,7 +19,7 @@ export const Root: React.FC = () => {
 
     return (
         <BackendProvider backend={backend}>
-            <WorkspaceProvider workspace={process.env.WORKSPACE ?? DEFAULT_WORKSPACE}>
+            <WorkspaceProvider workspace={process.env.WORKSPACE || DEFAULT_WORKSPACE}>
                 <App />
             </WorkspaceProvider>
         </BackendProvider>

--- a/tools/dashboard-plugin-template/src/harness/backend.ts
+++ b/tools/dashboard-plugin-template/src/harness/backend.ts
@@ -1,18 +1,23 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import bearFactory, {
     FixedLoginAndPasswordAuthProvider,
     ContextDeferredAuthProvider,
 } from "@gooddata/sdk-backend-bear";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
+import { DEFAULT_BACKEND_URL } from "./constants";
 
 export function hasCredentialsSetup(): boolean {
     return !!(process.env.GDC_USERNAME && process.env.GDC_PASSWORD);
 }
 
+export function needsAuthentication(): boolean {
+    return !!process.env.BACKEND_URL && process.env.BACKEND_URL !== DEFAULT_BACKEND_URL;
+}
+
 function getBackend(): IAnalyticalBackend {
     const newBackend = bearFactory();
 
-    if (hasCredentialsSetup()) {
+    if (hasCredentialsSetup() && needsAuthentication()) {
         return newBackend.withAuthentication(
             new FixedLoginAndPasswordAuthProvider(process.env.GDC_USERNAME!, process.env.GDC_PASSWORD!),
         );

--- a/tools/dashboard-plugin-template/src/harness/constants.ts
+++ b/tools/dashboard-plugin-template/src/harness/constants.ts
@@ -1,3 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export const DEFAULT_WORKSPACE = "xms7ga4tf3g3nzucd8380o2bev8oeknp";
 export const DEFAULT_DASHBOARD_ID = "aeO5PVgShc0T";
+export const DEFAULT_BACKEND_URL = "https://live-examples-proxy.herokuapp.com";


### PR DESCRIPTION
- replacing nullish coalescing with OR operator to replace empty strings from env file with defaults as well
- add check if the authentication is required or not

The plugin is now running smoothly without the need to set up the backend, workspace, or dashboard id in the harness application to test the plugin locally. 

JIRA: RAIL-4190

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
