### PR TITLE
RELATED: FET-1034 Fix security audit issues in urijs

### DIFF
--- a/common/config/rush/.pnpmfile.cjs
+++ b/common/config/rush/.pnpmfile.cjs
@@ -43,7 +43,7 @@ function readPackage(packageJson, context) {
 
   // bump urijs dependency of @heroku-cli/plugin-apps-v5 to a safer version (it is a patch upgrade, should be safe)
   if (packageJson.name === '@heroku-cli/plugin-apps-v5' || packageJson.name === '@heroku-cli/plugin-apps') {
-    packageJson.dependencies['urijs'] = "1.19.7";
+    packageJson.dependencies['urijs'] = "1.19.11";
   }
 
   return packageJson;

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1981,8 +1981,8 @@ packages:
     engines: {node: '>= 4'}
     dependencies:
       stylelint: 13.13.1
-      stylelint-config-standard: 20.0.0_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-standard: 20.0.0_stylelint@13.13.1
       stylelint-order: 4.1.0_stylelint@13.13.1
       stylelint-scss: 3.21.0_stylelint@13.13.1
     transitivePeerDependencies:
@@ -2067,7 +2067,7 @@ packages:
       sparkline: 0.2.0
       strftime: 0.10.1
       term-img: 4.1.0
-      urijs: 1.19.7
+      urijs: 1.19.11
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2085,7 +2085,7 @@ packages:
       inquirer: 7.3.3
       shell-escape: 0.2.0
       tslib: 1.14.1
-      urijs: 1.19.7
+      urijs: 1.19.11
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2111,10 +2111,10 @@ packages:
       '@heroku-cli/command': 8.5.0
       '@oclif/command': 1.8.16
       '@oclif/config': 1.18.3
+      chalk: 2.4.2
       cli-ux: 4.9.3
       debug: 4.3.4
       fs-extra: 7.0.1
-      chalk: 2.4.2
       lodash.flatten: 4.4.0
       tslib: 1.9.3
     transitivePeerDependencies:
@@ -2517,13 +2517,13 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
       ansi-escapes: 4.3.2
+      chalk: 4.1.2
       emittery: 0.8.1
       exit: 0.1.2
       graceful-fs: 4.2.10
-      chalk: 4.1.2
+      jest-changed-files: 27.5.1
       jest-config: 27.5.1_ts-node@10.7.0
       jest-haste-map: 27.5.1
-      jest-changed-files: 27.5.1
       jest-message-util: 27.5.1
       jest-regex-util: 27.5.1
       jest-resolve: 27.5.1
@@ -2592,11 +2592,11 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
+      chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.2.0
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       istanbul-lib-coverage: 3.2.0
       istanbul-lib-instrument: 5.1.0
       istanbul-lib-report: 3.0.0
@@ -2653,10 +2653,10 @@ packages:
       '@babel/core': 7.17.9
       '@jest/types': 27.5.1
       babel-plugin-istanbul: 6.1.1
+      chalk: 4.1.2
       convert-source-map: 1.8.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       jest-haste-map: 27.5.1
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
@@ -2958,8 +2958,8 @@ packages:
     engines: {node: '>=8.0.0', npm: '>=5.0.0'}
     hasBin: true
     dependencies:
-      consola: 2.15.3
       chalk: 4.1.2
+      consola: 2.15.3
       node-fetch: 2.6.7
     transitivePeerDependencies:
       - encoding
@@ -3255,11 +3255,11 @@ packages:
     dependencies:
       '@oclif/color': 0.0.0
       '@oclif/command': 1.5.18
+      chalk: 2.4.2
       cli-ux: 5.6.7
       debug: 4.3.4
       fs-extra: 7.0.1
       http-call: 5.3.0
-      chalk: 2.4.2
       load-json-file: 5.3.0
       npm-run-path: 3.1.0
       semver: 5.7.1
@@ -3299,10 +3299,10 @@ packages:
       '@oclif/command': 1.5.18
       '@oclif/config': 1.13.2
       '@oclif/errors': 1.2.2
+      chalk: 2.4.2
       debug: 4.3.4
       fs-extra: 7.0.1
       http-call: 5.3.0
-      chalk: 2.4.2
       lodash.template: 4.5.0
       semver: 5.7.1
     transitivePeerDependencies:
@@ -3335,13 +3335,13 @@ packages:
       '@nestjs/common': 8.2.6_88a789cb3f20cca25c3f70fe96f41643
       '@nestjs/core': 8.2.6_0f75cad7c3bc55c714d492fe95499bdf
       '@nuxtjs/opencollective': 0.3.2
+      chalk: 4.1.2
       commander: 8.3.0
       compare-versions: 3.6.0
       concurrently: 6.5.1
       console.table: 0.10.0
       fs-extra: 10.0.0
       glob: 7.1.6
-      chalk: 4.1.2
       inquirer: 8.2.0
       lodash: 4.17.21
       reflect-metadata: 0.1.13
@@ -3570,10 +3570,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@storybook/api': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channels': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/channels': 6.4.20
       '@storybook/router': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/theming': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@types/webpack-env': 1.16.3
@@ -3590,10 +3590,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      '@storybook/channels': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/channels': 6.4.20
       '@storybook/router': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.4.20_react-dom@17.0.2+react@17.0.2
@@ -3644,13 +3644,13 @@ packages:
       '@babel/preset-typescript': 7.16.7_@babel+core@7.17.9
       '@storybook/addons': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/api': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channel-postmessage': 6.4.20
+      '@storybook/channels': 6.4.20
       '@storybook/client-api': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.4.20
       '@storybook/components': 6.4.20_b49bddbe4b905ced4713cb857cca91fa
       '@storybook/core-common': 6.4.20_56a8b41080d40451c6ac9c939a1a4cac
       '@storybook/core-events': 6.4.20
-      '@storybook/channel-postmessage': 6.4.20
-      '@storybook/channels': 6.4.20
       '@storybook/node-logger': 6.4.20
       '@storybook/preview-web': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/router': 6.4.20_react-dom@17.0.2+react@17.0.2
@@ -3705,9 +3705,9 @@ packages:
   /@storybook/channel-postmessage/6.4.20:
     resolution: {integrity: sha512-rKgQZ74WZhcpQY8I9SyMMADWbQ2GQopfzvE35qYJl/7mpEggXjY2nSP6PdQ7uIZzUSiwZFQ3tesCT5frEjF/DA==}
     dependencies:
+      '@storybook/channels': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
-      '@storybook/channels': 6.4.20
       core-js: 3.21.1
       global: 4.4.0
       qs: 6.10.3
@@ -3717,8 +3717,8 @@ packages:
   /@storybook/channel-websocket/6.4.20:
     resolution: {integrity: sha512-PYQAX53oTaY2zmHzd+GuDjRVDg34Z9Igo648qmBmpbUypWj54QmHeAcLMN8/RZpcsmjtj/gGkS8TwHGew4soZA==}
     dependencies:
-      '@storybook/client-logger': 6.4.20
       '@storybook/channels': 6.4.20
+      '@storybook/client-logger': 6.4.20
       core-js: 3.21.1
       global: 4.4.0
       telejson: 5.3.3
@@ -3739,11 +3739,11 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@storybook/addons': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channel-postmessage': 6.4.20
+      '@storybook/channels': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/channel-postmessage': 6.4.20
-      '@storybook/channels': 6.4.20
       '@storybook/store': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@types/qs': 6.9.7
       '@types/webpack-env': 1.16.3
@@ -3817,12 +3817,12 @@ packages:
         optional: true
     dependencies:
       '@storybook/addons': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channel-postmessage': 6.4.20
+      '@storybook/channel-websocket': 6.4.20
       '@storybook/client-api': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/channel-postmessage': 6.4.20
-      '@storybook/channel-websocket': 6.4.20
       '@storybook/preview-web': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/store': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/ui': 6.4.20_b49bddbe4b905ced4713cb857cca91fa
@@ -3882,6 +3882,7 @@ packages:
       babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
       babel-plugin-macros: 3.1.0
       babel-plugin-polyfill-corejs3: 0.1.7_@babel+core@7.17.9
+      chalk: 4.1.2
       core-js: 3.21.1
       express: 4.17.3
       file-system-cache: 1.0.5
@@ -3890,7 +3891,6 @@ packages:
       fs-extra: 9.1.0
       glob: 7.2.0
       handlebars: 4.7.7
-      chalk: 4.1.2
       interpret: 2.2.0
       json5: 2.2.1
       lazy-universal-dotenv: 3.0.1
@@ -3953,6 +3953,7 @@ packages:
       '@types/webpack': 4.41.32
       better-opn: 2.1.1
       boxen: 5.1.2
+      chalk: 4.1.2
       cli-table3: 0.6.1
       commander: 6.2.1
       compression: 1.7.4
@@ -3963,7 +3964,6 @@ packages:
       file-system-cache: 1.0.5
       fs-extra: 9.1.0
       globby: 11.1.0
-      chalk: 4.1.2
       ip: 1.1.5
       lodash: 4.17.21
       node-fetch: 2.6.7
@@ -4079,6 +4079,7 @@ packages:
       '@types/webpack': 4.41.32
       babel-loader: 8.2.4_598a497cebab8e15ee8f9e5632178e63
       case-sensitive-paths-webpack-plugin: 2.4.0
+      chalk: 4.1.2
       core-js: 3.21.1
       css-loader: 3.6.0_webpack@4.46.0
       express: 4.17.3
@@ -4087,7 +4088,6 @@ packages:
       find-up: 5.0.0
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      chalk: 4.1.2
       node-fetch: 2.6.7
       pnp-webpack-plugin: 1.6.4_typescript@4.0.2
       react: 17.0.2
@@ -4119,8 +4119,8 @@ packages:
     resolution: {integrity: sha512-8E34tK4NPkXn+Ga20d5Oba0mVem9w60B2bBQk66TMGXJdZnAqO9xrBlVYEQkeb58g4Mb2WVBFTY6fsDVHwzZyw==}
     dependencies:
       '@types/npmlog': 4.1.4
-      core-js: 3.21.1
       chalk: 4.1.2
+      core-js: 3.21.1
       npmlog: 5.0.1
       pretty-hrtime: 1.0.3
     dev: false
@@ -4144,10 +4144,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@storybook/addons': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channel-postmessage': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/core-events': 6.4.20
       '@storybook/csf': 0.0.2--canary.87bc651.0
-      '@storybook/channel-postmessage': 6.4.20
       '@storybook/store': 6.4.20_react-dom@17.0.2+react@17.0.2
       ansi-to-html: 0.6.15
       core-js: 3.21.1
@@ -4331,10 +4331,10 @@ packages:
       '@emotion/core': 10.3.1_react@17.0.2
       '@storybook/addons': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/api': 6.4.20_react-dom@17.0.2+react@17.0.2
+      '@storybook/channels': 6.4.20
       '@storybook/client-logger': 6.4.20
       '@storybook/components': 6.4.20_b49bddbe4b905ced4713cb857cca91fa
       '@storybook/core-events': 6.4.20
-      '@storybook/channels': 6.4.20
       '@storybook/router': 6.4.20_react-dom@17.0.2+react@17.0.2
       '@storybook/semver': 7.3.2
       '@storybook/theming': 6.4.20_react-dom@17.0.2+react@17.0.2
@@ -6069,10 +6069,10 @@ packages:
     engines: {node: '>=8.0'}
     hasBin: true
     dependencies:
+      chromium-pickle-js: 0.2.0
       commander: 2.20.3
       cuint: 0.2.2
       glob: 7.2.0
-      chromium-pickle-js: 0.2.0
       minimatch: 3.1.2
       mkdirp: 0.5.6
       tmp-promise: 1.1.0
@@ -6242,8 +6242,8 @@ packages:
       '@types/babel__core': 7.1.19
       babel-plugin-istanbul: 6.1.1
       babel-preset-jest: 27.5.1_@babel+core@7.17.9
-      graceful-fs: 4.2.10
       chalk: 4.1.2
+      graceful-fs: 4.2.10
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
@@ -6676,8 +6676,8 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 5.3.1
-      cli-boxes: 2.2.1
       chalk: 3.0.0
+      cli-boxes: 2.2.1
       string-width: 4.2.3
       term-size: 2.2.1
       type-fest: 0.8.1
@@ -6690,8 +6690,8 @@ packages:
     dependencies:
       ansi-align: 3.0.1
       camelcase: 6.3.0
-      cli-boxes: 2.2.1
       chalk: 4.1.2
+      cli-boxes: 2.2.1
       string-width: 4.2.3
       type-fest: 0.20.2
       widest-line: 3.1.0
@@ -6914,10 +6914,10 @@ packages:
     resolution: {integrity: sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==}
     dependencies:
       bluebird: 3.7.2
+      chownr: 1.1.4
       figgy-pudding: 3.5.2
       glob: 7.2.0
       graceful-fs: 4.2.10
-      chownr: 1.1.4
       infer-owner: 1.0.4
       lru-cache: 5.1.1
       mississippi: 3.0.0
@@ -6936,9 +6936,9 @@ packages:
     dependencies:
       '@npmcli/fs': 1.1.1
       '@npmcli/move-file': 1.1.2
+      chownr: 2.0.0
       fs-minipass: 2.1.0
       glob: 7.2.0
-      chownr: 2.0.0
       infer-owner: 1.0.4
       lru-cache: 6.0.0
       minipass: 3.1.6
@@ -7017,8 +7017,8 @@ packages:
       '@types/error-stack-parser': 2.0.0
       '@types/lodash': 4.14.181
       callsite: 1.0.0
-      highlight-es: 1.0.3
       chalk: 2.4.2
+      highlight-es: 1.0.3
       lodash: 4.17.21
       pinkie-promise: 2.0.1
     dev: false
@@ -7100,9 +7100,9 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       assertion-error: 1.1.0
+      check-error: 1.0.2
       deep-eql: 3.0.1
       get-func-name: 2.0.0
-      check-error: 1.0.2
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: false
@@ -7215,10 +7215,10 @@ packages:
     resolution: {integrity: sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==}
     engines: {node: '>= 6'}
     dependencies:
+      cheerio-select: 1.6.0
       dom-serializer: 1.3.2
       domhandler: 4.3.1
       htmlparser2: 6.1.0
-      cheerio-select: 1.6.0
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       tslib: 2.3.1
@@ -7438,11 +7438,11 @@ packages:
       ansi-escapes: 3.2.0
       ansi-styles: 3.2.1
       cardinal: 2.1.1
+      chalk: 2.4.2
       clean-stack: 2.2.0
       extract-stack: 1.0.0
       fs-extra: 7.0.1
       hyperlinker: 1.0.0
-      chalk: 2.4.2
       indent-string: 3.2.0
       is-wsl: 1.1.0
       lodash: 4.17.21
@@ -7467,12 +7467,12 @@ packages:
       ansi-escapes: 4.3.2
       ansi-styles: 4.3.0
       cardinal: 2.1.1
+      chalk: 4.1.2
       clean-stack: 3.0.1
       cli-progress: 3.10.0
       extract-stack: 2.0.0
       fs-extra: 8.1.0
       hyperlinker: 1.0.0
-      chalk: 4.1.2
       indent-string: 4.0.0
       is-wsl: 2.2.0
       js-yaml: 3.14.1
@@ -7719,8 +7719,8 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      serialize-javascript: 5.0.1
       schema-utils: 3.1.1
+      serialize-javascript: 5.0.1
       webpack: 5.72.0
     dev: false
 
@@ -7760,8 +7760,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
     dependencies:
-      date-fns: 2.28.0
       chalk: 4.1.2
+      date-fns: 2.28.0
       lodash: 4.17.21
       rxjs: 6.6.7
       spawn-command: 0.0.2-1
@@ -8054,8 +8054,8 @@ packages:
       postcss-modules-scope: 2.2.0
       postcss-modules-values: 3.0.0
       postcss-value-parser: 4.2.0
-      semver: 6.3.0
       schema-utils: 2.7.1
+      semver: 6.3.0
       webpack: 4.46.0
     dev: false
 
@@ -8073,8 +8073,8 @@ packages:
       postcss-modules-scope: 3.0.0_postcss@8.4.12
       postcss-modules-values: 4.0.0_postcss@8.4.12
       postcss-value-parser: 4.2.0
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
     dev: false
 
   /css-loader/5.2.7_webpack@5.72.0:
@@ -8091,8 +8091,8 @@ packages:
       postcss-modules-scope: 3.0.0_postcss@8.4.12
       postcss-modules-values: 4.0.0_postcss@8.4.12
       postcss-value-parser: 4.2.0
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
       webpack: 5.72.0_webpack-cli@4.9.2
     dev: false
 
@@ -8224,6 +8224,8 @@ packages:
       blob-util: 2.0.2
       bluebird: 3.7.2
       cachedir: 2.3.0
+      chalk: 4.1.2
+      check-more-types: 2.24.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.1
       commander: 5.1.0
@@ -8238,8 +8240,6 @@ packages:
       figures: 3.2.0
       fs-extra: 9.1.0
       getos: 3.2.1
-      chalk: 4.1.2
-      check-more-types: 2.24.0
       is-ci: 3.0.1
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
@@ -8610,13 +8610,13 @@ packages:
       acorn-loose: 8.2.1
       acorn-walk: 8.2.0
       ajv: 8.8.2
+      chalk: 4.1.2
       commander: 8.3.0
       enhanced-resolve: 5.8.3
       figures: 3.2.0
       get-stream: 6.0.1
       glob: 7.2.0
       handlebars: 4.7.7
-      chalk: 4.1.2
       indent-string: 4.0.0
       inquirer: 8.2.0
       json5: 2.2.0
@@ -9145,11 +9145,11 @@ packages:
     resolution: {integrity: sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==}
     dependencies:
       array.prototype.flat: 1.2.5
+      cheerio: 1.0.0-rc.10
       enzyme-shallow-equal: 1.0.4
       function.prototype.name: 1.1.5
       has: 1.0.3
       html-element-map: 1.3.1
-      cheerio: 1.0.0-rc.10
       is-boolean-object: 1.1.2
       is-callable: 1.2.4
       is-number-object: 1.0.7
@@ -9318,8 +9318,8 @@ packages:
     dependencies:
       '@types/eslint': 7.29.0
       ansi-escapes: 4.3.2
-      eslint-rule-docs: 1.1.231
       chalk: 4.1.2
+      eslint-rule-docs: 1.1.231
       log-symbols: 4.1.0
       plur: 4.0.0
       string-width: 4.2.3
@@ -9530,6 +9530,7 @@ packages:
       '@eslint/eslintrc': 1.2.1
       '@humanwhocodes/config-array': 0.9.5
       ajv: 6.12.6
+      chalk: 4.1.2
       cross-spawn: 7.0.3
       debug: 4.3.4
       doctrine: 3.0.0
@@ -9545,7 +9546,6 @@ packages:
       functional-red-black-tree: 1.0.1
       glob-parent: 6.0.2
       globals: 13.13.0
-      chalk: 4.1.2
       ignore: 5.2.0
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
@@ -10282,17 +10282,17 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.7
       '@types/json-schema': 7.0.11
+      chalk: 4.1.2
+      chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
       eslint: 8.12.0
       fs-extra: 9.1.0
       glob: 7.2.0
-      chalk: 4.1.2
-      chokidar: 3.5.3
       memfs: 3.4.1
       minimatch: 3.1.2
-      semver: 7.3.6
       schema-utils: 2.7.0
+      semver: 7.3.6
       tapable: 1.1.3
       typescript: 4.0.2
       webpack: 4.46.0
@@ -10314,17 +10314,17 @@ packages:
     dependencies:
       '@babel/code-frame': 7.16.7
       '@types/json-schema': 7.0.11
+      chalk: 4.1.2
+      chokidar: 3.5.3
       cosmiconfig: 6.0.0
       deepmerge: 4.2.2
       eslint: 8.12.0
       fs-extra: 9.1.0
       glob: 7.2.0
-      chalk: 4.1.2
-      chokidar: 3.5.3
       memfs: 3.4.1
       minimatch: 3.1.2
-      semver: 7.3.6
       schema-utils: 2.7.0
+      semver: 7.3.6
       tapable: 1.1.3
       typescript: 4.0.2
       webpack: 5.72.0
@@ -11210,10 +11210,10 @@ packages:
       ansi-escapes: 3.2.0
       ansi-styles: 3.2.1
       cardinal: 2.1.1
+      chalk: 2.4.2
       co: 4.6.0
       got: 8.3.2
       heroku-client: 3.1.0
-      chalk: 2.4.2
       lodash: 4.17.21
       netrc-parser: 3.1.6
       opn: 3.0.3
@@ -11833,11 +11833,11 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       ansi-escapes: 3.2.0
+      chalk: 2.4.2
       cli-cursor: 2.1.0
       cli-width: 2.2.1
       external-editor: 3.1.0
       figures: 2.0.0
-      chalk: 2.4.2
       lodash: 4.17.21
       mute-stream: 0.0.7
       run-async: 2.4.1
@@ -11852,11 +11852,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      chalk: 4.1.2
       lodash: 4.17.21
       mute-stream: 0.0.8
       run-async: 2.4.1
@@ -11871,11 +11871,11 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       ansi-escapes: 4.3.2
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      chalk: 4.1.2
       lodash: 4.17.21
       mute-stream: 0.0.8
       ora: 5.4.1
@@ -12662,10 +12662,10 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
+      chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
       expect: 27.5.1
-      chalk: 4.1.2
       is-generator-fn: 2.1.0
       jest-each: 27.5.1
       jest-matcher-utils: 27.5.1
@@ -12694,9 +12694,9 @@ packages:
       '@jest/core': 27.5.1_ts-node@10.7.0
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
+      chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       import-local: 3.1.0
       jest-config: 27.5.1_ts-node@10.7.0
       jest-util: 27.5.1
@@ -12724,11 +12724,11 @@ packages:
       '@jest/test-sequencer': 27.5.1
       '@jest/types': 27.5.1
       babel-jest: 27.5.1_@babel+core@7.17.9
+      chalk: 4.1.2
       ci-info: 3.3.0
       deepmerge: 4.2.2
       glob: 7.2.0
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       jest-circus: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -12756,8 +12756,8 @@ packages:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      diff-sequences: 27.5.1
       chalk: 4.1.2
+      diff-sequences: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
     dev: false
@@ -12881,9 +12881,9 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
+      chalk: 4.1.2
       co: 4.6.0
       expect: 27.5.1
-      chalk: 4.1.2
       is-generator-fn: 2.1.0
       jest-each: 27.5.1
       jest-matcher-utils: 27.5.1
@@ -12931,8 +12931,8 @@ packages:
       '@babel/code-frame': 7.16.7
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
-      graceful-fs: 4.2.10
       chalk: 4.1.2
+      graceful-fs: 4.2.10
       micromatch: 4.0.5
       pretty-format: 27.5.1
       slash: 3.0.0
@@ -12980,8 +12980,8 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@jest/types': 27.5.1
-      graceful-fs: 4.2.10
       chalk: 4.1.2
+      graceful-fs: 4.2.10
       jest-haste-map: 27.5.1
       jest-pnp-resolver: 1.2.2_jest-resolve@27.5.1
       jest-util: 27.5.1
@@ -13001,9 +13001,9 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
+      chalk: 4.1.2
       emittery: 0.8.1
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       jest-docblock: 27.5.1
       jest-environment-jsdom: 27.5.1
       jest-environment-node: 27.5.1
@@ -13034,12 +13034,12 @@ packages:
       '@jest/test-result': 27.5.1
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
+      chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
       execa: 5.1.1
       glob: 7.2.0
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       jest-haste-map: 27.5.1
       jest-message-util: 27.5.1
       jest-mock: 27.5.1
@@ -13075,9 +13075,9 @@ packages:
       '@types/babel__traverse': 7.14.2
       '@types/prettier': 2.4.4
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.17.9
+      chalk: 4.1.2
       expect: 27.5.1
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       jest-haste-map: 27.5.1
@@ -13097,9 +13097,9 @@ packages:
     dependencies:
       '@jest/types': 27.5.1
       '@types/node': 16.11.26
+      chalk: 4.1.2
       ci-info: 3.3.0
       graceful-fs: 4.2.10
-      chalk: 4.1.2
       picomatch: 2.3.1
     dev: false
 
@@ -14821,11 +14821,11 @@ packages:
     requiresBuild: true
     dependencies:
       async-foreach: 0.1.3
+      chalk: 4.1.2
       cross-spawn: 7.0.3
       gaze: 1.1.3
       get-stdin: 4.0.1
       glob: 7.2.0
-      chalk: 4.1.2
       lodash: 4.17.21
       meow: 9.0.0
       nan: 2.15.0
@@ -14919,8 +14919,8 @@ packages:
     hasBin: true
     dependencies:
       ansi-styles: 3.2.1
-      cross-spawn: 6.0.5
       chalk: 2.4.2
+      cross-spawn: 6.0.5
       memorystream: 0.3.1
       minimatch: 3.1.2
       pidtree: 0.3.1
@@ -15208,9 +15208,9 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       bl: 4.1.0
+      chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1
-      chalk: 4.1.2
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -15841,8 +15841,8 @@ packages:
       klona: 2.0.5
       loader-utils: 2.0.2
       postcss: 7.0.39
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
       webpack: 4.46.0
     dev: false
 
@@ -16097,9 +16097,9 @@ packages:
     peerDependencies:
       prettier: '>=2.0.0'
     dependencies:
+      chalk: 3.0.0
       execa: 4.1.0
       find-up: 4.1.0
-      chalk: 3.0.0
       ignore: 5.2.0
       mri: 1.2.0
       multimatch: 4.0.0
@@ -17092,8 +17092,8 @@ packages:
       react-is: 16.13.1
       react-resize-detector: 6.7.8_react-dom@17.0.2+react@17.0.2
       react-smooth: 2.0.0_react-dom@17.0.2+react@17.0.2
-      reduce-css-calc: 2.1.8
       recharts-scale: 0.4.5
+      reduce-css-calc: 2.1.8
     transitivePeerDependencies:
       - prop-types
     dev: false
@@ -17735,8 +17735,8 @@ packages:
       klona: 2.0.5
       loader-utils: 2.0.2
       neo-async: 2.6.2
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
     dev: false
 
   /sass-loader/10.2.1_e3a10481b6e5cbf93aa3f98fa5ee62a3:
@@ -17760,8 +17760,8 @@ packages:
       neo-async: 2.6.2
       node-sass: 7.0.1
       sass: 1.50.0
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
       webpack: 5.72.0_webpack-cli@4.9.2
     dev: false
 
@@ -17785,8 +17785,8 @@ packages:
       loader-utils: 2.0.2
       neo-async: 2.6.2
       sass: 1.50.0
-      semver: 7.3.6
       schema-utils: 3.1.1
+      semver: 7.3.6
       webpack: 5.72.0_webpack-cli@4.9.2
     dev: false
 
@@ -18896,6 +18896,7 @@ packages:
       '@stylelint/postcss-markdown': 0.36.2_4f7b71a942b8b7a555b8adf78f88122b
       autoprefixer: 9.8.8
       balanced-match: 2.0.0
+      chalk: 4.1.2
       cosmiconfig: 7.0.1
       debug: 4.3.4
       execall: 2.0.0
@@ -18907,7 +18908,6 @@ packages:
       globby: 11.1.0
       globjoin: 0.1.4
       html-tags: 3.2.0
-      chalk: 4.1.2
       ignore: 5.2.0
       import-lazy: 4.0.0
       imurmurhash: 0.1.4
@@ -19116,8 +19116,8 @@ packages:
     resolution: {integrity: sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==}
     engines: {node: '>= 10'}
     dependencies:
-      fs-minipass: 2.1.0
       chownr: 2.0.0
+      fs-minipass: 2.1.0
       minipass: 3.1.6
       minizlib: 2.1.2
       mkdirp: 1.0.4
@@ -19186,8 +19186,8 @@ packages:
       cacache: 12.0.4
       find-cache-dir: 2.1.0
       is-wsl: 1.1.0
-      serialize-javascript: 4.0.0
       schema-utils: 1.0.0
+      serialize-javascript: 4.0.0
       source-map: 0.6.1
       terser: 4.8.0
       webpack: 4.46.0
@@ -19205,8 +19205,8 @@ packages:
       find-cache-dir: 3.3.2
       jest-worker: 26.6.2
       p-limit: 3.1.0
-      serialize-javascript: 5.0.1
       schema-utils: 3.1.1
+      serialize-javascript: 5.0.1
       source-map: 0.6.1
       terser: 5.12.1
       webpack: 4.46.0
@@ -19230,8 +19230,8 @@ packages:
         optional: true
     dependencies:
       jest-worker: 27.5.1
-      serialize-javascript: 6.0.0
       schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.12.1
       webpack: 5.72.0_webpack-cli@4.9.2
@@ -19414,6 +19414,9 @@ packages:
       bowser: 2.11.0
       callsite: 1.0.0
       callsite-record: 4.1.4
+      chai: 4.3.4
+      chalk: 2.4.2
+      chrome-remote-interface: 0.30.1
       coffeescript: 2.6.1
       commander: 8.3.0
       debug: 4.3.4
@@ -19430,9 +19433,6 @@ packages:
       graceful-fs: 4.2.10
       graphlib: 2.1.8
       humanize-duration: 3.27.1
-      chai: 4.3.4
-      chalk: 2.4.2
-      chrome-remote-interface: 0.30.1
       import-lazy: 3.1.0
       indent-string: 1.2.2
       is-ci: 1.2.1
@@ -19833,8 +19833,8 @@ packages:
       typescript: '*'
       webpack: '*'
     dependencies:
-      enhanced-resolve: 4.5.0
       chalk: 4.1.2
+      enhanced-resolve: 4.5.0
       loader-utils: 2.0.2
       micromatch: 4.0.5
       semver: 7.3.6
@@ -19848,8 +19848,8 @@ packages:
       typescript: '*'
       webpack: '*'
     dependencies:
-      enhanced-resolve: 4.5.0
       chalk: 4.1.2
+      enhanced-resolve: 4.5.0
       loader-utils: 2.0.2
       micromatch: 4.0.5
       semver: 7.3.6
@@ -19910,8 +19910,8 @@ packages:
   /tsconfig-paths-webpack-plugin/3.5.2:
     resolution: {integrity: sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==}
     dependencies:
-      enhanced-resolve: 5.9.2
       chalk: 4.1.2
+      enhanced-resolve: 5.9.2
       tsconfig-paths: 3.14.1
     dev: false
 
@@ -20290,9 +20290,9 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       boxen: 4.2.0
+      chalk: 3.0.0
       configstore: 5.0.1
       has-yarn: 2.1.0
-      chalk: 3.0.0
       import-lazy: 2.1.0
       is-ci: 2.0.0
       is-installed-globally: 0.3.2
@@ -20320,8 +20320,8 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /urijs/1.19.7:
-    resolution: {integrity: sha512-Id+IKjdU0Hx+7Zx717jwLPsPeUqz7rAtuVBRLLs+qn+J2nf9NGITWVCxcijgYxBqe83C7sqsQPs6H1pyz3x9gA==}
+  /urijs/1.19.11:
+    resolution: {integrity: sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==}
     dev: false
 
   /urix/0.1.0:
@@ -20702,9 +20702,9 @@ packages:
     dependencies:
       acorn: 8.7.0
       acorn-walk: 8.2.0
+      chalk: 4.1.2
       commander: 7.2.0
       gzip-size: 6.0.0
-      chalk: 4.1.2
       lodash: 4.17.21
       opener: 1.5.2
       sirv: 1.0.19
@@ -20863,6 +20863,7 @@ packages:
     dependencies:
       ansi-html-community: 0.0.8
       bonjour: 3.5.0
+      chokidar: 2.1.8
       compression: 1.7.4
       connect-history-api-fallback: 1.6.0
       debug: 4.3.4_supports-color@6.1.0
@@ -20870,7 +20871,6 @@ packages:
       express: 4.17.3
       html-entities: 1.4.0
       http-proxy-middleware: 0.19.1_debug@4.3.4
-      chokidar: 2.1.8
       import-local: 2.0.0
       internal-ip: 4.3.0
       ip: 1.1.5
@@ -20880,10 +20880,10 @@ packages:
       opn: 5.5.0
       p-retry: 3.0.1
       portfinder: 1.0.28
+      schema-utils: 1.0.0
       selfsigned: 1.10.14
       semver: 6.3.0
       serve-index: 1.9.1
-      schema-utils: 1.0.0
       sockjs: 0.3.24
       sockjs-client: 1.6.0
       spdy: 4.0.2_supports-color@6.1.0
@@ -20970,9 +20970,9 @@ packages:
       acorn: 6.4.2
       ajv: 6.12.6
       ajv-keywords: 3.5.2_ajv@6.12.6
+      chrome-trace-event: 1.0.3
       enhanced-resolve: 4.5.0
       eslint-scope: 4.0.3
-      chrome-trace-event: 1.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 2.4.0
       loader-utils: 1.4.0
@@ -21006,13 +21006,13 @@ packages:
       acorn: 8.7.0
       acorn-import-assertions: 1.8.0_acorn@8.7.0
       browserslist: 4.20.2
+      chrome-trace-event: 1.0.3
       enhanced-resolve: 5.9.2
       es-module-lexer: 0.9.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
-      chrome-trace-event: 1.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 4.2.0
       mime-types: 2.1.35
@@ -21046,13 +21046,13 @@ packages:
       acorn: 8.7.0
       acorn-import-assertions: 1.8.0_acorn@8.7.0
       browserslist: 4.20.2
+      chrome-trace-event: 1.0.3
       enhanced-resolve: 5.9.2
       es-module-lexer: 0.9.3
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
-      chrome-trace-event: 1.0.3
       json-parse-better-errors: 1.0.2
       loader-runner: 4.2.0
       mime-types: 2.1.35
@@ -21486,7 +21486,7 @@ packages:
     dev: false
 
   file:projects/api-client-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-KQnMYZfJN+eu/SsP4hQqxOLp8bt3UJfuIoNi/pJYN/jBtqubeSljtigFZU3MCl4Z2B/VYBWfR5JHavdTcXIb1Q==, tarball: file:projects/api-client-bear.tgz}
