### PR TITLE
Increase render worker timeout

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commands/render.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/render.ts
@@ -28,10 +28,10 @@ export interface RequestAsyncRender extends IDashboardCommand {
  * - You must request async rendering for at least 1 component within 2 seconds of the {@link DashboardInitialized} event.
  *   (If you do not register any asynchronous rendering, after 2 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
  * - You can request async rendering for any number of components. Requests are valid if the first rule is met
- *   and not all asynchronous renderings have been resolved and the maximum timeout (60s by default) has not elapsed.
+ *   and not all asynchronous renderings have been resolved and the maximum timeout (20min by default) has not elapsed.
  * - The component may again request asynchronous rendering within 2 seconds of resolution. Maximum 3x.
  *   (this is necessary to cover possible re-renders caused by data received from the components themselves, after they are rendered)
- * - Maximum rendering time of the dashboard is 60s - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
+ * - Maximum rendering time of the dashboard is 20min - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
  *
  * - Each component on the dashboard that is rendered asynchronously should fire this command.
  * - Once the component is rendered, it should notify the dashboard by dispatching {@link resolveAsyncRender} command

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardAsyncRender.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardAsyncRender.ts
@@ -30,10 +30,10 @@ export interface UseDashboardAsyncRender {
  * - You must request async rendering for at least 1 component within 2 seconds of the {@link DashboardInitialized} event.
  *   (If you do not register any asynchronous rendering, after 2 seconds the dashboard will announce that it is rendered by dispatching {@link DashboardRenderResolved} event.)
  * - You can request async rendering for any number of components. Requests are valid if the first rule is met
- *   and not all asynchronous renderings have been resolved and the maximum timeout (60s by default) has not elapsed.
+ *   and not all asynchronous renderings have been resolved and the maximum timeout (20min by default) has not elapsed.
  * - The component may again request asynchronous rendering within 2 seconds of resolution. Maximum 3x.
  *   (this is necessary to cover possible re-renders caused by data received from the components themselves, after they are rendered)
- * - Maximum rendering time of the dashboard is 60s - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
+ * - Maximum rendering time of the dashboard is 20min - if some asynchronous renderings are not yet resolved at this time, {@link DashboardRenderResolved} event is dispatched anyway.
  *
  * Request async rendering of the component by calling onRequestAsyncRender() callback.
  * Resolve async rendering of the component by calling onResolveAsyncRender() callback.


### PR DESCRIPTION
JIRA: TNT-791
Sync SDK timeout with exporter timeout to use its full potential on extensive dashboards

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
