### PR TITLE
Propagate failed test result to CI

### DIFF
--- a/libs/sdk-ui-tests/backstop/backstop.config.js
+++ b/libs/sdk-ui-tests/backstop/backstop.config.js
@@ -16,7 +16,6 @@ const backstopConfig = {
             height: 768,
         },
     ],
-    delay: 1000,
     onReadyScript: "puppet/onReady.js",
     scenarios,
     paths: {
@@ -55,6 +54,7 @@ const backstopConfig = {
             "--no-sandbox",
             "--disable-software-rasterizer",
             "--disable-gpu",
+            "--disable-setuid-sandbox",
         ],
     },
     report: ["CI"],


### PR DESCRIPTION
- so you can see storybook link in github comment, when tests fail

JIRA: RAIL-1027
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
