### PR TITLE
RELATED: FET-903 simplify and clean up auth-related code

### DIFF
--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -218,11 +218,12 @@ export class UserModule {
     /**
      * Returns the feature flags valid for the currently logged in user.
      */
-    public getFeatureFlags(): Promise<GdcUser.IFeatureFlags> {
-        return this.xhr
-            .get("/gdc/app/account/bootstrap")
-            .then((r: any) => r.getData())
-            .then((result: any) => result.bootstrapResource.current.featureFlags);
+    public async getFeatureFlags(): Promise<GdcUser.IFeatureFlags> {
+        const { bootstrapResource } = await this.xhr.getParsed<GdcUser.IBootstrapResource>(
+            "/gdc/app/account/bootstrap",
+        );
+
+        return bootstrapResource.current!.featureFlags!;
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -51,25 +51,11 @@ export class UserModule {
      *                   resolves with false if user logged in and project not available,
      *                   rejects if user not logged in
      */
-    public isLoggedInProject(projectId: string): Promise<boolean> {
-        return this.getCurrentProfile().then((profile) => {
-            return new Promise((resolve, reject) => {
-                const projectModule = new ProjectModule(this.xhr);
-
-                projectModule.getProjects(profile!.links!.self!.split("/")![4]).then(
-                    (projects) => {
-                        if (projects.find((p: any) => p.links.self === `/gdc/projects/${projectId}`)) {
-                            resolve(true);
-                        } else {
-                            resolve(false);
-                        }
-                    },
-                    (err: ApiResponseError) => {
-                        reject(err);
-                    },
-                );
-            });
-        });
+    public async isLoggedInProject(projectId: string): Promise<boolean> {
+        const profile = await this.getCurrentProfile();
+        const projectModule = new ProjectModule(this.xhr);
+        const projects = await projectModule.getProjects(profile!.links!.self!.split("/")![4]);
+        return projects.some((p) => p.links?.self === `/gdc/projects/${projectId}`);
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -64,19 +64,17 @@ export class UserModule {
      * every subsequent API call in a current session will be authenticated.
      */
     public login(username: string, password: string): Promise<any> {
-        return this.xhr
-            .post("/gdc/account/login", {
-                body: JSON.stringify({
-                    postUserLogin: {
-                        login: username,
-                        password,
-                        remember: 1,
-                        captcha: "",
-                        verifyCaptcha: "",
-                    },
-                }),
-            })
-            .then((r) => r.getData());
+        return this.xhr.postParsed("/gdc/account/login", {
+            body: JSON.stringify({
+                postUserLogin: {
+                    login: username,
+                    password,
+                    remember: 1,
+                    captcha: "",
+                    verifyCaptcha: "",
+                },
+            }),
+        });
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -156,7 +156,7 @@ export class UserModule {
     /**
      * Returns info about currently logged in user from bootstrap resource
      */
-    public getAccountInfo(): Promise<{
+    public async getAccountInfo(): Promise<{
         login: string;
         loginMD5: string;
         firstName: string;
@@ -164,17 +164,18 @@ export class UserModule {
         organizationName: string;
         profileUri: string;
     }> {
-        return this.xhr.get("/gdc/app/account/bootstrap").then((result: any) => {
-            const { bootstrapResource } = result.getData();
-            return {
-                login: bootstrapResource.accountSetting.login,
-                loginMD5: bootstrapResource.current.loginMD5,
-                firstName: bootstrapResource.accountSetting.firstName,
-                lastName: bootstrapResource.accountSetting.lastName,
-                organizationName: bootstrapResource.settings.organizationName,
-                profileUri: bootstrapResource.accountSetting.links.self,
-            };
-        });
+        const { bootstrapResource } = await this.xhr.getParsed<GdcUser.IBootstrapResource>(
+            "/gdc/app/account/bootstrap",
+        );
+
+        return {
+            login: bootstrapResource.accountSetting.login!,
+            loginMD5: bootstrapResource.current!.loginMD5!,
+            firstName: bootstrapResource.accountSetting.firstName,
+            lastName: bootstrapResource.accountSetting.lastName,
+            organizationName: bootstrapResource.settings!.organizationName,
+            profileUri: bootstrapResource.accountSetting.links!.self!,
+        };
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -121,7 +121,9 @@ export class UserModule {
      * @returns Resolves with account setting object
      */
     public getCurrentProfile(): Promise<GdcUser.IAccountSetting> {
-        return this.xhr.get("/gdc/account/profile/current").then((r) => r.getData().accountSetting);
+        return this.xhr
+            .getParsed<GdcUser.IWrappedAccountSetting>("/gdc/account/profile/current")
+            .then((r) => r.accountSetting);
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -184,15 +184,12 @@ export class UserModule {
      * @param userId - A user identifier
      * @returns An array of user configs setting item
      */
-    public getUserConfigs(userId: string): Promise<IUserConfigsSettingItem[]> {
-        return this.xhr.get(`/gdc/account/profile/${userId}/config`).then((apiResponse: ApiResponse) => {
-            const userConfigs: IUserConfigsResponse = apiResponse.getData();
-            const {
-                settings: { items },
-            } = userConfigs;
+    public async getUserConfigs(userId: string): Promise<IUserConfigsSettingItem[]> {
+        const userConfig = await this.xhr.getParsed<IUserConfigsResponse>(
+            `/gdc/account/profile/${userId}/config`,
+        );
 
-            return items || [];
-        });
+        return userConfig.settings.items || [];
     }
 
     /**

--- a/libs/api-client-bear/src/user.ts
+++ b/libs/api-client-bear/src/user.ts
@@ -31,25 +31,16 @@ export class UserModule {
      *
      * @returns resolves with true if user logged in, false otherwise
      */
-    public isLoggedIn(): Promise<boolean> {
-        return new Promise((resolve, reject) => {
-            this.xhr.get("/gdc/account/token").then(
-                (r) => {
-                    if (r.response.ok) {
-                        resolve(true);
-                    }
-
-                    resolve(false);
-                },
-                (err: any) => {
-                    if (err?.response?.status === 401) {
-                        resolve(false);
-                    } else {
-                        reject(err);
-                    }
-                },
-            );
-        });
+    public async isLoggedIn(): Promise<boolean> {
+        try {
+            const result = await this.xhr.get("/gdc/account/token");
+            return !!result.response.ok;
+        } catch (err: any) {
+            if (err?.response?.status === 401) {
+                return false;
+            }
+            throw err;
+        }
     }
 
     /**

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -320,7 +320,7 @@ export class BearBackend implements IAnalyticalBackend {
             return this.authApiCall(async (sdk) => {
                 const principal = await this.authProvider.getCurrentPrincipal({ client: sdk, backend: this });
                 invariant(principal, "Principal must be defined");
-                return principal!;
+                return principal;
             });
         }
 
@@ -412,7 +412,8 @@ export class BearBackend implements IAnalyticalBackend {
     };
 
     /**
-     * Triggers onNotAuthenticated handler of the the authProvider if the provided error is an instance of {@link @gooddata/sdk-backend-spi#NotAuthenticated}.
+     * Triggers onNotAuthenticated handler of the the authProvider if the provided error is an instance
+     * of {@link @gooddata/sdk-backend-spi#NotAuthenticated}.
      *
      * @param err - error to observe and trigger handler for
      * @returns the original error to facilitate re-throwing
@@ -434,11 +435,8 @@ export class BearBackend implements IAnalyticalBackend {
                 client: this.sdk,
                 backend: this,
             });
-            if (principal) {
-                return principal;
-            }
 
-            return this.authProvider.authenticate(this.getAuthenticationContext());
+            return principal ?? this.authProvider.authenticate(this.getAuthenticationContext());
         };
 
         return {
@@ -456,15 +454,15 @@ function isNotAuthenticatedResponse(err: any): boolean {
 }
 
 function configSanitize(config?: IAnalyticalBackendConfig): IAnalyticalBackendConfig {
-    return config ? config : {};
+    return config ?? {};
 }
 
 function bearConfigSanitize(implConfig?: BearBackendConfig): BearBackendConfig {
-    return implConfig ? implConfig : {};
+    return implConfig ?? {};
 }
 
 function telemetrySanitize(telemetry?: TelemetryData): TelemetryData {
-    return telemetry ? telemetry : {};
+    return telemetry ?? {};
 }
 
 function newSdkInstance(

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -303,21 +303,16 @@ export class BearBackend implements IAnalyticalBackend {
         return new BearBackend(this.config, this.implConfig, this.telemetry, guardedAuthProvider);
     }
 
-    public isAuthenticated = (): Promise<IAuthenticatedPrincipal | null> => {
-        return new Promise((resolve, reject) => {
-            this.authProvider
-                .getCurrentPrincipal({ client: this.sdk, backend: this })
-                .then((res) => {
-                    resolve(res);
-                })
-                .catch((err) => {
-                    if (isNotAuthenticatedResponse(err)) {
-                        resolve(null);
-                    }
-
-                    reject(err);
-                });
-        });
+    public isAuthenticated = async (): Promise<IAuthenticatedPrincipal | null> => {
+        try {
+            // the return await is crucial here so that we also catch the async errors
+            return await this.authProvider.getCurrentPrincipal({ client: this.sdk, backend: this });
+        } catch (err) {
+            if (isNotAuthenticatedResponse(err)) {
+                return null;
+            }
+            throw err;
+        }
     };
 
     public authenticate = (force: boolean): Promise<IAuthenticatedPrincipal> => {


### PR DESCRIPTION
Go through the auth-related code in tiger and bear and simplify it/clean it up. The transformations were meant to maintain the original behaviour as much as possible. The transformations include:
* using async if it makes the code simpler
* avoiding separate error handlers that can be merged
* removing boilerplate-y code especially in api-client-ber user section

The transformations were done one-by-commit in bear and then applied in bulk to tiger so go commit by commit for some more info on a given transformation.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
