### PR TITLE
RELATED: TNT-845 Revert "Use useCancelablePromise in TranslationsCustomization"

### DIFF
--- a/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/TranslationsCustomizationProvider.tsx
+++ b/libs/sdk-ui/src/base/localization/TranslationsCustomizationProvider/TranslationsCustomizationProvider.tsx
@@ -1,12 +1,11 @@
 // (C) 2021-2022 GoodData Corporation
-import React, { useMemo } from "react";
 import { IAnalyticalBackend, IWorkspaceSettings } from "@gooddata/sdk-backend-spi";
+import React, { useEffect, useState } from "react";
 import { useBackend } from "../../react/BackendContext";
 import { useWorkspace } from "../../react/WorkspaceContext";
 import { TranslationsCustomizationContextProvider } from "./Context";
 import { getWorkspaceSettingsLoader } from "./workspaceSettingsLoader";
 import { pickCorrectWording } from "./utils";
-import { useCancelablePromise } from "../../react/useCancelablePromise";
 
 declare global {
     interface Window {
@@ -75,38 +74,34 @@ export const TranslationsCustomizationProvider: React.FC<ITranslationsCustomizat
 }) => {
     const backend = useBackend(backendParam);
     const workspace = useWorkspace(workspaceParam);
+    const [translations, setTranslations] = useState(() => customize(translationsParam));
+    const [isLoading, setIsLoading] = useState(false);
 
-    const { status, result: settings } = useCancelablePromise(
-        {
-            promise:
-                backend && workspace
-                    ? () => {
-                          /**
-                           * Load the settings using a centralized loader with cache to prevent duplicate network requests.
-                           */
-                          const loader = getWorkspaceSettingsLoader();
-                          return loader.load(backend, workspace);
-                      }
-                    : undefined,
-            onSuccess: (settings) => {
-                /**
-                 * Because of issues described in the ticket FET-855, we decided to use this workaround.
-                 * After the issues that are described in the ticket are solved or at least reduced,
-                 * this workaround can be removed.
-                 */
-                window.gdSettings = settings;
-            },
-        },
-        [backend, workspace, translationsParam],
-    );
+    useEffect(() => {
+        const fetchSettings = async () => {
+            if (!backend || !workspace) {
+                return;
+            }
+            setIsLoading(true);
 
-    const translations = useMemo(() => {
-        return customize(translationsParam, settings);
-    }, [customize, settings, translationsParam]);
+            /**
+             * Load the settings using a centralized loader with cache to prevent duplicate network requests.
+             */
+            const loader = getWorkspaceSettingsLoader();
+            const settings = await loader.load(backend, workspace);
 
-    const isLoading = !!(
-        (status === "loading" || (backend && workspace && status === "pending")) // only consider pending as loading if there is a chance we will load at all
-    );
+            /**
+             * Because of issues described in the ticket FET-855, we decided to use this workaround.
+             * After the issues that are described in the ticket are solved or at least reduced,
+             * this workaround can be removed.
+             */
+            window.gdSettings = settings;
+            setTranslations(customize(translationsParam, settings));
+            setIsLoading(false);
+        };
+
+        fetchSettings();
+    }, [backend, workspace, translationsParam]);
 
     return (
         <TranslationsCustomizationContextProvider


### PR DESCRIPTION
This reverts commit be863c7315159d5f52c90dd9f4cc9c4655402e51.

TNT: TNT-845

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