+    resolution: {integrity: sha512-whXZaQSekJ/eUGnRkrlvlVd6LkLBIQDupXwswDBDRtm8lxUjSmpkU+YY5yt/UZP3nOiBNZglWAg2VYPQnUc+5A==, tarball: file:projects/api-client-bear.tgz}
     id: file:projects/api-client-bear.tgz
     name: '@rush-temp/api-client-bear'
     version: 0.0.0
@@ -21553,7 +21553,7 @@ packages:
     dev: false
 
   file:projects/api-client-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-XXl5WFUvidE+ENOy4ZTga45trQJHVKBeBXRqp+baa80D2nxHbSh3WXcSbwmFey9qAi3Zmg7Jz7R6hlQ1fyY3xg==, tarball: file:projects/api-client-tiger.tgz}
+    resolution: {integrity: sha512-4L8qc8mX08KmLCwmgi/DnQrhq7YjSngJwp8/sZ4u4GIoswKlSBjgqE405ZzXTPCOZzj8x7d4ayBgUZQPu9fsvw==, tarball: file:projects/api-client-tiger.tgz}
     id: file:projects/api-client-tiger.tgz
     name: '@rush-temp/api-client-tiger'
     version: 0.0.0
@@ -21666,6 +21666,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
       blessed: 0.1.81
