### PR TITLE
RELATED: RAIL-4171 Allow dashboard loaders load empty dashboards

### DIFF
--- a/libs/sdk-ui-loaders/api/sdk-ui-loaders.api.md
+++ b/libs/sdk-ui-loaders/api/sdk-ui-loaders.api.md
@@ -61,7 +61,7 @@ export const DashboardStub: React_2.FC<IDashboardStubProps>;
 
 // @public
 export interface IDashboardBasePropsForLoader extends Omit<IDashboardBaseProps, "dashboard"> {
-    dashboard: string | ObjRef;
+    dashboard: string | ObjRef | undefined;
 }
 
 // @public

--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/adaptiveComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/adaptiveComponentLoaders.ts
@@ -24,8 +24,8 @@ import { IDashboardPluginsLoaderOptions, LoadedPlugin, ModuleFederationIntegrati
  */
 export const adaptiveDashboardEngineLoaderFactory =
     (moduleFederationIntegration: ModuleFederationIntegration) =>
-    (dashboard: IDashboardWithReferences): Promise<IDashboardEngine> => {
-        if (!isEmpty(dashboard.references.plugins)) {
+    (dashboard: IDashboardWithReferences | undefined): Promise<IDashboardEngine> => {
+        if (dashboard && !isEmpty(dashboard.references.plugins)) {
             return dynamicDashboardEngineLoader(dashboard, moduleFederationIntegration);
         }
 
@@ -45,10 +45,10 @@ export const adaptiveDashboardPluginLoaderFactory =
     (moduleFederationIntegration: ModuleFederationIntegration) =>
     (
         ctx: DashboardContext,
-        dashboard: IDashboardWithReferences,
+        dashboard: IDashboardWithReferences | undefined,
         options?: IDashboardPluginsLoaderOptions,
     ): Promise<LoadedPlugin[]> => {
-        if (!isEmpty(dashboard.references.plugins)) {
+        if (dashboard && !isEmpty(dashboard.references.plugins)) {
             options?.beforePluginsLoaded({ externalPluginsCount: dashboard.references.plugins.length });
             return dynamicDashboardPluginLoader(ctx, dashboard, moduleFederationIntegration);
         }
@@ -67,8 +67,8 @@ export const adaptiveDashboardPluginLoaderFactory =
  */
 export const adaptiveDashboardBeforeLoadFactory =
     (_moduleFederationIntegration: ModuleFederationIntegration) =>
-    (ctx: DashboardContext, dashboard: IDashboardWithReferences): Promise<void> => {
-        if (!isEmpty(dashboard.references.plugins)) {
+    (ctx: DashboardContext, dashboard: IDashboardWithReferences | undefined): Promise<void> => {
+        if (dashboard && !isEmpty(dashboard.references.plugins)) {
             return dynamicDashboardBeforeLoad(ctx, dashboard);
         }
 

--- a/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/staticComponentLoaders.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/loadingStrategies/staticComponentLoaders.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 
 import { IDashboardWithReferences } from "@gooddata/sdk-backend-spi";
 import { DashboardContext, IDashboardEngine, newDashboardEngine } from "@gooddata/sdk-ui-dashboard";
@@ -11,7 +11,9 @@ import { LoadedPlugin } from "../types";
  * @param _dashboard - ignored
  * @internal
  */
-export function staticDashboardEngineLoader(_dashboard: IDashboardWithReferences): Promise<IDashboardEngine> {
+export function staticDashboardEngineLoader(
+    _dashboard: IDashboardWithReferences | undefined,
+): Promise<IDashboardEngine> {
     return Promise.resolve(newDashboardEngine());
 }
 
@@ -29,7 +31,7 @@ export function staticDashboardEngineLoader(_dashboard: IDashboardWithReferences
  */
 export function noopDashboardPluginLoader(
     _ctx: DashboardContext,
-    _dashboard: IDashboardWithReferences,
+    _dashboard: IDashboardWithReferences | undefined,
 ): Promise<LoadedPlugin[]> {
     return Promise.resolve([]);
 }
@@ -47,7 +49,7 @@ export function noopDashboardPluginLoader(
  */
 export function noopDashboardBeforeLoad(
     _ctx: DashboardContext,
-    _dashboard: IDashboardWithReferences,
+    _dashboard: IDashboardWithReferences | undefined,
 ): Promise<void> {
     return Promise.resolve();
 }

--- a/libs/sdk-ui-loaders/src/dashboard/types.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/types.ts
@@ -31,13 +31,13 @@ export interface IEmbeddedPlugin {
  */
 export interface IDashboardBasePropsForLoader extends Omit<IDashboardBaseProps, "dashboard"> {
     /**
-     * Specify reference to an existing dashboard that should be loaded.
+     * Specify reference to an existing dashboard that should be loaded or undefined to initialize an empty one.
      *
      * @remarks
      * You may specify an `idRef` or `uriRef`; as a convenience you may also specify dashboard object
      * identifier (string) - that's same as using `idRef(objectIdentifier)`.
      */
-    dashboard: string | ObjRef;
+    dashboard: string | ObjRef | undefined;
 }
 
 /**

--- a/libs/sdk-ui-loaders/src/dashboard/useDashboardLoader.ts
+++ b/libs/sdk-ui-loaders/src/dashboard/useDashboardLoader.ts
@@ -115,14 +115,16 @@ export function useDashboardLoader(options: IDashboardLoadOptions): DashboardLoa
 
         // eslint-disable-next-line no-console
         console.log(
-            `Dashboard loader initialized in ${loadingMode} mode to load ${objRefToString(dashboardRef)}.`,
+            `Dashboard loader initialized in ${loadingMode} mode to load ${
+                dashboardRef ? objRefToString(dashboardRef) : "empty dashboard"
+            }.`,
         );
 
         return loader;
     }, [
         backend,
         workspace,
-        serializeObjRef(dashboardRef),
+        dashboardRef && serializeObjRef(dashboardRef),
         filterContextRef,
         config,
         permissions,


### PR DESCRIPTION
This is useful for loading an empty dashboard with some local plugins.

JIRA: RAIL-4171

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
