### PR TITLE
Revert "Remove svg and css files from sideEffects"

### DIFF
--- a/libs/sdk-ui-charts/package.json
+++ b/libs/sdk-ui-charts/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-dashboard/package.json
+++ b/libs/sdk-ui-dashboard/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-ext/package.json
+++ b/libs/sdk-ui-ext/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-geo/package.json
+++ b/libs/sdk-ui-geo/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-kit/package.json
+++ b/libs/sdk-ui-kit/package.json
@@ -14,7 +14,13 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg",
+        "*.ttf",
+        "*.woff",
+        "*.eot"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-loaders/package.json
+++ b/libs/sdk-ui-loaders/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-pivot/package.json
+++ b/libs/sdk-ui-pivot/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-tests-e2e/package.json
+++ b/libs/sdk-ui-tests-e2e/package.json
@@ -14,7 +14,10 @@
     "module": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui-vis-commons/package.json
+++ b/libs/sdk-ui-vis-commons/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",

--- a/libs/sdk-ui/package.json
+++ b/libs/sdk-ui/package.json
@@ -14,7 +14,10 @@
     "es2015": "esm/index.js",
     "browser": "dist/index.js",
     "typings": "esm/index.d.ts",
-    "sideEffects": false,
+    "sideEffects": [
+        "*.css",
+        "*.svg"
+    ],
     "files": [
         "dist/**/*.js",
         "dist/**/*.json",


### PR DESCRIPTION
This reverts commit 919aa0a1c21e82278a5c2d88cc756b8aecfb3b6a.
- `"sideEffects": false` in SDK libraries causes that es6 imports of the SDK styles in applications are tree shaked and removed.

JIRA: FET-1002

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