+      chokidar: 3.5.3
       commander: 8.3.0
       cross-spawn: 7.0.3
       dependency-cruiser: 10.9.0
@@ -21678,7 +21679,6 @@ packages:
       eslint-plugin-sonarjs: 0.11.0_eslint@8.12.0
       eslint-plugin-tsdoc: 0.2.15
       find-up: 5.0.0
-      chokidar: 3.5.3
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
       json5: 2.2.1
@@ -21703,7 +21703,7 @@ packages:
     dev: false
 
   file:projects/catalog-export.tgz:
-    resolution: {integrity: sha512-k9RM908z0z83eg0P+uUOAS6rb3s1uECqxZAukp3Dv00nmtnE02vQh1f66LrVIs5TttsckiIhut3E6TejT2TWsA==, tarball: file:projects/catalog-export.tgz}
+    resolution: {integrity: sha512-rNM9eXU8qViOoT6h2W7VRzZlWJQ0ZTLbS0QtStoDZcihOe5ry1UIo40qUkHMimPFqgpdTnzayqo9I3oJm3JUdw==, tarball: file:projects/catalog-export.tgz}
     name: '@rush-temp/catalog-export'
     version: 0.0.0
     dependencies:
@@ -21717,6 +21717,7 @@ packages:
       '@types/prettier': 1.18.4
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
+      chalk: 4.1.2
       commander: 8.3.0
       dependency-cruiser: 10.9.0
       dotenv: 10.0.0
