### PR TITLE
Related: TNT-793, TNT-794 Removed auto correction of Start time based on End Time

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePicker.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePicker.tsx
@@ -6,7 +6,7 @@ import MomentLocaleUtils from "react-day-picker/moment";
 import DayPickerInput from "react-day-picker/DayPickerInput";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { translationUtils } from "@gooddata/util";
-import { mergeDayPickerProps, areRangeBoundsCrossed } from "./utils";
+import { mergeDayPickerProps } from "./utils";
 import { DateRangePickerError } from "./DateRangePickerError";
 import { IExtendedDateFilterErrors } from "../interfaces";
 import { DateTimePicker } from "./DateTimePicker";
@@ -140,19 +140,13 @@ class DateRangePickerComponent extends React.Component<IDateRangePickerProps & W
     };
 
     private handleFromChange = (from: Date) => {
-        const useFrom = from && this.props.range.to && areRangeBoundsCrossed(from, this.props.range.to);
-        const to = useFrom ? from : this.props.range.to;
         const sanitizedFrom = this.getSanitizedInputValue(this.fromInputRef, from);
-
-        this.updateRange(sanitizedFrom, to);
+        this.updateRange(sanitizedFrom, this.props.range.to);
     };
 
     private handleToChange = (to: Date) => {
-        const useTo = to && this.props.range.from && areRangeBoundsCrossed(this.props.range.from, to);
-        const from = useTo ? to : this.props.range.from;
         const sanitizedTo = this.getSanitizedInputValue(this.toInputRef, to);
-
-        this.updateRange(from, sanitizedTo);
+        this.updateRange(this.props.range.from, sanitizedTo);
     };
 }
 export const DateRangePicker = injectIntl(DateRangePickerComponent);

--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/tests/DateRangePicker.test.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/tests/DateRangePicker.test.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { mount } from "enzyme";
 
 import { DateRangePicker, IDateRange } from "../DateRangePicker";
-import { childGetter, writeTo, clickOn, writeToWithBlur } from "../../tests/utils";
+import { childGetter, writeTo, clickOn } from "../../tests/utils";
 import { IntlDecorator } from "./IntlDecorators";
 
 const getFromInput = childGetter(".s-date-range-picker-from .s-date-range-picker-input-field");
