### PR TITLE
Copy all configuration files for plugin template

### DIFF
--- a/tools/plugin-toolkit/scripts/build.sh
+++ b/tools/plugin-toolkit/scripts/build.sh
@@ -10,8 +10,10 @@ TSNODE_BIN="${PACKAGE_DIR}/node_modules/.bin/ts-node"
 PREPARE_PACKAGE_JSON="${TSNODE_BIN} ${PACKAGE_DIR}/scripts/preparePackageJson.ts"
 
 DASHBOARD_PLUGIN_TEMPLATE_DIR="${PACKAGE_DIR}/../dashboard-plugin-template"
-JS_CONFIG_TEMPLATES="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/js/.[^.]*"
-TS_CONFIG_TEMPLATES="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/ts/.[^.]*"
+JS_CONFIG_TEMPLATES="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/js/*"
+JS_CONFIG_TEMPLATES_DOT="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/js/.[^.]*"
+TS_CONFIG_TEMPLATES="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/ts/*"
+TS_CONFIG_TEMPLATES_DOT="${DASHBOARD_PLUGIN_TEMPLATE_DIR}/configTemplates/ts/.[^.]*"
 BUILD_DIR="${PACKAGE_DIR}/build"
 JS_BUILD_DIR="${BUILD_DIR}/dashboard-plugin-template.js"
 TS_BUILD_DIR="${BUILD_DIR}/dashboard-plugin-template.ts"
@@ -51,6 +53,7 @@ cp -R "${TS_BUILD_DIR}" "${JS_BUILD_DIR}"
 
 # copy over the eslint, prettier and jest config files for the TypeScript project
 cp ${TS_CONFIG_TEMPLATES} "${TS_BUILD_DIR}"
+cp ${TS_CONFIG_TEMPLATES_DOT} "${TS_BUILD_DIR}"
 
 # create archive with TypeScript template
 tar -czf "${TS_TAR}" -C "${TS_BUILD_DIR}" .
@@ -61,8 +64,9 @@ tar -czf "${TS_TAR}" -C "${TS_BUILD_DIR}" .
 
 $PREPARE_PACKAGE_JSON remove-ts "${JS_BUILD_DIR}"
 
-# copy over the eslint, prettier and jest config files for the TypeScript project
+# copy over the eslint, prettier and jest config files for the JavaScript project
 cp ${JS_CONFIG_TEMPLATES} "${JS_BUILD_DIR}"
+cp ${JS_CONFIG_TEMPLATES_DOT} "${JS_BUILD_DIR}"
 
 # transpile TypeScript files to JavaScript
 $BABEL_BIN --no-babelrc \


### PR DESCRIPTION
- Currently, only files starting with a dot are copied
- Fix this to copy also files not starting with a dot

JIRA: RAIL-4270

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