@@ -21728,7 +21729,6 @@ packages:
       eslint-plugin-prettier: 4.0.0_eslint@8.12.0+prettier@2.5.1
       eslint-plugin-sonarjs: 0.11.0_eslint@8.12.0
       eslint-plugin-tsdoc: 0.2.15
-      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
@@ -21757,7 +21757,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-template.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-6bEF+17CNS6JK2gu0xbam5yHlU7dzIXvT0cTHWU7eUJe4V6vdYUrsWi50stp27gPAkfY9ZmZq7CuGphsPB2c/g==, tarball: file:projects/dashboard-plugin-template.tgz}
+    resolution: {integrity: sha512-7+YtBE2iyIfeHB4FYOsVJQ+Zl5gMPYR5SkROLjukIzfFDDodJWwr18OBAHVVTOoc3AmhR6LywC351N24BUIf8g==, tarball: file:projects/dashboard-plugin-template.tgz}
     id: file:projects/dashboard-plugin-template.tgz
     name: '@rush-temp/dashboard-plugin-template'
     version: 0.0.0
@@ -21834,7 +21834,7 @@ packages:
     dev: false
 
   file:projects/dashboard-plugin-tests.tgz:
-    resolution: {integrity: sha512-bEcdHfShkqGZx391K7CvfmN90JsQVD5j31lXuZMPUiFDSKrkKQRp44nHrS8rf+qupurhVkrCp2KnuguGO9p/WQ==, tarball: file:projects/dashboard-plugin-tests.tgz}
+    resolution: {integrity: sha512-q35kQBzlRxB0fYcgtnlitFiSaAk7XLAwt8TdJlpFyoGnLA7mhvIF+ejjC9AqejQU528MAs0+OuXats8VThtvxA==, tarball: file:projects/dashboard-plugin-tests.tgz}
     name: '@rush-temp/dashboard-plugin-tests'
     version: 0.0.0
     dependencies:
