### PR TITLE
FET-863 - Reimplement autofocus in InputPure

### DIFF
--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -2320,6 +2320,8 @@ export class InputPure extends React_2.PureComponent<InputPureProps> implements 
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
+    componentDidUpdate(prevProps: Readonly<InputPureProps>): void;
+    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: {
@@ -2397,8 +2399,6 @@ export interface InputPureProps extends IDomNativeProps {
     labelPositionTop: boolean;
     // (undocumented)
     maxlength: number;
-    // (undocumented)
-    nativeLikeAutofocus?: boolean;
     // (undocumented)
     onBlur: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Input/Input.tsx
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Input/Input.tsx
@@ -1,0 +1,53 @@
+// (C) 2020 GoodData Corporation
+import React from "react";
+import { Input } from "@gooddata/sdk-ui-kit";
+import { storiesOf } from "../../../_infra/storyRepository";
+import { UiKit } from "../../../_infra/storyGroups";
+
+import "@gooddata/sdk-ui-kit/styles/css/main.css";
+import "./styles.scss";
+
+class AutofocsExamples extends React.PureComponent {
+    public state = {
+        autofocus1: false,
+    };
+
+    render() {
+        return (
+            <div className="library-component">
+                <h4>Input without autofocus</h4>
+
+                <Input
+                    onChange={(val) => console.log(val)} // eslint-disable-line no-console
+                    placeholder="Search attributes..."
+                    autofocus={this.state.autofocus1}
+                />
+                <button onClick={() => this.setState({ autofocus1: !this.state.autofocus1 })}>
+                    {this.state.autofocus1 ? "Turn off autofocus" : "Turn on autofocus"}
+                </button>
+
+                <h4>Input with autofocus</h4>
+                <Input
+                    onChange={(val) => console.log(val)} // eslint-disable-line no-console
+                    placeholder="Search attributes..."
+                    autofocus
+                />
+
+                <h4>Hidden input with autofocus</h4>
+                <p>
+                    This show <code>console.warn</code> messsage after some time because autofocus is not
+                    possible!
+                </p>
+                <div style={{ display: "none" }}>
+                    <Input
+                        onChange={(val) => console.log(val)} // eslint-disable-line no-console
+                        placeholder="Search attributes..."
+                        autofocus
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+storiesOf(`${UiKit}/Input`).add("autofocus", () => <AutofocsExamples />, {});

--- a/libs/sdk-ui-tests/stories/visual-regression/kit/Input/styles.scss
+++ b/libs/sdk-ui-tests/stories/visual-regression/kit/Input/styles.scss
@@ -1,0 +1,8 @@
+// (C) 2020 GoodData Corporation
+@import "../styles/goodstrap.scss";
+
+.gd-input-with-prefix,
+.gd-input-with-suffix,
+.gd-input-with-label {
+    margin: 1em 0;
+}


### PR DESCRIPTION
Autofocus reimplementation
 - run autofocus method to start request animation frame and try to focus input as soon as possible (is visible, not hidden and has size)
 - clear after unmount to disable autofocus
 - reset after props changed

JIRA: FET-863
---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
