### PR TITLE
RELATED: RAIL-4240 Add factory notation support for column sizing

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
@@ -1,11 +1,6 @@
 // (C) 2021-2022 GoodData Corporation
-import isNil from "lodash/isNil";
 import { IInsight, IInsightDefinition, insightSanitize, ISettings } from "@gooddata/sdk-model";
-import {
-    IAttributeColumnWidthItem,
-    IPivotTableProps,
-    isAttributeColumnWidthItem,
-} from "@gooddata/sdk-ui-pivot";
+import { IPivotTableProps } from "@gooddata/sdk-ui-pivot";
 import { BucketNames } from "@gooddata/sdk-ui";
 
 import {
@@ -34,6 +29,7 @@ import {
     totalsInsightConversion,
 } from "../../../utils/embeddingCodeGenerator";
 import { pivotTableConfigFromInsight } from "./pivotTableConfigFromInsight";
+import { pivotTableAdditionalFactories } from "./pivotTableAdditionalFactories";
 
 export class PivotTableDescriptor extends BaseChartDescriptor implements IVisualizationDescriptor {
     public getFactory(): PluggableVisualizationFactory {
@@ -97,20 +93,7 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
                 pivotTableConfigFromInsight,
             ),
         }),
-        additionalFactories: [
-            {
-                importInfo: {
-                    name: "newWidthForAttributeColumn",
-                    package: "@gooddata/sdk-ui-pivot",
-                    importType: "named",
-                },
-                transformation: (obj) => {
-                    return isAttributeColumnWidthItem(obj)
-                        ? factoryNotationForAttributeColumnWidthItem(obj)
-                        : undefined;
-                },
-            },
-        ],
+        additionalFactories: pivotTableAdditionalFactories,
     });
 
     public getMeta(): IVisualizationMeta {
@@ -119,14 +102,4 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
             supportsExport: true,
         };
     }
