### PR TITLE
RAIL-4271 "Defined as" tooltip not working for metrics using new grammar

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/measures/index.ts
@@ -70,7 +70,13 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
             return { type: regexToken.type, value: regexToken.value };
         }
         const [type, id] = regexToken.value.split("/");
-        if (type === "metric" || type === "fact" || type === "attribute" || type === "label") {
+        if (
+            type === "metric" ||
+            type === "fact" ||
+            type === "attribute" ||
+            type === "label" ||
+            type === "dataset"
+        ) {
             return this.resolveObjectToken(id, type, metric.included || [], metric.data.id);
         }
         throw new Error(`Cannot resolve title of object type ${type}`);
@@ -78,7 +84,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
 
     private resolveObjectToken(
         objectId: string,
-        objectType: "metric" | "fact" | "attribute" | "label",
+        objectType: "metric" | "fact" | "attribute" | "label" | "dataset",
         includedObjects: ReadonlyArray<any>,
         identifier: string,
     ): IMeasureExpressionToken {
@@ -94,6 +100,7 @@ export class TigerWorkspaceMeasures implements IWorkspaceMeasuresService {
             fact: "fact",
             attribute: "attribute",
             label: "attribute",
+            dataset: "dataSet",
         };
 
         const value = includedObject?.attributes?.title || `${objectType}/${objectId}`;


### PR DESCRIPTION
JIRA: RAIL-4271

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
