### PR TITLE
Proper conversion of intersection to filter

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillDownHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillDownHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { put } from "redux-saga/effects";
 import { DashboardContext } from "../../types/commonTypes";
@@ -14,7 +14,12 @@ export function* drillDownHandler(
 
     yield put(drillDownRequested(ctx, insight, drillDefinition, drillEvent, cmd.correlationId));
 
-    const insightWithDrillDownApplied = getInsightWithAppliedDrillDown(insight, drillEvent, drillDefinition);
+    const insightWithDrillDownApplied = getInsightWithAppliedDrillDown(
+        insight,
+        drillEvent,
+        drillDefinition,
+        ctx.backend.capabilities.supportsElementUris ?? true,
+    );
 
     return drillDownResolved(
         ctx,

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToInsightHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToInsightHandler.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { put, select } from "redux-saga/effects";
 import { DashboardContext } from "../../types/commonTypes";
@@ -22,6 +22,7 @@ export function* drillToInsightHandler(
     const insightWithDrillsApplied = addIntersectionFiltersToInsight(
         insight,
         drillEvent.drillContext.intersection!,
+        ctx.backend.capabilities.supportsElementUris ?? true,
     );
 
     return drillToInsightResolved(

--- a/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
+++ b/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
@@ -34,7 +34,7 @@ import { WithIntlProps } from 'react-intl';
 import { WrappedComponentProps } from 'react-intl';
 
 // @internal (undocumented)
-export function addIntersectionFiltersToInsight(source: IInsight, intersection: IDrillEventIntersectionElement[]): IInsight;
+export function addIntersectionFiltersToInsight(source: IInsight, intersection: IDrillEventIntersectionElement[], backendSupportsElementUris: boolean): IInsight;
 
 // @public
 export function clearInsightViewCaches(): void;
@@ -78,7 +78,7 @@ export function getInsightSizeInfo(insight: IInsightDefinition, settings: ISetti
 export function getInsightVisualizationMeta(insight: IInsightDefinition): IVisualizationMeta;
 
 // @internal (undocumented)
-export function getInsightWithAppliedDrillDown(insight: IInsight, drillEvent: IDrillEvent, drillDefinition: IDrillDownDefinition): IInsight;
+export function getInsightWithAppliedDrillDown(insight: IInsight, drillEvent: IDrillEvent, drillDefinition: IDrillDownDefinition, backendSupportsElementUris: boolean): IInsight;
 
 // @beta
 export interface IDrillDownDefinition {

--- a/libs/sdk-ui-ext/src/index.ts
+++ b/libs/sdk-ui-ext/src/index.ts
@@ -65,11 +65,16 @@ export function getInsightWithAppliedDrillDown(
     insight: IInsight,
     drillEvent: IDrillEvent,
     drillDefinition: IDrillDownDefinition,
+    backendSupportsElementUris: boolean,
 ): IInsight {
-    return FullVisualizationCatalog.forInsight(insight).applyDrillDown(insight, {
-        drillDefinition,
-        event: drillEvent,
-    });
+    return FullVisualizationCatalog.forInsight(insight).applyDrillDown(
+        insight,
+        {
+            drillDefinition,
+            event: drillEvent,
+        },
+        backendSupportsElementUris,
+    );
 }
 
 /**

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -324,7 +324,11 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         sourceVisualization: IInsight,
         drillDownContext: IDrillDownContext,
     ): IInsight {
-        return this.visualization.getInsightWithDrillDownApplied(sourceVisualization, drillDownContext);
+        return this.visualization.getInsightWithDrillDownApplied(
+            sourceVisualization,
+            drillDownContext,
+            this.props.backend.capabilities.supportsElementUris ?? true,
+        );
     }
 
     public getExecution() {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/AbstractPluggableVisualization.tsx
@@ -300,12 +300,14 @@ export abstract class AbstractPluggableVisualization implements IVisualization {
      *
      * @param sourceVisualization - drill down source {@link IInsight}
      * @param _drillDownContext - drill context (unused in this implementation)
+     * @param _backendSupportsElementUris - whether backend supports elements by uri (unused in this implementation)
      * @returns the `sourceVisualization`
      * @see {@link IVisualization.getInsightWithDrillDownApplied} for more information
      */
     public getInsightWithDrillDownApplied(
         sourceVisualization: IInsight,
         _drillDownContext: IDrillDownContext,
+        _backendSupportsElementUris: boolean,
     ): IInsight {
         return sourceVisualization;
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/PluggableColumnBarCharts.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import set from "lodash/set";
 import cloneDeep from "lodash/cloneDeep";
 import {
@@ -110,19 +110,29 @@ export class PluggableColumnBarCharts extends PluggableBaseChart {
         return hasStackByAttributes ? arrayUtils.shiftArrayRight(intersection) : intersection;
     }
 
-    private addFiltersForColumnBar(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFiltersForColumnBar(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
 
         const reorderedIntersection = this.adjustIntersectionForColumnBar(source, event);
         const cutIntersection = getIntersectionPartAfter(reorderedIntersection, clicked);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFiltersForColumnBar(
             source,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/AreaChartDescriptor.ts
@@ -34,11 +34,16 @@ export class AreaChartDescriptor extends BigChartDescriptor implements IVisualiz
         return (params) => new PluggableAreaChart(params);
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFilters(
             insight,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
@@ -69,8 +74,13 @@ export class AreaChartDescriptor extends BigChartDescriptor implements IVisualiz
         };
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/PluggableAreaChart.tsx
@@ -152,8 +152,17 @@ export class PluggableAreaChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 
@@ -233,9 +242,14 @@ export class PluggableAreaChart extends PluggableBaseChart {
         }
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
     private updateCustomSupportedProperties(insight: IInsightDefinition): void {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/areaChart/tests/PluggableAreaChart.test.tsx
@@ -760,10 +760,14 @@ describe("PluggableAreaChart", () => {
                     "first",
                 );
 
-                const result: IInsight = chart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("treemap", drillIntersection),
-                });
+                const result: IInsight = chart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("treemap", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/barChart/BarChartDescriptor.ts
@@ -37,11 +37,16 @@ export class BarChartDescriptor extends BaseChartDescriptor implements IVisualiz
         return (params) => new PluggableBarChart(params);
     }
 
-    public applyDrillDown(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFiltersForColumnBar(
             source,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
@@ -83,11 +88,16 @@ export class BarChartDescriptor extends BaseChartDescriptor implements IVisualiz
         return hasStackByAttributes ? arrayUtils.shiftArrayRight(intersection) : intersection;
     }
 
-    private addFiltersForColumnBar(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFiltersForColumnBar(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
 
         const reorderedIntersection = this.adjustIntersectionForColumnBar(source, event);
         const cutIntersection = getIntersectionPartAfter(reorderedIntersection, clicked);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/BaseChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/BaseChartDescriptor.ts
@@ -61,9 +61,17 @@ export abstract class BaseChartDescriptor implements IVisualizationDescriptor {
         return MAX_VISUALIZATION_HEIGHT;
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const intersection = drillDownContext.event.drillContext.intersection;
-        const withFilters = addIntersectionFiltersToInsight(insight, intersection);
+        const withFilters = addIntersectionFiltersToInsight(
+            insight,
+            intersection,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/PluggableBaseChart.tsx
@@ -150,9 +150,13 @@ export class PluggableBaseChart extends AbstractPluggableVisualization {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const intersection = drillDownContext.event.drillContext.intersection;
-        const withFilters = addIntersectionFiltersToInsight(source, intersection);
+        const withFilters = addIntersectionFiltersToInsight(source, intersection, backendSupportsElementUris);
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/baseChart/tests/PluggableBaseChart.test.tsx
@@ -527,10 +527,14 @@ describe("PluggableBaseChart", () => {
                     "first",
                 );
 
-                const result: IInsight = bulletChart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("column", drillIntersection),
-                });
+                const result: IInsight = bulletChart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("column", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/BulletChartDescriptor.ts
@@ -30,11 +30,16 @@ export class BulletChartDescriptor extends BaseChartDescriptor implements IVisua
         return (params) => new PluggableBulletChart(params);
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFiltersForBullet(
             insight,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
@@ -72,10 +77,15 @@ export class BulletChartDescriptor extends BaseChartDescriptor implements IVisua
         };
     }
 
-    private addFiltersForBullet(insight: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFiltersForBullet(
+        insight: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
 
         const cutIntersection = getIntersectionPartAfter(event.drillContext.intersection, clicked);
-        return addIntersectionFiltersToInsight(insight, cutIntersection);
+        return addIntersectionFiltersToInsight(insight, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/PluggableBulletChart.tsx
@@ -130,18 +130,28 @@ export class PluggableBulletChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    private addFiltersForBullet(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFiltersForBullet(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
 
         const cutIntersection = getIntersectionPartAfter(event.drillContext.intersection, clicked);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFiltersForBullet(
             source,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/bulletChart/tests/PluggableBulletChart.test.tsx
@@ -621,10 +621,14 @@ describe("PluggableBulletChart", () => {
                     "first",
                 );
 
-                const result: IInsight = chart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("bullet", drillIntersection),
-                });
+                const result: IInsight = chart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("bullet", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/columnChart/ColumnChartDescriptor.ts
@@ -37,11 +37,16 @@ export class ColumnChartDescriptor extends BaseChartDescriptor implements IVisua
         return (params) => new PluggableColumnChart(params);
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFiltersForColumnBar(
             insight,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
@@ -83,11 +88,16 @@ export class ColumnChartDescriptor extends BaseChartDescriptor implements IVisua
         return hasStackByAttributes ? arrayUtils.shiftArrayRight(intersection) : intersection;
     }
 
-    private addFiltersForColumnBar(insight: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFiltersForColumnBar(
+        insight: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
 
         const reorderedIntersection = this.adjustIntersectionForColumnBar(insight, event);
         const cutIntersection = getIntersectionPartAfter(reorderedIntersection, clicked);
-        return addIntersectionFiltersToInsight(insight, cutIntersection);
+        return addIntersectionFiltersToInsight(insight, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
@@ -117,15 +117,23 @@ export function sanitizeTableProperties(insight: IInsight): IInsight {
     return removePropertiesForRemovedAttributes(insight);
 }
 
-export function convertIntersectionToFilters(intersections: IDrillEventIntersectionElement[]): IFilter[] {
+export function convertIntersectionToFilters(
+    intersections: IDrillEventIntersectionElement[],
+    backendSupportsElementUris: boolean = true,
+): IFilter[] {
     return intersections
         .map((intersection) => intersection.header)
         .filter(isDrillIntersectionAttributeItem)
-        .map((header) =>
-            newPositiveAttributeFilter(header.attributeHeader.ref, {
-                uris: [header.attributeHeaderItem.uri],
-            }),
-        );
+        .map((header) => {
+            if (backendSupportsElementUris) {
+                return newPositiveAttributeFilter(header.attributeHeader.ref, {
+                    uris: [header.attributeHeaderItem.uri],
+                });
+            }
+            return newPositiveAttributeFilter(header.attributeHeader.ref, {
+                values: [header.attributeHeaderItem.name],
+            });
+        });
 }
 
 export function reverseAndTrimIntersection(
@@ -147,8 +155,9 @@ export function reverseAndTrimIntersection(
 export function addIntersectionFiltersToInsight(
     source: IInsight,
     intersection: IDrillEventIntersectionElement[],
+    backendSupportsElementUris: boolean,
 ): IInsight {
-    const filters = convertIntersectionToFilters(intersection);
+    const filters = convertIntersectionToFilters(intersection, backendSupportsElementUris);
     const resultFilters = [...source.insight.filters, ...filters];
 
     return insightSetFilters(source, resultFilters);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/HeatmapDescriptor.ts
@@ -30,11 +30,16 @@ export class HeatmapDescriptor extends BigChartDescriptor implements IVisualizat
         return (params) => new PluggableHeatmap(params);
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const withFilters = this.addFilters(
             insight,
             drillDownContext.drillDefinition,
             drillDownContext.event,
+            backendSupportsElementUris,
         );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
@@ -65,13 +70,18 @@ export class HeatmapDescriptor extends BigChartDescriptor implements IVisualizat
         };
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
         const cutIntersection = (event.drillContext.intersection || []).filter(
             (i) =>
                 isDrillIntersectionAttributeItem(i.header) &&
                 i.header.attributeHeader.localIdentifier === clicked,
         );
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/PluggableHeatmap.tsx
@@ -150,18 +150,32 @@ export class PluggableHeatmap extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const clicked = drillDownFromAttributeLocalId(drillConfig);
         const cutIntersection = (event.drillContext.intersection || []).filter(
             (i) =>
                 isDrillIntersectionAttributeItem(i.header) &&
                 i.header.attributeHeader.localIdentifier === clicked,
         );
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/heatMap/tests/PluggableHeatmap.test.tsx
@@ -197,10 +197,14 @@ describe("PluggableHeatmap", () => {
                     "first",
                 );
 
-                const result: IInsight = chart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("treemap", drillIntersection),
-                });
+                const result: IInsight = chart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("treemap", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/LineChartDescriptor.ts
@@ -33,8 +33,17 @@ export class LineChartDescriptor extends BaseChartDescriptor implements IVisuali
         return (params) => new PluggableLineChart(params);
     }
 
-    public applyDrillDown(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public applyDrillDown(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 
@@ -64,8 +73,13 @@ export class LineChartDescriptor extends BaseChartDescriptor implements IVisuali
         };
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/PluggableLineChart.tsx
@@ -133,8 +133,17 @@ export class PluggableLineChart extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 
@@ -285,9 +294,14 @@ export class PluggableLineChart extends PluggableBaseChart {
         ]);
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
     private getDefaultAndAvailableSort(referencePoint: IReferencePoint): {

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/lineChart/tests/PluggableLineChart.test.tsx
@@ -614,10 +614,14 @@ describe("PluggableLineChart", () => {
                     "first",
                 );
 
-                const result: IInsight = chart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("treemap", drillIntersection),
-                });
+                const result: IInsight = chart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("treemap", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PivotTableDescriptor.ts
@@ -57,7 +57,11 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
         };
     }
 
-    public applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight {
+    public applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
         const drillDownInsight = modifyBucketsAttributesForDrillDown(
             insight,
             drillDownContext.drillDefinition,
@@ -65,6 +69,7 @@ export class PivotTableDescriptor extends BaseChartDescriptor implements IVisual
         const drillDownInsightWithFilters = addIntersectionFiltersToInsight(
             drillDownInsight,
             drillDownContext.event.drillContext.intersection,
+            backendSupportsElementUris,
         );
         return sanitizeTableProperties(insightSanitize(drillDownInsightWithFilters));
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/PluggablePivotTable.tsx
@@ -263,6 +263,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
     public getInsightWithDrillDownApplied(
         sourceVisualization: IInsight,
         drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
     ): IInsight {
         const drillDownInsight = modifyBucketsAttributesForDrillDown(
             sourceVisualization,
@@ -271,6 +272,7 @@ export class PluggablePivotTable extends AbstractPluggableVisualization {
         const drillDownInsightWithFilters = addIntersectionFiltersToInsight(
             drillDownInsight,
             drillDownContext.event.drillContext.intersection,
+            backendSupportsElementUris,
         );
         return sanitizeTableProperties(insightSanitize(drillDownInsightWithFilters));
     }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/pivotTable/tests/PluggablePivotTable.test.tsx
@@ -88,6 +88,7 @@ describe("PluggablePivotTable", () => {
                     drillDefinition: getInsightWithDrillDownApplied.drillConfig,
                     event: createDrillEvent("column", getInsightWithDrillDownApplied.intersection),
                 },
+                true,
             );
 
             expect(result).toEqual(getInsightWithDrillDownApplied.expectedInsight);
@@ -101,6 +102,7 @@ describe("PluggablePivotTable", () => {
                     drillDefinition: getInsightWithDrillDownApplied.drillConfig,
                     event: createDrillEvent("column", getInsightWithDrillDownApplied.intersection),
                 },
+                true,
             );
 
             expect(result).toEqual(getInsightWithDrillDownApplied.expectedInsightWithTotals);

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/tests/PluggableColumnBarCharts.test.tsx
@@ -562,10 +562,14 @@ describe("PluggableColumnBarCharts", () => {
                     "first",
                 );
 
-                const result: IInsight = columnChart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("column", drillIntersection),
-                });
+                const result: IInsight = columnChart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("column", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/PluggableTreemap.tsx
@@ -183,13 +183,27 @@ export class PluggableTreemap extends PluggableBaseChart {
         return Promise.resolve(sanitizeFilters(newReferencePoint));
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 
-    public getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/TreemapDescriptor.ts
@@ -31,8 +31,17 @@ export class TreemapDescriptor extends BigChartDescriptor {
         return (params) => new PluggableTreemap(params);
     }
 
-    public applyDrillDown(source: IInsight, drillDownContext: IDrillDownContext): IInsight {
-        const withFilters = this.addFilters(source, drillDownContext.drillDefinition, drillDownContext.event);
+    public applyDrillDown(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight {
+        const withFilters = this.addFilters(
+            source,
+            drillDownContext.drillDefinition,
+            drillDownContext.event,
+            backendSupportsElementUris,
+        );
         return modifyBucketsAttributesForDrillDown(withFilters, drillDownContext.drillDefinition);
     }
 
@@ -61,8 +70,13 @@ export class TreemapDescriptor extends BigChartDescriptor {
         };
     }
 
-    private addFilters(source: IInsight, drillConfig: IDrillDownDefinition, event: IDrillEvent) {
+    private addFilters(
+        source: IInsight,
+        drillConfig: IDrillDownDefinition,
+        event: IDrillEvent,
+        backendSupportsElementUris: boolean,
+    ) {
         const cutIntersection = reverseAndTrimIntersection(drillConfig, event.drillContext.intersection);
-        return addIntersectionFiltersToInsight(source, cutIntersection);
+        return addIntersectionFiltersToInsight(source, cutIntersection, backendSupportsElementUris);
     }
 }

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/tests/PluggableTreemap.test.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/treeMap/tests/PluggableTreemap.test.tsx
@@ -181,10 +181,14 @@ describe("PluggableTreemap", () => {
                     "first",
                 );
 
-                const result: IInsight = chart.getInsightWithDrillDownApplied(sourceInsight, {
-                    drillDefinition,
-                    event: createDrillEvent("treemap", drillIntersection),
-                });
+                const result: IInsight = chart.getInsightWithDrillDownApplied(
+                    sourceInsight,
+                    {
+                        drillDefinition,
+                        event: createDrillEvent("treemap", drillIntersection),
+                    },
+                    true,
+                );
 
                 expect(result).toEqual(expectedInsight);
             },

--- a/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/Visualization.ts
@@ -401,9 +401,14 @@ export interface IVisualization {
      *
      * @param source - {@link IInsight} to be used for the the Drill Down execution
      * @param drillDownContext - Drill Down configuration used to properly create the result
+     * @param backendSupportsElementUris - whether current backend supports elements by uri. Affects how filters for insight are created
      * @returns `source` as the Drill Down target {@link IInsight}
      */
-    getInsightWithDrillDownApplied(source: IInsight, drillDownContext: IDrillDownContext): IInsight;
+    getInsightWithDrillDownApplied(
+        source: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight;
 
     /**
      * Called whenever inputs for default sorts calculation changed and it should provide current sort and also all valid available sorts for actual reference point/properties

--- a/libs/sdk-ui-ext/src/internal/interfaces/VisualizationDescriptor.ts
+++ b/libs/sdk-ui-ext/src/internal/interfaces/VisualizationDescriptor.ts
@@ -154,9 +154,14 @@ export interface IVisualizationDescriptor {
      *
      * @param insight - {@link @gooddata/sdk-model#IInsight} to be used for the the drill down application
      * @param drillDownContext - drill down configuration used to properly create the result
+     * @param backendSupportsElementUris - whether current backend supports elements by uri. Affects how filters for insight are created
      * @returns {@link @gooddata/sdk-model#IInsight} with modified buckets and filters according to the provided drill down context.
      */
-    applyDrillDown(insight: IInsight, drillDownContext: IDrillDownContext): IInsight;
+    applyDrillDown(
+        insight: IInsight,
+        drillDownContext: IDrillDownContext,
+        backendSupportsElementUris: boolean,
+    ): IInsight;
 
     /**
      * When called, returns a source code that can be used to embed the visualization in a custom application.


### PR DESCRIPTION
JIRA: TNT-836
For Tiger which does not support elements by Uri we need to use element's value when converting attribute item from drill intersection to the attribute filter when drilling to the insight

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
