### PR TITLE
RELATED: RAIL-4110 Add generalized to define custom components with render mode support

### DIFF
--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -12,6 +12,13 @@ options = {
         // TODO: RAIL-3611
         // depCruiser.moduleWithDependencies("_staging", "src/_staging",["src/types.ts"]),
         depCruiser.moduleWithDependencies("converters", "src/converters", ["src/types.ts"]),
+        depCruiser.moduleWithDependencies("componentDefinition", "src/presentation/componentDefinition", [
+            "src/model",
+            "src/model/store/ui/uiSelectors.ts",
+            "src/presentation/filterBar",
+            "src/presentation/widget",
+            "src/types.ts",
+        ]),
         depCruiser.moduleWithDependencies(
             "dashboard",
             "src/presentation/dashboard/", // the trailing / is necessary here, otherwise dashboardContexts is matched as well
@@ -83,6 +90,7 @@ options = {
             "src/logUserInteraction",
             "src/model",
             "src/model/events/widget.ts",
+            "src/model/store/ui/uiSelectors.ts",
             "src/types.ts",
         ]),
         depCruiser.moduleWithDependencies("scheduledEmail", "src/presentation/scheduledEmail", [

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -11,6 +11,7 @@ import { Action } from '@reduxjs/toolkit';
 import { AnyAction } from '@reduxjs/toolkit';
 import { CaseReducer } from '@reduxjs/toolkit';
 import { CaseReducerActions } from '@reduxjs/toolkit';
+import { ComponentPropsWithRef } from 'react';
 import { ComponentType } from 'react';
 import { DashboardDateFilterConfigMode } from '@gooddata/sdk-model';
 import { DataViewFacade } from '@gooddata/sdk-ui';
@@ -246,6 +247,9 @@ export function applyDateFilter(filter: IDateFilter, correlationId?: string): Ch
 
 // @alpha (undocumented)
 export type AttributeFilterComponentProvider = (filter: IDashboardAttributeFilter) => CustomDashboardAttributeFilterComponent;
+
+// @internal
+export type AttributeFilterComponentSet = CustomComponentBase<IDashboardAttributeFilterProps> & DraggableComponent & CreatablePlaceholderComponent & CreatableByDragComponent;
 
 // @public
 export type AttributeFilterSelectionType = "IN" | "NOT_IN";
@@ -557,6 +561,27 @@ export interface ConfigState {
     config?: ResolvedDashboardConfig;
 }
 
+// @internal
+export type ConfigurableWidget = {
+    configuration: {
+        WidgetConfigPanelComponent: ComponentType<WidgetConfigPanelProps>;
+    };
+};
+
+// @internal
+export type CreatableByDragComponent = DraggableComponent & {
+    creating: {
+        DrawerItemComponent: ComponentType;
+    };
+};
+
+// @internal
+export type CreatablePlaceholderComponent = {
+    creating: {
+        CreatingPlaceholderComponent: ComponentType;
+    };
+};
+
 // @alpha
 export interface CreateAlert extends IDashboardCommand {
     // (undocumented)
@@ -592,6 +617,11 @@ export interface CreateScheduledEmailPayload {
 
 // @alpha (undocumented)
 export type CustomButtonBarComponent = ComponentType<IButtonBarProps>;
+
+// @internal (undocumented)
+export interface CustomComponentBase<TMainProps> {
+    MainComponent: ComponentType<TMainProps>;
+}
 
 // @alpha (undocumented)
 export type CustomDashboardAttributeFilterComponent = ComponentType<IDashboardAttributeFilterProps>;
@@ -643,6 +673,9 @@ export type CustomTitleComponent = ComponentType<ITitleProps>;
 
 // @alpha (undocumented)
 export type CustomTopBarComponent = ComponentType<ITopBarProps>;
+
+// @internal
+export type CustomWidgetComponentSet = CustomComponentBase<IDashboardWidgetProps> & DraggableComponent & Partial<ConfigurableWidget> & Partial<CreatableByDragComponent>;
 
 // @internal (undocumented)
 export const Dashboard: React_2.FC<IDashboardProps>;
@@ -2019,6 +2052,21 @@ export function disableKpiWidgetDateFilter(ref: ObjRef, correlationId?: string):
 // @alpha
 export function dispatchAndWaitFor<TCommand extends DashboardCommands, TResult>(dispatch: DashboardDispatch, command: TCommand): Promise<TResult>;
 
+// @internal
+export type DraggableComponent = {
+    dragging: {
+        DraggingComponent: ComponentType<DraggingComponentProps>;
+        type: DraggableItemType;
+    };
+};
+
+// @internal (undocumented)
+export type DraggableItemType = "attributeFilter" | "widget" | "custom";
+
+// @internal (undocumented)
+export interface DraggingComponentProps {
+}
+
 // @alpha (undocumented)
 export interface Drill extends IDashboardCommand {
     // (undocumented)
@@ -2171,6 +2219,17 @@ export function drillToLegacyDashboard(drillDefinition: IDrillToLegacyDashboard,
 export interface DrillToLegacyDashboardPayload {
     readonly drillDefinition: IDrillToLegacyDashboard;
     readonly drillEvent: IDashboardDrillEvent;
+}
+
+// @internal
+export type DropTarget = {
+    dropping: {
+        DropTargetComponent: ComponentType<DropTargetComponentProps>;
+    };
+};
+
+// @internal (undocumented)
+export interface DropTargetComponentProps {
 }
 
 // @alpha
@@ -3479,6 +3538,9 @@ export interface KpiWidgetComparison {
     comparisonType?: IKpiComparisonTypeComparison;
 }
 
+// @internal
+export type KpiWidgetComponentSet = CustomComponentBase<IDashboardKpiProps> & DraggableComponent & CreatableByDragComponent & CreatablePlaceholderComponent & ConfigurableWidget;
+
 // @alpha (undocumented)
 export type LayoutStash = Record<string, ExtendedDashboardItem[]>;
 
@@ -4033,6 +4095,11 @@ export interface RenameDashboardPayload {
 
 // @internal (undocumented)
 export type RenderMode = "view" | "edit";
+
+// @internal
+export function renderModeAware<T extends ComponentType<any>>(components: {
+    view: T;
+} & Partial<Record<RenderMode, T>>): ComponentType<ComponentPropsWithRef<T>>;
 
 // @alpha
 export function replaceInsightWidgetFilterSettings(ref: ObjRef, settings: Omit<FilterOpReplaceAll, "type">, correlationId?: string): ChangeInsightWidgetFilterSettings;
@@ -5373,6 +5440,10 @@ export function useWidgetFilters(widget: ExtendedDashboardWidget | undefined, in
 
 // @public (undocumented)
 export type WidgetComponentProvider = (widget: ExtendedDashboardWidget) => CustomDashboardWidgetComponent;
+
+// @internal (undocumented)
+export interface WidgetConfigPanelProps {
+}
 
 // @alpha
 export type WidgetFilterOperation = FilterOpEnableDateFilter | FilterOpDisableDateFilter | FilterOpReplaceAttributeIgnores | FilterOpIgnoreAttributeFilter | FilterOpUnignoreAttributeFilter | FilterOpReplaceAll;

--- a/libs/sdk-ui-dashboard/src/presentation/componentDefinition/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/componentDefinition/index.ts
@@ -1,0 +1,4 @@
+// (C) 2022 GoodData Corporation
+
+export * from "./types";
+export { renderModeAware } from "./renderModeAware";

--- a/libs/sdk-ui-dashboard/src/presentation/componentDefinition/renderModeAware.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/componentDefinition/renderModeAware.tsx
@@ -1,0 +1,23 @@
+// (C) 2022 GoodData Corporation
+import React, { ComponentPropsWithRef, ComponentType } from "react";
+import { useDashboardSelector } from "../../model";
+import { selectRenderMode } from "../../model/store/ui/uiSelectors";
+import { RenderMode } from "../../types";
+
+/**
+ * Returns a component that wraps components for different render modes and automatically chooses the correct one.
+ * If component for current render mode is not defined, component for "view" mode is used.
+ *
+ * @param components - the components to choose from
+ * @internal
+ */
+export function renderModeAware<T extends ComponentType<any>>(
+    components: { view: T } & Partial<Record<RenderMode, T>>,
+): ComponentType<ComponentPropsWithRef<T>> {
+    return function RenderModeAware(props: ComponentPropsWithRef<T>) {
+        const renderMode = useDashboardSelector(selectRenderMode);
+        const Component = components[renderMode] ?? components["view"];
+
+        return <Component {...props} />;
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/componentDefinition/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/componentDefinition/types.ts
@@ -1,0 +1,141 @@
+// (C) 2022 GoodData Corporation
+import { ComponentType } from "react";
+import { IDashboardAttributeFilterProps } from "../filterBar";
+import { IDashboardKpiProps, IDashboardWidgetProps } from "../widget";
+
+/**
+ * @internal
+ */
+export interface CustomComponentBase<TMainProps> {
+    /**
+     * The main body of the component that is shown by default in view and edit modes.
+     */
+    MainComponent: ComponentType<TMainProps>;
+}
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DraggingComponentProps {
+    // TODO define when dragging will be implemented
+}
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface DropTargetComponentProps {
+    // TODO define when dragging will be implemented
+}
+
+/**
+ * @internal
+ */
+export type DraggableItemType = "attributeFilter" | "widget" | "custom";
+
+/**
+ * Capability saying the component can be dragged somewhere.
+ * @internal
+ */
+export type DraggableComponent = {
+    dragging: {
+        /**
+         * Component shown when it is being dragged somewhere.
+         */
+        DraggingComponent: ComponentType<DraggingComponentProps>;
+
+        /**
+         * type of dragged item
+         */
+        type: DraggableItemType;
+    };
+};
+
+/**
+ * Capability saying the component can receive draggable items.
+ * @internal
+ */
+export type DropTarget = {
+    dropping: {
+        /**
+         * Component shown when item is dragged onto component.
+         */
+        DropTargetComponent: ComponentType<DropTargetComponentProps>;
+    };
+};
+
+/**
+ * Capability saying the component can be created by dragging it from the side drawer.
+ * @internal
+ */
+export type CreatableByDragComponent = DraggableComponent & {
+    creating: {
+        /**
+         * Component used to render the item in the left drawer menu used to create a new instance of this component on the dashboard
+         */
+        DrawerItemComponent: ComponentType;
+    };
+};
+
+/**
+ * Capability saying the component displays something else than the Main component while it is being configured for the first time after being created.
+ * @internal
+ */
+export type CreatablePlaceholderComponent = {
+    creating: {
+        /**
+         * Component used to render the item before the initial configuration is done.
+         */
+        CreatingPlaceholderComponent: ComponentType;
+    };
+};
+
+/**
+ * @internal
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface WidgetConfigPanelProps {
+    // TODO define when config component will be defined
+}
+
+/**
+ * Capability saying the component can be configured in edit mode.
+ * @internal
+ */
+export type ConfigurableWidget = {
+    configuration: {
+        /**
+         * Component used to render the insides of the configuration panel.
+         */
+        WidgetConfigPanelComponent: ComponentType<WidgetConfigPanelProps>;
+    };
+};
+
+/**
+ * Definition of attribute filter components
+ * @internal
+ */
+export type AttributeFilterComponentSet = CustomComponentBase<IDashboardAttributeFilterProps> &
+    DraggableComponent &
+    CreatablePlaceholderComponent &
+    CreatableByDragComponent;
+
+/**
+ * Definition of KPI widget
+ * @internal
+ */
+export type KpiWidgetComponentSet = CustomComponentBase<IDashboardKpiProps> &
+    DraggableComponent &
+    CreatableByDragComponent &
+    CreatablePlaceholderComponent &
+    ConfigurableWidget;
+
+/**
+ * Definition of widget
+ * @internal
+ */
+export type CustomWidgetComponentSet = CustomComponentBase<IDashboardWidgetProps> &
+    DraggableComponent &
+    Partial<ConfigurableWidget> &
+    Partial<CreatableByDragComponent>;

--- a/libs/sdk-ui-dashboard/src/presentation/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/index.ts
@@ -1,4 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
+
+export * from "./componentDefinition";
 export * from "./dashboard";
 // only export the types for this, not the actual code
 export * from "./dashboardContexts/types";


### PR DESCRIPTION
- add helper function for switching component by render mode
- add types for defining custom attributeFilter, KpiWidget and general Widget in all modes and helper components

JIRA: RAIL-4110

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
