### PR TITLE
RELATED: RAIL-4192 Remove obsolete dependencies

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21565,7 +21565,6 @@ packages:
       '@openapitools/openapi-generator-cli': 2.4.26
       '@types/jest': 27.4.1
       '@types/lodash': 4.14.181
-      '@types/spark-md5': 3.0.2
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
       axios: 0.21.4
@@ -21586,7 +21585,6 @@ packages:
       lodash: 4.17.21
       mkdirp: 1.0.4
       prettier: 2.5.1
-      spark-md5: 3.0.2
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1
       typescript: 4.0.2

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -21565,7 +21565,6 @@ packages:
       '@openapitools/openapi-generator-cli': 2.4.26
       '@types/jest': 27.4.1
       '@types/lodash': 4.14.181
-      '@types/qs': 6.9.7
       '@types/spark-md5': 3.0.2
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
@@ -21587,7 +21586,6 @@ packages:
       lodash: 4.17.21
       mkdirp: 1.0.4
       prettier: 2.5.1
-      qs: 6.10.3
       spark-md5: 3.0.2
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1

--- a/libs/api-client-tiger/package.json
+++ b/libs/api-client-tiger/package.json
@@ -53,7 +53,6 @@
         "@gooddata/sdk-model": "^8.10.0-alpha.78",
         "axios": "^0.21.4",
         "lodash": "^4.17.19",
-        "spark-md5": "^3.0.0",
         "tslib": "^2.0.0"
     },
     "devDependencies": {
@@ -64,7 +63,6 @@
         "@openapitools/openapi-generator-cli": "^2.4.26",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.158",
-        "@types/spark-md5": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",
         "commander": "^8.1.0",

--- a/libs/api-client-tiger/package.json
+++ b/libs/api-client-tiger/package.json
@@ -53,7 +53,6 @@
         "@gooddata/sdk-model": "^8.10.0-alpha.78",
         "axios": "^0.21.4",
         "lodash": "^4.17.19",
-        "qs": "^6.8.0",
         "spark-md5": "^3.0.0",
         "tslib": "^2.0.0"
     },
@@ -65,7 +64,6 @@
         "@openapitools/openapi-generator-cli": "^2.4.26",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.158",
-        "@types/qs": "^6.5.1",
         "@types/spark-md5": "^3.0.1",
         "@typescript-eslint/eslint-plugin": "^5.5.0",
         "@typescript-eslint/parser": "^5.5.0",


### PR DESCRIPTION
qs is no longer used in api-client-tiger after the tooling upgrade.
spark-md5 was never used in api-client-tiger in the first place.

JIRA: RAIL-4192

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
