### PR TITLE
RELATED: RAIL-4273 more dashboard perf improvements

### DIFF
--- a/examples/playground/tsconfig.json
+++ b/examples/playground/tsconfig.json
@@ -32,6 +32,6 @@
         },
         "moduleResolution": "node"
     },
-    "include": ["src", "typings"],
+    "include": ["src/index.tsx", "typings"],
     "exclude": ["**/node_modules", "dist"]
 }

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -10,26 +10,41 @@ import { ShareDialogDashboardHeader } from "./ShareDialogDashboardHeader";
 import { ScheduledEmailDialogProvider } from "./ScheduledEmailDialogProvider";
 import { DeleteDialog, useDeleteDialogProps } from "../../deleteDialog";
 
+// these wrapper components are here to prevent the whole DashboardHeader from re-rendering whenever some
+// of the sub-components' props change. by isolating the hooks more, we make sure only the really changed component re-renders.
+const DeleteDialogWrapper = () => {
+    const deleteDialogProps = useDeleteDialogProps();
+    return <DeleteDialog {...deleteDialogProps} />;
+};
+
+const SaveAsDialogWrapper = () => {
+    const saveAsDialogProps = useSaveAsDialogProps();
+    return <SaveAsDialog {...saveAsDialogProps} />;
+};
+
+const TopBarWrapper = () => {
+    const topBarProps = useTopBarProps();
+    return <TopBar {...topBarProps} />;
+};
+
+const FilterBarWrapper = () => {
+    const filterBarProps = useFilterBarProps();
+    return <FilterBar {...filterBarProps} />;
+};
+
 // split the header parts of the dashboard so that changes to their state
 // (e.g. opening email dialog) do not re-render the dashboard body
 export const DashboardHeader = (): JSX.Element => {
-    const deleteDialogProps = useDeleteDialogProps();
-    const saveAsDialogProps = useSaveAsDialogProps();
-
-    const filterBarProps = useFilterBarProps();
-    const topBarProps = useTopBarProps();
-
     return (
         <>
             <ToastMessages />
             <ExportDialogProvider />
             <ScheduledEmailDialogProvider />
             <ShareDialogDashboardHeader />
-            <DeleteDialog {...deleteDialogProps} />
-            <SaveAsDialog {...saveAsDialogProps} />
-
-            <TopBar {...topBarProps} />
-            <FilterBar {...filterBarProps} />
+            <DeleteDialogWrapper />
+            <SaveAsDialogWrapper />
+            <TopBarWrapper />
+            <FilterBarWrapper />
         </>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/ShareDialogDashboardHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/DashboardHeader/ShareDialogDashboardHeader.tsx
@@ -1,5 +1,5 @@
-// (C) 2020 GoodData Corporation
-import React, { useCallback, useMemo } from "react";
+// (C) 2020-2022 GoodData Corporation
+import React, { useCallback } from "react";
 import { useToastMessage } from "@gooddata/sdk-ui-kit";
 import {
     useDashboardSelector,
@@ -25,10 +25,6 @@ const useShareDialogDashboardHeader = () => {
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
 
-    const closeShareDialog = useMemo(() => {
-        return () => dispatch(uiActions.closeShareDialog());
-    }, [dispatch, uiActions]);
-
     const { run: runChangeSharing } = useDashboardCommandProcessing({
         commandCreator: changeSharing,
         successEvent: "GDC.DASH/EVT.SHARING.CHANGED",
@@ -40,6 +36,8 @@ const useShareDialogDashboardHeader = () => {
             addError({ id: "messages.sharingChangedError.general" });
         },
     });
+
+    const closeShareDialog = useCallback(() => dispatch(uiActions.closeShareDialog()), [dispatch]);
 
     const onCloseShareDialog = useCallback(() => {
         closeShareDialog();
@@ -56,7 +54,7 @@ const useShareDialogDashboardHeader = () => {
     const onErrorShareDialog = useCallback(() => {
         dispatch(uiActions.closeShareDialog());
         addError({ id: "messages.sharingDialogError.general" });
-    }, [dispatch, addError, uiActions]);
+    }, [dispatch, addError]);
 
     return {
         backend,

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutWidgetRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutWidgetRenderer.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { CSSProperties } from "react";
 import cx from "classnames";
 import { IDashboardLayoutWidgetRenderProps } from "./interfaces";
@@ -41,7 +41,7 @@ export function DashboardLayoutWidgetRenderer(props: IDashboardLayoutWidgetRende
         }
 
         return computedStyle;
-    }, [heightAsRatio, debug, screen, height, minHeight, isResizedByLayoutSizingStrategy]);
+    }, [minHeight, height, allowOverflow, debug, heightAsRatio, isResizedByLayoutSizingStrategy]);
 
     const getClassNames = () => {
         return cx("gd-fluidlayout-column-container", className, {

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/EditableLabelWithBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/EditableLabelWithBubble.tsx
@@ -1,5 +1,5 @@
 // (C) 2019-2022 GoodData Corporation
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { Bubble, EditableLabel } from "@gooddata/sdk-ui-kit";
 import { useIntl } from "react-intl";
 
@@ -39,46 +39,39 @@ export function EditableLabelWithBubble({
     const [currentValue, setCurrentValue] = useState(value);
     const [editing, setEditing] = useState(false);
 
-    const bubbleMessage = useMemo(() => {
-        const charactersCountLeft = maxLength - currentValue.length;
-        const maximumCharactersCount = maxLength;
-        return intl.formatMessage(
-            { id: "layout.header.characters.left" },
-            { charactersCountLeft, maximumCharactersCount },
-        );
-    }, [maxLength, currentValue, intl]);
+    const charactersCountLeft = maxLength - currentValue.length;
+    const maximumCharactersCount = maxLength;
+    const bubbleMessage = intl.formatMessage(
+        { id: "layout.header.characters.left" },
+        { currentCharactersCount: charactersCountLeft, maximumCharactersCount },
+    );
 
-    const isBubbleVisible = useMemo(() => {
-        const currentValueLength = currentValue.length;
-        return editing && maxLength - currentValueLength <= warningLimit;
-    }, [currentValue, editing, maxLength, warningLimit]);
+    const currentValueLength = currentValue.length;
+    const isBubbleVisible = editing && maxLength - currentValueLength <= warningLimit;
 
     const onStart = useCallback(() => {
         setEditing(true);
         onEditingStart();
-    }, [setEditing, onEditingStart]);
+    }, [onEditingStart]);
 
-    const onCancelCallback = () => {
+    const onCancelCallback = useCallback(() => {
         setEditing(true);
         setCurrentValue(value);
         onCancel();
-    };
+    }, [onCancel, value]);
 
     const onSubmitCallback = useCallback(
-        (value: string) => {
+        (newValue: string) => {
             setEditing(true);
-            setCurrentValue(value);
-            onSubmit(value);
+            setCurrentValue(newValue);
+            onSubmit(newValue);
         },
-        [setEditing, setCurrentValue, onSubmit],
+        [onSubmit],
     );
 
-    const onChange = useCallback(
-        (value: string) => {
-            setCurrentValue(value);
-        },
-        [setCurrentValue],
-    );
+    const onChange = useCallback((newValue: string) => {
+        setCurrentValue(newValue);
+    }, []);
 
     return (
         <>

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/EditableHeader/SectionHeaderEditable.tsx
@@ -41,20 +41,20 @@ export function SectionHeaderEditable(props: ISectionHeaderEditOwnProps): JSX.El
     );
     const changeTitle = useCallback(
         (title: string) => dispatch(changeLayoutSectionHeader(index, { title }, true)),
-        [dispatch],
+        [dispatch, index],
     );
     const changeDescription = useCallback(
         (description: string) => dispatch(changeLayoutSectionHeader(index, { description }, true)),
-        [dispatch],
+        [dispatch, index],
     );
 
-    const onFocus = () => {
+    const onFocus = useCallback(() => {
         setActiveHeaderIndex(index);
-    };
+    }, [index, setActiveHeaderIndex]);
 
-    const onBlur = () => {
+    const onBlur = useCallback(() => {
         setActiveHeaderIndex(null);
-    };
+    }, [setActiveHeaderIndex]);
 
     const onTitleSubmit = useCallback(
         (title: string) => {

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemBase.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemBase.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 
 import { DashboardItemContent } from "./DashboardItemContent";
@@ -43,15 +43,17 @@ export interface IDashboardItemBaseProps {
     contentRef?: React.Ref<HTMLDivElement>;
 }
 
+const noopRender = () => null;
+
 export const DashboardItemBase: React.FC<IDashboardItemBaseProps> = ({
     children,
     contentClassName,
     visualizationClassName,
-    renderHeadline = () => null,
-    renderBeforeVisualization = () => null,
-    renderAfterVisualization = () => null,
-    renderBeforeContent = () => null,
-    renderAfterContent = () => null,
+    renderHeadline = noopRender,
+    renderBeforeVisualization = noopRender,
+    renderAfterVisualization = noopRender,
+    renderBeforeContent = noopRender,
+    renderAfterContent = noopRender,
     contentRef,
 }) => {
     return (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -102,7 +102,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
 
     const onScheduleExport = useCallback(() => {
         onScheduleEmailingOpen(widgetRef);
-    }, [widgetRef]);
+    }, [onScheduleEmailingOpen, widgetRef]);
     const scheduleExportEnabled = !isCustomWidget(widget);
 
     const { closeMenu, isMenuOpen, menuItems, openMenu } = useInsightMenu({

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -68,7 +68,7 @@ export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Elemen
                 onError(error, executionId);
             },
         });
-    }, [effectiveBackend, dispatchEvent]);
+    }, [effectiveBackend, dispatchEvent, widgetRef]);
 
     if (!isDashboardWidget(widget)) {
         throw new UnexpectedError(

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
@@ -94,7 +94,7 @@ export const useInsightMenu = (config: {
         return insightMenuItemsProvider
             ? insightMenuItemsProvider(insight, widget, defaultMenuItems, closeMenu)
             : defaultMenuItems;
-    }, [insight, widget, defaultMenuItems]);
+    }, [insightMenuItemsProvider, insight, widget, defaultMenuItems, closeMenu]);
 
     return { menuItems, isMenuOpen, openMenu, closeMenu };
 };

--- a/libs/sdk-ui/src/base/index.tsx
+++ b/libs/sdk-ui/src/base/index.tsx
@@ -167,7 +167,8 @@ export { usePrevious } from "./react/usePrevious";
 
 export { ILocale, DefaultLocale } from "./localization/Locale";
 export { getTranslation, getIntl } from "./localization/IntlStore";
-export { IntlWrapper, IIntlWrapperProps, messagesMap, ITranslations } from "./localization/IntlWrapper";
+export { IntlWrapper, IIntlWrapperProps } from "./localization/IntlWrapper";
+export { messagesMap, ITranslations } from "./localization/messagesMap";
 export {
     TranslationsProvider,
     IntlTranslationsProvider,

--- a/libs/sdk-ui/src/base/localization/IntlStore.ts
+++ b/libs/sdk-ui/src/base/localization/IntlStore.ts
@@ -1,33 +1,9 @@
 // (C) 2007-2022 GoodData Corporation
 import isEmpty from "lodash/isEmpty";
-
 import { IntlShape, createIntl } from "react-intl";
-import { translationUtils } from "@gooddata/util";
 
-import enUS from "./bundles/en-US.json";
-import deDE from "./bundles/de-DE.json";
-import esES from "./bundles/es-ES.json";
-import frFR from "./bundles/fr-FR.json";
-import jaJP from "./bundles/ja-JP.json";
-import nlNL from "./bundles/nl-NL.json";
-import ptBR from "./bundles/pt-BR.json";
-import ptPT from "./bundles/pt-PT.json";
-import zhHans from "./bundles/zh-Hans.json";
-import ruRU from "./bundles/ru-RU.json";
 import { DefaultLocale, ILocale } from "./Locale";
-
-const messagesMap = {
-    "en-US": translationUtils.removeMetadata(enUS),
-    "de-DE": deDE,
-    "es-ES": esES,
-    "fr-FR": frFR,
-    "ja-JP": jaJP,
-    "nl-NL": nlNL,
-    "pt-BR": ptBR,
-    "pt-PT": ptPT,
-    "zh-Hans": zhHans,
-    "ru-RU": ruRU,
-};
+import { messagesMap } from "./messagesMap";
 
 const intlStore = {};
 

--- a/libs/sdk-ui/src/base/localization/IntlWrapper.tsx
+++ b/libs/sdk-ui/src/base/localization/IntlWrapper.tsx
@@ -1,44 +1,11 @@
 // (C) 2007-2022 GoodData Corporation
 import React, { useMemo } from "react";
 import { IntlProvider } from "react-intl";
-import { translationUtils } from "@gooddata/util";
 import { DefaultLocale } from "./Locale";
 import { pickCorrectWording } from "./TranslationsCustomizationProvider/utils";
 
-import enUS from "./bundles/en-US.json";
-import deDE from "./bundles/de-DE.json";
-import esES from "./bundles/es-ES.json";
-import frFR from "./bundles/fr-FR.json";
-import jaJP from "./bundles/ja-JP.json";
-import nlNL from "./bundles/nl-NL.json";
-import ptBR from "./bundles/pt-BR.json";
-import ptPT from "./bundles/pt-PT.json";
-import zhHans from "./bundles/zh-Hans.json";
-import ruRU from "./bundles/ru-RU.json";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
-
-/**
- * @internal
- */
-export interface ITranslations {
-    [key: string]: string;
-}
-
-/**
- * @internal
- */
-export const messagesMap: { [locale: string]: ITranslations } = {
-    "en-US": translationUtils.removeMetadata(enUS),
-    "de-DE": deDE,
-    "es-ES": esES,
-    "fr-FR": frFR,
-    "ja-JP": jaJP,
-    "nl-NL": nlNL,
-    "pt-BR": ptBR,
-    "pt-PT": ptPT,
-    "zh-Hans": zhHans,
-    "ru-RU": ruRU,
-};
+import { messagesMap } from "./messagesMap";
 
 /**
  * @internal
@@ -58,10 +25,7 @@ export const IntlWrapper: React.FC<IIntlWrapperProps> = ({ locale = DefaultLocal
      */
     const settings = window.gdSettings as IWorkspaceSettings;
 
-    const messages = useMemo(
-        () => pickCorrectWording(messagesMap[locale], settings),
-        [locale, settings, messagesMap],
-    );
+    const messages = useMemo(() => pickCorrectWording(messagesMap[locale], settings), [locale, settings]);
 
     return (
         <IntlProvider locale={locale} messages={messages}>

--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/tests/utils.test.ts
@@ -6,7 +6,7 @@ import {
     removeAllWordingTranslationsWithSpecialSuffix,
 } from "../utils";
 import { IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
-import { ITranslations } from "../../../localization/IntlWrapper";
+import { ITranslations } from "../../../localization/messagesMap";
 
 const mockTranslation: ITranslations = {
     "mock.translation|insight": "Insight",

--- a/libs/sdk-ui/src/base/localization/intlUtils.tsx
+++ b/libs/sdk-ui/src/base/localization/intlUtils.tsx
@@ -1,7 +1,7 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { IntlProvider, createIntl, IntlShape } from "react-intl";
-import { ITranslations, messagesMap } from "./IntlWrapper";
+import { ITranslations, messagesMap } from "./messagesMap";
 import { DefaultLocale, ILocale } from "./Locale";
 import { wrapDisplayName } from "../react/wrapDisplayName";
 

--- a/libs/sdk-ui/src/base/localization/messagesMap.ts
+++ b/libs/sdk-ui/src/base/localization/messagesMap.ts
@@ -1,0 +1,36 @@
+// (C) 2007-2022 GoodData Corporation
+import { translationUtils } from "@gooddata/util";
+
+import enUS from "./bundles/en-US.json";
+import deDE from "./bundles/de-DE.json";
+import esES from "./bundles/es-ES.json";
+import frFR from "./bundles/fr-FR.json";
+import jaJP from "./bundles/ja-JP.json";
+import nlNL from "./bundles/nl-NL.json";
+import ptBR from "./bundles/pt-BR.json";
+import ptPT from "./bundles/pt-PT.json";
+import zhHans from "./bundles/zh-Hans.json";
+import ruRU from "./bundles/ru-RU.json";
+
+/**
+ * @internal
+ */
+export interface ITranslations {
+    [key: string]: string;
+}
+
+/**
+ * @internal
+ */
+export const messagesMap: { [locale: string]: ITranslations } = {
+    "en-US": translationUtils.removeMetadata(enUS),
+    "de-DE": deDE,
+    "es-ES": esES,
+    "fr-FR": frFR,
+    "ja-JP": jaJP,
+    "nl-NL": nlNL,
+    "pt-BR": ptBR,
+    "pt-PT": ptPT,
+    "zh-Hans": zhHans,
+    "ru-RU": ruRU,
+};


### PR DESCRIPTION
Several smaller improvements to the performance of Dashboard component.
Also improve the code around Intl: deduplicate some code and rewrite Customizations to use cancelable promises.
Also improve type checking in playground: it now ignores unused files making the error output clearer.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