@@ -21926,7 +21926,7 @@ packages:
     dev: false
 
   file:projects/experimental-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-hZoXf47e/FkJddylgloOt+VQEqInXCSDFHquw5/x4gcvixsVL4aWRAfyNSO3Qp+3WDaBIJCjmXR03e+OdZi38w==, tarball: file:projects/experimental-workspace.tgz}
+    resolution: {integrity: sha512-vlen+fsVl/l4rUer7l3yadD4X4H7rZ4Jjpb4cDgA+KpbiHdm3bN22f8JZl/1LvH0GYCxOmwgfMJhYh2w0iSUWw==, tarball: file:projects/experimental-workspace.tgz}
     id: file:projects/experimental-workspace.tgz
     name: '@rush-temp/experimental-workspace'
     version: 0.0.0
@@ -21968,7 +21968,7 @@ packages:
     dev: false
 
   file:projects/live-examples-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-E4gHa6vuXW3Mu76MH5RSrbqH66rr4jsuMZci7QTese6hWWRuo69VlV7dAMl/azQpPaXNlcHnuyVM/+rvS6pTGQ==, tarball: file:projects/live-examples-workspace.tgz}
+    resolution: {integrity: sha512-oEWfwr0HacP6OCYJ1NUgOvaJWdJp1jNtgNCKiia/8oiy6flBpva8hTNQXgoycwJqj9zKl7mv1oxL+W4CGvBubw==, tarball: file:projects/live-examples-workspace.tgz}
     id: file:projects/live-examples-workspace.tgz
     name: '@rush-temp/live-examples-workspace'
     version: 0.0.0
