### PR TITLE
RELATED: TNT-798 Increased default limit for displayed datapoints

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/commonConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/commonConfiguration.ts
@@ -17,7 +17,7 @@ const isTouchDevice = "ontouchstart" in window || navigator.msMaxTouchPoints;
 const HIGHCHART_PLOT_LIMITED_RANGE = 1e5;
 
 export const DEFAULT_SERIES_LIMIT = 1000;
-export const DEFAULT_CATEGORIES_LIMIT = 366;
+export const DEFAULT_CATEGORIES_LIMIT = 3000;
 export const DEFAULT_DATA_POINTS_LIMIT = 2000;
 export const MAX_POINT_WIDTH = 100;
 export const HOVER_BRIGHTNESS = 0.1;

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/test/chartOptionsBuilder.test.ts
@@ -292,7 +292,8 @@ describe("chartOptionsBuilder", () => {
 
             const testData = [
                 ["false", "less", 3, { dataTooLarge: false, hasNegativeValue: false }],
-                ["true", "greater", 31, { dataTooLarge: true, hasNegativeValue: false }],
+                ["false", "greater", 31, { dataTooLarge: false, hasNegativeValue: false }],
+                ["true", "greater", 100, { dataTooLarge: true, hasNegativeValue: false }],
             ];
 
             it.each(testData)(
@@ -305,6 +306,9 @@ describe("chartOptionsBuilder", () => {
                             categories: Array(31),
                         }),
                     };
+
+                    // validation for number of categories has to satisfy
+                    // (categoriesNum * 31) < LIMIT of default categories(currently set to 3000)
                     const validationResult = validateData(undefined, { ...chartOptions, data });
                     expect(validationResult).toEqual(expected);
                 },


### PR DESCRIPTION
It has been decided to change the limit for all the charts using default limit since we have not experienced any performance issue.

JIRA: TNT-798

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
