### PR TITLE
RELATED: RAIL-4228 Draft the API for AttributeFilterHandler

### DIFF
--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -201,6 +201,9 @@ export type DrillTransition = m.DrillTransition;
 export type DrillType = m.DrillType;
 
 // @public
+export type ElementsQueryOptionsElementsSpecification = IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByPrimaryDisplayFormValue | IElementsQueryOptionsElementsByUri;
+
+// @public
 export type ErrorConverter = (e: Error) => AnalyticalBackendError;
 
 // @internal
@@ -677,7 +680,7 @@ export interface IElementsQueryFactory {
 // @public
 export interface IElementsQueryOptions {
     complement?: boolean;
-    elements?: IElementsQueryOptionsElementsByValue | IElementsQueryOptionsElementsByPrimaryDisplayFormValue | IElementsQueryOptionsElementsByUri;
+    elements?: ElementsQueryOptionsElementsSpecification;
     excludePrimaryLabel?: boolean;
     filter?: string;
     includeTotalCountWithoutFilters?: boolean;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -59,6 +59,7 @@ export {
     IElementsQueryOptionsElementsByUri,
     IElementsQueryOptionsElementsByValue,
     IElementsQueryOptionsElementsByPrimaryDisplayFormValue,
+    ElementsQueryOptionsElementsSpecification,
     isElementsQueryOptionsElementsByValue,
     isElementsQueryOptionsElementsByPrimaryDisplayFormValue,
     isValueBasedElementsQueryOptionsElements,

--- a/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/attributes/elements/index.ts
@@ -86,6 +86,16 @@ export interface IElementsQueryOptionsElementsByUri {
 }
 
 /**
+ * Specification of particular elements to load in {@link IElementsQueryOptions}.
+ *
+ * @public
+ */
+export type ElementsQueryOptionsElementsSpecification =
+    | IElementsQueryOptionsElementsByValue
+    | IElementsQueryOptionsElementsByPrimaryDisplayFormValue
+    | IElementsQueryOptionsElementsByUri;
+
+/**
  * Configuration options for querying attribute elements
  *
  * @public
@@ -134,10 +144,7 @@ export interface IElementsQueryOptions {
      * @remarks
      * This is commonly used to preload selected elements in the attribute filter.
      */
-    elements?:
-        | IElementsQueryOptionsElementsByValue
-        | IElementsQueryOptionsElementsByPrimaryDisplayFormValue
-        | IElementsQueryOptionsElementsByUri;
+    elements?: ElementsQueryOptionsElementsSpecification;
 
     /**
      * Decides whether result will include also the primary label elements or only requested label ones.

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -8,10 +8,12 @@ import { AttributeFiltersOrPlaceholders } from '@gooddata/sdk-ui';
 import { DashboardDateFilterConfigMode } from '@gooddata/sdk-model';
 import { DateFilterGranularity } from '@gooddata/sdk-model';
 import { DateString } from '@gooddata/sdk-model';
+import { ElementsQueryOptionsElementsSpecification } from '@gooddata/sdk-backend-spi';
 import { IAbsoluteDateFilterForm } from '@gooddata/sdk-model';
 import { IAbsoluteDateFilterPreset } from '@gooddata/sdk-model';
 import { IAllTimeDateFilterOption } from '@gooddata/sdk-model';
 import { IAnalyticalBackend } from '@gooddata/sdk-backend-spi';
+import { IAttributeDisplayFormMetadataObject } from '@gooddata/sdk-model';
 import { IAttributeElement } from '@gooddata/sdk-model';
 import { IAttributeFilter } from '@gooddata/sdk-model';
 import { IDateFilter } from '@gooddata/sdk-model';
@@ -19,10 +21,12 @@ import { IElementsQueryAttributeFilter } from '@gooddata/sdk-backend-spi';
 import { IElementsQueryOptions } from '@gooddata/sdk-backend-spi';
 import { IElementsQueryResult } from '@gooddata/sdk-backend-spi';
 import { ILocale } from '@gooddata/sdk-ui';
+import { IMeasure } from '@gooddata/sdk-model';
 import { IMeasureValueFilter } from '@gooddata/sdk-model';
 import { IntlShape } from 'react-intl';
 import { IPlaceholder } from '@gooddata/sdk-ui';
 import { IRankingFilter } from '@gooddata/sdk-model';
+import { IRelativeDateFilter } from '@gooddata/sdk-model';
 import { IRelativeDateFilterForm } from '@gooddata/sdk-model';
 import { IRelativeDateFilterPreset } from '@gooddata/sdk-model';
 import { IRelativeDateFilterPresetOfGranularity } from '@gooddata/sdk-model';
@@ -40,11 +44,122 @@ export type AbsoluteDateFilterOption = IUiAbsoluteDateFilterForm | IAbsoluteDate
 // @public
 export const AttributeElements: React_2.ComponentType<IAttributeElementsProps>;
 
+// @internal (undocumented)
+export interface AttributeElementSelection {
+    // (undocumented)
+    isInverted: boolean;
+    // (undocumented)
+    items: string[];
+}
+
+// @internal (undocumented)
+export interface AttributeElementSelectionFull {
+    // (undocumented)
+    elements: IAttributeElement[];
+    // (undocumented)
+    isInverted: boolean;
+}
+
 // @public
 export const AttributeFilter: React_2.ComponentType<IAttributeFilterProps>;
 
 // @public (undocumented)
 export const AttributeFilterButton: React_2.FC<IAttributeFilterButtonOwnProps>;
+
+// @internal (undocumented)
+export class AttributeFilterHandler implements IAttributeFilterHandler {
+    constructor(config: IAttributeFilterHandlerConfig);
+    // (undocumented)
+    cancelDisplayFormInfoLoad: () => void;
+    // (undocumented)
+    cancelElementLoad(): void;
+    // (undocumented)
+    changeSelection: (selection: AttributeElementSelection) => void;
+    // (undocumented)
+    clearSelection: () => void;
+    // (undocumented)
+    commitSelection: () => void;
+    // (undocumented)
+    protected displayForm: ObjRef;
+    // (undocumented)
+    protected displayFormLoader: IAttributeDisplayFormLoader;
+    // (undocumented)
+    protected elementLoader: IAttributeElementLoader;
+    // (undocumented)
+    getAllItems: () => IAttributeElement[];
+    // (undocumented)
+    getCommittedSelection: () => AttributeElementSelection;
+    // (undocumented)
+    getCountWithCurrentSettings: () => number;
+    // (undocumented)
+    getDisplayFormInfo: () => Loadable<IAttributeDisplayFormMetadataObject>;
+    // (undocumented)
+    getFilter: () => IAttributeFilter;
+    // (undocumented)
+    getItemsByKey: (keys: string[]) => IAttributeElement[];
+    // (undocumented)
+    getLoadingStatus: () => LoadableStatus;
+    // (undocumented)
+    getSearch: () => string;
+    // (undocumented)
+    getSelectedItems: () => AttributeElementSelectionFull;
+    // (undocumented)
+    getTotalCount: () => number;
+    // (undocumented)
+    getWorkingSelection: () => AttributeElementSelection;
+    // (undocumented)
+    invertSelection: () => void;
+    // (undocumented)
+    protected isElementsByRef: boolean;
+    // (undocumented)
+    loadDisplayFormInfo: (correlation?: Correlation) => void;
+    // (undocumented)
+    loadElementsRange: (offset: number, limit: number, correlation?: Correlation) => void;
+    // (undocumented)
+    loadParticularElements: (elements: ElementsQueryOptionsElementsSpecification, correlation?: Correlation) => void;
+    // (undocumented)
+    onDisplayFormLoadCancel: CallbackRegistration;
+    // (undocumented)
+    onDisplayFormLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onDisplayFormLoadStart: CallbackRegistration;
+    // (undocumented)
+    onDisplayFormLoadSuccess: CallbackRegistration<{
+        displayForm: IAttributeDisplayFormMetadataObject;
+    }>;
+    // (undocumented)
+    onElementsRangeLoadCancel: CallbackRegistration;
+    // (undocumented)
+    onElementsRangeLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onElementsRangeLoadStart: CallbackRegistration;
+    // (undocumented)
+    onElementsRangeLoadSuccess: CallbackRegistration<IElementsLoadResult>;
+    // (undocumented)
+    onSelectionChanged: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    // (undocumented)
+    onSelectionCommitted: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    // (undocumented)
+    revertSelection: () => void;
+    // (undocumented)
+    setLimitingAttributeFilters: (filters: IElementsQueryAttributeFilter[], correlation?: Correlation) => void;
+    // (undocumented)
+    setLimitingDateFilters: (filters: IRelativeDateFilter[], correlation?: Correlation) => void;
+    // (undocumented)
+    setLimitingMeasures: (measures: IMeasure[], correlation?: Correlation) => void;
+    // (undocumented)
+    setSearch: (search: string, correlation?: Correlation) => void;
+    // (undocumented)
+    protected stagedSelectionHandler: IStagedAttributeElementsSelectionHandler;
+}
 
 // @alpha (undocumented)
 export class AttributeFilterLoader {
@@ -58,6 +173,20 @@ export class AttributeFilterLoader {
 
 // @public (undocumented)
 export type AttributeListItem = IAttributeElement | EmptyListItem;
+
+// @internal (undocumented)
+export type Callback<T extends object = {}> = (payload: CallbackPayload<T>) => void;
+
+// @internal (undocumented)
+export type CallbackPayload<T extends object = {}> = T & {
+    correlation?: Correlation;
+};
+
+// @internal (undocumented)
+export type CallbackRegistration<T extends object = {}> = (cb: Callback<T>) => Unsubscribe;
+
+// @internal (undocumented)
+export type Correlation = string;
 
 // @public
 export class DateFilter extends React_2.PureComponent<IDateFilterProps, IDateFilterState> {
@@ -104,8 +233,146 @@ export type DateFilterRelativeOptionGroup = {
     [key in DateFilterGranularity]?: Array<IRelativeDateFilterPresetOfGranularity<key>>;
 };
 
+// @internal (undocumented)
+export class DefaultAttributeDisplayFormLoader implements IAttributeDisplayFormLoader {
+    constructor(displayFormRef: ObjRef, backend: IAnalyticalBackend, workspace: string, displayFormLoad?: DisplayFormLoad);
+    // (undocumented)
+    cancelDisplayFormInfoLoad: () => void;
+    // (undocumented)
+    getDisplayFormInfo: () => Loadable<IAttributeDisplayFormMetadataObject>;
+    // (undocumented)
+    loadDisplayFormInfo: (correlation?: Correlation) => void;
+    // (undocumented)
+    onDisplayFormLoadCancel: CallbackRegistration<{}>;
+    // (undocumented)
+    onDisplayFormLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onDisplayFormLoadStart: CallbackRegistration<{}>;
+    // (undocumented)
+    onDisplayFormLoadSuccess: CallbackRegistration<{
+        displayForm: IAttributeDisplayFormMetadataObject;
+    }>;
+}
+
+// @internal (undocumented)
+export class DefaultAttributeElementsLoader implements IAttributeElementLoader {
+    constructor(displayFormRef: ObjRef, backend: IAnalyticalBackend, workspace: string, elementsLoad?: ElementsLoad);
+    // (undocumented)
+    cancelElementLoad: () => void;
+    // (undocumented)
+    getAllItems: () => IAttributeElement[];
+    // (undocumented)
+    getCountWithCurrentSettings: () => number;
+    // (undocumented)
+    getItemsByKey: (keys: string[]) => IAttributeElement[];
+    // (undocumented)
+    getLoadingStatus: () => LoadableStatus;
+    // (undocumented)
+    getSearch: () => string;
+    // (undocumented)
+    getTotalCount: () => number;
+    // (undocumented)
+    loadElementsRange: (offset: number, limit: number, correlation?: string) => void;
+    // (undocumented)
+    loadParticularElements: (elements: ElementsQueryOptionsElementsSpecification, correlation?: string) => void;
+    // (undocumented)
+    onElementsRangeLoadCancel: CallbackRegistration<{}>;
+    // (undocumented)
+    onElementsRangeLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onElementsRangeLoadStart: CallbackRegistration<{}>;
+    // (undocumented)
+    onElementsRangeLoadSuccess: CallbackRegistration<IElementsLoadResult>;
+    // (undocumented)
+    setLimitingAttributeFilters: (filters: IElementsQueryAttributeFilter[], _correlation?: Correlation) => void;
+    // (undocumented)
+    setLimitingDateFilters: (filters: IRelativeDateFilter[], _correlation?: Correlation) => void;
+    // (undocumented)
+    setLimitingMeasures: (measures: IMeasure[], _correlation?: Correlation) => void;
+    // (undocumented)
+    setSearch: (search: string, _correlation?: Correlation) => void;
+}
+
+// @internal (undocumented)
+export class DefaultAttributeElementsSelectionHandler implements IAttributeElementsSelectionHandler {
+    constructor(selection?: AttributeElementSelection);
+    // (undocumented)
+    changeSelection: (selection: AttributeElementSelection) => void;
+    // (undocumented)
+    clearSelection: () => void;
+    // (undocumented)
+    getSelection: () => AttributeElementSelection;
+    // (undocumented)
+    invertSelection: () => void;
+}
+
 // @public
 export const defaultDateFilterOptions: IDateFilterOptionsByType;
+
+// @internal (undocumented)
+export class DefaultStagedAttributeElementsSelectionHandler implements IStagedAttributeElementsSelectionHandler {
+    constructor(initialSelection?: AttributeElementSelection);
+    // (undocumented)
+    changeSelection: (selection: AttributeElementSelection, correlation?: Correlation) => void;
+    // (undocumented)
+    clearSelection: () => void;
+    // (undocumented)
+    commitSelection: (correlation?: Correlation) => void;
+    // (undocumented)
+    protected committedSelectionHandler: IAttributeElementsSelectionHandler;
+    // (undocumented)
+    getCommittedSelection: () => AttributeElementSelection;
+    // (undocumented)
+    getWorkingSelection: () => AttributeElementSelection;
+    // (undocumented)
+    invertSelection: () => void;
+    // (undocumented)
+    onSelectionChanged: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    // (undocumented)
+    onSelectionCommitted: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    // (undocumented)
+    revertSelection: (correlation?: Correlation) => void;
+    // (undocumented)
+    protected workingSelectionHandler: IAttributeElementsSelectionHandler;
+}
+
+// @internal (undocumented)
+export type DisplayFormLoad = (backend: IAnalyticalBackend, workspace: string, displayForm: ObjRef) => Promise<IAttributeDisplayFormMetadataObject>;
+
+// @internal (undocumented)
+export type ElementsLoad = (config: ElementsLoadConfig) => Promise<IElementsLoadResult>;
+
+// @internal (undocumented)
+export interface ElementsLoadConfig {
+    // (undocumented)
+    backend: IAnalyticalBackend;
+    // (undocumented)
+    displayForm: ObjRef;
+    // (undocumented)
+    elements?: ElementsQueryOptionsElementsSpecification;
+    // (undocumented)
+    limit: number;
+    // (undocumented)
+    limitingAttributeFilters?: IElementsQueryAttributeFilter[];
+    // (undocumented)
+    limitingDateFilters?: IRelativeDateFilter[];
+    // (undocumented)
+    limitingMeasures?: IMeasure[];
+    // (undocumented)
+    offset: number;
+    // (undocumented)
+    search?: string;
+    // (undocumented)
+    workspace: string;
+}
 
 // @public (undocumented)
 export interface EmptyListItem {
@@ -118,6 +385,25 @@ export function filterVisibleDateFilterOptions(dateFilterOptions: IDateFilterOpt
 
 // @beta (undocumented)
 export type GranularityIntlKey = "day" | "minute" | "hour" | "week" | "month" | "quarter" | "year";
+
+// @internal
+export interface IAttributeDisplayFormLoader {
+    cancelDisplayFormInfoLoad(): void;
+    getDisplayFormInfo(): Loadable<IAttributeDisplayFormMetadataObject>;
+    loadDisplayFormInfo(correlation?: Correlation): void;
+    // (undocumented)
+    onDisplayFormLoadCancel: CallbackRegistration;
+    // (undocumented)
+    onDisplayFormLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onDisplayFormLoadStart: CallbackRegistration;
+    // (undocumented)
+    onDisplayFormLoadSuccess: CallbackRegistration<{
+        displayForm: IAttributeDisplayFormMetadataObject;
+    }>;
+}
 
 // @public (undocumented)
 export interface IAttributeDropdownBodyExtendedProps extends IAttributeDropdownBodyProps {
@@ -209,6 +495,39 @@ export interface IAttributeDropdownListItemProps extends WrappedComponentProps {
     source?: any;
 }
 
+// @internal
+export interface IAttributeElementLoader {
+    cancelElementLoad(): void;
+    // (undocumented)
+    getAllItems(): IAttributeElement[];
+    // (undocumented)
+    getCountWithCurrentSettings(): number;
+    // (undocumented)
+    getItemsByKey(keys: string[]): IAttributeElement[];
+    // (undocumented)
+    getLoadingStatus(): LoadableStatus;
+    // (undocumented)
+    getSearch(): string;
+    // (undocumented)
+    getTotalCount(): number;
+    loadElementsRange(offset: number, limit: number, correlation?: Correlation): void;
+    loadParticularElements(elements: ElementsQueryOptionsElementsSpecification, correlation?: Correlation): void;
+    // (undocumented)
+    onElementsRangeLoadCancel: CallbackRegistration;
+    // (undocumented)
+    onElementsRangeLoadError: CallbackRegistration<{
+        error: Error;
+    }>;
+    // (undocumented)
+    onElementsRangeLoadStart: CallbackRegistration;
+    // (undocumented)
+    onElementsRangeLoadSuccess: CallbackRegistration<IElementsLoadResult>;
+    setLimitingAttributeFilters(filters: IElementsQueryAttributeFilter[], correlation?: Correlation): void;
+    setLimitingDateFilters(filters: IRelativeDateFilter[], correlation?: Correlation): void;
+    setLimitingMeasures(measures: IMeasure[], correlation?: Correlation): void;
+    setSearch(search: string, correlation?: Correlation): void;
+}
+
 // @public
 export interface IAttributeElementsChildren {
     error: any;
@@ -229,6 +548,18 @@ export interface IAttributeElementsProps {
     onError?: OnError;
     options?: IElementsQueryOptions;
     workspace?: string;
+}
+
+// @internal
+export interface IAttributeElementsSelectionHandler {
+    // (undocumented)
+    changeSelection(selection: AttributeElementSelection): void;
+    // (undocumented)
+    clearSelection(): void;
+    // (undocumented)
+    getSelection(): AttributeElementSelection;
+    // (undocumented)
+    invertSelection(): void;
 }
 
 // @public (undocumented)
@@ -253,6 +584,26 @@ export interface IAttributeFilterButtonOwnProps {
 
 // @public (undocumented)
 export type IAttributeFilterButtonProps = IAttributeFilterButtonOwnProps & WrappedComponentProps;
+
+// @internal
+export interface IAttributeFilterHandler extends IAttributeDisplayFormLoader, IAttributeElementLoader, IStagedAttributeElementsSelectionHandler {
+    getFilter(): IAttributeFilter;
+    getSelectedItems(): AttributeElementSelectionFull;
+}
+
+// @internal (undocumented)
+export interface IAttributeFilterHandlerConfig {
+    // (undocumented)
+    readonly backend: IAnalyticalBackend;
+    // (undocumented)
+    readonly displayFormLoad?: DisplayFormLoad;
+    // (undocumented)
+    readonly elementsLoad?: ElementsLoad;
+    // (undocumented)
+    readonly filter: IAttributeFilter;
+    // (undocumented)
+    readonly workspace: string;
+}
 
 // @public (undocumented)
 export interface IAttributeFilterProps {
@@ -373,10 +724,30 @@ export interface IDateTranslator {
     formatDate: IntlShape["formatDate"];
 }
 
+// @internal (undocumented)
+export interface IElementsLoadResult {
+    // (undocumented)
+    readonly items: IAttributeElement[];
+    // (undocumented)
+    readonly limit: number;
+    // (undocumented)
+    readonly offset: number;
+    // (undocumented)
+    readonly totalCount: number;
+}
+
 // @public
 export interface IExtendedDateFilterErrors {
     absoluteForm?: IDateFilterAbsoluteFormErrors;
     relativeForm?: IDateFilterRelativeFormErrors;
+}
+
+// @internal (undocumented)
+export interface ILoadRangeOptions {
+    // (undocumented)
+    readonly limit: number;
+    // (undocumented)
+    readonly offset: number;
 }
 
 // @beta (undocumented)
@@ -505,6 +876,24 @@ export const isNonEmptyListItem: (item: Partial<AttributeListItem>) => item is I
 // @public
 export const isRelativeDateFilterOption: (obj: unknown) => obj is RelativeDateFilterOption;
 
+// @internal
+export interface IStagedAttributeElementsSelectionHandler extends Omit<IAttributeElementsSelectionHandler, "getSelection"> {
+    commitSelection(): void;
+    // (undocumented)
+    getCommittedSelection(): AttributeElementSelection;
+    // (undocumented)
+    getWorkingSelection(): AttributeElementSelection;
+    // (undocumented)
+    onSelectionChanged: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    // (undocumented)
+    onSelectionCommitted: CallbackRegistration<{
+        selection: AttributeElementSelection;
+    }>;
+    revertSelection(): void;
+}
+
 // @public
 export const isUiRelativeDateFilterForm: (obj: unknown) => obj is IUiRelativeDateFilterForm;
 
@@ -525,6 +914,40 @@ export interface IUiRelativeDateFilterForm extends Omit<IRelativeDateFilterForm,
 export type IWarningMessage = {
     text: string;
     severity: "low" | "medium" | "high";
+};
+
+// @internal
+export type Loadable<TResult, TError = Error> = LoadablePending | LoadableLoading | LoadableError<TError> | LoadableSuccess<TResult>;
+
+// @internal
+export type LoadableError<TError> = {
+    result: undefined;
+    error: TError;
+    status: "error";
+};
+
+// @internal
+export type LoadableLoading = {
+    result: undefined;
+    error: undefined;
+    status: "loading";
+};
+
+// @internal
+export type LoadablePending = {
+    result: undefined;
+    error: undefined;
+    status: "pending";
+};
+
+// @internal
+export type LoadableStatus = Loadable<any, any>["status"];
+
+// @internal
+export type LoadableSuccess<TResult> = {
+    result: TResult;
+    error: undefined;
+    status: "success";
 };
 
 // @beta (undocumented)
@@ -553,6 +976,9 @@ export const RankingFilterDropdown: React_2.FC<IRankingFilterDropdownProps>;
 
 // @public
 export type RelativeDateFilterOption = IUiRelativeDateFilterForm | IRelativeDateFilterPreset;
+
+// @internal (undocumented)
+export type Unsubscribe = () => void;
 
 // @beta (undocumented)
 export type WarningMessage = string | IWarningMessage;

--- a/libs/sdk-ui-filters/package.json
+++ b/libs/sdk-ui-filters/package.json
@@ -132,6 +132,7 @@
         "stylelint-config-prettier": "^8.0.2",
         "ts-jest": "^27.0.5",
         "typescript": "4.0.2",
-        "eslint-plugin-tsdoc": "^0.2.14"
+        "eslint-plugin-tsdoc": "^0.2.14",
+        "@types/uuid": "^8.3.4"
     }
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler.ts
@@ -1,0 +1,970 @@
+// (C) 2022 GoodData Corporation
+/* eslint-disable @typescript-eslint/ban-types */
+import { v4 as uuid } from "uuid";
+import {
+    ElementsQueryOptionsElementsSpecification,
+    IAnalyticalBackend,
+    IElementsQueryAttributeFilter,
+} from "@gooddata/sdk-backend-spi";
+import {
+    IAttributeElement,
+    IAttributeDisplayFormMetadataObject,
+    ObjRef,
+    IAttributeFilter,
+    filterObjRef,
+    newNegativeAttributeFilter,
+    newPositiveAttributeFilter,
+    isNegativeAttributeFilter,
+    filterAttributeElements,
+    isAttributeElementsByRef,
+    IAttributeElements,
+    IMeasure,
+    IRelativeDateFilter,
+} from "@gooddata/sdk-model";
+
+/**
+ * @internal
+ */
+export interface IElementsLoadResult {
+    readonly items: IAttributeElement[];
+    readonly limit: number;
+    readonly offset: number;
+    readonly totalCount: number;
+}
+
+/**
+ * @internal
+ */
+export interface ILoadRangeOptions {
+    readonly limit: number;
+    readonly offset: number;
+}
+
+/**
+ * @internal
+ */
+export type Correlation = string;
+/**
+ * @internal
+ */
+export type Unsubscribe = () => void;
+/**
+ * @internal
+ */
+export type CallbackPayload<T extends object = {}> = T & { correlation?: Correlation };
+/**
+ * @internal
+ */
+export type Callback<T extends object = {}> = (payload: CallbackPayload<T>) => void;
+/**
+ * @internal
+ */
+export type CallbackRegistration<T extends object = {}> = (cb: Callback<T>) => Unsubscribe;
+
+/**
+ * @internal
+ */
+export interface AttributeElementSelection {
+    items: string[];
+    isInverted: boolean;
+}
+
+/**
+ * @internal
+ */
+export interface AttributeElementSelectionFull {
+    elements: IAttributeElement[];
+    isInverted: boolean;
+}
+
+/**
+ * @internal
+ */
+export type DisplayFormLoad = (
+    backend: IAnalyticalBackend,
+    workspace: string,
+    displayForm: ObjRef,
+) => Promise<IAttributeDisplayFormMetadataObject>;
+
+/**
+ * @internal
+ */
+export interface ElementsLoadConfig {
+    backend: IAnalyticalBackend;
+    workspace: string;
+    displayForm: ObjRef;
+    offset: number;
+    limit: number;
+    search?: string;
+    limitingAttributeFilters?: IElementsQueryAttributeFilter[];
+    limitingMeasures?: IMeasure[];
+    limitingDateFilters?: IRelativeDateFilter[];
+    elements?: ElementsQueryOptionsElementsSpecification;
+}
+
+/**
+ * @internal
+ */
+export type ElementsLoad = (config: ElementsLoadConfig) => Promise<IElementsLoadResult>;
+
+/**
+ * Indicates pending state of a loadable item.
+ * @internal
+ */
+export type LoadablePending = {
+    result: undefined;
+    error: undefined;
+    status: "pending";
+};
+
+/**
+ * Indicates loading state of a loadable item.
+ * @internal
+ */
+export type LoadableLoading = {
+    result: undefined;
+    error: undefined;
+    status: "loading";
+};
+
+/**
+ * Indicates error state of a loadable item.
+ * @internal
+ */
+export type LoadableError<TError> = {
+    result: undefined;
+    error: TError;
+    status: "error";
+};
+
+/**
+ * Indicates success state of a loadable item.
+ * @internal
+ */
+export type LoadableSuccess<TResult> = {
+    result: TResult;
+    error: undefined;
+    status: "success";
+};
+
+/**
+ * Indicates the current state of a loadable item.
+ * @internal
+ */
+export type Loadable<TResult, TError = Error> =
+    | LoadablePending
+    | LoadableLoading
+    | LoadableError<TError>
+    | LoadableSuccess<TResult>;
+
+/**
+ * Indicates the current state of the promise inside of a loadable item.
+ * @internal
+ */
+export type LoadableStatus = Loadable<any, any>["status"];
+
+//
+//
+//
+
+/**
+ * Handles the loading of the display form info (e.g. its title).
+ * @internal
+ */
+export interface IAttributeDisplayFormLoader {
+    // manipulators
+    /**
+     * Trigger the load of the display form handled by this handler.
+     *
+     * @remarks
+     * You can provide a correlation value that will be included in all the events fired by this.
+     * This is useful if you want to "pair" loading and loaded events from the same initiated by the same
+     * loadDisplayFormInfo call.
+     *
+     * @param correlation - the correlation value
+     */
+    loadDisplayFormInfo(correlation?: Correlation): void;
+    /**
+     * Cancel the loading of the display form if any is in progress.
+     */
+    cancelDisplayFormInfoLoad(): void;
+    // selectors
+    /**
+     * Get the currently loaded value of the display form.
+     * @privateRemarks
+     */
+    getDisplayFormInfo(): Loadable<IAttributeDisplayFormMetadataObject>;
+    // callbacks
+    onDisplayFormLoadStart: CallbackRegistration;
+    onDisplayFormLoadSuccess: CallbackRegistration<{ displayForm: IAttributeDisplayFormMetadataObject }>;
+    onDisplayFormLoadError: CallbackRegistration<{ error: Error }>;
+    onDisplayFormLoadCancel: CallbackRegistration;
+}
+
+/**
+ * Handles the loading of the elements
+ * @internal
+ */
+export interface IAttributeElementLoader {
+    // manipulators
+    /**
+     * Trigger the load of a attribute elements range.
+     *
+     * @remarks
+     * Will cancel any running loads if there are any.
+     *
+     * You can provide a correlation value that will be included in all the events fired by this.
+     * This is useful if you want to "pair" loading and loaded events from the same initiated by the same
+     * loadElementsRange call.
+     *
+     * @param offset - the number of elements to skip
+     * @param limit - the number of elements to load
+     * @param correlation - the correlation value
+     */
+    loadElementsRange(offset: number, limit: number, correlation?: Correlation): void;
+    /**
+     * Trigger a load of elements specified.
+     *
+     * @remarks
+     * Will cancel any running loads if there are any.
+     *
+     * You can provide a correlation value that will be included in all the events fired by this.
+     * This is useful if you want to "pair" loading and loaded events from the same initiated by the same
+     * loadElementsRange call.
+     *
+     * @param elements - the elements to load
+     * @param correlation - the correlation value
+     */
+    loadParticularElements(
+        elements: ElementsQueryOptionsElementsSpecification,
+        correlation?: Correlation,
+    ): void;
+    /**
+     * Set the search value used to filter the elements.
+     *
+     * @remarks
+     * MUST NOT trigger a page load. MUST reset any loaded elements as they are no longer relevant.
+     *
+     * You can provide a correlation value that will be included in all the events fired by this.
+     * This is useful if you want to "pair" loading and loaded events from the same initiated by the same
+     * loadElementsRange call.
+     *
+     * @param search - the search string to use. Use empty string to reset search.
+     * @param correlation - the correlation value // TODO is this useful here?
+     */
+    setSearch(search: string, correlation?: Correlation): void;
+    /**
+     * Set the measure that will limit the available elements.
+     *
+     * @param measures - the measures to use
+     * @param correlation - the correlation value // TODO is this useful here?
+     */
+    setLimitingMeasures(measures: IMeasure[], correlation?: Correlation): void;
+    /**
+     * Set the attribute filters that will limit the available elements.
+     *
+     * @param filters - the filters to use
+     * @param correlation - the correlation value // TODO is this useful here?
+     */
+    setLimitingAttributeFilters(filters: IElementsQueryAttributeFilter[], correlation?: Correlation): void;
+    /**
+     * Set the date filters that will limit the available elements.
+     *
+     * @param filters - the filters to use
+     * @param correlation - the correlation value // TODO is this useful here?
+     */
+    setLimitingDateFilters(filters: IRelativeDateFilter[], correlation?: Correlation): void;
+    /**
+     * Cancel any loading of the elements if any is in progress.
+     */
+    cancelElementLoad(): void;
+    // selectors
+    getAllItems(): IAttributeElement[];
+    getItemsByKey(keys: string[]): IAttributeElement[];
+    getSearch(): string;
+    getTotalCount(): number;
+    getCountWithCurrentSettings(): number;
+    getLoadingStatus(): LoadableStatus;
+    // callbacks
+    onElementsRangeLoadStart: CallbackRegistration;
+    onElementsRangeLoadSuccess: CallbackRegistration<IElementsLoadResult>;
+    onElementsRangeLoadError: CallbackRegistration<{ error: Error }>;
+    onElementsRangeLoadCancel: CallbackRegistration;
+}
+
+/**
+ * Handles simple selection of items
+ * @internal
+ */
+export interface IAttributeElementsSelectionHandler {
+    // manipulators
+    changeSelection(selection: AttributeElementSelection): void;
+    invertSelection(): void;
+    clearSelection(): void;
+    // selectors
+    getSelection(): AttributeElementSelection;
+}
+
+/**
+ * Handles selection of items with stages: working and committed.
+ * @internal
+ */
+export interface IStagedAttributeElementsSelectionHandler
+    extends Omit<IAttributeElementsSelectionHandler, "getSelection"> {
+    // manipulators
+    /**
+     * Commit the current working selection making it the new committed selection.
+     */
+    commitSelection(): void;
+    /**
+     * Revert the current working selection by resetting it to the committed selection.
+     */
+    revertSelection(): void;
+    // selectors
+    getWorkingSelection(): AttributeElementSelection;
+    getCommittedSelection(): AttributeElementSelection;
+    // callbacks
+    onSelectionChanged: CallbackRegistration<{ selection: AttributeElementSelection }>;
+    onSelectionCommitted: CallbackRegistration<{ selection: AttributeElementSelection }>;
+}
+
+/**
+ * Handles the whole attribute filter experience
+ * @internal
+ */
+export interface IAttributeFilterHandler
+    extends IAttributeDisplayFormLoader,
+        IAttributeElementLoader,
+        IStagedAttributeElementsSelectionHandler {
+    // selectors
+    /**
+     * Get the currently selected attribute elements (using the working selection).
+     */
+    getSelectedItems(): AttributeElementSelectionFull;
+    /**
+     * Get the effective filter (using the committed selection).
+     */
+    getFilter(): IAttributeFilter;
+}
+
+//
+//
+//
+
+const defaultDisplayFormLoad: DisplayFormLoad = (backend, workspace, displayForm) => {
+    return backend.workspace(workspace).attributes().getAttributeDisplayForm(displayForm);
+};
+
+const defaultElementsLoad: ElementsLoad = (config) => {
+    const {
+        backend,
+        displayForm,
+        limit,
+        offset,
+        workspace,
+        limitingAttributeFilters,
+        limitingDateFilters,
+        limitingMeasures,
+        search,
+        elements,
+    } = config;
+    let loader = backend.workspace(workspace).attributes().elements().forDisplayForm(displayForm);
+    if (limit) {
+        loader = loader.withLimit(limit);
+    }
+    if (offset) {
+        loader = loader.withOffset(limit);
+    }
+    if (search || elements) {
+        loader = loader.withOptions({ filter: search, elements });
+    }
+    if (limitingDateFilters) {
+        loader = loader.withDateFilters(limitingDateFilters);
+    }
+    if (limitingAttributeFilters) {
+        loader = loader.withAttributeFilters(limitingAttributeFilters);
+    }
+    if (limitingMeasures) {
+        loader = loader.withMeasures(limitingMeasures);
+    }
+
+    return loader.query().then((res) => ({
+        items: res.items,
+        limit: res.limit,
+        offset: res.offset,
+        totalCount: res.totalCount,
+    }));
+};
+
+const newCallbackHandler = <T extends object = {}>() => {
+    let subscribers: Array<Callback<T>> = [];
+    const subscribe: CallbackRegistration<T> = (cb) => {
+        subscribers.push(cb);
+        return () => {
+            subscribers = subscribers.filter((i) => i != cb);
+        };
+    };
+    const triggerAll = (payload: CallbackPayload<T>) => {
+        subscribers.forEach((cb) => cb(payload));
+    };
+
+    return {
+        triggerAll,
+        subscribe,
+    };
+};
+
+// TODO: element load: parent filtered, measure filtered, date filtered, custom
+
+/**
+ * @internal
+ */
+export class DefaultAttributeElementsSelectionHandler implements IAttributeElementsSelectionHandler {
+    private selection: AttributeElementSelection;
+
+    constructor(selection?: AttributeElementSelection) {
+        this.selection = selection ?? { isInverted: true, items: [] };
+    }
+
+    // manipulators
+    changeSelection = (selection: AttributeElementSelection): void => {
+        this.selection = selection;
+    };
+
+    invertSelection = (): void => {
+        const current = this.getSelection();
+        this.changeSelection({ ...current, isInverted: !current.isInverted });
+    };
+
+    clearSelection = (): void => {
+        this.changeSelection({ isInverted: true, items: [] });
+    };
+
+    // selectors
+    getSelection = (): AttributeElementSelection => {
+        return this.selection;
+    };
+}
+
+/**
+ * @internal
+ */
+export class DefaultStagedAttributeElementsSelectionHandler
+    implements IStagedAttributeElementsSelectionHandler
+{
+    protected committedSelectionHandler: IAttributeElementsSelectionHandler;
+    protected workingSelectionHandler: IAttributeElementsSelectionHandler;
+
+    private onSelectionChangedHandler = newCallbackHandler<{ selection: AttributeElementSelection }>();
+    private onSelectionConfirmedHandler = newCallbackHandler<{ selection: AttributeElementSelection }>();
+
+    constructor(initialSelection: AttributeElementSelection = { isInverted: true, items: [] }) {
+        this.committedSelectionHandler = new DefaultAttributeElementsSelectionHandler(initialSelection);
+        this.workingSelectionHandler = new DefaultAttributeElementsSelectionHandler(initialSelection);
+    }
+
+    // manipulators
+    commitSelection = (correlation: Correlation = uuid()): void => {
+        this.committedSelectionHandler = { ...this.workingSelectionHandler };
+        this.onSelectionConfirmedHandler.triggerAll({
+            correlation,
+            selection: this.committedSelectionHandler.getSelection(),
+        });
+    };
+
+    revertSelection = (correlation: Correlation = uuid()): void => {
+        this.workingSelectionHandler = { ...this.committedSelectionHandler };
+        this.onSelectionChangedHandler.triggerAll({
+            correlation,
+            selection: this.committedSelectionHandler.getSelection(),
+        });
+    };
+
+    changeSelection = (selection: AttributeElementSelection, correlation: Correlation = uuid()): void => {
+        this.workingSelectionHandler.changeSelection(selection);
+        this.onSelectionChangedHandler.triggerAll({
+            correlation,
+            selection: this.workingSelectionHandler.getSelection(),
+        });
+    };
+
+    invertSelection = (): void => {
+        const current = this.getWorkingSelection();
+        this.changeSelection({
+            ...current,
+            isInverted: !current.isInverted,
+        });
+    };
+
+    clearSelection = (): void => {
+        this.changeSelection({ isInverted: true, items: [] });
+    };
+
+    // selectors
+    getWorkingSelection = (): AttributeElementSelection => {
+        return this.workingSelectionHandler.getSelection();
+    };
+
+    getCommittedSelection = (): AttributeElementSelection => {
+        return this.committedSelectionHandler.getSelection();
+    };
+
+    // callbacks
+    onSelectionChanged = this.onSelectionChangedHandler.subscribe;
+    onSelectionCommitted = this.onSelectionChangedHandler.subscribe;
+}
+
+/**
+ * @internal
+ */
+export class DefaultAttributeDisplayFormLoader implements IAttributeDisplayFormLoader {
+    private displayForm: Loadable<IAttributeDisplayFormMetadataObject> = {
+        status: "pending",
+        result: undefined,
+        error: undefined,
+    };
+
+    private onLoaded = newCallbackHandler<{ displayForm: IAttributeDisplayFormMetadataObject }>();
+    private onLoading = newCallbackHandler();
+    private onError = newCallbackHandler<{ error: Error }>();
+    private onCancelled = newCallbackHandler();
+
+    constructor(
+        private readonly displayFormRef: ObjRef,
+        private readonly backend: IAnalyticalBackend,
+        private readonly workspace: string,
+        private readonly displayFormLoad: DisplayFormLoad = defaultDisplayFormLoad,
+    ) {}
+
+    // manipulators
+    loadDisplayFormInfo = (correlation?: Correlation): void => {
+        this.onLoading.triggerAll({ correlation });
+        this.displayForm = { status: "loading", result: undefined, error: undefined };
+        this.displayFormLoad(this.backend, this.workspace, this.displayFormRef)
+            .then((displayForm) => {
+                this.displayForm = { status: "success", result: displayForm, error: undefined };
+                this.onLoaded.triggerAll({ correlation, displayForm });
+            })
+            .catch((error: Error) => {
+                if (error.name === "AbortError") {
+                    this.onCancelled.triggerAll({ correlation });
+                } else {
+                    this.onError.triggerAll({ correlation, error });
+                }
+                this.displayForm = { status: "error", error, result: undefined };
+            });
+    };
+
+    cancelDisplayFormInfoLoad = (): void => {
+        // TODO: actually cancel
+    };
+
+    // selectors
+    getDisplayFormInfo = (): Loadable<IAttributeDisplayFormMetadataObject> => {
+        return this.displayForm;
+    };
+
+    // callbacks
+    onDisplayFormLoadSuccess = this.onLoaded.subscribe;
+    onDisplayFormLoadStart = this.onLoading.subscribe;
+    onDisplayFormLoadError = this.onError.subscribe;
+    onDisplayFormLoadCancel = this.onCancelled.subscribe;
+}
+
+/**
+ * @internal
+ */
+export class DefaultAttributeElementsLoader implements IAttributeElementLoader {
+    private search: string | undefined;
+    private items: IAttributeElement[] = [];
+    private dictionary: Map<string, IAttributeElement> = new Map();
+    private totalCount: number = -1;
+    private currentSettingsCount: number = -1;
+    private limitingMeasures: IMeasure[] = [];
+    private limitingAttributeFilters: IElementsQueryAttributeFilter[] = [];
+    private limitingDateFilters: IRelativeDateFilter[] = [];
+    private loadingStatus: LoadableStatus = "pending";
+
+    private onLoaded = newCallbackHandler<IElementsLoadResult>();
+    private onLoading = newCallbackHandler();
+    private onError = newCallbackHandler<{ error: Error }>();
+    private onCancelled = newCallbackHandler();
+
+    constructor(
+        private readonly displayFormRef: ObjRef,
+        private readonly backend: IAnalyticalBackend,
+        private readonly workspace: string,
+        private readonly elementsLoad: ElementsLoad = defaultElementsLoad,
+    ) {
+        this.loadTotalCount();
+    }
+
+    // manipulators
+    private loadTotalCount = (): void => {
+        this.elementsLoad({
+            backend: this.backend,
+            workspace: this.workspace,
+            displayForm: this.displayFormRef,
+            offset: 0,
+            limit: 1,
+            search: "",
+        }).then((res) => {
+            this.totalCount = res.totalCount;
+        });
+    };
+
+    loadElementsRange = (offset: number, limit: number, correlation?: string): void => {
+        this.onLoading.triggerAll({ correlation });
+        this.loadingStatus = "loading";
+        this.elementsLoad({
+            backend: this.backend,
+            workspace: this.workspace,
+            displayForm: this.displayFormRef,
+            offset,
+            limit,
+            search: this.search,
+            limitingMeasures: this.limitingMeasures,
+            limitingAttributeFilters: this.limitingAttributeFilters,
+            limitingDateFilters: this.limitingDateFilters,
+        })
+            .then((res) => {
+                this.items.push(...res.items); // TODO actually merge
+                res.items.forEach((item) => {
+                    this.dictionary.set(item.uri, item);
+                });
+                this.currentSettingsCount = res.totalCount;
+                this.onLoaded.triggerAll({ correlation, ...res });
+                this.loadingStatus = "success";
+            })
+            // eslint-disable-next-line sonarjs/no-identical-functions
+            .catch((error: Error) => {
+                if (error.name === "AbortError") {
+                    this.onCancelled.triggerAll({ correlation });
+                } else {
+                    this.onError.triggerAll({ correlation, error });
+                }
+                this.loadingStatus = "error";
+            });
+    };
+
+    loadParticularElements = (
+        elements: ElementsQueryOptionsElementsSpecification,
+        correlation?: string,
+    ): void => {
+        this.onLoading.triggerAll({ correlation });
+        this.elementsLoad({
+            backend: this.backend,
+            workspace: this.workspace,
+            displayForm: this.displayFormRef,
+            limit: 1000, // TODO actual max limit or length of elements?
+            offset: 0,
+            elements,
+        })
+            .then((res) => {
+                res.items.forEach((item) => {
+                    this.dictionary.set(item.uri, item);
+                });
+                this.onLoaded.triggerAll({ correlation, ...res });
+            })
+            // eslint-disable-next-line sonarjs/no-identical-functions
+            .catch((error: Error) => {
+                if (error.name === "AbortError") {
+                    this.onCancelled.triggerAll({ correlation });
+                } else {
+                    this.onError.triggerAll({ correlation, error });
+                }
+            });
+    };
+
+    setSearch = (search: string, _correlation?: Correlation): void => {
+        this.cancelElementLoad();
+        this.search = search;
+        this.items = [];
+        this.currentSettingsCount = -1;
+    };
+
+    setLimitingMeasures = (measures: IMeasure[], _correlation?: Correlation): void => {
+        this.cancelElementLoad();
+        this.limitingMeasures = measures;
+        this.items = [];
+        this.currentSettingsCount = -1;
+    };
+
+    setLimitingAttributeFilters = (
+        filters: IElementsQueryAttributeFilter[],
+        _correlation?: Correlation,
+    ): void => {
+        this.cancelElementLoad();
+        this.limitingAttributeFilters = filters;
+        this.items = [];
+        this.currentSettingsCount = -1;
+    };
+
+    setLimitingDateFilters = (filters: IRelativeDateFilter[], _correlation?: Correlation): void => {
+        this.cancelElementLoad();
+        this.limitingDateFilters = filters;
+        this.items = [];
+        this.currentSettingsCount = -1;
+    };
+
+    getSearch = (): string => {
+        return this.search ?? "";
+    };
+
+    cancelElementLoad = (): void => {
+        // TODO actually cancel
+    };
+
+    // selectors
+    getAllItems = (): IAttributeElement[] => {
+        return this.items;
+    };
+
+    getItemsByKey = (keys: string[]): IAttributeElement[] => {
+        return keys.map((key) => this.dictionary.get(key));
+    };
+
+    getTotalCount = (): number => {
+        return this.totalCount;
+    };
+
+    getCountWithCurrentSettings = (): number => {
+        return this.currentSettingsCount;
+    };
+
+    getLoadingStatus = (): LoadableStatus => {
+        return this.loadingStatus;
+    };
+
+    // callbacks
+    onElementsRangeLoadSuccess = this.onLoaded.subscribe;
+    onElementsRangeLoadStart = this.onLoading.subscribe;
+    onElementsRangeLoadError = this.onError.subscribe;
+    onElementsRangeLoadCancel = this.onCancelled.subscribe;
+}
+
+/**
+ * @internal
+ */
+export interface IAttributeFilterHandlerConfig {
+    readonly backend: IAnalyticalBackend;
+    readonly workspace: string;
+    readonly filter: IAttributeFilter;
+    readonly displayFormLoad?: DisplayFormLoad;
+    readonly elementsLoad?: ElementsLoad;
+}
+
+/**
+ * @internal
+ */
+export class AttributeFilterHandler implements IAttributeFilterHandler {
+    protected displayFormLoader: IAttributeDisplayFormLoader;
+    protected elementLoader: IAttributeElementLoader;
+    protected stagedSelectionHandler: IStagedAttributeElementsSelectionHandler;
+    protected displayForm: ObjRef;
+    protected isElementsByRef: boolean;
+
+    constructor(config: IAttributeFilterHandlerConfig) {
+        this.displayForm = filterObjRef(config.filter);
+        this.displayFormLoader = new DefaultAttributeDisplayFormLoader(
+            this.displayForm,
+            config.backend,
+            config.workspace,
+            config.displayFormLoad,
+        );
+
+        const elements = filterAttributeElements(config.filter);
+        const initialSelection: AttributeElementSelection = {
+            isInverted: isNegativeAttributeFilter(config.filter),
+            items: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
+        };
+        this.isElementsByRef = isAttributeElementsByRef(elements);
+        this.stagedSelectionHandler = new DefaultStagedAttributeElementsSelectionHandler(initialSelection);
+
+        this.elementLoader = new DefaultAttributeElementsLoader(
+            this.displayForm,
+            config.backend,
+            config.workspace,
+            config.elementsLoad,
+        );
+
+        this.init(initialSelection);
+    }
+
+    private init = (selection: AttributeElementSelection) => {
+        const correlation = "__INIT__";
+        this.loadDisplayFormInfo(correlation);
+        this.ensureSelectionLoaded(selection, correlation);
+    };
+
+    private ensureSelectionLoaded = (selection: AttributeElementSelection, correlation: Correlation) => {
+        this.elementLoader.loadParticularElements(
+            {
+                uris: selection.items, // TODO detect other types of filters: value, primaryValue,...
+            },
+            correlation,
+        );
+    };
+
+    // manipulators
+    clearSelection = (): void => {
+        return this.stagedSelectionHandler.clearSelection();
+    };
+
+    revertSelection = (): void => {
+        return this.stagedSelectionHandler.revertSelection();
+    };
+
+    changeSelection = (selection: AttributeElementSelection): void => {
+        return this.stagedSelectionHandler.changeSelection(selection);
+    };
+
+    invertSelection = (): void => {
+        return this.stagedSelectionHandler.invertSelection();
+    };
+
+    commitSelection = (): void => {
+        return this.stagedSelectionHandler.commitSelection();
+    };
+
+    loadDisplayFormInfo = (correlation: Correlation = uuid()): void => {
+        return this.displayFormLoader.loadDisplayFormInfo(correlation);
+    };
+
+    cancelDisplayFormInfoLoad = (): void => {
+        return this.displayFormLoader.cancelDisplayFormInfoLoad();
+    };
+
+    loadElementsRange = (offset: number, limit: number, correlation: Correlation = uuid()): void => {
+        return this.elementLoader.loadElementsRange(offset, limit, correlation);
+    };
+
+    loadParticularElements = (
+        elements: ElementsQueryOptionsElementsSpecification,
+        correlation: Correlation = uuid(),
+    ): void => {
+        return this.elementLoader.loadParticularElements(elements, correlation);
+    };
+
+    cancelElementLoad(): void {
+        return this.elementLoader.cancelElementLoad();
+    }
+
+    setSearch = (search: string, correlation: Correlation = uuid()): void => {
+        this.stagedSelectionHandler.changeSelection({ isInverted: true, items: [] }); // maybe not?
+        return this.elementLoader.setSearch(search, correlation);
+    };
+
+    setLimitingMeasures = (measures: IMeasure[], correlation: Correlation = uuid()): void => {
+        return this.elementLoader.setLimitingMeasures(measures, correlation);
+    };
+
+    setLimitingAttributeFilters = (
+        filters: IElementsQueryAttributeFilter[],
+        correlation: Correlation = uuid(),
+    ): void => {
+        return this.elementLoader.setLimitingAttributeFilters(filters, correlation);
+    };
+
+    setLimitingDateFilters = (filters: IRelativeDateFilter[], correlation: Correlation = uuid()): void => {
+        return this.elementLoader.setLimitingDateFilters(filters, correlation);
+    };
+
+    // selectors
+    getWorkingSelection = (): AttributeElementSelection => {
+        return this.stagedSelectionHandler.getWorkingSelection();
+    };
+
+    getCommittedSelection = (): AttributeElementSelection => {
+        return this.stagedSelectionHandler.getCommittedSelection();
+    };
+
+    getSelectedItems = (): AttributeElementSelectionFull => {
+        const selection = this.getWorkingSelection();
+        return {
+            isInverted: selection.isInverted,
+            elements: this.getItemsByKey(selection.items),
+        };
+    };
+
+    getSearch = (): string => {
+        return this.elementLoader.getSearch();
+    };
+
+    getAllItems = (): IAttributeElement[] => {
+        return this.elementLoader.getAllItems();
+    };
+
+    getItemsByKey = (keys: string[]): IAttributeElement[] => {
+        return this.elementLoader.getItemsByKey(keys);
+    };
+
+    getTotalCount = (): number => {
+        return this.elementLoader.getTotalCount();
+    };
+
+    getCountWithCurrentSettings = (): number => {
+        return this.elementLoader.getCountWithCurrentSettings();
+    };
+
+    getDisplayFormInfo = (): Loadable<IAttributeDisplayFormMetadataObject> => {
+        return this.displayFormLoader.getDisplayFormInfo();
+    };
+
+    getFilter = (): IAttributeFilter => {
+        const committedSelection = this.getCommittedSelection();
+        const elements: IAttributeElements = this.isElementsByRef
+            ? { uris: committedSelection.items }
+            : { values: committedSelection.items };
+        return committedSelection.isInverted
+            ? newNegativeAttributeFilter(this.displayForm, elements)
+            : newPositiveAttributeFilter(this.displayForm, elements);
+    };
+
+    getLoadingStatus = (): LoadableStatus => {
+        return this.elementLoader.getLoadingStatus();
+    };
+
+    // callbacks
+    onElementsRangeLoadSuccess: CallbackRegistration<IElementsLoadResult> = (cb) => {
+        return this.elementLoader.onElementsRangeLoadSuccess(cb);
+    };
+
+    onElementsRangeLoadStart: CallbackRegistration = (cb) => {
+        return this.elementLoader.onElementsRangeLoadStart(cb);
+    };
+
+    onElementsRangeLoadError: CallbackRegistration<{ error: Error }> = (cb) => {
+        return this.elementLoader.onElementsRangeLoadError(cb);
+    };
+
+    onElementsRangeLoadCancel: CallbackRegistration = (cb) => {
+        return this.elementLoader.onElementsRangeLoadCancel(cb);
+    };
+
+    onSelectionChanged: CallbackRegistration<{ selection: AttributeElementSelection }> = (cb) => {
+        return this.stagedSelectionHandler.onSelectionChanged(cb);
+    };
+
+    onSelectionCommitted: CallbackRegistration<{ selection: AttributeElementSelection }> = (cb) => {
+        return this.stagedSelectionHandler.onSelectionCommitted(cb);
+    };
+
+    onDisplayFormLoadSuccess: CallbackRegistration<{ displayForm: IAttributeDisplayFormMetadataObject }> = (
+        cb,
+    ) => {
+        return this.displayFormLoader.onDisplayFormLoadSuccess(cb);
+    };
+
+    onDisplayFormLoadStart: CallbackRegistration = (cb) => {
+        return this.displayFormLoader.onDisplayFormLoadStart(cb);
+    };
+
+    onDisplayFormLoadError: CallbackRegistration<{ error: Error }> = (cb) => {
+        return this.displayFormLoader.onDisplayFormLoadError(cb);
+    };
+
+    onDisplayFormLoadCancel: CallbackRegistration = (cb) => {
+        return this.displayFormLoader.onDisplayFormLoadCancel(cb);
+    };
+}

--- a/libs/sdk-ui-filters/src/index.ts
+++ b/libs/sdk-ui-filters/src/index.ts
@@ -77,3 +77,4 @@ export {
     ICustomGranularitySelection,
 } from "./RankingFilter/types";
 export { AttributeFilterLoader } from "./AttributeFilterLoader";
+export * from "./AttributeFilterHandler";


### PR DESCRIPTION
This is the first version of the proposed API for the attribute filter
helper class. It does not yet cover all the use cases we want, but is
complete enough for us to start implementing it.

Also add a common type for ElementsQueryOptionsElementsSpecification.

JIRA: RAIL-4228

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
