### PR TITLE
RELATED: FET-1013 Optimise uses of Array.reduce

### DIFF
--- a/examples/sdk-examples/test/utils/config.ts
+++ b/examples/sdk-examples/test/utils/config.ts
@@ -44,13 +44,10 @@ program.parse(process.argv);
 // get config defaults
 const configDefaults = definedOptions
     .filter((definedOption) => definedOption.defaultValue)
-    .reduce(
-        (defaults, defaultOption) => ({
-            ...defaults,
-            [defaultOption.key]: defaultOption.defaultValue,
-        }),
-        {} as IConfig,
-    );
+    .reduce((defaults: IConfig, defaultOption) => {
+        defaults[defaultOption.key] = defaultOption.defaultValue;
+        return defaults;
+    }, {});
 
 const options = program.opts();
 // get options from local config if it exists
@@ -71,16 +68,12 @@ if (configExists) {
 }
 
 // get options from params
-const paramOptions = definedOptionKeys.reduce(
-    (setOptions, key) =>
-        options[key] !== undefined
-            ? {
-                  ...setOptions,
-                  [key]: options[key],
-              }
-            : setOptions,
-    {} as IConfig,
-);
+const paramOptions = definedOptionKeys.reduce((setOptions: IConfig, key) => {
+    if (options[key] !== undefined) {
+        setOptions[key] = options[key];
+    }
+    return setOptions;
+}, {});
 
 interface IConfig {
     username?: string;

--- a/libs/api-client-bear/src/execution/experimental-executions.ts
+++ b/libs/api-client-bear/src/execution/experimental-executions.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import SparkMD5 from "spark-md5";
 import invariant from "ts-invariant";
 import cloneDeep from "lodash/cloneDeep";
@@ -497,10 +497,10 @@ function getAttributesInBucket(bucket: any) {
 
 function getAttributes(mdObject: any) {
     const buckets = getBuckets(mdObject);
-    return buckets.reduce(
-        (categoriesList: any, bucket: any) => categoriesList.concat(getAttributesInBucket(bucket)),
-        [],
-    );
+    return buckets.reduce((categoriesList: any, bucket: any) => {
+        categoriesList.push(...getAttributesInBucket(bucket));
+        return categoriesList;
+    }, []);
 }
 
 function getDefinition(measure: any) {
@@ -518,10 +518,10 @@ function getMeasuresInBucket(bucket: any) {
 
 function getMeasures(mdObject: any) {
     const buckets = getBuckets(mdObject);
-    return buckets.reduce(
-        (measuresList: any, bucket: any) => measuresList.concat(getMeasuresInBucket(bucket)),
-        [],
-    );
+    return buckets.reduce((categoriesList: any, bucket: any) => {
+        categoriesList.push(...getMeasuresInBucket(bucket));
+        return categoriesList;
+    }, []);
 }
 
 function getMeasureFilters(measure: any) {

--- a/libs/api-model-bear/src/visualizationObject/utils.ts
+++ b/libs/api-model-bear/src/visualizationObject/utils.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { GdcVisualizationObject } from "./GdcVisualizationObject";
 import IVisualizationObjectContent = GdcVisualizationObject.IVisualizationObjectContent;
 import IBucket = GdcVisualizationObject.IBucket;
@@ -23,11 +23,10 @@ function getAttributesInBucket(bucket: IBucket): IVisualizationAttributeContent[
 
 function getAttributes(mdObject: IVisualizationObjectContent): IVisualizationAttributeContent[] {
     const buckets = mdObject.buckets;
-    return buckets.reduce(
-        (categoriesList: IVisualizationAttributeContent[], bucket: IBucket) =>
-            categoriesList.concat(getAttributesInBucket(bucket)),
-        [],
-    );
+    return buckets.reduce((categoriesList: IVisualizationAttributeContent[], bucket: IBucket) => {
+        categoriesList.push(...getAttributesInBucket(bucket));
+        return categoriesList;
+    }, []);
 }
 
 function getMeasuresInBucket(bucket: IBucket): IMeasureContent[] {
@@ -47,11 +46,10 @@ function getDefinition(measure: IMeasureContent): IMeasureDefinition["measureDef
 
 function getMeasures(mdObject: IVisualizationObjectContent): IMeasureContent[] {
     const buckets = mdObject.buckets;
-    return buckets.reduce(
-        (measuresList: IMeasureContent[], bucket: IBucket) =>
-            measuresList.concat(getMeasuresInBucket(bucket)),
-        [],
-    );
+    return buckets.reduce((measuresList: IMeasureContent[], bucket: IBucket) => {
+        measuresList.push(...getMeasuresInBucket(bucket));
+        return measuresList;
+    }, []);
 }
 
 function getMeasureFilters(measure: IMeasureContent): Filter[] {
@@ -63,11 +61,10 @@ function getMeasureAttributeFilters(measure: IMeasureContent): AttributeFilter[]
 }
 
 function getAttributeFilters(mdObject: IVisualizationObjectContent): AttributeFilter[] {
-    return getMeasures(mdObject).reduce(
-        (filters: AttributeFilter[], measure: IMeasureContent) =>
-            filters.concat(getMeasureAttributeFilters(measure)),
-        [],
-    );
+    return getMeasures(mdObject).reduce((filters: AttributeFilter[], measure: IMeasureContent) => {
+        filters.push(...getMeasureAttributeFilters(measure));
+        return filters;
+    }, []);
 }
 
 function getAttributeFilterDisplayForm(measureFilter: AttributeFilter): string {

--- a/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/catalog/factory.ts
@@ -68,10 +68,8 @@ const createLookups = (
             const displayForm = displayFormByUri[displayFormUri];
             const attributeUri = displayForm.content.formOf;
             const attribute = attributeByUri[attributeUri];
-            return {
-                ...acc,
-                [displayFormUri]: attribute,
-            };
+            acc[displayFormUri] = attribute;
+            return acc;
         },
         {},
     );

--- a/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/insights/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import flatMap from "lodash/flatMap";
 import flow from "lodash/flow";
 import map from "lodash/fp/map";
@@ -101,14 +101,11 @@ export class BearWorkspaceInsights implements IWorkspaceInsightsService {
         [key: string]: string;
     }> => {
         const visualizationClasses = await this.getVisualizationClasses(options);
-        return visualizationClasses.reduce((acc, el) => {
-            if (!el.visualizationClass.uri) {
-                return acc;
+        return visualizationClasses.reduce((acc: Record<string, string>, el) => {
+            if (el.visualizationClass.uri) {
+                acc[el.visualizationClass.uri] = el.visualizationClass.url;
             }
-            return {
-                ...acc,
-                [el.visualizationClass.uri]: el.visualizationClass.url,
-            };
+            return acc;
         }, {});
     };
 

--- a/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/measures/index.ts
@@ -71,34 +71,27 @@ export class BearWorkspaceMeasures implements IWorkspaceMeasuresService {
         );
 
         const objectsByUri = allExpressionObjects.reduce(
-            (acc: { [key: string]: GdcMetadataObject.IObject }, el) => {
-                return {
-                    ...acc,
-                    [el.meta.uri!]: el,
-                };
+            (acc: Record<string, GdcMetadataObject.IObject>, el) => {
+                acc[el.meta.uri!] = el;
+                return acc;
             },
             {},
         );
 
         const objectsByIdentifier = allExpressionObjects.reduce(
-            (acc: { [key: string]: GdcMetadataObject.IObject }, el) => {
-                return {
-                    ...acc,
-                    [el.meta.identifier!]: el,
-                };
+            (acc: Record<string, GdcMetadataObject.IObject>, el) => {
+                acc[el.meta.identifier!] = el;
+                return acc;
             },
             {},
         );
 
         const attributeElementsByUri = allExpressionAttributeElements.reduce(
-            (acc: { [key: string]: GdcMetadata.IAttributeElement }, el) => {
-                if (!el) {
-                    return acc;
+            (acc: Record<string, GdcMetadata.IAttributeElement>, el) => {
+                if (el) {
+                    acc[el.uri] = el;
                 }
-                return {
-                    ...acc,
-                    [el.uri]: el,
-                };
+                return acc;
             },
             {},
         );

--- a/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/layout.ts
+++ b/libs/sdk-backend-bear/src/convertors/fromBackend/DashboardConverter/layout.ts
@@ -45,10 +45,7 @@ export const convertLayoutItemSize = (
     return allScreens.reduce((acc: IDashboardLayoutSizeByScreenSize, el) => {
         const size = column[el];
         if (size) {
-            return {
-                ...acc,
-                [el]: convertLayoutSize(size),
-            };
+            acc[el] = convertLayoutSize(size);
         }
 
         return acc;

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -115,10 +115,7 @@ export const convertLayoutItemSize = (
     return allScreens.reduce((acc: GdcDashboardLayout.IFluidLayoutColSize, el) => {
         const size = column[el];
         if (size) {
-            return {
-                ...acc,
-                [el]: convertLayoutSize(size),
-            };
+            acc[el] = convertLayoutSize(size);
         }
 
         return acc;

--- a/libs/sdk-backend-bear/src/convertors/toBackend/WorkspaceConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/WorkspaceConverter.ts
@@ -21,10 +21,9 @@ export const convertPermissions = ({ permissions }: GdcUser.IProjectPermissions)
     const workspacePermissions = Object.keys(permissions).reduce(
         (acc: Partial<IWorkspacePermissions>, permission) => {
             const hasPermission = permissions[permission as GdcUser.ProjectPermission];
-            return {
-                ...acc,
-                [permission]: hasPermission === "1",
-            };
+            // the cast is necessary here, otherwise the indexing does not work
+            (acc as any)[permission] = hasPermission === "1";
+            return acc;
         },
         {},
     );

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/ExecutionConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/ExecutionConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
 import { GdcExecuteAFM } from "@gooddata/api-model-bear";
 import { convertFilters } from "./FilterConverter";
@@ -49,7 +49,10 @@ function convertNativeTotals(def: IExecutionDefinition): GdcExecuteAFM.INativeTo
     // first find all native totals defined across dimensions
     const nativeTotals = def.dimensions
         .map(dimensionTotals)
-        .reduce((acc, totals) => acc.concat(...totals), [])
+        .reduce((acc, totals) => {
+            acc.push(...totals);
+            return acc;
+        }, [])
         .filter(totalIsNative);
 
     return nativeTotals.map((t) => {

--- a/libs/sdk-ui-charts/src/highcharts/adapter/legendHelpers.ts
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/legendHelpers.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import head from "lodash/head";
 import isEmpty from "lodash/isEmpty";
 
@@ -120,7 +120,7 @@ export function groupSeriesItemsByType(series: ISeriesItem[]): { [key: string]: 
     const primaryType = head(series)?.type;
 
     return series.reduce(
-        (result: { [key: string]: ISeriesItem[] }, item: ISeriesItem) => {
+        (result: Record<string, ISeriesItem[]>, item: ISeriesItem) => {
             if (primaryType === item.type) {
                 result.primaryItems.push(item);
             } else {

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/extendedStackingChartOptions.ts
@@ -34,11 +34,7 @@ export function getCategoriesForTwoAttributes(
     const { items: parent } = viewByParentAttribute;
 
     const combinedResult = parent.reduce(
-        (
-            result: { [property: string]: NameAndCategories },
-            parentAttr: IResultAttributeHeader,
-            index: number,
-        ) => {
+        (result: Record<string, NameAndCategories>, parentAttr: IResultAttributeHeader, index: number) => {
             const uri = parentAttr?.attributeHeaderItem?.uri ?? "";
             const name = parentAttr?.attributeHeaderItem?.name ?? "";
             const value = children[index]?.attributeHeaderItem?.name ?? "";
@@ -50,13 +46,12 @@ export function getCategoriesForTwoAttributes(
                 keys.push(uri);
             }
 
-            return {
-                ...result,
-                [uri]: {
-                    name,
-                    categories: [...childCategories, value], // append value
-                },
+            result[uri] = {
+                name,
+                categories: [...childCategories, value], // append value
             };
+
+            return result;
         },
         {},
     );

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
@@ -23,7 +23,10 @@ export const immutableSet = <T extends object, U>(
 ): T => setWith({ ...dataSet }, path, newValue, clone);
 
 export const repeatItemsNTimes = <T>(array: T[], n: number): T[] =>
-    new Array(n).fill(null).reduce((result) => [...result, ...array], []);
+    new Array(n).fill(null).reduce((result: T[]) => {
+        result.push(...array);
+        return result;
+    }, []);
 
 export const unEscapeAngleBrackets = (str: string): string =>
     str?.replace(/&lt;|&#60;/g, "<").replace(/&gt;|&#62;/g, ">");

--- a/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/defaultConfig.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/dateFilterConfig/defaultConfig.ts
@@ -24,7 +24,9 @@ export const defaultDateFilterConfig: IDateFilterConfig = {
         (presets: IRelativeDateFilterPreset[], granularityKey: string) => {
             const granularityPresets: IRelativeDateFilterPreset[] =
                 DateFilterHelpers.defaultDateFilterOptions.relativePreset![granularityKey];
-            return [...presets, ...granularityPresets];
+
+            presets.push(...granularityPresets);
+            return presets;
         },
         [],
     ),

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/sizing.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/utils/sizing.ts
@@ -64,13 +64,11 @@ export function unifyDashboardLayoutItemHeights<TWidget>(
             sections: DashboardLayoutFacade.for(itemsOrLayout)
                 .sections()
                 .reduce((acc: IDashboardLayoutSection<TWidget>[], section) => {
-                    return [
-                        ...acc,
-                        {
-                            ...section.raw(),
-                            items: unifyDashboardLayoutItemHeights(section.items().raw()),
-                        },
-                    ];
+                    acc.push({
+                        ...section.raw(),
+                        items: unifyDashboardLayoutItemHeights(section.items().raw()),
+                    });
+                    return acc;
                 }, []),
         };
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -266,15 +266,16 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
 
         const dashboardAttachments = schedule.attachments.filter(isDashboardAttachment);
         const widgetAttachments = schedule.attachments.filter(isWidgetAttachment);
-        const widgetsSelected = this.props.dashboardInsightWidgets.reduce((acc, widget) => {
-            const widgetKey = objRefToString(widget);
-            return {
-                ...acc,
-                [widgetKey]: widgetAttachments.some((widgetAttachment) => {
+        const widgetsSelected = this.props.dashboardInsightWidgets.reduce(
+            (acc: IWidgetsSelection, widget) => {
+                const widgetKey = objRefToString(widget);
+                acc[widgetKey] = widgetAttachments.some((widgetAttachment) => {
                     return areObjRefsEqual(widgetAttachment.widget, widget);
-                }),
-            };
-        }, {});
+                });
+                return acc;
+            },
+            {},
+        );
 
         const configuration: IWidgetExportConfiguration =
             widgetAttachments.length === 0
@@ -316,10 +317,10 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         } else {
             return {
                 dashboardSelected: true,
-                widgetsSelected: dashboardInsightWidgets.reduce(
-                    (acc, widget) => ({ ...acc, [objRefToString(widget)]: false }),
-                    {},
-                ),
+                widgetsSelected: dashboardInsightWidgets.reduce((acc: IWidgetsSelection, widget) => {
+                    acc[objRefToString(widget)] = false;
+                    return acc;
+                }, {}),
             };
         }
     }
@@ -777,13 +778,10 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
                       includeFilters: configuration.includeFilters,
                   }
                 : undefined;
-        const widgetsRefStringToUriRefMap = this.props.dashboardInsightWidgets.reduce(
-            (acc, widget) => ({
-                [objRefToString(widget)]: uriRef(widget.uri),
-                ...acc,
-            }),
-            {},
-        );
+        const widgetsRefStringToUriRefMap = this.props.dashboardInsightWidgets.reduce((acc, widget) => {
+            acc[objRefToString(widget)] = uriRef(widget.uri);
+            return acc;
+        }, {});
         for (const widgetRefString in widgetsSelected) {
             if (widgetsSelected[widgetRefString]) {
                 result.push({

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/PluggableComboChartDeprecated.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import React from "react";
 import { render } from "react-dom";
@@ -67,7 +67,7 @@ export class PluggableComboChartDeprecated extends PluggableBaseChart {
                 [BucketNames.MEASURES, BucketNames.SECONDARY_MEASURES],
                 [METRIC],
             );
-            secondaryMeasures = secondaryMeasures.concat(restMeasures);
+            secondaryMeasures.push(...restMeasures);
         } else {
             // take all measures, first and its derived to primary, rest to secondary
             const allMeasures = getAllItemsByType(buckets, [METRIC]);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import {
     areObjRefsEqual,
     attributeLocalId,
@@ -91,25 +91,24 @@ function removePropertiesForRemovedAttributes(insight: IInsight): IInsight {
         bucketItemLocalId(bucketItem),
     );
 
-    const result = Object.entries(properties).reduce((acc, [key, value]) => {
-        if (key === ENUM_PROPERTIES_TYPE.CONTROLS && value.columnWidths) {
-            const columns = value.columnWidths.filter((columnWidth: ColumnWidthItem) => {
-                if (isAttributeColumnWidthItem(columnWidth)) {
-                    return identifiers.includes(columnWidth.attributeColumnWidthItem.attributeIdentifier);
-                }
-                return true;
-            });
-
-            return {
-                ...acc,
-                [key]: {
+    const result = Object.entries(properties).reduce(
+        (acc, [key, value]) => {
+            if (key === ENUM_PROPERTIES_TYPE.CONTROLS && value.columnWidths) {
+                const columns = value.columnWidths.filter((columnWidth: ColumnWidthItem) => {
+                    if (isAttributeColumnWidthItem(columnWidth)) {
+                        return identifiers.includes(columnWidth.attributeColumnWidthItem.attributeIdentifier);
+                    }
+                    return true;
+                });
+                acc[key] = {
                     columnWidths: columns,
-                },
-            };
-        }
+                };
+            }
 
-        return { ...acc };
-    }, properties);
+            return acc;
+        },
+        { ...properties },
+    );
 
     return insightSetProperties(insight, result);
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/sortItemsHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/sortItemsHelpers.ts
@@ -58,7 +58,7 @@ function filterInvalidSortItems(
                 filteredSortItem.measureSortItem.locators.length ===
                     columnAttributeLocalIdentifiers.length + 1
             ) {
-                return [...sortItems, filteredSortItem];
+                sortItems.push(filteredSortItem);
             }
 
             // otherwise just carry over previous sortItems

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/widthItemsHelpers.ts
@@ -171,7 +171,8 @@ function adaptWidthItemsToPivotTable(
             if (firstColumnAttributeAdded) {
                 const transformedWeakMeasureWidthItem = transformToWeakMeasureColumnWidthItem(columnWidth);
                 if (transformedWeakMeasureWidthItem) {
-                    return [...columnWidths, transformedWeakMeasureWidthItem];
+                    columnWidths.push(transformedWeakMeasureWidthItem);
+                    return columnWidths;
                 }
             }
 
@@ -183,7 +184,8 @@ function adaptWidthItemsToPivotTable(
                     filteredColumnAttributeLocalIdentifiers.length,
                 )
             ) {
-                return [...columnWidths, filteredMeasureColumnWidthItem];
+                columnWidths.push(filteredMeasureColumnWidthItem);
+                return columnWidths;
             }
         } else if (isAttributeColumnWidthItem(columnWidth)) {
             if (
@@ -192,13 +194,15 @@ function adaptWidthItemsToPivotTable(
                     columnWidth.attributeColumnWidthItem.attributeIdentifier,
                 )
             ) {
-                return [...columnWidths, columnWidth];
+                columnWidths.push(columnWidth);
+                return columnWidths;
             }
         } else if (
             (isAllMeasureColumnWidthItem(columnWidth) || isWeakMeasureColumnWidthItem(columnWidth)) &&
             measureLocalIdentifiers.length > 0
         ) {
-            return [...columnWidths, columnWidth];
+            columnWidths.push(columnWidth);
+            return columnWidths;
         }
 
         return columnWidths;

--- a/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/bucketRules.ts
@@ -49,7 +49,7 @@ export function hasOneMasterMeasureInBucket(buckets: IBucketOfFun[], bucketLocal
 
 export function filteredByDerivedMeasure(buckets: IBucketOfFun[], filters: IFilters): boolean {
     const measures = getAllItemsByType(buckets, [METRIC]);
-    const derivedMeasuresLocalIdentifiers = measures.reduce((acc, measure) => {
+    const derivedMeasuresLocalIdentifiers = measures.reduce((acc: string[], measure) => {
         if (measure.masterLocalIdentifier) {
             acc.push(measure.localIdentifier);
         }

--- a/libs/sdk-ui-ext/src/internal/utils/sort.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/sort.ts
@@ -32,7 +32,7 @@ import { BucketNames, VisualizationTypes } from "@gooddata/sdk-ui";
 import { getTranslation } from "./translations";
 
 import { SORT_DIR_DESC } from "../constants/sort";
-import { IBucketItem, IBucketOfFun, IExtendedReferencePoint } from "../interfaces/Visualization";
+import { IBucketItem, IExtendedReferencePoint } from "../interfaces/Visualization";
 import { IAvailableSortsGroup } from "../interfaces/SortConfig";
 
 export function getAttributeSortItem(
@@ -178,9 +178,10 @@ export function createSorts(
 
 export function getBucketItemIdentifiers(referencePoint: IExtendedReferencePoint): string[] {
     const buckets = referencePoint?.buckets ?? [];
-    return buckets.reduce((localIdentifiers: string[], bucket: IBucketOfFun): string[] => {
+    return buckets.reduce((localIdentifiers: string[], bucket): string[] => {
         const items = bucket?.items ?? [];
-        return localIdentifiers.concat(items.map((item: IBucketItem): string => item.localIdentifier));
+        localIdentifiers.push(...items.map((item) => item.localIdentifier));
+        return localIdentifiers;
     }, []);
 }
 

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartInner.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartInner.tsx
@@ -380,15 +380,9 @@ export class GeoChartInner extends React.PureComponent<IGeoChartInnerProps, IGeo
         };
 
         if (segmentIndex) {
-            const selectedSegmentItems: string[] = categoryItems.reduce(
-                (result: string[], item: IPushpinCategoryLegendItem): string[] => {
-                    if (item.isVisible) {
-                        return [...result, item.uri];
-                    }
-                    return result;
-                },
-                [],
-            );
+            const selectedSegmentItems = categoryItems
+                .filter((item) => item.isVisible)
+                .map((item) => item.uri);
             return {
                 ...chartProps,
                 config: { ...config, selectedSegmentItems },

--- a/libs/sdk-ui-geo/src/core/geoChart/geoChartColor.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/geoChartColor.ts
@@ -55,10 +55,9 @@ export function getColorPaletteMapping(colorStrategy: IColorStrategy): ColorPale
             const name: string = isResultAttributeHeader(item.headerItem)
                 ? item.headerItem.attributeHeaderItem.name
                 : DEFAULT_SEGMENT_ITEM;
-            return {
-                ...result,
-                [name]: colorPalette,
-            };
+
+            result[name] = colorPalette;
+            return result;
         },
         {},
     );

--- a/libs/sdk-ui-geo/src/core/geoChart/geoChartDataSource.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/geoChartDataSource.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { getPushpinColors } from "./geoChartColor";
 import {
     DEFAULT_CLUSTER_RADIUS,
@@ -71,40 +71,39 @@ function transformPushpinDataSource(dataSourceProps: IGeoDataSourceProps): IGeoD
 
             const pushpinColor = pushpinColors[index] || pushpinColors[0] || {};
 
-            return [
-                ...result,
-                {
-                    type: "Feature",
-                    geometry: {
-                        type: "Point",
-                        coordinates: [lng, lat], // Mapbox requires number[]
+            result.push({
+                type: "Feature",
+                geometry: {
+                    type: "Point",
+                    coordinates: [lng, lat], // Mapbox requires number[]
+                },
+                properties: {
+                    pushpinSize,
+                    locationName: {
+                        title: locationNameTitle,
+                        value: locationNameData[index],
                     },
-                    properties: {
-                        pushpinSize,
-                        locationName: {
-                            title: locationNameTitle,
-                            value: locationNameData[index],
-                        },
-                        locationIndex: index,
-                        color: {
-                            ...pushpinColor,
-                            title: colorTitle,
-                            value: colorValue,
-                            format: colorFormat,
-                        },
-                        size: {
-                            title: sizeTitle,
-                            value: sizeData[index],
-                            format: sizeFormat,
-                        },
-                        segment: {
-                            title: segmentTitle,
-                            value: segmentValue,
-                            uri: segmentUri,
-                        },
+                    locationIndex: index,
+                    color: {
+                        ...pushpinColor,
+                        title: colorTitle,
+                        value: colorValue,
+                        format: colorFormat,
+                    },
+                    size: {
+                        title: sizeTitle,
+                        value: sizeData[index],
+                        format: sizeFormat,
+                    },
+                    segment: {
+                        title: segmentTitle,
+                        value: segmentValue,
+                        uri: segmentUri,
                     },
                 },
-            ];
+            });
+
+            return result;
         },
         [],
     );

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
@@ -11,7 +11,6 @@ import {
     attributeDisplayFormRef,
     attributeLocalId,
     IAttributeOrMeasure,
-    IBucket,
     Identifier,
     isAttribute,
     isIdentifierRef,
@@ -127,13 +126,10 @@ function getBucketItemNameAndDataIndex(dv: DataViewFacade): IGeoData {
     const measureDescriptors = dv.meta().measureDescriptors();
     const attributeDescriptors = dv.meta().attributeDescriptors();
 
-    const bucketItemInfos = buckets.reduce(
-        (result: BucketInfos, bucket: IBucket): BucketInfos => ({
-            ...result,
-            [bucket.localIdentifier!]: getBucketItemInfo(bucket.items[0]),
-        }),
-        {},
-    );
+    const bucketItemInfos = buckets.reduce((result: BucketInfos, bucket) => {
+        result[bucket.localIdentifier!] = getBucketItemInfo(bucket.items[0]);
+        return result;
+    }, {});
 
     // init data
     const result: IGeoData = {};

--- a/libs/sdk-ui-kit/src/Header/tests/activateHeaderMenuItems.test.ts
+++ b/libs/sdk-ui-kit/src/Header/tests/activateHeaderMenuItems.test.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { getAccountMenuFeatureFlagsMock, getWorkspacePermissionsMock } from "./mock";
 import {
     generateHeaderMenuItemsGroups,
@@ -12,9 +12,10 @@ describe("activateHeaderMenuItems", () => {
     let items: IHeaderMenuItem[][];
 
     function findAllActiveIds(all: IHeaderMenuItem[][]): string[] {
-        return all.reduce((prev, current) => {
-            return [...prev, ...current.filter((item) => item.isActive).map((item) => item.key)];
-        }, [] as string[]);
+        return all.reduce((acc: string[], current) => {
+            acc.push(...current.filter((item) => item.isActive).map((item) => item.key));
+            return acc;
+        }, []);
     }
 
     beforeAll(() => {

--- a/libs/sdk-ui-pivot/src/impl/resizing/columnSizing.ts
+++ b/libs/sdk-ui-pivot/src/impl/resizing/columnSizing.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import invariant, { InvariantError } from "ts-invariant";
 import omit from "lodash/omit";
 import omitBy from "lodash/omitBy";
@@ -329,24 +329,20 @@ export class ResizedColumnsStore {
         columnWidths: ColumnWidthItem[] | undefined,
     ): IWeakMeasureColumnWidthItemsMap => {
         if (columnWidths) {
-            const onlyWeakWidthItems: IWeakMeasureColumnWidthItem[] = columnWidths.filter(
-                isWeakMeasureColumnWidthItem,
-            );
+            const onlyWeakWidthItems = columnWidths.filter(isWeakMeasureColumnWidthItem);
             return onlyWeakWidthItems.reduce(
                 (map: IWeakMeasureColumnWidthItemsMap, weakWidthItem: IWeakMeasureColumnWidthItem) => {
                     const validatedWidth = defaultWidthValidator(weakWidthItem.measureColumnWidthItem.width);
 
                     if (isAbsoluteColumnWidth(validatedWidth)) {
-                        return {
-                            ...map,
-                            [weakWidthItem.measureColumnWidthItem.locator.measureLocatorItem
-                                .measureIdentifier]: {
-                                measureColumnWidthItem: {
-                                    ...weakWidthItem.measureColumnWidthItem,
-                                    width: {
-                                        ...weakWidthItem.measureColumnWidthItem.width,
-                                        value: validatedWidth.value,
-                                    },
+                        map[
+                            weakWidthItem.measureColumnWidthItem.locator.measureLocatorItem.measureIdentifier
+                        ] = {
+                            measureColumnWidthItem: {
+                                ...weakWidthItem.measureColumnWidthItem,
+                                width: {
+                                    ...weakWidthItem.measureColumnWidthItem.width,
+                                    value: validatedWidth.value,
                                 },
                             },
                         };

--- a/libs/sdk-ui/src/base/react/placeholders/resolve.ts
+++ b/libs/sdk-ui/src/base/react/placeholders/resolve.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import isArray from "lodash/isArray";
 import {
     IPlaceholder,
@@ -102,11 +102,13 @@ export function resolveValueWithPlaceholders<T, C>(
                 if (!resolvedValue) {
                     return acc;
                 } else if (isArray(resolvedValue)) {
-                    return [...acc, ...resolvedValue.filter((v) => typeof v !== "undefined")];
+                    acc.push(...resolvedValue.filter((v) => typeof v !== "undefined"));
+                    return acc;
                 }
             }
 
-            return [...acc, resolvedValue];
+            acc.push(resolvedValue);
+            return acc;
         }, []);
     }
 


### PR DESCRIPTION
Avoid spread operator and concat on accumulators in reduce callbacks
as they both create new objects. That is wasteful and slow, we should
prefer mutating the accumulator instead.

JIRA: FET-1013

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [x] `check` passes
-   [x] `check-extended` passes
-   [x] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
