### PR TITLE
RELATED: RAIL-4268 Skip color palette for some backends in code gen

### DIFF
--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -72,6 +72,7 @@ const CAPABILITIES: IBackendCapabilities = {
     allowsInconsistentRelations: false,
     supportsTimeGranularities: false,
     supportsHierarchicalWorkspaces: false,
+    supportsCustomColorPalettes: true,
 };
 
 /**

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -83,6 +83,7 @@ export const defaultRecordedBackendCapabilities: IBackendCapabilities = {
     supportsOwners: true,
     allowsInconsistentRelations: false,
     supportsHierarchicalWorkspaces: false,
+    supportsCustomColorPalettes: true,
 };
 
 /**

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -357,6 +357,7 @@ export interface IBackendCapabilities {
     maxDimensions?: number;
     supportsAccessControl?: boolean;
     supportsCsvUploader?: boolean;
+    supportsCustomColorPalettes?: boolean;
     supportsElementsQueryParentFiltering?: boolean;
     supportsElementUris?: boolean;
     supportsExplain?: boolean;

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -157,6 +157,11 @@ export interface IBackendCapabilities {
     supportsHierarchicalWorkspaces?: boolean;
 
     /**
+     * Indicates whether backend supports custom color palettes.
+     */
+    supportsCustomColorPalettes?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -71,6 +71,7 @@ const CAPABILITIES: IBackendCapabilities = {
     allowsInconsistentRelations: true,
     supportsTimeGranularities: true,
     supportsHierarchicalWorkspaces: true,
+    supportsCustomColorPalettes: false,
 };
 
 /**

--- a/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
+++ b/libs/sdk-model/src/execution/objectFactoryNotation/tests/index.test.ts
@@ -457,8 +457,8 @@ describe("factoryNotationFor", () => {
                         identifier: "foo",
                     },
                     granularity: "GDC.time.year",
-                    from: -42,
-                    to: 42,
+                    from: 0,
+                    to: 0,
                 },
             };
             const actual = factoryNotationFor(input);

--- a/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
@@ -229,6 +229,7 @@ Object {
         "canCalculateSubTotals": true,
         "canCalculateTotals": true,
         "supportsCsvUploader": true,
+        "supportsCustomColorPalettes": true,
         "supportsHierarchicalWorkspaces": false,
         "supportsKpiWidget": true,
         "supportsOwners": true,

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/chartCodeGenUtils.ts
@@ -54,10 +54,11 @@ export function chartConfigFromInsight(
 ): IChartConfig {
     const properties = insightProperties(insight);
     const controls = properties?.controls ?? {};
+    const includeColorPalette = ctx?.backend?.capabilities.supportsCustomColorPalettes ?? false;
     const withValuesFromContext = {
         ...controls,
-        ...(ctx?.colorPalette ? { colorPalette: ctx?.colorPalette } : {}),
-        ...(ctx?.settings?.separators ? { separators: ctx?.settings?.separators } : {}),
+        ...(ctx?.colorPalette && includeColorPalette ? { colorPalette: ctx.colorPalette } : {}),
+        ...(ctx?.settings?.separators ? { separators: ctx.settings.separators } : {}),
         ...(ctx?.settings?.enableChartsSorting ? { enableChartSorting: true } : {}),
         ...(ctx?.settings?.enableAxisNameViewByTwoAttributes ? { enableJoinedAttributeAxisName: true } : {}),
     };


### PR DESCRIPTION
For backends that do not allow custom colorPalettes it makes no sense
to include them in the generated code.

JIRA: RAIL-4268

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
