### PR TITLE
RAIL-4271 "Defined as" tooltip not working for metrics using new grammar

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/measureExpressionTokens.ts
@@ -8,6 +8,7 @@ export type ExpressionTokenType =
     | "metric"
     | "attribute"
     | "label"
+    | "dataset"
     | "comment";
 
 export interface IExpressionToken {
@@ -25,6 +26,7 @@ const TOKEN_TYPE_REGEXP_PAIRS: Array<[ExpressionTokenType, RegExp]> = [
     ["metric", /^\{metric\/[^}]*\}/],
     ["label", /^\{label\/[^}]*\}/],
     ["attribute", /^\{attribute\/[^}]*\}/],
+    ["dataset", /^\{dataset\/[^}]*\}/],
     ["comment", /#[^\n]*/],
 ];
 

--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/test/measureExpressionTokens.test.ts
@@ -116,4 +116,14 @@ describe("tokenizeExpression", () => {
             { type: "comment", value: "# WHERE SUM({fact/sum}) > 5" },
         ]);
     });
+
+    it("parses MAQL with dataset", () => {
+        const tokens = tokenizeExpression("SELECT COUNT({dataset/campaign_channels})");
+        expect(tokens).toEqual([
+            { type: "text", value: "SELECT COUNT" },
+            { type: "bracket", value: "(" },
+            { type: "dataset", value: "dataset/campaign_channels" },
+            { type: "bracket", value: ")" },
+        ]);
+    });
 });


### PR DESCRIPTION
JIRA: RAIL-4271

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
