### PR TITLE
RELATED: RAIL-4226 Unify InsightBody display logic

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/Insight/DashboardInsight.tsx
@@ -167,6 +167,18 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
         clientWidth < DASHBOARD_LAYOUT_RESPONSIVE_SMALL_WIDTH &&
         !enableKDWidgetCustomHeight;
 
+    // Error handling
+    const handleError = useCallback<OnError>(
+        (error) => {
+            setVisualizationError(error);
+            onError?.(error);
+            executionsHandler.onError(error);
+        },
+        [onError, executionsHandler.onError],
+    );
+
+    const effectiveError = filtersError ?? visualizationError;
+
     // CSS
     const insightPositionStyle: CSSProperties = useMemo(() => {
         return {
@@ -181,20 +193,8 @@ export const DashboardInsight = (props: IDashboardInsightProps): JSX.Element => 
     }, [isPositionRelative]);
 
     const insightWrapperStyle: CSSProperties | undefined = useMemo(() => {
-        return isVisualizationLoading ? { height: 0 } : undefined;
-    }, [isVisualizationLoading]);
-
-    // Error handling
-    const handleError = useCallback<OnError>(
-        (error) => {
-            setVisualizationError(error);
-            onError?.(error);
-            executionsHandler.onError(error);
-        },
-        [onError, executionsHandler.onError],
-    );
-
-    const effectiveError = filtersError ?? visualizationError;
+        return isVisualizationLoading || effectiveError ? { height: 0 } : undefined;
+    }, [isVisualizationLoading, effectiveError]);
 
     const visualizationProperties = insightProperties(insightWithAddedWidgetProperties);
     const isZoomable = visualizationProperties?.controls.zoomInsight;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -140,6 +140,10 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
     );
     const effectiveError = filtersError ?? visualizationError;
 
+    const insightWrapperStyle: CSSProperties | undefined = useMemo(() => {
+        return isVisualizationLoading || effectiveError ? { height: 0 } : undefined;
+    }, [isVisualizationLoading, effectiveError]);
+
     return (
         <div style={insightStyle}>
             <div style={insightPositionStyle}>
@@ -153,10 +157,7 @@ export const DrillDialogInsight = (props: IDashboardInsightProps): JSX.Element =
                         />
                     )}
                     {filtersStatus === "success" && (
-                        <div
-                            className="insight-view-visualization"
-                            style={isVisualizationLoading || effectiveError ? { height: 0 } : undefined}
-                        >
+                        <div className="insight-view-visualization" style={insightWrapperStyle}>
                             <InsightBody
                                 widget={widget}
                                 insight={insightWithAddedWidgetProperties}


### PR DESCRIPTION
Make sure the InsightBody is hidden on error so that the caller can handle the error consistently.

JIRA: RAIL-4226

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
