### PR TITLE
RELATED: TNT-422 Percentage format propagation into insight

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -386,7 +386,11 @@ export function percentageDataLabelFormatter(config?: IChartConfig): string {
     //  * left or right axis on single axis chart, or
     //  * primary axis on dual axis chart
     if (this.percentage && (isSingleAxis || isPrimaryAxis)) {
-        return percentFormatter(this.percentage);
+        return percentFormatter(
+            this.percentage,
+            this.series?.data?.length > 0 && this.series.data[0].format,
+            this.separators,
+        );
     }
 
     return labelFormatter.call(this, config);

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/test/customConfiguration.test.ts
@@ -942,6 +942,47 @@ describe("getCustomizedConfiguration", () => {
                     expect(result).toBe(expected);
                 },
             );
+
+            const testNumber = 25.012345678;
+            const roundingNumber = 25.654321;
+            it.each([
+                ["with 0 decimals", testNumber, "#,##0%", "25%"],
+                ["with 0 decimals but rounded up", roundingNumber, "#,##0%", "26%"],
+                ["with given decimals", testNumber, "#,##0.000%", "25.012%"],
+                ["with given decimals", testNumber, "#,##0.0000%", "25.0123%"],
+                [
+                    "with given decimals even though there is a white space",
+                    testNumber,
+                    "#,##0.0000% ",
+                    "25.0123%",
+                ],
+                [
+                    "with default decimals since last character is not '%'",
+                    testNumber,
+                    "#,##0.0000%_",
+                    "25.01%",
+                ],
+                [
+                    "with default decimals since the format does not contain '%'",
+                    testNumber,
+                    "#,##0.0000",
+                    "25.01%",
+                ],
+            ])(
+                "should format data labels to percentage %s",
+                (_state: string, input: number, format: string, expected: string) => {
+                    const dataLabel = {
+                        separators: { decimal: ".", thousand: "," },
+                        percentage: input,
+                        stackMeasuresToPercent: true,
+                        series: {
+                            data: [{ format }],
+                        },
+                    };
+                    const result = percentageDataLabelFormatter.call(dataLabel);
+                    expect(result).toBe(expected);
+                },
+            );
         });
     });
 

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/tooltip.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/tooltip.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { colors2Object, INumberObject, ISeparators, numberFormat } from "@gooddata/numberjs";
 import { customEscape, percentFormatter } from "../_util/common";
 import isNil from "lodash/isNil";
@@ -25,5 +25,5 @@ export function getFormattedValueForTooltip(
         stackMeasuresToPercent === false || isNil(percentageValue) || isDualChartWithRightAxis;
     return isNotStackToPercent
         ? formatValueForTooltip(target ?? y, format, separators)
-        : percentFormatter(percentageValue);
+        : percentFormatter(percentageValue, format, separators);
 }

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
@@ -3,7 +3,7 @@ import clone from "lodash/clone";
 import includes from "lodash/includes";
 import isNil from "lodash/isNil";
 import setWith from "lodash/setWith";
-import { numberFormat } from "@gooddata/numberjs";
+import { ISeparators, numberFormat } from "@gooddata/numberjs";
 import escape from "lodash/escape";
 import isEqual from "lodash/fp/isEqual";
 import unescape from "lodash/unescape";
@@ -166,8 +166,31 @@ export const unwrap = (wrappedObject: unknown): any => {
     return wrappedObject[Object.keys(wrappedObject)[0]];
 };
 
-export function percentFormatter(value: number): string {
-    return isNil(value) ? "" : `${parseFloat(value.toFixed(2))}%`;
+const getNumberWithGivenDecimals = (value: number, decimalNumbers: number) =>
+    decimalNumbers === 0 ? `${Math.round(value)}%` : `${parseFloat(value.toFixed(decimalNumbers))}%`;
+
+const getNumberOfFormatDecimals = (format: string, decimalSeparator: string): number => {
+    const splittedFormat = format.split(decimalSeparator);
+
+    if (splittedFormat.length !== 2) {
+        return 0;
+    }
+
+    return Array.from(splittedFormat[1]).reduce(
+        (numberOfDecimals, letter) => (letter === "0" ? numberOfDecimals + 1 : numberOfDecimals),
+        0,
+    );
+};
+
+export function percentFormatter(value: number, format?: string, separators?: ISeparators): string {
+    if (isNil(value)) {
+        return "";
+    }
+
+    const isPercentageFormat = format && format.trim().slice(-1) === "%" && separators;
+    const numberOfDecimals = isPercentageFormat ? getNumberOfFormatDecimals(format, separators.decimal) : 2;
+
+    return getNumberWithGivenDecimals(value, numberOfDecimals);
 }
 
 export const isCssMultiLineTruncationSupported = (): boolean => {


### PR DESCRIPTION
If stackTo100 is set then it propagates only percentage and custom format (with '%' in the end of string) from bucket to insight values. In case of any other format it sets decimal points to two.

JIRA: TNT-422

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
