### PR TITLE
RELATED: RAIL-4129 Improve the usability of the IInsightBodyProps

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3038,9 +3038,9 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
         isExportMode?: boolean;
     };
     drillableItems: ExplicitDrill[] | undefined;
-    ErrorComponent: React.ComponentType<IErrorProps> | undefined;
+    ErrorComponent: React.ComponentType<IErrorProps>;
     insight: IInsight;
-    LoadingComponent: React.ComponentType<ILoadingProps> | undefined;
+    LoadingComponent: React.ComponentType<ILoadingProps>;
     locale: ILocale;
     settings: IUserWorkspaceSettings | undefined;
     widget: IInsightWidget;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/types.ts
@@ -212,12 +212,12 @@ export interface IInsightBodyProps extends Partial<IVisualizationCallbacks> {
     /**
      * Component to render if embedding fails.
      */
-    ErrorComponent: React.ComponentType<IErrorProps> | undefined;
+    ErrorComponent: React.ComponentType<IErrorProps>;
 
     /**
      * Component to render while the insight is loading.
      */
-    LoadingComponent: React.ComponentType<ILoadingProps> | undefined;
+    LoadingComponent: React.ComponentType<ILoadingProps>;
 
     /**
      * The current user settings.


### PR DESCRIPTION
Make the Error and Loading component mandatory so that
the implementers do not have to check that they are there.

JIRA: RAIL-4129

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
