### PR TITLE
Plugin harness - add GeoPushpin and PivotTable css

### DIFF
--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -63,6 +63,8 @@
         "@gooddata/sdk-ui": "^8.10.0-alpha.88",
         "@gooddata/sdk-ui-charts": "^8.10.0-alpha.88",
         "@gooddata/sdk-ui-ext": "^8.10.0-alpha.88",
+        "@gooddata/sdk-ui-geo": "^8.10.0-alpha.88",
+        "@gooddata/sdk-ui-pivot": "^8.10.0-alpha.88",
         "react": "^16.10.0 || ^17.0.0",
         "react-dom": "^16.10.0 || ^17.0.0"
     },

--- a/tools/dashboard-plugin-template/src/harness/index.tsx
+++ b/tools/dashboard-plugin-template/src/harness/index.tsx
@@ -1,10 +1,12 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import ReactDOM from "react-dom";
 
 import "@gooddata/sdk-ui-charts/styles/css/main.css";
 import "@gooddata/sdk-ui-ext/styles/css/main.css";
 import "@gooddata/sdk-ui-dashboard/styles/css/main.css";
+import "@gooddata/sdk-ui-pivot/styles/css/main.css";
+import "@gooddata/sdk-ui-geo/styles/css/main.css";
 
 import { Root } from "./Root";
 


### PR DESCRIPTION
- So PivotTable and GeoPushpin charts are rendered correctly when running plugin locally

JIRA: RAIL-4205

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
