### PR TITLE
RELATED: RAIL-4273 prevent unnecessary re-renders in edit mode

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4707,6 +4707,9 @@ export const selectEnableKPIDashboardSchedule: OutputSelector<DashboardState, bo
 // @public
 export const selectEnableKPIDashboardScheduleRecipients: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
+// @internal
+export const selectEnableWidgetCustomHeight: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
+
 // @alpha (undocumented)
 export const selectExecutionResult: (state: DashboardState, id: string | number) => IExecutionResultEnvelope | undefined;
 

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -303,3 +303,12 @@ export const selectDashboardEditModeDevRollout = createSelector(selectConfig, (s
 export const selectEnableAnalyticalDashboardPermissions = createSelector(selectConfig, (state) => {
     return state.settings?.enableAnalyticalDashboardPermissions ?? false;
 });
+
+/**
+ * Returns whether custom widget heights are enabled
+ *
+ * @internal
+ */
+export const selectEnableWidgetCustomHeight = createSelector(selectConfig, (state) => {
+    return state.settings?.enableKDWidgetCustomHeight ?? false;
+});

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -36,6 +36,7 @@ export {
     selectEnableKPIDashboardDrillToURL,
     selectEnableKPIDashboardImplicitDrillDown,
     selectHideKpiDrillInEmbedded,
+    selectEnableWidgetCustomHeight,
 } from "./config/configSelectors";
 export { PermissionsState } from "./permissions/permissionsState";
 export {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -13,6 +13,7 @@ import {
 } from "@gooddata/sdk-model";
 import {
     ExtendedDashboardWidget,
+    selectEnableWidgetCustomHeight,
     selectInsightsMap,
     selectSettings,
     useDashboardSelector,
@@ -82,6 +83,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
     const { item, screen, DefaultWidgetRenderer, onDrill, onFiltersChange, onError } = props;
     const insights = useDashboardSelector(selectInsightsMap);
     const settings = useDashboardSelector(selectSettings);
+    const enableWidgetCustomHeight = useDashboardSelector(selectEnableWidgetCustomHeight);
+
     const { ErrorComponent, LoadingComponent } = useDashboardComponentsContext();
     // TODO: we should probably do something more meaningful when item has no widget; should that even
     //  be allowed? undefined widget will make things explode down the line away so..
@@ -94,7 +97,7 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
             : undefined;
 
     const allowOverflow = !!currentSize.heightAsRatio;
-    const className = settings.enableKDWidgetCustomHeight ? "custom-height" : undefined;
+    const className = enableWidgetCustomHeight ? "custom-height" : undefined;
     const index = getWidgetIndex(item);
 
     return (

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayout.tsx
@@ -15,13 +15,13 @@ import {
 } from "@gooddata/sdk-model";
 
 import {
-    selectSettings,
     useDashboardSelector,
     selectIsExport,
     selectIsLayoutEmpty,
     selectLayout,
     ExtendedDashboardWidget,
     selectInsightsMap,
+    selectEnableWidgetCustomHeight,
 } from "../../model";
 import { useDashboardComponentsContext } from "../dashboardContexts";
 
@@ -97,11 +97,12 @@ const itemKeyGetter: IDashboardLayoutItemKeyGetter<ExtendedDashboardWidget> = (k
 export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Element => {
     const { onFiltersChange, onDrill, onError, ErrorComponent: CustomError } = props;
 
+    const { ErrorComponent } = useDashboardComponentsContext({ ErrorComponent: CustomError });
+
     const layout = useDashboardSelector(selectLayout);
     const isLayoutEmpty = useDashboardSelector(selectIsLayoutEmpty);
-    const settings = useDashboardSelector(selectSettings);
+    const enableWidgetCustomHeight = useDashboardSelector(selectEnableWidgetCustomHeight);
     const insights = useDashboardSelector(selectInsightsMap);
-    const { ErrorComponent } = useDashboardComponentsContext({ ErrorComponent: CustomError });
     const isExport = useDashboardSelector(selectIsExport);
 
     const getInsightByRef = useCallback(
@@ -121,12 +122,12 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
                 section
                     .modifyItems(polluteWidgetRefsWithBothIdAndUri(getInsightByRef))
                     .modifyItems(
-                        validateItemsSize(getInsightByRef, settings.enableKDWidgetCustomHeight!),
+                        validateItemsSize(getInsightByRef, enableWidgetCustomHeight),
                         selectAllItemsWithInsights,
                     ),
             )
             .build();
-    }, [layout, isExport, getInsightByRef]);
+    }, [layout, isExport, getInsightByRef, enableWidgetCustomHeight]);
 
     const widgetRenderer = useCallback<IDashboardLayoutWidgetRenderer<ExtendedDashboardWidget>>(
         (renderProps) => {
@@ -150,7 +151,7 @@ export const DefaultDashboardLayout = (props: IDashboardLayoutProps): JSX.Elemen
             layout={transformedLayout}
             itemKeyGetter={itemKeyGetter}
             widgetRenderer={widgetRenderer}
-            enableCustomHeight={settings.enableKDWidgetCustomHeight}
+            enableCustomHeight={enableWidgetCustomHeight}
             sectionHeaderRenderer={RenderModeAwareDashboardLayoutSectionHeaderRenderer}
         />
     );

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayout.tsx
@@ -16,6 +16,14 @@ import { DASHBOARD_LAYOUT_GRID_CONFIGURATION } from "../../constants";
 
 setConfiguration(DASHBOARD_LAYOUT_GRID_CONFIGURATION);
 
+const removeHeights = <TWidget,>(layout: IDashboardLayout<TWidget>, enableCustomHeight: boolean) => {
+    if (enableCustomHeight) {
+        return layout;
+    }
+
+    return getLayoutWithoutGridHeights(layout);
+};
+
 /**
  * DashboardLayout is customizable component for rendering {@link IDashboardLayout}.
  *
@@ -36,14 +44,6 @@ export function DashboardLayout<TWidget>(props: IDashboardLayoutRenderProps<TWid
         onMouseLeave,
         enableCustomHeight,
     } = props;
-
-    const removeHeights = (layout: IDashboardLayout<TWidget>, enableCustomHeight: boolean) => {
-        if (enableCustomHeight) {
-            return layout;
-        }
-
-        return getLayoutWithoutGridHeights(layout);
-    };
 
     const { layoutFacade, resizedItemPositions } = useMemo(() => {
         const updatedLayout = removeHeights(layout, !!enableCustomHeight);

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutUtils.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutUtils.ts
@@ -1,0 +1,133 @@
+// (C) 2020-2022 GoodData Corporation
+import {
+    ObjRef,
+    IInsight,
+    insightId,
+    insightUri,
+    isWidget,
+    widgetUri,
+    widgetId,
+    isInsightWidget,
+    IDashboardWidget,
+    IDashboardLayoutItem,
+} from "@gooddata/sdk-model";
+import invariant from "ts-invariant";
+import { LRUCache } from "@gooddata/util";
+import stringify from "json-stable-stringify";
+import flow from "lodash/flow";
+
+import {
+    DashboardLayoutItemModifications,
+    IDashboardLayoutItemBuilder,
+    validateDashboardLayoutWidgetSize,
+} from "./DefaultDashboardLayoutRenderer";
+
+/**
+ * We need to aggressively memoize the widget sanitization results in order to prevent expensive re-renders
+ * down the line - we need to keep the widgets referentially equal whenever they are not changed.
+ */
+export const getMemoizedWidgetSanitizer =
+    <TWidget>(cache: LRUCache<IDashboardLayoutItem<TWidget>>) =>
+    (
+        getInsightByRef: (insightRef: ObjRef) => IInsight | undefined,
+        enableKDWidgetCustomHeight: boolean,
+    ): DashboardLayoutItemModifications<TWidget> => {
+        return (item) => {
+            const widget = item.facade().widget();
+            const insightAvailable = isInsightWidget(widget) && !!getInsightByRef(widget.insight);
+            // we need to check if the result was made with insight available or not, it might change the result
+            // of polluteWidgetRefsWithBothIdAndUri which touches the insight as well
+            const cacheKey = `${stringify(item.facade().raw(), { space: 0 })}__${insightAvailable}`;
+
+            if (!cache.has(cacheKey)) {
+                const resultBuilder: IDashboardLayoutItemBuilder<TWidget> = flow(
+                    polluteWidgetRefsWithBothIdAndUri(getInsightByRef),
+                    validateItemsSize(getInsightByRef, enableKDWidgetCustomHeight),
+                )(item);
+                cache.set(cacheKey, resultBuilder.build());
+            }
+
+            return item.setItem(cache.get(cacheKey)!);
+        };
+    };
+
+/**
+ * Ensure that areObjRefsEqual() and other predicates will be working with uncontrolled user ref inputs
+ * in custom layout transformation and/or custom widget/item renderers.
+ *
+ * @internal
+ */
+export function polluteWidgetRefsWithBothIdAndUri<TWidget = IDashboardWidget>(
+    getInsightByRef: (insightRef: ObjRef) => IInsight | undefined,
+): DashboardLayoutItemModifications<TWidget> {
+    return (item) =>
+        item.widget((c) => {
+            let updatedContent = c;
+            if (isWidget(updatedContent)) {
+                updatedContent = {
+                    ...updatedContent,
+                    ref: {
+                        ...updatedContent.ref,
+                        uri: widgetUri(updatedContent),
+                        identifier: widgetId(updatedContent),
+                    },
+                };
+            }
+            if (isInsightWidget(updatedContent)) {
+                const insight = getInsightByRef(updatedContent.insight);
+                // sometimes this seems to be called sooner than insights are loaded leading to invariant errors
+                // since the behavior is nearly impossible to replicate reliably, let's be defensive here
+                if (insight) {
+                    updatedContent = {
+                        ...updatedContent,
+                        insight: {
+                            ...updatedContent.insight,
+                            uri: insightUri(insight),
+                            identifier: insightId(insight),
+                        },
+                    };
+                }
+            }
+
+            return updatedContent;
+        });
+}
+
+/**
+ * Ensure the insight widgets conform to their allowed sizes.
+ *
+ * @internal
+ */
+export function validateItemsSize<TWidget = IDashboardWidget>(
+    getInsightByRef: (insightRef: ObjRef) => IInsight | undefined,
+    enableKDWidgetCustomHeight: boolean,
+): DashboardLayoutItemModifications<TWidget> {
+    return (item) => {
+        const widget = item.facade().widget();
+        if (isInsightWidget(widget)) {
+            const insight = getInsightByRef(widget.insight);
+            invariant(insight, "Inconsistent insight store");
+            const currentSize = item.facade().size().xl;
+            const { gridWidth: currentWidth, gridHeight: currentHeight } = currentSize;
+            const { validWidth, validHeight } = validateDashboardLayoutWidgetSize(
+                currentWidth,
+                currentHeight,
+                "insight",
+                insight,
+                { enableKDWidgetCustomHeight },
+            );
+            if (currentWidth !== validWidth || currentHeight !== validHeight) {
+                const gridWidthProp = currentWidth !== validWidth ? { gridWidth: validWidth } : {};
+                const gridHeightProp = currentHeight !== validHeight ? { gridHeight: validHeight } : {};
+                return item.size({
+                    xl: {
+                        ...currentSize,
+                        ...gridWidthProp,
+                        ...gridHeightProp,
+                    },
+                });
+            }
+        }
+        return item;
+    };
+}


### PR DESCRIPTION
Make sure the widgets are only re-rendered when they actually change.
This is done by memoizing the widget sanitization results and reusing as much as possible.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
