### PR TITLE
RELATED: RAIL-4249,RAIL-4251,RAIL-4252,RAIL-4253,RAIL-4260 codegen fixes

### DIFF
--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
@@ -24,6 +24,7 @@ import {
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
     sortsInsightConversion,
+    localeInsightConversion,
 } from "../../../utils/embeddingCodeGenerator";
 import { chartAdditionalFactories, chartConfigInsightConversion } from "../chartCodeGenUtils";
 
@@ -54,6 +55,7 @@ export class AreaChartDescriptor extends BigChartDescriptor implements IVisualiz
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
@@ -23,6 +23,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesBucketConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
@@ -57,6 +58,7 @@ export class BarChartDescriptor extends BaseChartDescriptor implements IVisualiz
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/BubbleChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bubbleChart/BubbleChartDescriptor.ts
@@ -13,6 +13,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     singleAttributeBucketConversion,
     singleMeasureBucketConversion,
     sortsInsightConversion,
@@ -38,6 +39,7 @@ export class BubbleChartDescriptor extends BigChartDescriptor implements IVisual
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
@@ -17,6 +17,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesBucketConversion,
     singleAttributeOrMeasureBucketConversion,
     sortsInsightConversion,
@@ -57,6 +58,7 @@ export class BulletChartDescriptor extends BaseChartDescriptor implements IVisua
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
@@ -28,6 +28,7 @@ const supportedChartConfigProperties = new Set<keyof IChartConfig>([
     "dataPoints",
     "dualAxis",
     "enableJoinedAttributeAxisName",
+    "enableChartSorting",
     "grid",
     "legend",
     "legendLayout",
@@ -58,6 +59,7 @@ export function chartConfigFromInsight(
         ...(ctx?.colorPalette ? { colorPalette: ctx?.colorPalette } : {}),
         ...(ctx?.settings?.separators ? { separators: ctx?.settings?.separators } : {}),
         ...(ctx?.settings?.locale ? { locale: ctx?.settings?.locale } : {}),
+        ...(ctx?.settings?.enableChartsSorting ? { enableChartSorting: true } : {}),
     };
 
     return flow(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
@@ -27,25 +27,25 @@ const supportedChartConfigProperties = new Set<keyof IChartConfig>([
     "dataLabels",
     "dataPoints",
     "dualAxis",
-    "enableJoinedAttributeAxisName",
     "enableChartSorting",
+    "enableJoinedAttributeAxisName",
     "grid",
     "legend",
     "legendLayout",
     "limits",
     "primaryChartType",
-    "secondaryChartType",
     "secondary_xaxis",
     "secondary_yaxis",
+    "secondaryChartType",
     "separators",
     "stackMeasures",
     "stackMeasuresToPercent",
+    "xaxis",
     "xFormat",
     "xLabel",
-    "xaxis",
+    "yaxis",
     "yFormat",
     "yLabel",
-    "yaxis",
 ]);
 
 export function chartConfigFromInsight(
@@ -60,6 +60,7 @@ export function chartConfigFromInsight(
         ...(ctx?.settings?.separators ? { separators: ctx?.settings?.separators } : {}),
         ...(ctx?.settings?.locale ? { locale: ctx?.settings?.locale } : {}),
         ...(ctx?.settings?.enableChartsSorting ? { enableChartSorting: true } : {}),
+        ...(ctx?.settings?.enableAxisNameViewByTwoAttributes ? { enableJoinedAttributeAxisName: true } : {}),
     };
 
     return flow(

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
@@ -58,7 +58,6 @@ export function chartConfigFromInsight(
         ...controls,
         ...(ctx?.colorPalette ? { colorPalette: ctx?.colorPalette } : {}),
         ...(ctx?.settings?.separators ? { separators: ctx?.settings?.separators } : {}),
-        ...(ctx?.settings?.locale ? { locale: ctx?.settings?.locale } : {}),
         ...(ctx?.settings?.enableChartsSorting ? { enableChartSorting: true } : {}),
         ...(ctx?.settings?.enableAxisNameViewByTwoAttributes ? { enableJoinedAttributeAxisName: true } : {}),
     };

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
@@ -23,6 +23,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesBucketConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
@@ -57,6 +58,7 @@ export class ColumnChartDescriptor extends BaseChartDescriptor implements IVisua
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/ComboChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/comboChart/ComboChartDescriptor.ts
@@ -16,6 +16,7 @@ import {
     sortsInsightConversion,
     multipleMeasuresBucketConversion,
     multipleAttributesBucketConversion,
+    localeInsightConversion,
 } from "../../../utils/embeddingCodeGenerator";
 import { chartAdditionalFactories, chartConfigInsightConversion } from "../chartCodeGenUtils";
 
@@ -40,6 +41,7 @@ export class ComboChartDescriptor extends BigChartDescriptor implements IVisuali
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/DonutChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/donutChart/DonutChartDescriptor.ts
@@ -13,6 +13,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
     sortsInsightConversion,
@@ -36,6 +37,7 @@ export class DonutChartDescriptor extends BaseChartDescriptor implements IVisual
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/FunnelChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/funnelChart/FunnelChartDescriptor.ts
@@ -13,6 +13,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
     sortsInsightConversion,
@@ -36,6 +37,7 @@ export class FunnelChartDescriptor extends BaseChartDescriptor implements IVisua
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/GeoPushpinChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/GeoPushpinChartDescriptor.ts
@@ -18,6 +18,7 @@ import {
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
     insightConversion,
+    localeInsightConversion,
     singleAttributeBucketConversion,
     singleAttributeOrMeasureBucketConversion,
     sortsInsightConversion,
@@ -74,6 +75,7 @@ export class GeoPushpinChartDescriptor extends BaseChartDescriptor implements IV
                 },
                 geoConfigFromInsight,
             ),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories({
             getColorMappingPredicatePackage: "@gooddata/sdk-ui-geo",

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/geoConfigFromInsight.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/geoChart/geoConfigFromInsight.ts
@@ -29,9 +29,14 @@ export function geoConfigFromInsight(insight: IInsightDefinition, ctx?: IEmbeddi
         ...(ctx?.settings?.separators ? { separators: ctx?.settings?.separators } : {}),
     };
 
-    return flow(
+    const configFromProperties = flow(
         toPairs,
         filter(([key, value]) => supportedGeoConfigProperties.has(key as any) && !isNil(value)),
         fromPairs,
     )(withValuesFromContext) as IGeoConfig;
+
+    return {
+        ...configFromProperties,
+        mapboxToken: "<fill your Mapbox token here>",
+    };
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/HeadlineDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/headline/HeadlineDescriptor.ts
@@ -17,6 +17,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     singleMeasureBucketConversion,
 } from "../../../utils/embeddingCodeGenerator";
 
@@ -85,6 +86,7 @@ export class HeadlineDescriptor implements IVisualizationDescriptor {
                 BucketNames.SECONDARY_MEASURES,
             ),
             filters: filtersInsightConversion("filters"),
+            locale: localeInsightConversion("locale"),
         }),
     });
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
@@ -17,6 +17,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     singleAttributeBucketConversion,
     singleAttributeOrMeasureBucketConversion,
     sortsInsightConversion,
@@ -50,6 +51,7 @@ export class HeatmapDescriptor extends BigChartDescriptor implements IVisualizat
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
@@ -20,6 +20,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
     sortsInsightConversion,
@@ -49,6 +50,7 @@ export class LineChartDescriptor extends BaseChartDescriptor implements IVisuali
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PieChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pieChart/PieChartDescriptor.ts
@@ -13,6 +13,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
     sortsInsightConversion,
@@ -36,6 +37,7 @@ export class PieChartDescriptor extends BaseChartDescriptor implements IVisualiz
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
@@ -23,6 +23,7 @@ import {
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
     insightConversion,
+    localeInsightConversion,
     multipleAttributesBucketConversion,
     multipleAttributesOrMeasuresBucketConversion,
     sortsInsightConversion,
@@ -92,6 +93,7 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
                 },
                 pivotTableConfigFromInsight,
             ),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: pivotTableAdditionalFactories,
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/pivotTableConfigFromInsight.ts
@@ -1,53 +1,36 @@
 // (C) 2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-import isNil from "lodash/isNil";
 import { IInsightDefinition, insightProperties } from "@gooddata/sdk-model";
-import { IColumnSizing, IPivotTableConfig, pivotTableMenuForCapabilities } from "@gooddata/sdk-ui-pivot";
+import { IPivotTableConfig } from "@gooddata/sdk-ui-pivot";
 import { IEmbeddingCodeContext } from "../../../interfaces/VisualizationDescriptor";
+import { createPivotTableConfig } from "./PluggablePivotTable";
+import { getColumnWidthsFromProperties } from "../../../utils/propertiesHelper";
 
 export function pivotTableConfigFromInsight(
     insight: IInsightDefinition,
     ctx: IEmbeddingCodeContext | undefined,
 ): IPivotTableConfig {
-    const properties = insightProperties(insight);
-    const controls = properties?.controls;
+    const baseConfig =
+        ctx?.settings && ctx.backend
+            ? createPivotTableConfig(
+                  { separators: ctx?.settings?.separators },
+                  "none",
+                  ctx.settings,
+                  ctx.backend.capabilities,
+                  getColumnWidthsFromProperties(insightProperties(insight)) ?? [],
+              )
+            : {};
 
-    const columnSizingFromControls = controls && getColumnSizingFromControls(controls, ctx);
-    const autoResizeAllSizing: IColumnSizing = { defaultWidth: "autoresizeAll" };
-
-    // use sizing from controls if specified, otherwise use autosize if the relevant FF is on
-    const columnSizing =
-        columnSizingFromControls || (ctx.settings?.enableTableColumnsAutoResizing && autoResizeAllSizing);
-
-    const columnSizingProp = !isEmpty(columnSizing) ? { columnSizing } : {};
-
-    const menuConfig = ctx?.backend && pivotTableMenuForCapabilities(ctx.backend.capabilities);
-    const menuProp = !isEmpty(menuConfig) ? { menu: menuConfig } : {};
-
-    const separatorsConfig = ctx?.settings?.separators;
-    const separatorsProp = !isEmpty(separatorsConfig) ? { separators: separatorsConfig } : {};
+    const columnSizingProp = !isEmpty(baseConfig.columnSizing)
+        ? { columnSizing: baseConfig.columnSizing }
+        : {};
+    const menuProp = !isEmpty(baseConfig.menu) ? { menu: baseConfig.menu } : {};
+    const separatorsProp = !isEmpty(baseConfig.separators) ? { separators: baseConfig.separators } : {};
 
     return {
         ...columnSizingProp,
         ...menuProp,
         ...separatorsProp,
-        // the user can fill the rest on their own later
-    };
-}
-
-function getColumnSizingFromControls(
-    controls: Record<string, any>,
-    ctx: IEmbeddingCodeContext | undefined,
-): IColumnSizing | undefined {
-    const { columnWidths } = controls;
-    const columnWidthsProp = !isEmpty(columnWidths) ? { columnWidths } : {};
-
-    const growToFitConfig = ctx?.settings?.enableTableColumnsGrowToFit;
-    const growToFitProp = !isNil(growToFitConfig) ? { growToFit: growToFitConfig } : {};
-
-    return {
-        ...columnWidthsProp,
-        ...growToFitProp,
         // the user can fill the rest on their own later
     };
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/ScatterPlotDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/scatterPlot/ScatterPlotDescriptor.ts
@@ -12,6 +12,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     singleAttributeBucketConversion,
     singleMeasureBucketConversion,
     sortsInsightConversion,
@@ -36,6 +37,7 @@ export class ScatterPlotDescriptor extends BigChartDescriptor {
             filters: filtersInsightConversion("filters"),
             sortBy: sortsInsightConversion("sortBy"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
@@ -19,6 +19,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     multipleAttributesOrMeasuresBucketConversion,
     singleAttributeBucketConversion,
 } from "../../../utils/embeddingCodeGenerator";
@@ -46,6 +47,7 @@ export class TreemapDescriptor extends BigChartDescriptor {
             segmentBy: singleAttributeBucketConversion("segmentBy", BucketNames.SEGMENT),
             filters: filtersInsightConversion("filters"),
             config: chartConfigInsightConversion("config"),
+            locale: localeInsightConversion("locale"),
         }),
         additionalFactories: chartAdditionalFactories(),
     });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/XirrDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/xirr/XirrDescriptor.ts