@@ -22009,7 +22009,7 @@ packages:
     dev: false
 
   file:projects/mock-handling.tgz:
-    resolution: {integrity: sha512-QryrbX9jC/EmZXrVrMZJ6mLp7KzvOxGfYM8deUZy1jRYi6cIDiiAaPiIu3U2m09U/IQCWUjCqaJqmvEy68gVhw==, tarball: file:projects/mock-handling.tgz}
+    resolution: {integrity: sha512-6jTFo9zxF7AzJS0IYjlbHmyBG2k+u5+CNEWuJdHEfeyaLwjLkf1aK/VRl6FIqvanXgb3S7l4ulgD1AZwKR8BGA==, tarball: file:projects/mock-handling.tgz}
     name: '@rush-temp/mock-handling'
     version: 0.0.0
     dependencies:
@@ -22023,6 +22023,7 @@ packages:
       '@types/rimraf': 2.0.5
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
+      chalk: 4.1.2
       commander: 8.3.0
       dependency-cruiser: 10.9.0
       eslint: 8.12.0
@@ -22033,7 +22034,6 @@ packages:
       eslint-plugin-prettier: 4.0.0_eslint@8.12.0+prettier@2.5.1
       eslint-plugin-sonarjs: 0.11.0_eslint@8.12.0
       eslint-plugin-tsdoc: 0.2.15
-      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
@@ -22063,7 +22063,7 @@ packages:
     dev: false
 
   file:projects/playground.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-wkqOxQL/K0Y6ed3aSZ6SydajbjbmM18sFvB1rA3ySyrmzNJ/OFWnDLD6hy5jjWJrpwfAGL0lbp3oAOPgvluLzg==, tarball: file:projects/playground.tgz}
+    resolution: {integrity: sha512-OhYm3qpKjdUT7ckFal9ODTe8oxEOGDefENLR9OgtuBi6U7sLVT8tlTPkVNNr8nFx/8tuy0uGavIuVlxEt/Lusw==, tarball: file:projects/playground.tgz}
     id: file:projects/playground.tgz
     name: '@rush-temp/playground'
     version: 0.0.0
@@ -22147,7 +22147,7 @@ packages:
     dev: false
 
   file:projects/plugin-toolkit.tgz:
-    resolution: {integrity: sha512-7kCVSPvTm8vjXaVoUDfRtnkAZQhy9fwnAKCLVwVbyI4bzhH0Z3k88C3hogfLmG8Aoa6YpxOPGRrUUuGFmGlaNQ==, tarball: file:projects/plugin-toolkit.tgz}
+    resolution: {integrity: sha512-vFB54A6Fi3c9k7y+F04xNHJ4cmZU5OvDuTgxALhUiSJO7JgacUSiOg/n/slX7Yia0Z/lau+EDop3v1XlM7l27w==, tarball: file:projects/plugin-toolkit.tgz}
     name: '@rush-temp/plugin-toolkit'
     version: 0.0.0
     dependencies:
@@ -22167,6 +22167,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.18.0_53b148e638f33f2f6f1c65934f996443
       '@typescript-eslint/parser': 5.18.0_eslint@8.12.0+typescript@4.0.2
       axios: 0.21.4
+      chalk: 4.1.2
       columnify: 1.6.0
       commander: 8.3.0
       concurrently: 6.5.1
@@ -22183,7 +22184,6 @@ packages:
       eslint-plugin-tsdoc: 0.2.15
       fast-glob: 3.2.11
       fs-extra: 10.0.1
-      chalk: 4.1.2
       inquirer: 7.3.3
       jest: 27.5.1_ts-node@10.7.0
       jest-junit: 3.7.0
@@ -22211,7 +22211,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace-mgmt.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-2uwCpFXT1hkGArj038A1uY54rrGyWdD4ZLzozQtAODNysa7mYVh77asTa0dsSQScHw1nKsy9N2dRtHOSL7nD2A==, tarball: file:projects/reference-workspace-mgmt.tgz}
+    resolution: {integrity: sha512-iJgQEjCjXoMhrGZiK00qS+YuWOxfihhL2FzzPi9EMvSmjanaK5t1vjiOLYqRezDZlqUgVkNQ2wnEHPJ8d2XLFg==, tarball: file:projects/reference-workspace-mgmt.tgz}
     id: file:projects/reference-workspace-mgmt.tgz
     name: '@rush-temp/reference-workspace-mgmt'
     version: 0.0.0
@@ -22251,7 +22251,7 @@ packages:
     dev: false
 
   file:projects/reference-workspace.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Fy7ZBvXupSOgUOYGJQmaaCGXgPG0nYKw4Mk7nbF4HrCGzLwpkvtQB3mMgLP5Z8R7spyQ4ZDz4LadbNmKiC3aRw==, tarball: file:projects/reference-workspace.tgz}
+    resolution: {integrity: sha512-G4jN/4cjqyKKZhZ9lWC37qPGWvd1C7Foys9eeH43H9jJEzReOnt0GIS9FyBT+InM26UaSnQk1Fn0ELdeqZ9I5A==, tarball: file:projects/reference-workspace.tgz}
     id: file:projects/reference-workspace.tgz
     name: '@rush-temp/reference-workspace'
     version: 0.0.0
@@ -22292,7 +22292,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-base.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-AmatE4oLjLz1DiAUNcmS14KzB+3oGkl8MC/hT6J7agoqKscZbTAU1TmrCSor7v0AXU5EqnQYa/ACiymB9nCnEQ==, tarball: file:projects/sdk-backend-base.tgz}
+    resolution: {integrity: sha512-4fTMqi+t/6SIZ6ZzTi1pq02PPA9OSjJ86TILFbJy7tVTbOTRo051gzLjpV0vP/d2/cckU626W7lQCZcjYRZ5tA==, tarball: file:projects/sdk-backend-base.tgz}
     id: file:projects/sdk-backend-base.tgz
     name: '@rush-temp/sdk-backend-base'
     version: 0.0.0
@@ -22343,7 +22343,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-bear.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-8rGxHsPVGx5JfjZHTEgePbwXi9WB4XgjxMaVz9e//LFZhyKf7+JJgUtRlDoH2xiaTD48Hnx02SyHuqm5S+vfMg==, tarball: file:projects/sdk-backend-bear.tgz}
+    resolution: {integrity: sha512-KEs+yG+V/21YkyZ+NrP8iopPtkPF/HfymA1kGYZegyx5Afp9Dx3XRnBR7D/5xxsxA3ieSj4ZUSYKJMFTPdGxvg==, tarball: file:projects/sdk-backend-bear.tgz}
     id: file:projects/sdk-backend-bear.tgz
     name: '@rush-temp/sdk-backend-bear'
     version: 0.0.0
@@ -22396,7 +22396,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-mockingbird.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-gUBO3LRX6/LuS2m4rnZR95lIDNhBp2s/Occ8LjDnIVrxDsZ+ep2ZZmvgvIbfYosEEWfn/sdUCBTBP6snuEc7Fg==, tarball: file:projects/sdk-backend-mockingbird.tgz}
+    resolution: {integrity: sha512-np0B1MzZ23ROPRrZPMM9T93GCXCCcsKQMDUFQ6GFsPAKAhfhMMnOimV64wt8nHvwKdf51m68/47exL7n4vs1jw==, tarball: file:projects/sdk-backend-mockingbird.tgz}
     id: file:projects/sdk-backend-mockingbird.tgz
     name: '@rush-temp/sdk-backend-mockingbird'
     version: 0.0.0
