### PR TITLE
RAIL-4234,RAIL-4235,RAIL-4238,RAIL-4239,RAIL-4240,RAIL-4241 codeine fixes

### DIFF
--- a/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
@@ -75,7 +75,9 @@ const addStringBuilderSegment =
     (identifier: string, helperName = identifier) =>
     (objToConvert: any) =>
     (value: string) =>
-        objToConvert[identifier] ? `${value}.${helperName}("${objToConvert[identifier]}")` : value;
+        objToConvert[identifier]
+            ? `${value}.${helperName}("${objToConvert[identifier].split("\n").join("\\n")}")`
+            : value;
 
 const addAggregation = addStringBuilderSegment("aggregation");
 const addAlias = addStringBuilderSegment("alias");

--- a/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
@@ -86,7 +86,9 @@ const addTitle = addStringBuilderSegment("title");
 const addFilters =
     ({ filters }: { filters?: IFilter[] }) =>
     (value: string) =>
-        filters ? `${value}.filters(${filters.map((f) => factoryNotationFor(f)).join(ARRAY_JOINER)})` : value;
+        filters?.length
+            ? `${value}.filters(${filters.map((f) => factoryNotationFor(f)).join(ARRAY_JOINER)})`
+            : value;
 
 const addRatio =
     ({ computeRatio }: { computeRatio?: boolean }) =>

