### PR TITLE
Enhanced Date filter button to use default times

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/utils/Translations/tests/DateFilterTitle.test.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/utils/Translations/tests/DateFilterTitle.test.ts
@@ -82,6 +82,15 @@ describe("getDateFilterTitleUsingTranslator", () => {
             );
             expect(actual).toEqual("01/01/2019 – 01/04/2019");
         });
+
+        it("should return the correct translation for absolute form filter for more days with no time within from/to", () => {
+            const actual = getDateFilterTitleUsingTranslator(
+                absoluteFormFilter,
+                serializingTranslator,
+                DEFAULT_DATE_FORMAT_WITH_TIME,
+            );
+            expect(actual).toEqual("01/01/2019 – 02/01/2019");
+        });
     });
 
     it("should return the correct translation for absolute preset filter", () => {


### PR DESCRIPTION
Enhanced Date filter button to use default times for start/end of the day

JIRA: TNT-783

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
