### PR TITLE
RELATED: RAIL-4265 Fix executions without measures

### DIFF
--- a/libs/sdk-ui/src/execution/tests/Execute.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/Execute.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { mount } from "enzyme";
 import { dummyBackend, dummyBackendEmptyData } from "@gooddata/sdk-backend-mockingbird";
@@ -254,6 +254,7 @@ describe("createExecution", () => {
                 totals: [newTotal("sum", ReferenceMd.Amount, ReferenceMd.Product.Name)],
             },
         ],
+        ["unscoped series only with only attributes (RAIL-4265)", { seriesBy: [ReferenceMd.Product.Name] }],
     ];
 
     it.each(Scenarios)("should create correct definition for %s", (_desc, props) => {

--- a/libs/sdk-ui/src/execution/tests/__snapshots__/Execute.test.tsx.snap
+++ b/libs/sdk-ui/src/execution/tests/__snapshots__/Execute.test.tsx.snap
@@ -337,6 +337,35 @@ Object {
 }
 `;
 
+exports[`createExecution should create correct definition for unscoped series only with only attributes (RAIL-4265) 1`] = `
+Object {
+  "attributes": Array [
+    Object {
+      "attribute": Object {
+        "displayForm": Object {
+          "identifier": "label.product.id.name",
+          "type": "displayForm",
+        },
+        "localIdentifier": "a_label.product.id.name",
+      },
+    },
+  ],
+  "buckets": Array [],
+  "dimensions": Array [
+    Object {
+      "itemIdentifiers": Array [
+        "a_label.product.id.name",
+      ],
+    },
+  ],
+  "filters": Array [],
+  "measures": Array [],
+  "postProcessing": Object {},
+  "sortBy": Array [],
+  "workspace": "testWorkspace",
+}
+`;
+
 exports[`createExecution should create correct definition for unscoped series with slicing 1`] = `
 Object {
   "attributes": Array [


### PR DESCRIPTION
Previously, the MeasureGroupIdentifier was included even if the seriesBy had only attributes in it (a legit use case, like PivotTable with Rows only). This would make the backend throw a 400 complaining about it like

> "Specified 'measureGroup' but no measures found in AFM"

This makes sure the MeasureGroupIdentifier is there only if needed.

JIRA: RAIL-4265

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