@@ -86,7 +86,7 @@ describe("DateRangePicker", () => {
         );
 
         it("should call the appropriate callback when FROM time configured to 11", () => {
-            writeToWithBlur("1100", getFromTimeInput(rendered));
+            writeTo("1100", getFromTimeInput(rendered));
             expect(onChange).toHaveBeenCalledWith({ ...defaultRange, from: new Date(2019, 4, 5, 11, 0) });
         });
 
@@ -99,7 +99,7 @@ describe("DateRangePicker", () => {
         it.each(toScenarios)(
             "should call the appropriate callback when %s",
             (_desc, value, expectedResult) => {
-                writeToWithBlur(value, getToTimeInput(rendered));
+                writeTo(value, getToTimeInput(rendered));
                 expect(onChange).toHaveBeenCalledWith({ ...defaultRange, to: expectedResult });
             },
         );

--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/utils.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/utils.ts
@@ -1,6 +1,7 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import moment from "moment";
 import { DayPickerProps, Modifiers } from "react-day-picker";
+import { platformDateFormat, TIME_FORMAT } from "../constants/Platform";
 
 const mergeModifiers = (
     defaultModifiers: Partial<Modifiers> | undefined,
@@ -24,3 +25,7 @@ export const mergeDayPickerProps = (
 
 export const areRangeBoundsCrossed = (from: Date, to: Date): boolean =>
     from && to ? moment(from).isAfter(moment(to)) : false;
+
+export const getPlatformStringFromDate = (value: Date) => moment(value).format(platformDateFormat);
+
+export const getTimeStringFromDate = (value: Date | undefined) => moment(value).format(TIME_FORMAT);

--- a/libs/sdk-ui-filters/src/DateFilter/tests/AbsoluteForm.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/tests/AbsoluteForm.tsx
@@ -28,12 +28,12 @@ export class AbsoluteForm {
 
     public setStartTime = (value: string) => {
         const input = this.wrapper.find(startTimeInput);
-        input.simulate("change", { target: { value } }).simulate("blur");
+        input.simulate("change", { target: { value } });
     };
 
     public setEndTime = (value: string) => {
         const input = this.wrapper.find(endTimeInput);
-        input.simulate("change", { target: { value } }).simulate("blur");
+        input.simulate("change", { target: { value } });
     };
 
     public getStartDate = (): string => {

--- a/libs/sdk-ui-filters/src/DateFilter/tests/DateFilter.test.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/tests/DateFilter.test.tsx
@@ -575,7 +575,7 @@ describe("DateFilter", () => {
             expect(isApplyButtonDisabled(wrapper)).toBe(false);
         });
 
-        it('should set "to" properly after setting "from" to a later value', () => {
+        it('should display error message when "Start" is later than "End" value and start is set twice', () => {
             const wrapper = createDateFilter();
             const absoluteForm = new AbsoluteForm(wrapper);
             clickDateFilterButton(wrapper);
@@ -586,12 +586,12 @@ describe("DateFilter", () => {
             absoluteForm.setStartDate(dateToAbsoluteInputFormat("2019-05-01"));
 
             expect(absoluteForm.getStartDate()).toEqual("05/01/2019");
-            expect(absoluteForm.getEndDate()).toEqual("05/01/2019");
-            expect(absoluteForm.isErrorVisible()).toBe(false);
-            expect(isApplyButtonDisabled(wrapper)).toBe(false);
+            expect(absoluteForm.getEndDate()).toEqual("01/31/2019");
+            expect(absoluteForm.isErrorVisible()).toBe(true);
+            expect(isApplyButtonDisabled(wrapper)).toBe(true);
         });
 
-        it('should set "from" properly after setting "to" a sooner value', () => {
+        it('should display error message when "Start" is later than "End" value', () => {
             const wrapper = createDateFilter();
             const absoluteForm = new AbsoluteForm(wrapper);
             clickDateFilterButton(wrapper);
@@ -600,10 +600,10 @@ describe("DateFilter", () => {
             absoluteForm.setStartDate(dateToAbsoluteInputFormat("2019-01-31"));
             absoluteForm.setEndDate(dateToAbsoluteInputFormat("2019-01-01"));
 
-            expect(absoluteForm.getStartDate()).toEqual("01/01/2019");
+            expect(absoluteForm.getStartDate()).toEqual("01/31/2019");
             expect(absoluteForm.getEndDate()).toEqual("01/01/2019");
-            expect(absoluteForm.isErrorVisible()).toBe(false);
-            expect(isApplyButtonDisabled(wrapper)).toBe(false);
+            expect(absoluteForm.isErrorVisible()).toBe(true);
+            expect(isApplyButtonDisabled(wrapper)).toBe(true);
         });
 
         it('should not have errors when "from" = "to"', () => {

--- a/libs/sdk-ui-filters/src/DateFilter/tests/utils.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/tests/utils.ts
@@ -12,6 +12,3 @@ export const pressButtonOn = (keyCode: number, component: CommonWrapper) =>
 
 export const writeTo = (value: string, component: CommonWrapper) =>
     component.simulate("change", { target: { value } });
-
-export const writeToWithBlur = (value: string, component: CommonWrapper) =>
-    component.simulate("change", { target: { value } }).simulate("blur");

--- a/libs/sdk-ui-filters/src/DateFilter/validation/OptionValidation.ts
+++ b/libs/sdk-ui-filters/src/DateFilter/validation/OptionValidation.ts
@@ -6,6 +6,7 @@ import {
     IUiRelativeDateFilterForm,
 } from "../interfaces";
 import { isAbsoluteDateFilterForm, isRelativeDateFilterForm } from "@gooddata/sdk-model";
+import { convertPlatformDateStringToDate } from "../utils/DateConversions";
 
 const validateVisibility = (filterOption: DateFilterOption): IExtendedDateFilterErrors => {
     const errors: IExtendedDateFilterErrors = {};
@@ -29,6 +30,16 @@ const validateAbsoluteForm = (filterOption: IUiAbsoluteDateFilterForm): IExtende
             }
         }
     });
+
+    if (!errors.absoluteForm) {
+        const start = convertPlatformDateStringToDate(filterOption.from);
+        const end = convertPlatformDateStringToDate(filterOption.to);
+
+        if (start > end) {
+            errors.absoluteForm = { to: "filters.staticPeriod.endDateBeforeStartDate" };
+        }
+    }
+
     return errors.absoluteForm ? errors : {};
 };
 

--- a/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
+++ b/libs/sdk-ui-filters/styles/scss/components/DateRangePicker.scss
@@ -297,7 +297,7 @@ $gd-day-picker-width: 268px;
     }
 
     &-error-message {
-        width: 270px;
+        width: 269px;
         margin-top: 5px;
         padding: 2px 10px;
         border-radius: 3px;

--- a/libs/sdk-ui/src/base/localization/bundles/en-US.json
+++ b/libs/sdk-ui/src/base/localization/bundles/en-US.json
@@ -1091,6 +1091,11 @@
         "comment": "Placeholder '{format}' is used for showing date format. Example 'The date must be in the MM/dd/yyyy format'. Don't translate placeholder '{format}'.",
         "limit": 0
     },
+    "filters.staticPeriod.endDateBeforeStartDate": {
+        "value": "End time must be later than start time",
+        "comment": "This error is displayed once there is a datetime range and End time is before To time",
+        "limit": 0
+    },
     "mvf.operator.all": {
         "value": "all",
         "comment": "Covers all the operators like 'Greater than', 'Less than', etc.",


### PR DESCRIPTION
Removed auto correction within Absolute Date filter once Start time is after End time. It has been replaced by highlighting of incorrect value.

JIRA: TNT-793, TNT-794

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