-}
-
-function factoryNotationForAttributeColumnWidthItem(obj: IAttributeColumnWidthItem): string {
-    const { attributeIdentifier, width } = obj.attributeColumnWidthItem;
-    const { value: widthValue, allowGrowToFit } = width;
-    // cannot use lodash compact, that would remove 0 values which we want to keep here
-    const params = [`"${attributeIdentifier}"`, `${widthValue}`, allowGrowToFit && "true"].filter(
-        (item) => !isNil(item),
-    );
-    return `newWidthForAttributeColumn(${params.join(", ")})`;
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableAdditionalFactories.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableAdditionalFactories.ts
@@ -1,0 +1,140 @@
+// (C) 2022 GoodData Corporation
+import isNil from "lodash/isNil";
+import isString from "lodash/isString";
+import partition from "lodash/partition";
+import {
+    ColumnLocator,
+    IAbsoluteColumnWidth,
+    IAllMeasureColumnWidthItem,
+    IAttributeColumnLocator,
+    IAttributeColumnWidthItem,
+    IMeasureColumnLocator,
+    IMeasureColumnWidthItem,
+    isAllMeasureColumnWidthItem,
+    isAttributeColumnLocator,
+    isAttributeColumnWidthItem,
+    isMeasureColumnLocator,
+    isMeasureColumnWidthItem,
+    isWeakMeasureColumnWidthItem,
+    IWeakMeasureColumnWidthItem,
+} from "@gooddata/sdk-ui-pivot";
+
+import { IAdditionalFactoryDefinition } from "../../../utils/embeddingCodeGenerator";
+
+export function factoryNotationForAttributeColumnWidthItem(obj: IAttributeColumnWidthItem): string {
+    const { attributeIdentifier, width } = obj.attributeColumnWidthItem;
+    const { value: widthValue, allowGrowToFit } = width;
+    // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const params = [`"${attributeIdentifier}"`, `${widthValue}`, allowGrowToFit && "true"].filter(
+        (item) => !isNil(item),
+    );
+    return `newWidthForAttributeColumn(${params.join(", ")})`;
+}
+
+export function factoryNotationForMeasureColumnWidthItem(obj: IMeasureColumnWidthItem): string {
+    const { locators, width } = obj.measureColumnWidthItem;
+
+    // we know there is exactly one measureLocator and several attributeLocators
+    const [[measureLocator], attributeLocators] = partition<ColumnLocator, IMeasureColumnLocator>(
+        locators,
+        isMeasureColumnLocator,
+    );
+
+    const allowGrowToFit = isString(width) ? false : (width as IAbsoluteColumnWidth).allowGrowToFit;
+    const attributeLocatorFactories = attributeLocators.map((locator) =>
+        factoryNotationForAttributeColumnLocator(locator),
+    );
+
+    // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const params = [
+        `"${measureLocator.measureLocatorItem.measureIdentifier}"`,
+        `[${attributeLocatorFactories.join(", ")}]`,
+        isString(width.value) ? `"${width.value}"` : width.value,
+        allowGrowToFit && "true",
+    ].filter((item) => !isNil(item));
+    return `newWidthForSelectedColumns(${params.join(", ")})`;
+}
+
+export function factoryNotationForAttributeColumnLocator(obj: IAttributeColumnLocator): string {
+    const { attributeIdentifier, element } = obj.attributeLocatorItem;
+    // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const params = [`"${attributeIdentifier}"`, element && `"${element}"`].filter((item) => !isNil(item));
+    return `newAttributeColumnLocator(${params.join(", ")})`;
+}
+
+export function factoryNotationForWeakMeasureColumnWidthItem(obj: IWeakMeasureColumnWidthItem): string {
+    const { locator, width } = obj.measureColumnWidthItem;
+    // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const params = [
+        `"${locator.measureLocatorItem.measureIdentifier}"`,
+        width.value,
+        width.allowGrowToFit && "true",
+    ].filter((item) => !isNil(item));
+    return `newWidthForAllColumnsForMeasure(${params.join(", ")})`;
+}
+
+export function factoryNotationForAllMeasureColumnWidthItem(obj: IAllMeasureColumnWidthItem): string {
+    const { value, allowGrowToFit } = obj.measureColumnWidthItem.width;
+    // cannot use lodash compact, that would remove 0 values which we want to keep here
+    const params = [value, allowGrowToFit && "true"].filter((item) => !isNil(item));
+    return `newWidthForAllMeasureColumns(${params.join(", ")})`;
+}
+
+export const pivotTableAdditionalFactories: IAdditionalFactoryDefinition[] = [
+    {
+        importInfo: {
+            name: "newWidthForAttributeColumn",
+            package: "@gooddata/sdk-ui-pivot",
+            importType: "named",
+        },
+        transformation: (obj) => {
+            return isAttributeColumnWidthItem(obj)
+                ? factoryNotationForAttributeColumnWidthItem(obj)
+                : undefined;
+        },
+    },
+    {
+        importInfo: {
+            name: "newAttributeColumnLocator",
+            package: "@gooddata/sdk-ui-pivot",
+            importType: "named",
+        },
+        transformation: (obj) => {
+            return isAttributeColumnLocator(obj) ? factoryNotationForAttributeColumnLocator(obj) : undefined;
+        },
+    },
+    {
+        importInfo: {
+            name: "newWidthForAllColumnsForMeasure",
+            package: "@gooddata/sdk-ui-pivot",
+            importType: "named",
+        },
+        transformation: (obj) => {
+            return isWeakMeasureColumnWidthItem(obj)
+                ? factoryNotationForWeakMeasureColumnWidthItem(obj)
+                : undefined;
+        },
+    },
+    {
+        importInfo: {
+            name: "newWidthForSelectedColumns",
+            package: "@gooddata/sdk-ui-pivot",
+            importType: "named",
+        },
+        transformation: (obj) => {
+            return isMeasureColumnWidthItem(obj) ? factoryNotationForMeasureColumnWidthItem(obj) : undefined;
+        },
+    },
+    {
+        importInfo: {
+            name: "newWidthForAllMeasureColumns",
+            package: "@gooddata/sdk-ui-pivot",
+            importType: "named",
+        },
+        transformation: (obj) => {
+            return isAllMeasureColumnWidthItem(obj)
+                ? factoryNotationForAllMeasureColumnWidthItem(obj)
+                : undefined;
+        },
+    },
+];

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/pivotTableAdditionalFactories.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/__snapshots__/pivotTableAdditionalFactories.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pivotTableAdditionalFactories factoryNotationForAllMeasureColumnWidthItem should handle item with grow to fit 1`] = `"newWidthForAllMeasureColumns(123, true)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForAllMeasureColumnWidthItem should handle item without grow to fit 1`] = `"newWidthForAllMeasureColumns(123)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForAttributeColumnLocator should handle item with element 1`] = `"newAttributeColumnLocator(\\"some-id\\", \\"some-element\\")"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForAttributeColumnLocator should handle item without element 1`] = `"newAttributeColumnLocator(\\"some-id\\")"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForAttributeColumnWidthItem should handle item with grow to fit 1`] = `"newWidthForAttributeColumn(\\"some-id\\", 123, true)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForAttributeColumnWidthItem should handle item without grow to fit 1`] = `"newWidthForAttributeColumn(\\"some-id\\", 123)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForMeasureColumnWidthItem with numeric width value should handle item with grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], 123, true)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForMeasureColumnWidthItem with numeric width value should handle item without grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], 123)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForMeasureColumnWidthItem with string width value should handle item with grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForMeasureColumnWidthItem with string width value should handle item without grow to fit 1`] = `"newWidthForSelectedColumns(\\"some-id\\", [newAttributeColumnLocator(\\"attr-id\\")], \\"auto\\")"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForWeakMeasureColumnWidthItem should handle item with grow to fit 1`] = `"newWidthForAllColumnsForMeasure(\\"some-id\\", 123, true)"`;
+
+exports[`pivotTableAdditionalFactories factoryNotationForWeakMeasureColumnWidthItem should handle item without grow to fit 1`] = `"newWidthForAllColumnsForMeasure(\\"some-id\\", 123)"`;

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/pivotTableAdditionalFactories.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/pivotTableAdditionalFactories.test.ts
@@ -1,0 +1,89 @@
+// (C) 2022 GoodData Corporation
+import {
+    newAttributeColumnLocator,
+    newWidthForAllColumnsForMeasure,
+    newWidthForAllMeasureColumns,
+    newWidthForAttributeColumn,
+    newWidthForSelectedColumns,
+} from "@gooddata/sdk-ui-pivot";
+import {
+    factoryNotationForAllMeasureColumnWidthItem,
+    factoryNotationForAttributeColumnLocator,
+    factoryNotationForAttributeColumnWidthItem,
+    factoryNotationForMeasureColumnWidthItem,
+    factoryNotationForWeakMeasureColumnWidthItem,
+} from "../pivotTableAdditionalFactories";
+
+describe("pivotTableAdditionalFactories", () => {
+    describe("factoryNotationForAttributeColumnWidthItem", () => {
+        it("should handle item without grow to fit", () => {
+            const input = newWidthForAttributeColumn("some-id", 123);
+            const actual = factoryNotationForAttributeColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+        it("should handle item with grow to fit", () => {
+            const input = newWidthForAttributeColumn("some-id", 123, true);
+            const actual = factoryNotationForAttributeColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+    });
+
+    describe("factoryNotationForMeasureColumnWidthItem", () => {
+        const attributeLocators = [newAttributeColumnLocator("attr-id")];
+
+        describe.each([
+            ["numeric", 123],
+            ["string", "auto"],
+        ] as const)("with %s width value", (_, width) => {
+            it("should handle item without grow to fit", () => {
+                const input = newWidthForSelectedColumns("some-id", attributeLocators, width);
+                const actual = factoryNotationForMeasureColumnWidthItem(input);
+                expect(actual).toMatchSnapshot();
+            });
+            it("should handle item with grow to fit", () => {
+                const input = newWidthForSelectedColumns("some-id", attributeLocators, width, true);
+                const actual = factoryNotationForMeasureColumnWidthItem(input);
+                expect(actual).toMatchSnapshot();
+            });
+        });
+    });
+
+    describe("factoryNotationForAttributeColumnLocator", () => {
+        it("should handle item without element", () => {
+            const input = newAttributeColumnLocator("some-id");
+            const actual = factoryNotationForAttributeColumnLocator(input);
+            expect(actual).toMatchSnapshot();
+        });
+        it("should handle item with element", () => {
+            const input = newAttributeColumnLocator("some-id", "some-element");
+            const actual = factoryNotationForAttributeColumnLocator(input);
+            expect(actual).toMatchSnapshot();
+        });
+    });
+
+    describe("factoryNotationForWeakMeasureColumnWidthItem", () => {
+        it("should handle item without grow to fit", () => {
+            const input = newWidthForAllColumnsForMeasure("some-id", 123);
+            const actual = factoryNotationForWeakMeasureColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+        it("should handle item with grow to fit", () => {
+            const input = newWidthForAllColumnsForMeasure("some-id", 123, true);
+            const actual = factoryNotationForWeakMeasureColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+    });
+
+    describe("factoryNotationForAllMeasureColumnWidthItem", () => {
+        it("should handle item without grow to fit", () => {
+            const input = newWidthForAllMeasureColumns(123);
+            const actual = factoryNotationForAllMeasureColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+        it("should handle item with grow to fit", () => {
+            const input = newWidthForAllMeasureColumns(123, true);
+            const actual = factoryNotationForAllMeasureColumnWidthItem(input);
+            expect(actual).toMatchSnapshot();
+        });
+    });
+});

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -33221,7 +33221,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with attribute and metric column size 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33234,16 +33234,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33267,7 +33258,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with attribute and metric column size 2`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33280,16 +33271,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33313,7 +33295,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with attribute and metric column size 3`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33326,16 +33308,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33359,7 +33332,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with attribute and metric column size 4`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, newWidthForAttributeColumn, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAttributeColumn, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33372,16 +33345,7 @@ const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33549,7 +33513,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with custom metric column size 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33561,16 +33525,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33594,7 +33549,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with custom metric column size 2`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33606,16 +33561,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33639,7 +33585,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with custom metric column size 3`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33651,16 +33597,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -33684,7 +33621,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - simple table with custom metric column size 4`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForSelectedColumns, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
@@ -33696,16 +33633,7 @@ const rows: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locators: [
-                        {
-                            measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                        }
-                    ],
-                    width: {value: 60}
-                }
-            }
+            newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -34208,7 +34136,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - table with multiple measure columns and weak measure size 1`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAllColumnsForMeasure, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -34224,14 +34152,7 @@ const columns: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locator: {
-                        measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                    },
-                    width: {value: 60}
-                }
-            }
+            newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -34256,7 +34177,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - table with multiple measure columns and weak measure size 2`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAllColumnsForMeasure, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -34272,14 +34193,7 @@ const columns: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locator: {
-                        measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                    },
-                    width: {value: 60}
-                }
-            }
+            newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -34304,7 +34218,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - table with multiple measure columns and weak measure size 3`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAllColumnsForMeasure, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -34320,14 +34234,7 @@ const columns: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locator: {
-                        measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                    },
-                    width: {value: 60}
-                }
-            }
+            newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}
@@ -34352,7 +34259,7 @@ export function MyComponent() {
 exports[`getEmbeddingCode functionality should generate code for PivotTable - table with multiple measure columns and weak measure size 4`] = `
 "import React from \\"react\\";
 import { IAttribute, IAttributeOrMeasure, idRef, newAttribute, newMeasure } from \\"@gooddata/sdk-model\\";
-import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
+import { IPivotTableConfig, newWidthForAllColumnsForMeasure, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
@@ -34368,14 +34275,7 @@ const columns: IAttribute[] = [
 const config: IPivotTableConfig = {
     columnSizing: {
         columnWidths: [
-            {
-                measureColumnWidthItem: {
-                    locator: {
-                        measureLocatorItem: {measureIdentifier: \\"m_aangOxLSeztu\\"}
-                    },
-                    width: {value: 60}
-                }
-            }
+            newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
     separators: {decimal: \\".\\", thousand: \\",\\"}


### PR DESCRIPTION
This makes the codegen output much more readable and shorter when using the PivotTable column sizing features.

JIRA: RAIL-4240

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
