### PR TITLE
RAIL-4194 - Plugin bootstrap removes eslint config from package on init

### DIFF
--- a/tools/dashboard-plugin-template/package.json
+++ b/tools/dashboard-plugin-template/package.json
@@ -23,9 +23,6 @@
         "dist/**/*.map",
         "dist/**/*.svg"
     ],
-    "config": {
-        "eslint": "-c .eslintrc.js --ext ts,tsx src/"
-    },
     "scripts": {
         "clean": "rm -rf ci dist esm coverage *.log styles/css && jest --clearCache",
         "build": "webpack --mode production --config-name harness",
@@ -39,8 +36,8 @@
         "test": "jest --watch --passWithNoTests",
         "test-once": "jest --maxWorkers=${JEST_MAX_WORKERS:-'45%'} --passWithNoTests",
         "test-ci": "JEST_JUNIT_OUTPUT=./ci/results/test-results.xml jest --ci --config jest.ci.js --passWithNoTests",
-        "eslint": "eslint $npm_package_config_eslint",
-        "eslint-ci": "mkdir -p ./ci/results && eslint -f checkstyle -o ci/results/eslint-results.xml $npm_package_config_eslint",
+        "eslint": "eslint -c .eslintrc.js --ext ts,tsx src/",
+        "eslint-ci": "mkdir -p ./ci/results && eslint -f checkstyle -o ci/results/eslint-results.xml -c .eslintrc.js --ext ts,tsx src/",
         "prettier-check": "prettier --check '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "prettier-write": "prettier --write '{src,stories,styles,__mocks__}/**/*.{ts,tsx,json,scss,md,yaml,html}'",
         "dep-cruiser": "depcruise --validate .dependency-cruiser.js --output-type err-long src/",

--- a/tools/plugin-toolkit/scripts/preparePackageJson.ts
+++ b/tools/plugin-toolkit/scripts/preparePackageJson.ts
@@ -23,16 +23,7 @@ import { keys } from "lodash";
  * this script to clean things up programatically.
  */
 
-const GdScripts = [
-    "test-ci",
-    "eslint-ci",
-    "prettier-check",
-    "prettier-write",
-    "dep-cruiser",
-    "dep-cruiser-ci",
-    "validate",
-    "validate-ci",
-];
+const GdScriptsRemove = ["test-ci", "eslint-ci", "dep-cruiser", "dep-cruiser-ci", "validate", "validate-ci"];
 
 const UnnecessaryDevDependencies = ["@gooddata/eslint-config", "dependency-cruiser", "eslint-plugin-sonarjs"];
 
@@ -50,17 +41,17 @@ function removeGdStuff(packageJson: Record<string, any>) {
     packageJson.author = "";
     packageJson.description = "";
 
-    delete packageJson.repository;
-
     const { scripts, devDependencies } = packageJson;
 
-    GdScripts.forEach((script) => {
+    GdScriptsRemove.forEach((script) => {
         delete scripts[script];
     });
 
     UnnecessaryDevDependencies.forEach((dep) => {
         delete devDependencies[dep];
     });
+
+    delete packageJson.repository;
 }
 
 function removeTs(packageJson: Record<string, any>) {


### PR DESCRIPTION
Keep prettier scripts
replace config eslint directly in package.json

JIRA: RAIL-4194

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