@@ -16,6 +16,7 @@ import {
     filtersInsightConversion,
     getInsightToPropsConverter,
     getReactEmbeddingCodeGenerator,
+    localeInsightConversion,
     singleAttributeBucketConversion,
     singleMeasureBucketConversion,
 } from "../../../utils/embeddingCodeGenerator";
@@ -79,6 +80,7 @@ export class XirrDescriptor implements IVisualizationDescriptor {
             measure: singleMeasureBucketConversion("measure", BucketNames.MEASURES),
             attribute: singleAttributeBucketConversion("attribute", BucketNames.ATTRIBUTE),
             filters: filtersInsightConversion("filters"),
+            locale: localeInsightConversion("locale"),
         }),
     });
 

--- a/libs/sdk-ui-ext/src/internal/components/tests/VisualizationCatalog.test.ts
+++ b/libs/sdk-ui-ext/src/internal/components/tests/VisualizationCatalog.test.ts
@@ -69,11 +69,21 @@ describe("getEmbeddingCode functionality", () => {
                     settings: {
                         enableAxisNameConfiguration: true,
                         enableHidingOfDataPoints: true,
+                        enableTableColumnsManualResizing: true,
+                        enableTableColumnsAutoResizing: true,
                         locale: "en-US",
                         separators: { decimal: ".", thousand: "," },
                         userId: "user",
                         workspace: "workspace",
                     },
+                    backend: {
+                        capabilities: {
+                            canCalculateGrandTotals: true,
+                            canCalculateNativeTotals: true,
+                            canCalculateSubTotals: true,
+                            canCalculateTotals: true,
+                        },
+                    } as any,
                 },
                 language: "ts",
             }),