@@ -22442,7 +22442,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-spi.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-z1oYkPG/EahIJXcsTaXe8rAjIjm1RO4TNazgojJ0fiDnaGStLYFGAbpkbUh2pwuVfrqtPEbHovAMBLjjKEnB5g==, tarball: file:projects/sdk-backend-spi.tgz}
+    resolution: {integrity: sha512-/chR6uO/A0Yrzu5wSj7qh4USWQ5bAPneFWimYeucwdgxvs8XECN5BFVZHfacCy/srddpee5dnEC1BnVdwcoRVw==, tarball: file:projects/sdk-backend-spi.tgz}
     id: file:projects/sdk-backend-spi.tgz
     name: '@rush-temp/sdk-backend-spi'
     version: 0.0.0
@@ -22486,7 +22486,7 @@ packages:
     dev: false
 
   file:projects/sdk-backend-tiger.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-mvfYCV/HSwCy9xWiCvq9ez7bXmOiUgncyQaYZK/qer23Qzo8ptLjwljhdKRs722HWOEO2Vmae6ufAEpPrQC9dA==, tarball: file:projects/sdk-backend-tiger.tgz}
+    resolution: {integrity: sha512-Xbg0mHfMxKM7l/1OfQprIb3mXslWT069xrnIMlTs5RUNtWlaJfu5bA4Dy5dYutWlAVe9t5l+aKKzwSvHfjKryA==, tarball: file:projects/sdk-backend-tiger.tgz}
     id: file:projects/sdk-backend-tiger.tgz
     name: '@rush-temp/sdk-backend-tiger'
     version: 0.0.0
@@ -22538,7 +22538,7 @@ packages:
     dev: false
 
   file:projects/sdk-embedding.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-POjtTAlKZ0v7M5tqW8/gnqBq6RFkWvSZyP/MOf8f+EICsK1TmOm799zeGBMLa/CpfowIC8rb/eVllxwVGRUv1A==, tarball: file:projects/sdk-embedding.tgz}
+    resolution: {integrity: sha512-1BHQn/CZVj7yikE3Il3ryk1UxbOIVistev5QT4KULJSM9zoPv6pePJwi1C/zND6+wuwwtMEtQEY8VtQH90A0pg==, tarball: file:projects/sdk-embedding.tgz}
     id: file:projects/sdk-embedding.tgz
     name: '@rush-temp/sdk-embedding'
     version: 0.0.0
@@ -22582,7 +22582,7 @@ packages:
     dev: false
 
   file:projects/sdk-examples.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-u1opRSReum6bBmLOIh1Cw9R01jOkIAJZnPjgF8+rpig0ltMmWm+Q0qpVqO+ONK1ob+NsoO9QdzpMdyUywDCI2g==, tarball: file:projects/sdk-examples.tgz}
+    resolution: {integrity: sha512-zUgzlWDCu7O9nZ0QK416hxmN1vO0eXauKRd64t8+SCs6p0Tr+dPegcACFVT7SJ9yp3o/4A8TfXTUwY/ovV5Ttg==, tarball: file:projects/sdk-examples.tgz}
     id: file:projects/sdk-examples.tgz
     name: '@rush-temp/sdk-examples'
     version: 0.0.0
@@ -22847,7 +22847,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-all.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-JyCI1a5NwPYkqi4gxBQ4ZMWSS0gNzRisszGl+0hMjcFTob8QbJ0sCqosi8BS/c8VxSp8i+xPmInTMIGbRfNXbg==, tarball: file:projects/sdk-ui-all.tgz}
+    resolution: {integrity: sha512-W89TqZ/GaS03tOLERMoHoX+ls8pOmHVASa8AtcgQaUttztQyFXbxeN8Vc31o6SukXBjEP2DT8MpftmMqLB1sfg==, tarball: file:projects/sdk-ui-all.tgz}
     id: file:projects/sdk-ui-all.tgz
     name: '@rush-temp/sdk-ui-all'
     version: 0.0.0
@@ -22888,7 +22888,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-charts.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-okvOJkiYvVZCWmdMBMJtnuNBOkAdZAn2W1YT/pxKLse986eZKTMmZqwuMfgtovhyisNtsBS++yfL/BaZPok0mQ==, tarball: file:projects/sdk-ui-charts.tgz}
+    resolution: {integrity: sha512-ehuLRNZUYC/qGPMLXBimVE37URl+BQIZeFFZqty/dNZxIi/Llj6c+ExiiZtxOV58ZY5HfBh9LqJmirh4qr/khg==, tarball: file:projects/sdk-ui-charts.tgz}
     id: file:projects/sdk-ui-charts.tgz
     name: '@rush-temp/sdk-ui-charts'
     version: 0.0.0
@@ -22944,8 +22944,8 @@ packages:
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       svg-classlist-polyfill: 1.0.6
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
@@ -22966,7 +22966,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-dashboard.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-kpSDMTOjkVOZvIIQQznyMi2Xswt8KWeEJCDwlXG0GNi2+VXSOxhBTU/xwXw6QHBZmA5ZwPf+SZkzBSoFTelvOw==, tarball: file:projects/sdk-ui-dashboard.tgz}
+    resolution: {integrity: sha512-xszE/EaW8074B/wMSU9jR1qMzeKHbUdwRpR2zCGPFVETvRZIDN1LYYsredIqPnNPPZjXLU1lrcWpVnzLZ8DHNw==, tarball: file:projects/sdk-ui-dashboard.tgz}
     id: file:projects/sdk-ui-dashboard.tgz
     name: '@rush-temp/sdk-ui-dashboard'
     version: 0.0.0
@@ -23031,8 +23031,8 @@ packages:
       redux-batched-actions: 0.5.0
       redux-saga: 1.1.3
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       svgo: 2.8.0
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
@@ -23055,7 +23055,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-ext.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-toulUNh1iFUeqSE0iCWdMwSOYjuKwNf4M9CBBuZYH9THspyf15cDr5DLOpeOu250IWgQgzJtvzao0U371/IhKg==, tarball: file:projects/sdk-ui-ext.tgz}
+    resolution: {integrity: sha512-NRKD2JGD5WyZECPCQhTj1pCZ594f7tjYvT4PzzPG8dxHorcmOVwQdnqjj5APcv+ICm1fnXiSmq5VI4id6p5iJw==, tarball: file:projects/sdk-ui-ext.tgz}
     id: file:projects/sdk-ui-ext.tgz
     name: '@rush-temp/sdk-ui-ext'
     version: 0.0.0
@@ -23115,8 +23115,8 @@ packages:
       react-select: 3.2.0_react-dom@17.0.2+react@17.0.2
       react-transition-group: 4.4.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       svgo: 2.8.0
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
@@ -23137,7 +23137,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-filters.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-yAtlznB9m75GU/9UXA5f+LteoEWv7KayQJyHXVQoRK/4XxTvliHQWqWTz5O81UZFp7snwKz9hgPuhw9Ag64INg==, tarball: file:projects/sdk-ui-filters.tgz}
+    resolution: {integrity: sha512-fCT1Ojwwtxz6hgVf4TaUjH9C6FXEPBtpVskm3jDqURnxSpSkiiCUC7J+e08CWVJkd8Ra5qHFkYeLQ0WzayP7nA==, tarball: file:projects/sdk-ui-filters.tgz}
     id: file:projects/sdk-ui-filters.tgz
     name: '@rush-temp/sdk-ui-filters'
     version: 0.0.0
@@ -23195,8 +23195,8 @@ packages:
       react-responsive: 8.2.0_react@17.0.2
       react-window: 1.8.6_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1
