### PR TITLE
NAS-3696 - Workspace selector header just shows a list of first 20 workspaces

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -5604,26 +5604,17 @@ export interface ObjectLinksContainer {
 }
 
 // @internal
-export type OrganizationGetEntitiesFn<T extends OrganizationGetEntitiesResult, P> = (params: P, options: OrganizationGetEntitiesOptions) => AxiosPromise<T>;
+export type OrganizationGetEntitiesFn<T extends OrganizationGetEntitiesResult, P extends OrganizationGetEntitiesParams> = (params: P, options: AxiosRequestConfig) => AxiosPromise<T>;
 
 // @internal
-export type OrganizationGetEntitiesOptions = {
-    headers?: object;
-    query?: {
-        page?: number;
-        size?: number;
-        include?: any;
-        sort?: any;
-        tags?: any;
-    };
-};
+export type OrganizationGetEntitiesParams = EntitiesApiGetAllEntitiesAttributesRequest | EntitiesApiGetAllEntitiesFactsRequest | EntitiesApiGetAllEntitiesAnalyticalDashboardsRequest | EntitiesApiGetAllEntitiesDashboardPluginsRequest | EntitiesApiGetAllEntitiesVisualizationObjectsRequest | EntitiesApiGetAllEntitiesMetricsRequest | EntitiesApiGetAllEntitiesWorkspacesRequest;
 
 // @internal
 export type OrganizationGetEntitiesResult = JsonApiUserOutList | JsonApiUserGroupOutList | JsonApiWorkspaceOutList;
 
 // @internal
 export class OrganizationUtilities {
-    static getAllPagesOf: <T extends OrganizationGetEntitiesResult, P>(client: ITigerClient, entitiesGet: OrganizationGetEntitiesFn<T, P>, params: P, options?: OrganizationGetEntitiesOptions) => Promise<T[]>;
+    static getAllPagesOf: <T extends OrganizationGetEntitiesResult, P extends OrganizationGetEntitiesParams>(client: ITigerClient, entitiesGet: OrganizationGetEntitiesFn<T, P>, params: P, options?: AxiosRequestConfig) => Promise<T[]>;
     static mergeEntitiesResults<T extends OrganizationGetEntitiesResult>(pages: T[]): T;
 }
 

--- a/libs/api-client-tiger/src/index.ts
+++ b/libs/api-client-tiger/src/index.ts
@@ -180,7 +180,7 @@ export {
     OrganizationUtilities,
     OrganizationGetEntitiesResult,
     OrganizationGetEntitiesFn,
-    OrganizationGetEntitiesOptions,
+    OrganizationGetEntitiesParams,
 } from "./organizationUtilities";
 
 const defaultTigerClient: ITigerClient = tigerClientFactory(defaultAxios);


### PR DESCRIPTION
Workspace selector header just shows a list of first 20 workspaces
Repair function for getting all pages of entities in tiger client

JIRA: NAS-3696

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