--- a/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
+++ b/libs/sdk-ui-ext/src/internal/components/tests/__snapshots__/VisualizationCatalog.test.ts.snap
@@ -32933,7 +32933,11 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -32966,7 +32970,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33000,7 +33008,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33034,7 +33046,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33068,7 +33084,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33102,7 +33122,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33136,7 +33160,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33170,7 +33198,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33201,7 +33233,11 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\")),
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name_1\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33232,11 +33268,13 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33269,11 +33307,13 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33306,11 +33346,13 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33343,11 +33385,13 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400),
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33380,10 +33424,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33416,10 +33462,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33452,10 +33500,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33488,10 +33538,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAttributeColumn(\\"a_label.product.id.name\\", 400)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33524,10 +33576,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33560,10 +33614,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33596,10 +33652,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33632,10 +33690,12 @@ const rows: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForSelectedColumns(\\"m_aangOxLSeztu\\", [], 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -33662,7 +33722,11 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33686,7 +33750,11 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33710,7 +33778,11 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33748,7 +33820,11 @@ const totals: ITotal[] = [
     newTotal(\\"max\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"nat\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33786,7 +33862,11 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33824,7 +33904,11 @@ const columns: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.product.id.name\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33862,7 +33946,11 @@ const columns: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.owner.department\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33896,7 +33984,11 @@ const rows: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.owner.department\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33927,7 +34019,11 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_aangOxLSeztu\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33960,7 +34056,11 @@ const rows: IAttribute[] = [
 const sortBy: ISortItem[] = [
     newAttributeSort(\\"a_label.product.id.name\\", \\"desc\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -33989,7 +34089,11 @@ const measures: IAttributeOrMeasure[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34020,7 +34124,11 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34049,7 +34157,11 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34081,7 +34193,11 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34115,7 +34231,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34151,10 +34271,12 @@ const columns: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -34192,10 +34314,12 @@ const columns: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -34233,10 +34357,12 @@ const columns: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -34274,10 +34400,12 @@ const columns: IAttribute[] = [
 ];
 const config: IPivotTableConfig = {
     columnSizing: {
+        defaultWidth: \\"autoresizeAll\\",
         columnWidths: [
             newWidthForAllColumnsForMeasure(\\"m_aangOxLSeztu\\", 60)
         ]
     },
+    menu: {aggregations: true, aggregationsSubMenu: true},
     separators: {decimal: \\".\\", thousand: \\",\\"}
 };
 const style = {height: 400};
@@ -34313,7 +34441,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34352,7 +34484,11 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34392,7 +34528,11 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34430,7 +34570,11 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34458,7 +34602,11 @@ const measures: IAttributeOrMeasure[] = [
     newMeasure(idRef(\\"aangOxLSeztu\\", \\"measure\\"), m => m.localId(\\"m_aangOxLSeztu\\")),
     newMeasure(idRef(\\"acugFHNJgsBy\\", \\"measure\\"), m => m.localId(\\"m_acugFHNJgsBy\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34501,7 +34649,11 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34543,7 +34695,11 @@ const totals: ITotal[] = [
     newTotal(\\"max\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34585,7 +34741,11 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34624,7 +34784,11 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34664,7 +34828,11 @@ const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\"),
     newTotal(\\"sum\\", \\"m_acugFHNJgsBy\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34703,7 +34871,11 @@ const columns: IAttribute[] = [
 const totals: ITotal[] = [
     newTotal(\\"sum\\", \\"m_aangOxLSeztu\\", \\"a_label.product.id.name\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34734,7 +34906,11 @@ const measures: IAttributeOrMeasure[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34766,7 +34942,11 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34796,7 +34976,11 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34826,7 +35010,11 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_aangOxLSeztu\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34857,7 +35045,11 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
 const sortBy: ISortItem[] = [newMeasureSort(\\"m_acugFHNJgsBy\\", \\"desc\\", [])];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34893,7 +35085,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34927,7 +35123,11 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34962,7 +35162,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -34992,7 +35196,11 @@ const rows: IAttribute[] = [
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.owner.department\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.department\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35017,7 +35225,11 @@ import { IPivotTableConfig, PivotTable } from \\"@gooddata/sdk-ui-pivot\\";
 const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35053,7 +35265,11 @@ const columns: IAttribute[] = [
 const filters: IFilter[] = [
     newAbsoluteDateFilter(idRef(\\"activity.dataset.dt\\", \\"dataSet\\"), \\"2021-01-01\\", \\"2021-02-01\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35090,7 +35306,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35126,7 +35346,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.opportunitysnapshot.forecastcategory\\", \\"displayForm\\"), a => a.localId(\\"a_label.opportunitysnapshot.forecastcategory\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35160,7 +35384,11 @@ const columns: IAttribute[] = [
     newAttribute(idRef(\\"label.stage.name.stagename\\", \\"displayForm\\"), a => a.localId(\\"a_label.stage.name.stagename\\")),
     newAttribute(idRef(\\"label.owner.region\\", \\"displayForm\\"), a => a.localId(\\"a_label.owner.region\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35190,7 +35418,11 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35219,7 +35451,11 @@ const measures: IAttributeOrMeasure[] = [
 const rows: IAttribute[] = [
     newAttribute(idRef(\\"label.product.id.name\\", \\"displayForm\\"), a => a.localId(\\"a_label.product.id.name\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35263,7 +35499,11 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35309,7 +35549,11 @@ const totals: ITotal[] = [
     newTotal(\\"med\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\"),
     newTotal(\\"nat\\", \\"m_acugFHNJgsBy\\", \\"a_label.owner.department\\")
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {
@@ -35337,7 +35581,11 @@ const rows: IAttribute[] = [
     newAttribute(idRef(\\"created.aag81lMifn6q\\", \\"displayForm\\"), a => a.localId(\\"a_created.aag81lMifn6q\\")),
     newAttribute(idRef(\\"created.aag81lMifn6q\\", \\"displayForm\\"), a => a.localId(\\"a_created.aag81lMifn6q_1\\"))
 ];
-const config: IPivotTableConfig = {separators: {decimal: \\".\\", thousand: \\",\\"}};
+const config: IPivotTableConfig = {
+    columnSizing: {defaultWidth: \\"autoresizeAll\\"},
+    menu: {aggregations: true, aggregationsSubMenu: true},
+    separators: {decimal: \\".\\", thousand: \\",\\"}
+};
 const style = {height: 400};
 
 export function MyComponent() {

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/getReactEmbeddingCodeGenerator.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/getReactEmbeddingCodeGenerator.ts
@@ -95,12 +95,14 @@ const renderImports: (imports: IImportInfo[]) => string = flow(
 
         return compact([
             "import",
-            defaultImport?.name,
-            namedImports.length &&
-                `{ ${sortBy(
-                    namedImports.map((i) => i.name),
-                    (i) => i.toLowerCase(), // sort by lower case, otherwise "Z" would be before "a"
-                ).join(", ")} }`,
+            compact([
+                defaultImport?.name,
+                namedImports.length &&
+                    `{ ${sortBy(
+                        namedImports.map((i) => i.name),
+                        (i) => i.toLowerCase(), // sort by lower case, otherwise "Z" would be before "a"
+                    ).join(", ")} }`,
+            ]).join(", "),
             "from",
             `"${pkg}";`,
         ]).join(" ");

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/index.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/index.ts
@@ -14,5 +14,6 @@ export {
     sortsInsightConversion,
     totalsInsightConversion,
     IInsightToPropConversion,
+    localeInsightConversion,
 } from "./insightToPropsConverter";
 export * from "./types";

--- a/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/insightToPropsConverter/convenience.ts
+++ b/libs/sdk-ui-ext/src/internal/utils/embeddingCodeGenerator/insightToPropsConverter/convenience.ts
@@ -18,6 +18,7 @@ import {
     ITotal,
     relativeDateFilterValues,
 } from "@gooddata/sdk-model";
+import { DefaultLocale } from "@gooddata/sdk-ui";
 import isNil from "lodash/isNil";
 
 import { PropMeta } from "../types";
@@ -154,4 +155,22 @@ export function totalsInsightConversion<TProps extends object, TPropKey extends 
     propName: TPropKey,
 ): IInsightToPropConversion<TProps, TPropKey, ITotal[]> {
     return insightConversion(propName, sdkModelPropMetas.Total.Multiple, insightTotals);
+}
+
+/**
+ * Utility function for creating insight conversion for single {@link @gooddata/sdk-ui#ILocale} item.
+ */
+export function localeInsightConversion<TProps extends object, TPropKey extends keyof TProps>(
+    propName: TPropKey,
+): IInsightToPropConversion<TProps, TPropKey, string | undefined> {
+    return insightConversion(
+        propName,
+        {
+            cardinality: "scalar",
+        },
+        (_, ctx) => {
+            const val = ctx?.settings?.locale;
+            return val && val !== DefaultLocale ? val : undefined;
+        },
+    );
 }


### PR DESCRIPTION
* RAIL-4249 - Provide Mapbox token placeholder
* RAIL-4251 - Propagate enableJoinedAttributeAxisName
* RAIL-4252 - Handle enableChartSorting config
* RAIL-4253 - Fix pivot config in codegen: Now the config logic is reused from PluggablePivotTable. This means the menu config is now correct on both bear and tiger.
* RAIL-4260 - Handle locale in codegen

Also fix default and named imports from the same package at the same time.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