@@ -23215,7 +23215,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-geo.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-JWP1zCRs5Htd5f7ulBFbdceusMdKxERQS1QmptqrlEBtN6VXsbQ0rusF0mLKph/Wfld8Q6Ef9g1BAHarWUr35A==, tarball: file:projects/sdk-ui-geo.tgz}
+    resolution: {integrity: sha512-c2re4ga4XPU663vaMPDRGuX/M3eg8z5fUgif4FbONLcBCTDV8x9nH/cVrBWKPPauv/vU4fYFp7kpC4Q3KeNvPQ==, tarball: file:projects/sdk-ui-geo.tgz}
     id: file:projects/sdk-ui-geo.tgz
     name: '@rush-temp/sdk-ui-geo'
     version: 0.0.0
@@ -23266,8 +23266,8 @@ packages:
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1
@@ -23287,7 +23287,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-kit.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ujQvaycu8E3UWdVAaG/D8+F5RK/eTMAFAn18sTvauew/pCpRGOowvy43GDeEZ2FAvq3O/JLNygCf35Nu1KpNEA==, tarball: file:projects/sdk-ui-kit.tgz}
+    resolution: {integrity: sha512-SQYiAS3HMSs7nVxNhx+3PivOriSx17Y+hS686a6/Frd351SiGVTi0j8HpjZfyGBqGzDD4be/tvHyBJ0Aa/vZeA==, tarball: file:projects/sdk-ui-kit.tgz}
     id: file:projects/sdk-ui-kit.tgz
     name: '@rush-temp/sdk-ui-kit'
     version: 0.0.0
@@ -23363,8 +23363,8 @@ packages:
       react-textarea-autosize: 8.3.3_c8e45b4eb687790dba17b4e1c4b4273f
       react-transition-group: 4.4.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       svgo: 2.8.0
       tinycolor2: 1.4.2
       ts-invariant: 0.7.5
@@ -23386,7 +23386,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-loaders.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Baa84kyp7OIrG1PTOXzJuSqlAIl3GHejMsHUuwnyXt0mTHB05K/TeXXkgR3tp2DWPZCJDAgtL1KPEo7fIBeu1w==, tarball: file:projects/sdk-ui-loaders.tgz}
+    resolution: {integrity: sha512-mt4xLJqGu7zsXOT9kWpfZYT6DgRaNQLKqvei1bK3YhqB4eq6K0XZN7xoAYR7Mdbuf98DUZPupyXA37MZhUPXwQ==, tarball: file:projects/sdk-ui-loaders.tgz}
     id: file:projects/sdk-ui-loaders.tgz
     name: '@rush-temp/sdk-ui-loaders'
     version: 0.0.0
@@ -23447,7 +23447,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-pivot.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-P32J3FqvSrsYVpjgjkTwr1QQaSc686u/QBJAgUB1+/10LjO36tL0BzCeXOa4geprSPajMC9mT5PEMEfqFURtGQ==, tarball: file:projects/sdk-ui-pivot.tgz}
+    resolution: {integrity: sha512-EWIL0b1VWepz8TVE4RnlYSRU7eIZ2b4BwFiZA2oPbdqwYesMytqgFcfLErhROmWcLQSm2rhc5shDkfGE9MWd2A==, tarball: file:projects/sdk-ui-pivot.tgz}
     id: file:projects/sdk-ui-pivot.tgz
     name: '@rush-temp/sdk-ui-pivot'
     version: 0.0.0
@@ -23500,8 +23500,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1
@@ -23522,7 +23522,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests-e2e.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-Gi8TfcKN03ik5sr7IvF1rG2ccV9/ecalWXLljBjpERAEj3apP5YUObnMAJOcNMFarPubMkZTX0l9AeCx4j3SGA==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
+    resolution: {integrity: sha512-qqDcUvYeBDVlzmubnkWjlHGoKuSCq4oqtMvl6s2VNBqMMOe0ukZfd+KttGpvbvXED1Vh3//7zlBFsnGA8tzZcg==, tarball: file:projects/sdk-ui-tests-e2e.tgz}
     id: file:projects/sdk-ui-tests-e2e.tgz
     name: '@rush-temp/sdk-ui-tests-e2e'
     version: 0.0.0
@@ -23624,7 +23624,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-tests.tgz:
-    resolution: {integrity: sha512-lNpel4hBA6apzSPRAo1Dj7Gj62oBAoaFPbd/BG2q+r66hl47IqkObYCUQRnSClJ35r9WBbtRWXW4L+qwjXNKdw==, tarball: file:projects/sdk-ui-tests.tgz}
+    resolution: {integrity: sha512-M5oer3pFSX08n9VRLgwy+FBpy0LHS4ckm1AekLLu18rwDaLda5kmShTgPUn7TgRqFLUcBNB4b7REnw4abFYa3A==, tarball: file:projects/sdk-ui-tests.tgz}
     name: '@rush-temp/sdk-ui-tests'
     version: 0.0.0
     dependencies:
@@ -23690,8 +23690,8 @@ packages:
       spark-md5: 3.0.2
       style-loader: 1.3.0
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_04d0a0d69bd2aca5362e207508aff12f
       ts-loader: 8.3.0_typescript@4.0.2
@@ -23729,7 +23729,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-theme-provider.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-ocyXYe9du7s0Y39b/vQ0gSHRZbnscvihIOIzjGexYvZ2mPgkYQUFuP5g5NZGdM4OKSewdKe0KxuPaRiwO3wFAA==, tarball: file:projects/sdk-ui-theme-provider.tgz}
+    resolution: {integrity: sha512-2Sh4LWFMqU/qaaJUieDRh/UW38ZpIQEXrpZtvsF1UVx4gA0utJsJQfxF7m52UT1MZaAE0Phf3is3KO+QRW0RDw==, tarball: file:projects/sdk-ui-theme-provider.tgz}
     id: file:projects/sdk-ui-theme-provider.tgz
     name: '@rush-temp/sdk-ui-theme-provider'
     version: 0.0.0
@@ -23788,7 +23788,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui-vis-commons.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-eLs+NE2KLTrsYK6pTXGZiXQTxCwYYtGcP+FHpV/mnSbWonq4oRkymAvN2zUFQvrJVtdeV7wEVe1jltAWlR3Y7g==, tarball: file:projects/sdk-ui-vis-commons.tgz}
+    resolution: {integrity: sha512-V6IVdULXH579xUZrQt/tYZrc5zd9tw2ZSK/WaatdVvFnLXmuZAsEpPKJPON2AWPory0W1hL7eYZ7yzs0LXpAnw==, tarball: file:projects/sdk-ui-vis-commons.tgz}
     id: file:projects/sdk-ui-vis-commons.tgz
     name: '@rush-temp/sdk-ui-vis-commons'
     version: 0.0.0
@@ -23835,8 +23835,8 @@ packages:
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       react-measure: 2.5.2_react-dom@17.0.2+react@17.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tslib: 2.3.1
       typescript: 4.0.2
@@ -23854,7 +23854,7 @@ packages:
     dev: false
 
   file:projects/sdk-ui.tgz_ts-node@10.7.0:
-    resolution: {integrity: sha512-+9j6OQL8Zq0quyrkP+nm8cGb9OHlNFTYSNT7cNG84I+ZLaEAAfQViWS6QVgty5uwg2f8RGqedxuCuUxvgX++Mw==, tarball: file:projects/sdk-ui.tgz}
+    resolution: {integrity: sha512-du2tK2p1TktbGuhZl1qpXDiosBa9T4N8K1dPXidQQNUhYKPqvD72CF57s12s/H9ybSQLywwsQP6ZzTqs4SNMbw==, tarball: file:projects/sdk-ui.tgz}
     id: file:projects/sdk-ui.tgz
     name: '@rush-temp/sdk-ui'
     version: 0.0.0
@@ -23907,8 +23907,8 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       react-intl: 5.24.8_react@17.0.2+typescript@4.0.2
       stylelint: 13.13.1
-      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       stylelint-checkstyle-formatter: 0.1.2
+      stylelint-config-prettier: 8.0.2_stylelint@13.13.1
       ts-invariant: 0.7.5
       ts-jest: 27.1.4_dddc46dbe41fd8ba74d3d274e144bf21
       tsd: 0.15.1


### PR DESCRIPTION
The majority of changes in pnpm.lock is change from czech to english
ordering (H CH I to CH being sorted as C).

JIRA: FET-1034

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
