### PR TITLE
RELATED: RAIL-4108 Implement and test selectIsDashboardDirty

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4245,6 +4245,9 @@ export interface RemoveSectionItem extends IDashboardCommand {
 }
 
 // @alpha
+export function removeSectionItem(sectionIndex: number, itemIndex: number, stashIdentifier?: StashedDashboardItemsId, correlationId?: string): RemoveSectionItem;
+
+// @alpha
 export interface RemoveSectionItemPayload {
     readonly eager?: boolean;
     readonly itemIndex: RelativeIndex;

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/addLayoutSectionHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { SagaIterator } from "redux-saga";
 import { DashboardContext } from "../../types/commonTypes";
@@ -21,6 +21,7 @@ import {
     validateAndResolveItemFilterSettings,
 } from "./validation/itemValidation";
 import { addTemporaryIdentityToWidgets } from "../../utils/dashboardItemUtils";
+import { sanitizeHeader } from "./utils";
 
 type AddLayoutSectionContext = {
     readonly ctx: DashboardContext;
@@ -103,7 +104,7 @@ export function* addLayoutSectionHandler(
 
     const section: ExtendedDashboardLayoutSection = {
         type: "IDashboardLayoutSection",
-        header: initialHeader,
+        header: sanitizeHeader(initialHeader),
         items: itemsToAdd,
     };
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/changeLayoutSectionHeaderHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/changeLayoutSectionHeaderHandler.ts
@@ -10,6 +10,7 @@ import { IDashboardLayoutSectionHeader } from "@gooddata/sdk-model";
 import merge from "lodash/merge";
 import { layoutActions } from "../../store/layout";
 import { DashboardLayoutSectionHeaderChanged, layoutSectionHeaderChanged } from "../../events/layout";
+import { sanitizeHeader } from "./utils";
 
 export function* changeLayoutSectionHeaderHandler(
     ctx: DashboardContext,
@@ -28,16 +29,17 @@ export function* changeLayoutSectionHeaderHandler(
 
     const existingHeader: IDashboardLayoutSectionHeader = layout.sections[index]!.header ?? {};
     const newHeader = mergeHeaders ? merge({}, existingHeader, header) : header;
+    const sanitizedHeader = sanitizeHeader(newHeader);
 
     yield put(
         layoutActions.changeSectionHeader({
             index,
-            header: newHeader,
+            header: sanitizedHeader,
             undo: {
                 cmd,
             },
         }),
     );
 
-    return layoutSectionHeaderChanged(ctx, newHeader, index, cmd.correlationId);
+    return layoutSectionHeaderChanged(ctx, sanitizedHeader, index, cmd.correlationId);
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/utils.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/utils.ts
@@ -1,0 +1,13 @@
+// (C) 2022 GoodData Corporation
+import { IDashboardLayoutSectionHeader } from "@gooddata/sdk-model";
+
+/**
+ * @internal
+ */
+export function sanitizeHeader<T extends IDashboardLayoutSectionHeader | undefined>(header: T): T {
+    // get rid of empty values in header altogether
+    return (header && {
+        ...(header.description && { description: header.description }),
+        ...(header.title && { title: header.title }),
+    }) as T;
+}

--- a/libs/sdk-ui-dashboard/src/model/commands/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/index.ts
@@ -145,6 +145,7 @@ export {
     moveSectionItem,
     RemoveSectionItem,
     RemoveSectionItemPayload,
+    removeSectionItem,
     eagerRemoveSectionItem,
     UndoLayoutChanges,
     UndoLayoutChangesPayload,

--- a/libs/sdk-ui-dashboard/src/model/commands/insight.ts
+++ b/libs/sdk-ui-dashboard/src/model/commands/insight.ts
@@ -530,7 +530,6 @@ export interface RemoveDrillsForInsightWidget extends IDashboardCommand {
  * Creates the RemoveDrillsForInsightWidget command. Dispatching the created command will remove insight widget's
  * drill definition for the provided measure.
  *
- *
  * @param ref - reference of insight widget whose drill should be removed
  * @param origins - measure or attribute localIdentifiers whose drill definitions should be removed
  * @param correlationId - specify correlation id to use for this command. this will be included in all

--- a/libs/sdk-ui-dashboard/src/model/store/meta/tests/metaSelectors.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/tests/metaSelectors.test.ts
@@ -1,0 +1,217 @@
+// (C) 2022 GoodData Corporation
+import { newAbsoluteDateFilter, newPositiveAttributeFilter } from "@gooddata/sdk-model";
+import { ReferenceMd } from "@gooddata/reference-workspace";
+
+import { DashboardTester, preloadedTesterFactory } from "../../../tests/DashboardTester";
+import {
+    ComplexDashboardIdentifier,
+    ComplexDashboardFilters,
+    ComplexDashboardWidgets,
+} from "../../../tests/fixtures/ComplexDashboard.fixtures";
+import { TestCorrelation, TestStash } from "../../../tests/fixtures/Dashboard.fixtures";
+import {
+    applyAttributeFilter,
+    applyDateFilter,
+    changeLayoutSectionHeader,
+    moveAttributeFilter,
+    moveLayoutSection,
+    moveSectionItem,
+    removeAttributeFilter,
+    removeLayoutSection,
+    renameDashboard,
+    removeSectionItem,
+    addSectionItem,
+    replaceSectionItem,
+    addLayoutSection,
+    changeKpiWidgetHeader,
+    changeKpiWidgetMeasure,
+    changeKpiWidgetComparison,
+    unignoreFilterOnKpiWidget,
+    changeInsightWidgetHeader,
+    unignoreFilterOnInsightWidget,
+    changeInsightWidgetVisProperties,
+    removeDrillsForInsightWidget,
+    addAttributeFilter,
+} from "../../../commands";
+import { selectIsDashboardDirty } from "../metaSelectors";
+import { ExtendedDashboardItem, ICustomWidgetDefinition } from "../../../types/layoutTypes";
+
+describe("selectIsDashboardDirty", () => {
+    let Tester: DashboardTester;
+    beforeEach(
+        preloadedTesterFactory((tester) => {
+            Tester = tester;
+        }, ComplexDashboardIdentifier),
+    );
+
+    it("should return false for dashboard just opened", () => {
+        expect(Tester.select(selectIsDashboardDirty)).toBe(false);
+    });
+
+    const customWidget: ExtendedDashboardItem<ICustomWidgetDefinition> = {
+        size: { xl: { gridWidth: 12 } },
+        type: "IDashboardLayoutItem",
+    };
+
+    type Scenario = [name: string, command: any, event: string];
+    const scenarios: Scenario[] = [
+        // meta manipulations
+        ["title change", renameDashboard("New title", TestCorrelation), "GDC.DASH/EVT.RENAMED"],
+        // section manipulations
+        [
+            "section header change",
+            changeLayoutSectionHeader(0, { title: "New Title" }, false, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_HEADER_CHANGED",
+        ],
+        [
+            "section removal",
+            removeLayoutSection(0, TestStash, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_REMOVED",
+        ],
+        ["section move", moveLayoutSection(0, 1, TestCorrelation), "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_MOVED"],
+        [
+            "section addition",
+            addLayoutSection(0, undefined, [customWidget], false, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.SECTION_ADDED",
+        ],
+        // widget manipulations
+        ["widget move", moveSectionItem(0, 0, 1, 1, TestCorrelation), "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_MOVED"],
+        [
+            "widget removal",
+            removeSectionItem(0, 0, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REMOVED",
+        ],
+        [
+            "widget addition",
+            addSectionItem(0, 0, customWidget, false, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.ITEMS_ADDED",
+        ],
+        [
+            "widget replacement",
+            replaceSectionItem(0, 0, customWidget, TestCorrelation),
+            "GDC.DASH/EVT.FLUID_LAYOUT.ITEM_REPLACED",
+        ],
+        // kpi manipulations
+        [
+            "kpi rename",
+            changeKpiWidgetHeader(
+                ComplexDashboardWidgets.FirstSection.FirstKpi.ref,
+                { title: "New title" },
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.KPI_WIDGET.HEADER_CHANGED",
+        ],
+        [
+            "kpi measure change",
+            changeKpiWidgetMeasure(
+                ComplexDashboardWidgets.FirstSection.FirstKpi.ref,
+                ComplexDashboardWidgets.FirstSection.LastKpi.kpi.metric,
+                "from-measure",
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.KPI_WIDGET.MEASURE_CHANGED",
+        ],
+        [
+            "kpi filter change",
+            unignoreFilterOnKpiWidget(
+                ComplexDashboardWidgets.FirstSection.ThirdKpi.ref,
+                ComplexDashboardFilters.FirstAttribute.idRef,
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.KPI_WIDGET.FILTER_SETTINGS_CHANGED",
+        ],
+        [
+            "kpi comparison change",
+            changeKpiWidgetComparison(
+                ComplexDashboardWidgets.FirstSection.FirstKpi.ref,
+                {
+                    comparisonDirection: "growIsBad",
+                    comparisonType: "previousPeriod",
+                },
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.KPI_WIDGET.COMPARISON_CHANGED",
+        ],
+        // insight manipulations
+        [
+            "insight rename",
+            changeInsightWidgetHeader(
+                ComplexDashboardWidgets.SecondSection.FirstTable.ref,
+                { title: "New title" },
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.HEADER_CHANGED",
+        ],
+        [
+            "insight filter change",
+            unignoreFilterOnInsightWidget(
+                ComplexDashboardWidgets.SecondSection.FirstTable.ref,
+                ComplexDashboardFilters.FirstAttribute.idRef,
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.FILTER_SETTINGS_CHANGED",
+        ],
+        [
+            "insight properties change",
+            changeInsightWidgetVisProperties(
+                ComplexDashboardWidgets.SecondSection.FirstTable.ref,
+                { controls: { someProperty: 42 } },
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.PROPERTIES_CHANGED",
+        ],
+        [
+            "insight drills removal",
+            removeDrillsForInsightWidget(
+                ComplexDashboardWidgets.SecondSection.FirstTable.ref,
+                "*",
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.INSIGHT_WIDGET.DRILLS_REMOVED",
+        ],
+        // filter manipulations
+        [
+            "date filter change",
+            applyDateFilter(newAbsoluteDateFilter("foo", "2022-01-01", "2022-12-31"), TestCorrelation),
+            "GDC.DASH/EVT.FILTER_CONTEXT.DATE_FILTER.SELECTION_CHANGED",
+        ],
+        [
+            "attribute filter change",
+            applyAttributeFilter(
+                ComplexDashboardFilters.FirstAttribute.filter.attributeFilter.localIdentifier!,
+                newPositiveAttributeFilter(ComplexDashboardFilters.FirstAttribute.idRef, {
+                    uris: [ComplexDashboardFilters.FirstAttribute.sampleElementUri],
+                }),
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.SELECTION_CHANGED",
+        ],
+        [
+            "attribute filter move",
+            moveAttributeFilter(
+                ComplexDashboardFilters.FirstAttribute.filter.attributeFilter.localIdentifier!,
+                2,
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.MOVED",
+        ],
+        [
+            "attribute filter removal",
+            removeAttributeFilter(
+                ComplexDashboardFilters.FirstAttribute.filter.attributeFilter.localIdentifier!,
+                TestCorrelation,
+            ),
+            "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.REMOVED",
+        ],
+        [
+            "attribute filter add",
+            addAttributeFilter(ReferenceMd.Department.attribute.displayForm, -1, TestCorrelation),
+            "GDC.DASH/EVT.FILTER_CONTEXT.ATTRIBUTE_FILTER.ADDED",
+        ],
+    ];
+
+    it.each(scenarios)(`should detect %s`, async (_, command, event) => {
+        await Tester.dispatchAndWaitFor(command, event);
+        expect(Tester.select(selectIsDashboardDirty)).toBe(true);
+    });
+});

--- a/libs/sdk-ui-dashboard/src/model/tests/fixtures/ComplexDashboard.fixtures.ts
+++ b/libs/sdk-ui-dashboard/src/model/tests/fixtures/ComplexDashboard.fixtures.ts
@@ -8,6 +8,7 @@ import {
     IKpiWidget,
     IInsightWidget,
     IListedDashboard,
+    IFilterContext,
 } from "@gooddata/sdk-model";
 import { ReferenceRecordings } from "@gooddata/reference-workspace";
 
@@ -22,7 +23,8 @@ import { ReferenceRecordings } from "@gooddata/reference-workspace";
 export const ComplexDashboardIdentifier = "aeis6NlXcL7X";
 export const ComplexDashboardWithReferences = ReferenceRecordings.Recordings.metadata.dashboards
     .dash_aeis6NlXcL7X.obj as IDashboardWithReferences;
-export const ComplexDashboardFilterContext = ComplexDashboardWithReferences.dashboard.filterContext!;
+export const ComplexDashboardFilterContext = ComplexDashboardWithReferences.dashboard
+    .filterContext! as IFilterContext;
 
 /**
  * Contains breakdown of the complex dashboard's filters context. There is date filter and
@@ -35,6 +37,7 @@ export const ComplexDashboardFilters = {
         filter: ComplexDashboardFilterContext.filters[1] as IDashboardAttributeFilter,
         uriRef: uriRef("/gdc/md/referenceworkspace/obj/1087"),
         idRef: idRef("label.owner.region"),
+        sampleElementUri: "/gdc/md/l32xdyl4bjuzgf9kkqr2avl55gtuyjwf/obj/1086/elements?id=460489",
     },
     SecondAttribute: {
         filter: ComplexDashboardFilterContext.filters[2] as IDashboardAttributeFilter,


### PR DESCRIPTION
Makes use of several sub-selectors to improve performance.

Also sanitizes section headers removing unused fields.

JIRA: RAIL-4108

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
