### PR TITLE
Remove unnecessary IntlWrapper that triggers error

### DIFF
--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateTimePicker.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateTimePicker.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from "react";
 import cx from "classnames";
 import { DateRangePickerInputField } from "./DateRangePickerInputField";
 import { injectIntl, WrappedComponentProps } from "react-intl";
-import { IntlWrapper } from "@gooddata/sdk-ui";
 import DayPickerInput from "react-day-picker/DayPickerInput";
 import moment from "moment";
 import { DateRangePickerInputFieldBody } from "./DateRangePickerInputFieldBody";
@@ -163,9 +162,7 @@ DateTimePickerComponent.displayName = "DateTimePickerComponent";
 const DateTimePickerWithInt = injectIntl(DateTimePickerComponent, { forwardRef: true });
 
 const DateTimePicker = React.forwardRef<DayPickerInput, IDateTimePickerOwnProps>((props, ref) => (
-    <IntlWrapper locale={props.locale}>
-        <DateTimePickerWithInt {...props} ref={ref} />
-    </IntlWrapper>
+    <DateTimePickerWithInt {...props} ref={ref} />
 ));
 DateTimePicker.displayName = "DateTimePicker";
 


### PR DESCRIPTION
IntlWrapper must not be around this component as "locale" prop that is used here is converted to be compatible with moment.js that uses different locale name for Chinese language than used by GD. Application throws unrecoverable error when used in Chinese localization.

JIRA: TNT-792

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