--- a/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/index.ts
@@ -191,7 +191,8 @@ const convertAbsoluteDateFilter: Converter<IAbsoluteDateFilter> = ({
 const convertRelativeDateFilter: Converter<IRelativeDateFilter> = ({
     relativeDateFilter: { dataSet, granularity, from, to },
 }) => {
-    const restArgs = compact([granularity, from, to]).map(stringify);
+    // must not be compact, that would evict also 0 which is a legitimate value here
+    const restArgs = [granularity, from, to].filter((item) => !isNil(item)).map(stringify);
     return `newRelativeDateFilter(${[stringifyObjRef(dataSet), ...restArgs].join(ARRAY_JOINER)})`;
 };
 

--- a/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
@@ -433,6 +433,20 @@ describe("factoryNotationFor", () => {
             const actual = factoryNotationFor(input);
             testModelNotation(actual, input);
         });
+        it("should handle relative date filter with zeroes (RAIL-4234)", () => {
+            const input: IRelativeDateFilter = {
+                relativeDateFilter: {
+                    dataSet: {
+                        identifier: "foo",
+                    },
+                    granularity: "GDC.time.year",
+                    from: -42,
+                    to: 42,
+                },
+            };
+            const actual = factoryNotationFor(input);
+            testModelNotation(actual, input);
+        });
 
         describe("measure value filter", () => {
             it("should handle measure value filter with comparison", () => {

--- a/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
@@ -154,6 +154,23 @@ describe("factoryNotationFor", () => {
             const actual = factoryNotationFor(input);
             testModelNotation(actual, input);
         });
+        it("should handle measure with multiline format (RAIL-4241)", () => {
+            const input: IMeasure = {
+                measure: {
+                    definition: {
+                        measureDefinition: {
+                            item: {
+                                identifier: "foo",
+                            },
+                        },
+                    },
+                    format: "[<0](#,##0.0);\n#,##0.0",
+                    localIdentifier: "bar",
+                },
+            };
+            const actual = factoryNotationFor(input);
+            testModelNotation(actual, input);
+        });
         it("should handle measure with title", () => {
             const input: IMeasure = {
                 measure: {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
@@ -1,4 +1,5 @@
 // (C) 2021-2022 GoodData Corporation
+import isNil from "lodash/isNil";
 import { IInsight, IInsightDefinition, insightSanitize, ISettings } from "@gooddata/sdk-model";
 import {
     IAttributeColumnWidthItem,
@@ -123,7 +124,9 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
 function factoryNotationForAttributeColumnWidthItem(obj: IAttributeColumnWidthItem): string {
     const { attributeIdentifier, width } = obj.attributeColumnWidthItem;
     const { value: widthValue, allowGrowToFit } = width;
-    return allowGrowToFit
-        ? `newWidthForAttributeColumn(${attributeIdentifier}, ${widthValue}, true)`
-        : `newWidthForAttributeColumn(${attributeIdentifier}, ${widthValue})`;
+    // must be isNil to keep 0 values in
+    const params = [`"${attributeIdentifier}"`, `${widthValue}`, allowGrowToFit && "true"].filter(
+        (item) => !isNil(item),
+    );
+    return `newWidthForAttributeColumn(${params.join(", ")})`;
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
@@ -11,7 +11,9 @@ export function pivotTableConfigFromInsight(
 ): IPivotTableConfig {
     const properties = insightProperties(insight);
     const controls = properties?.controls;
+
     const columnSizing = controls && getColumnSizingFromControls(controls, ctx);
+    const columnSizingProp = !isEmpty(columnSizing) ? { columnSizing } : {};
 
     const menuConfig = ctx?.backend && pivotTableMenuForCapabilities(ctx.backend.capabilities);
     const menuProp = !isEmpty(menuConfig) ? { menu: menuConfig } : {};
@@ -20,7 +22,7 @@ export function pivotTableConfigFromInsight(
     const separatorsProp = !isEmpty(separatorsConfig) ? { separators: separatorsConfig } : {};
 
     return {
-        columnSizing,
+        ...columnSizingProp,
         ...menuProp,
         ...separatorsProp,
         // the user can fill the rest on their own later

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
@@ -12,7 +12,13 @@ export function pivotTableConfigFromInsight(
     const properties = insightProperties(insight);
     const controls = properties?.controls;
 
-    const columnSizing = controls && getColumnSizingFromControls(controls, ctx);
+    const columnSizingFromControls = controls && getColumnSizingFromControls(controls, ctx);
+    const autoResizeAllSizing: IColumnSizing = { defaultWidth: "autoresizeAll" };
+
+    // use sizing from controls if specified, otherwise use autosize if the relevant FF is on
+    const columnSizing =
+        columnSizingFromControls || (ctx.settings?.enableTableColumnsAutoResizing && autoResizeAllSizing);
+
     const columnSizingProp = !isEmpty(columnSizing) ? { columnSizing } : {};
 
     const menuConfig = ctx?.backend && pivotTableMenuForCapabilities(ctx.backend.capabilities);

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -33260,7 +33260,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400),
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             {
                 measureColumnWidthItem: {
                     locators: [
@@ -33306,7 +33306,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400),
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             {
                 measureColumnWidthItem: {
                     locators: [
@@ -33352,7 +33352,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400),
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             {
                 measureColumnWidthItem: {
                     locators: [
@@ -33398,7 +33398,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400),
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             {
                 measureColumnWidthItem: {
                     locators: [
@@ -33444,7 +33444,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400)
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33480,7 +33480,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400)
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33516,7 +33516,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400)
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33552,7 +33552,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            newWidthForAttributeColumn(a_label.product.id.name, 400)
+            newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -32933,10 +32933,7 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -32969,10 +32966,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33006,10 +33000,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33043,10 +33034,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33080,10 +33068,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33117,10 +33102,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33154,10 +33136,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33191,10 +33170,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33225,10 +33201,7 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\")),
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name_1\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33761,10 +33734,7 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33788,10 +33758,7 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33815,10 +33782,7 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33856,10 +33820,7 @@ const totals: ITotal[] = [
     newTotal(\\"max\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"nat\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33897,10 +33858,7 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33938,10 +33896,7 @@ const columns: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.product.id.name\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33979,10 +33934,7 @@ const columns: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.owner.department\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34016,10 +33968,7 @@ const rows: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.owner.department\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34050,10 +33999,7 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_aangOxLSeztu\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34086,10 +34032,7 @@ const rows: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.product.id.name\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34118,10 +34061,7 @@ const measures: IAttributeOrMeasure[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34152,10 +34092,7 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34184,10 +34121,7 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34219,10 +34153,7 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34256,10 +34187,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34485,10 +34413,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34527,10 +34452,7 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34570,10 +34492,7 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34611,10 +34530,7 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34642,10 +34558,7 @@ const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
     newMeasure(idRef(\\"acugFHNJgsBy\\", \\"measure\\"), m => m.localId(\\"m_acugFHNJgsBy\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34688,10 +34601,7 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34733,10 +34643,7 @@ const totals: ITotal[] = [
     newTotal(\\"max\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34778,10 +34685,7 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34820,10 +34724,7 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34863,10 +34764,7 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34905,10 +34803,7 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34939,10 +34834,7 @@ const measures: IAttributeOrMeasure[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34974,10 +34866,7 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35007,10 +34896,7 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35040,10 +34926,7 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_aangOxLSeztu\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35074,10 +34957,7 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_acugFHNJgsBy\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35113,10 +34993,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35150,10 +35027,7 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35188,10 +35062,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35221,10 +35092,7 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.department\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.department\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35249,10 +35117,7 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35288,10 +35153,7 @@ const columns: IAttribute[] = [
 const filters: IFilter[] = [
     newAbsoluteDateFilter(idRef(\\"activity.dataset.dt\\", \\"dataSet\\"), \\"2021-01-01\\", \\"2021-02-01\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35328,10 +35190,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35367,10 +35226,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35404,10 +35260,7 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35437,10 +35290,7 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35469,10 +35319,7 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35516,10 +35363,7 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35565,10 +35409,7 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35596,10 +35437,7 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"created.aag81lMifn6q\\", \\"displayForm\\"), a => a.localId(\\"a_created.aag81lMifn6q\\")),
     newAttribute(idRef(\\"created.aag81lMifn6q\\", \\"displayForm\\"), a => a.localId(\\"a_created.aag81lMifn6q_1\\"))
 ];
-const config: IPivotTableConfig = {
-    columnSizing: undefined,
-    separators: {decimal: \\".\\", thousand: \\",\\"}
-};
+const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
 const style = {height: 400};
 
 export function MyComponent() {


### PR DESCRIPTION
- RAIL-4234: Fix objectFactoryNotation for relative filters
- RAIL-4235: Omit All time filters in code generator
- RAIL-4238: Handle empty measure filters in factory notation
- RAIL-4239: Fix factoryNotationForAttributeColumnWidthItem
- RAIL-4240: Do not output columnSIzing if empty, Use autoresizeAll if applicable
- RAIL-4241: Fix multiline formats in objectFactoryNotation

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
