### PR TITLE
Fix view mode defaults and buttons visibility

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4736,7 +4736,7 @@ export const selectIsReadOnly: OutputSelector<DashboardState, boolean, (res: Res
 export const selectIsSaveAsDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
 
 // @internal (undocumented)
-export function selectIsSaveAsNewButtonVisible(state: DashboardState): boolean;
+export const selectIsSaveAsNewButtonVisible: OutputSelector<DashboardState, boolean, (res1: boolean, res2: boolean, res3: boolean, res4: boolean, res5: boolean, res6: boolean) => boolean>;
 
 // @alpha (undocumented)
 export const selectIsScheduleEmailDialogOpen: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveAsButton/DefaultSaveAsNewButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/saveAsButton/DefaultSaveAsNewButton.tsx
@@ -4,37 +4,61 @@ import React, { useCallback } from "react";
 import { useIntl } from "react-intl";
 import { Button } from "@gooddata/sdk-ui-kit";
 import {
-    DashboardState,
     selectCanCreateAnalyticalDashboard,
     selectEnableKPIDashboardSaveAsNew,
+    selectIsExport,
     uiActions,
     useDashboardDispatch,
     useDashboardSelector,
 } from "../../../../../model";
 import { ISaveAsNewButtonProps } from "./types";
-import { selectShouldHideControlButtons } from "../selectors";
-import { selectIsSaveAsNewButtonHidden } from "../../../../../model/store/config/configSelectors";
+import { selectCanEnterEditModeAndIsLoaded } from "../selectors";
+import {
+    selectDashboardEditModeDevRollout,
+    selectIsSaveAsNewButtonHidden,
+} from "../../../../../model/store/config/configSelectors";
+import { createSelector } from "@reduxjs/toolkit";
 
 /**
  * @internal
  */
-export function selectIsSaveAsNewButtonVisible(state: DashboardState) {
-    const isDashboardEditable = !selectShouldHideControlButtons(state);
-    const canCreateDashboard = selectCanCreateAnalyticalDashboard(state);
-    const isSaveAsButtonHidden = selectIsSaveAsNewButtonHidden(state);
-    const isSaveAsNewEnabled = selectEnableKPIDashboardSaveAsNew(state);
-
-    /*
-     * The reasoning behind this condition is as follows. Do not show separate Save As button if:
-     *
-     * 1.  The feature is not enabled or
-     * 2.  If is disabled by config
-     * 3.  If the dashboard can be edited; in this case, the save as option is part of the dropdown menu;
-     *     it is somewhat more hidden
-     * 4.  If the user cannot create dashboards - e.g. does not have permissions to do so (is viewer for example).
-     */
-    return isSaveAsNewEnabled && !isSaveAsButtonHidden && !isDashboardEditable && canCreateDashboard;
-}
+export const selectIsSaveAsNewButtonVisible = createSelector(
+    selectDashboardEditModeDevRollout,
+    selectEnableKPIDashboardSaveAsNew,
+    selectIsSaveAsNewButtonHidden,
+    selectCanEnterEditModeAndIsLoaded,
+    selectCanCreateAnalyticalDashboard,
+    selectIsExport,
+    (
+        isEditModeDevRollout,
+        isSaveAsNewEnabled,
+        isSaveAsButtonHidden,
+        isDashboardEditable,
+        canCreateDashboard,
+        isExport,
+    ) => {
+        /*
+         * The reasoning behind this condition is as follows. Do not show separate Save As button if:
+         *
+         * 0.  edit mode rollout flag enabled
+         *
+         * 1.  The feature is not enabled or
+         * 2.  If is disabled by config
+         * 3.  If the dashboard can be edited; in this case, the save as option is part of the dropdown menu;
+         *     it is somewhat more hidden
+         * 4.  dashboard is not in export mode
+         * 5.  If the user cannot create dashboards - e.g. does not have permissions to do so (is viewer for example).
+         */
+        return (
+            isEditModeDevRollout &&
+            isSaveAsNewEnabled &&
+            !isSaveAsButtonHidden &&
+            !isDashboardEditable &&
+            !isExport &&
+            canCreateDashboard
+        );
+    },
+);
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/selectors.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/buttonBar/button/selectors.ts
@@ -8,7 +8,6 @@ import {
     selectCanManageWorkspace,
     selectDashboardLockStatus,
     selectDashboardRef,
-    selectIsExport,
     selectIsLayoutEmpty,
     selectIsReadOnly,
     selectListedDashboardsMap,
@@ -65,15 +64,6 @@ export const selectCanEnterEditModeAndIsLoaded = createSelector(
     selectIsDashboardLoading,
     selectCanEnterEditMode,
     (isLoading, canEnterEditMode) => !isLoading && canEnterEditMode,
-);
-
-/**
- * @internal
- */
-export const selectShouldHideControlButtons = createSelector(
-    selectCanEnterEditModeAndIsLoaded,
-    selectIsExport,
-    (canEnterEditModeAndIsLoaded, isExport) => !canEnterEditModeAndIsLoaded || isExport,
 );
 
 /**


### PR DESCRIPTION
 - apply config defaults to resolved config as well
 - hide save as new Button when EditModeDevRollout is disabled

JIRA: RAIL-4106

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
