### PR TITLE
RELATED: RAIL-4231 add support for hiding attribute elements from the filter

### DIFF
--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -306,7 +306,6 @@ export type IAttributeFilterHandlerOptions = ISingleSelectAttributeFilterHandler
 
 // @alpha
 export interface IAttributeFilterHandlerOptionsBase {
-    // (undocumented)
     hiddenElements?: string[];
 }
 

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -302,6 +302,15 @@ export type IAttributeFilterButtonProps = IAttributeFilterButtonOwnProps & Wrapp
 export type IAttributeFilterHandler = IMultiSelectAttributeFilterHandler | ISingleSelectAttributeFilterHandler;
 
 // @alpha
+export type IAttributeFilterHandlerOptions = ISingleSelectAttributeFilterHandlerOptions | IMultiSelectAttributeFilterHandlerOptions;
+
+// @alpha
+export interface IAttributeFilterHandlerOptionsBase {
+    // (undocumented)
+    hiddenElements?: string[];
+}
+
+// @alpha
 export interface IAttributeFilterLoader extends IAttributeLoader, IAttributeElementLoader {
     getFilter(): IAttributeFilter;
     // (undocumented)
@@ -554,6 +563,12 @@ export interface IMessageTranslator {
 export interface IMultiSelectAttributeFilterHandler extends IAttributeFilterLoader, IStagedInvertableSelectionHandler<InvertableAttributeElementSelection> {
 }
 
+// @alpha
+export interface IMultiSelectAttributeFilterHandlerOptions extends IAttributeFilterHandlerOptionsBase {
+    // (undocumented)
+    selectionMode: "multi";
+}
+
 // @alpha (undocumented)
 export type InvertableAttributeElementSelection = InvertableSelection<IAttributeElement>;
 
@@ -625,6 +640,12 @@ export const isEmptyListItem: (item: Partial<AttributeListItem>) => item is Empt
 
 // @alpha
 export interface ISingleSelectAttributeFilterHandler extends IAttributeFilterLoader, IStagedSingleSelectionHandler<IAttributeElement | undefined> {
+}
+
+// @alpha
+export interface ISingleSelectAttributeFilterHandlerOptions extends IAttributeFilterHandlerOptionsBase {
+    // (undocumented)
+    selectionMode: "single";
 }
 
 // @alpha
@@ -748,14 +769,10 @@ export class MeasureValueFilterDropdown extends React_2.PureComponent<IMeasureVa
 }
 
 // @alpha (undocumented)
-export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, filter: IAttributeFilter, options: {
-    selectionMode: "single";
-}): ISingleSelectAttributeFilterHandler;
+export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, filter: IAttributeFilter, options: ISingleSelectAttributeFilterHandlerOptions): ISingleSelectAttributeFilterHandler;
 
 // @alpha (undocumented)
-export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, filter: IAttributeFilter, options: {
-    selectionMode: "multi";
-}): IMultiSelectAttributeFilterHandler;
+export function newAttributeFilterHandler(backend: IAnalyticalBackend, workspace: string, filter: IAttributeFilter, options: IMultiSelectAttributeFilterHandlerOptions): IMultiSelectAttributeFilterHandler;
 
 // @beta (undocumented)
 export const RankingFilter: React_2.FC<IRankingFilterProps>;

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/factory.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/factory.ts
@@ -15,6 +15,14 @@ import {
  * @alpha
  */
 export interface IAttributeFilterHandlerOptionsBase {
+    /**
+     * If specified, these will be excluded from the elements available for selection and will also be removed from the resulting filter.
+     * This effectively behaves as if those elements were not part of the underlying display form.
+     *
+     * @remarks
+     * The meaning of the items is determined by the way the filter is specified: if the filter uses URIs,
+     * then these are also interpreted as URIs, analogously with values.
+     */
     hiddenElements?: string[];
 }
 

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/factory.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/factory.ts
@@ -10,13 +10,40 @@ import {
 } from "./types";
 
 /**
- * Options for initialization of the {@link IAttributeFilterHandler}
+ * Common options for initialization of the {@link IAttributeFilterHandler}.
  *
  * @alpha
  */
-export interface IAttributeFilterHandlerOptions {
-    selectionMode?: "single" | "multi";
+export interface IAttributeFilterHandlerOptionsBase {
+    hiddenElements?: string[];
 }
+
+/**
+ * Options for initialization of the {@link IAttributeFilterHandler} with single selection.
+ *
+ * @alpha
+ */
+export interface ISingleSelectAttributeFilterHandlerOptions extends IAttributeFilterHandlerOptionsBase {
+    selectionMode: "single";
+}
+
+/**
+ * Options for initialization of the {@link IAttributeFilterHandler} with multi selection.
+ *
+ * @alpha
+ */
+export interface IMultiSelectAttributeFilterHandlerOptions extends IAttributeFilterHandlerOptionsBase {
+    selectionMode: "multi";
+}
+
+/**
+ * Options for initialization of the {@link IAttributeFilterHandler}.
+ *
+ * @alpha
+ */
+export type IAttributeFilterHandlerOptions =
+    | ISingleSelectAttributeFilterHandlerOptions
+    | IMultiSelectAttributeFilterHandlerOptions;
 
 /**
  * @alpha
@@ -25,9 +52,7 @@ export function newAttributeFilterHandler(
     backend: IAnalyticalBackend,
     workspace: string,
     filter: IAttributeFilter,
-    options: {
-        selectionMode: "single";
-    },
+    options: ISingleSelectAttributeFilterHandlerOptions,
 ): ISingleSelectAttributeFilterHandler;
 /**
  * @alpha
@@ -36,9 +61,7 @@ export function newAttributeFilterHandler(
     backend: IAnalyticalBackend,
     workspace: string,
     filter: IAttributeFilter,
-    options: {
-        selectionMode: "multi";
-    },
+    options: IMultiSelectAttributeFilterHandlerOptions,
 ): IMultiSelectAttributeFilterHandler;
 /**
  * @alpha
@@ -47,13 +70,13 @@ export function newAttributeFilterHandler(
     backend: IAnalyticalBackend,
     workspace: string,
     filter: IAttributeFilter,
-    options: IAttributeFilterHandlerOptions = {},
+    options: IAttributeFilterHandlerOptions = { selectionMode: "multi" },
 ): IAttributeFilterHandler {
-    const { selectionMode = "muilti" } = options;
+    const { selectionMode, hiddenElements } = options;
 
     if (selectionMode === "multi") {
-        return new MultiSelectAttributeFilterHandler({ backend, workspace, filter });
+        return new MultiSelectAttributeFilterHandler({ backend, workspace, filter, hiddenElements });
     }
 
-    return new SingleSelectAttributeFilterHandler({ backend, workspace, filter });
+    return new SingleSelectAttributeFilterHandler({ backend, workspace, filter, hiddenElements });
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/bridge/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/bridge/index.ts
@@ -21,7 +21,7 @@ import {
     Loadable,
     LoadableStatus,
 } from "../../types/common";
-import { InvertableAttributeElementSelection } from "../../types";
+import { IAttributeFilterHandlerConfig, InvertableAttributeElementSelection } from "../../types";
 import {
     actions,
     AttributeFilterStore,
@@ -61,15 +61,6 @@ export interface ElementsLoadConfig {
 /**
  * @internal
  */
-export interface IAttributeFilterHandlerConfig {
-    readonly backend: IAnalyticalBackend;
-    readonly workspace: string;
-    readonly filter: IAttributeFilter;
-}
-
-/**
- * @internal
- */
 export class AttributeFilterReduxBridge {
     private redux: AttributeFilterStore;
 
@@ -89,7 +80,9 @@ export class AttributeFilterReduxBridge {
                 this.callbacks.eventListener(action, select);
             },
         });
-        this.redux.dispatch(actions.init({ attributeFilter: config.filter }));
+        this.redux.dispatch(
+            actions.init({ attributeFilter: config.filter, hiddenElements: config.hiddenElements }),
+        );
     };
 
     reset = (): void => {

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/loader.ts
@@ -46,6 +46,7 @@ export interface IAttributeFilterHandlerConfig {
     readonly backend: IAnalyticalBackend;
     readonly workspace: string;
     readonly filter: IAttributeFilter;
+    readonly hiddenElements?: string[];
 }
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/loader.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/loader.ts
@@ -20,7 +20,7 @@ import {
     Loadable,
     LoadableStatus,
 } from "../types/common";
-import { IAttributeFilterLoader } from "../types";
+import { IAttributeFilterHandlerConfig, IAttributeFilterLoader } from "../types";
 import { AttributeFilterReduxBridge } from "./bridge";
 
 /**
@@ -37,16 +37,6 @@ export interface ElementsLoadConfig {
     limitingMeasures?: IMeasure[];
     limitingDateFilters?: IRelativeDateFilter[];
     elements?: ElementsQueryOptionsElementsSpecification;
-}
-
-/**
- * @internal
- */
-export interface IAttributeFilterHandlerConfig {
-    readonly backend: IAnalyticalBackend;
-    readonly workspace: string;
-    readonly filter: IAttributeFilter;
-    readonly hiddenElements?: string[];
 }
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/multiSelectHandler.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/multiSelectHandler.ts
@@ -1,7 +1,11 @@
 // (C) 2022 GoodData Corporation
 import { CallbackRegistration } from "../types/common";
-import { IMultiSelectAttributeFilterHandler, InvertableAttributeElementSelection } from "../types";
-import { AttributeFilterLoader, IAttributeFilterHandlerConfig } from "./loader";
+import {
+    IAttributeFilterHandlerConfig,
+    IMultiSelectAttributeFilterHandler,
+    InvertableAttributeElementSelection,
+} from "../types";
+import { AttributeFilterLoader } from "./loader";
 
 /**
  * @internal

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/singleSelectHandler.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/impl/singleSelectHandler.ts
@@ -8,8 +8,12 @@ import {
     isAttributeElementsByRef,
     isPositiveAttributeFilter,
 } from "@gooddata/sdk-model";
-import { CallbackRegistration, ISingleSelectAttributeFilterHandler } from "../types";
-import { AttributeFilterLoader, IAttributeFilterHandlerConfig } from "./loader";
+import {
+    CallbackRegistration,
+    IAttributeFilterHandlerConfig,
+    ISingleSelectAttributeFilterHandler,
+} from "../types";
+import { AttributeFilterLoader } from "./loader";
 
 /**
  * @internal

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/index.ts
@@ -1,3 +1,9 @@
 // (C) 2022 GoodData Corporation
 export * from "./types";
-export { newAttributeFilterHandler, IAttributeFilterHandlerOptions } from "./factory";
+export {
+    newAttributeFilterHandler,
+    IAttributeFilterHandlerOptions,
+    IAttributeFilterHandlerOptionsBase,
+    IMultiSelectAttributeFilterHandlerOptions,
+    ISingleSelectAttributeFilterHandlerOptions,
+} from "./factory";

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/attributeElements/sagas.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/attributeElements/sagas.ts
@@ -2,7 +2,8 @@
 import { SagaIterator } from "redux-saga";
 import { call, put, select, SagaReturnType, takeEvery } from "redux-saga/effects";
 
-import { selectAttributeFilterDisplayForm } from "../main/selectors";
+import { selectAttributeFilterDisplayForm, selectHiddenElementsAsAttributeElements } from "../main/selectors";
+import { selectAttribute } from "../attribute/selectors";
 import { cancelableEffect, getAttributeFilterContext } from "../common/sagas";
 import { actions } from "../slice";
 import { loadAttributeElements } from "./effects";
@@ -22,12 +23,24 @@ function* attributeElementsRequestSaga({
         selectAttributeFilterDisplayForm,
     );
 
+    const hiddenElements: ReturnType<typeof selectHiddenElementsAsAttributeElements> = yield select(
+        selectHiddenElementsAsAttributeElements,
+    );
+    const attribute: ReturnType<typeof selectAttribute> = yield select(selectAttribute);
+
     const cancelableElementsLoad = cancelableEffect({
         effect: () =>
-            loadAttributeElements(context, {
-                ...options,
-                displayFormRef,
-            }),
+            loadAttributeElements(
+                context,
+                {
+                    ...options,
+                    displayFormRef,
+                },
+                {
+                    hiddenElements,
+                    attribute,
+                },
+            ),
         isCancelRequest: (a) =>
             actions.attributeElementsCancelRequest.match(a) && a.payload.correlationId === correlationId,
     });

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/reducers.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/reducers.ts
@@ -16,9 +16,12 @@ import {
 } from "@gooddata/sdk-model";
 import { ILoadAttributeElementsOptions } from "../attributeElements/effects";
 
-const init: AttributeFilterReducer<
-    PayloadAction<{ attributeFilter: IAttributeFilter; hiddenElements?: string[] }>
-> = (state, action) => {
+/**
+ * @internal
+ */
+export type InitActionPayload = { attributeFilter: IAttributeFilter; hiddenElements?: string[] };
+
+const init: AttributeFilterReducer<PayloadAction<InitActionPayload>> = (state, action) => {
     state.displayForm = filterObjRef(action.payload.attributeFilter);
     const elements = filterAttributeElements(action.payload.attributeFilter);
     state.elementsForm = isAttributeElementsByValue(elements) ? "values" : "uris";

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/reducers.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/reducers.ts
@@ -16,10 +16,9 @@ import {
 } from "@gooddata/sdk-model";
 import { ILoadAttributeElementsOptions } from "../attributeElements/effects";
 
-const init: AttributeFilterReducer<PayloadAction<{ attributeFilter: IAttributeFilter }>> = (
-    state,
-    action,
-) => {
+const init: AttributeFilterReducer<
+    PayloadAction<{ attributeFilter: IAttributeFilter; hiddenElements?: string[] }>
+> = (state, action) => {
     state.displayForm = filterObjRef(action.payload.attributeFilter);
     const elements = filterAttributeElements(action.payload.attributeFilter);
     state.elementsForm = isAttributeElementsByValue(elements) ? "values" : "uris";
@@ -29,6 +28,7 @@ const init: AttributeFilterReducer<PayloadAction<{ attributeFilter: IAttributeFi
     const isInverted = isNegativeAttributeFilter(action.payload.attributeFilter);
     state.isCommitedSelectionInverted = isInverted;
     state.isWorkingSelectionInverted = isInverted;
+    state.hiddenElements = action.payload.hiddenElements;
 };
 
 const initSuccess: AttributeFilterReducer = identity;
@@ -67,6 +67,13 @@ const setLimitingDateFilters: AttributeFilterReducer<PayloadAction<{ filters: IR
     action,
 ) => {
     state.limitingDateFilters = action.payload.filters;
+};
+
+const setHiddenElements: AttributeFilterReducer<PayloadAction<{ hiddenElements: string[] | undefined }>> = (
+    state,
+    action,
+) => {
+    state.hiddenElements = action.payload.hiddenElements;
 };
 
 const loadElementsRangeRequest: AttributeFilterReducer<
@@ -109,6 +116,7 @@ export const mainReducers = {
     setLimitingAttributeFilters,
     setLimitingMeasures,
     setLimitingDateFilters,
+    setHiddenElements,
     //
     loadElementsRangeRequest,
     loadElementsRangeSuccess,

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/sagas/init.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/sagas/init.ts
@@ -1,11 +1,13 @@
 // (C) 2022 GoodData Corporation
 import { SagaIterator } from "redux-saga";
 import { all, call, cancelled, put, takeLatest } from "redux-saga/effects";
+import { PayloadAction } from "@reduxjs/toolkit";
 
 import { actions } from "../../slice";
 import { initAttributeSaga } from "../sagas/initAttribute";
 import { initSelectionSaga } from "../sagas/initSelection";
 import { initAttributeElementsSaga } from "../sagas/initAttributeElements";
+import { InitActionPayload } from "../reducers";
 
 /**
  * @internal
@@ -14,9 +16,16 @@ export function* initWorker(): SagaIterator<void> {
     yield takeLatest(actions.init.match, initSaga);
 }
 
-function* initSaga(): SagaIterator<void> {
+function* initSaga(action: PayloadAction<InitActionPayload>): SagaIterator<void> {
     try {
-        yield all([call(initAttributeSaga), call(initSelectionSaga), call(initAttributeElementsSaga)]);
+        if (action.payload.hiddenElements?.length > 0) {
+            yield call(initAttributeSaga);
+            // these need the attribute loaded for the hiddenElements to work
+            yield all([call(initSelectionSaga), call(initAttributeElementsSaga)]);
+        } else {
+            yield all([call(initAttributeSaga), call(initSelectionSaga), call(initAttributeElementsSaga)]);
+        }
+
         yield put(actions.initSuccess());
     } catch (error) {
         yield put(actions.initError({ error }));

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/selectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/main/selectors.ts
@@ -34,6 +34,11 @@ export const selectLimitingDateFilters = createSelector(selectState, (state) => 
 /**
  * @internal
  */
+export const selectHiddenElements = createSelector(selectState, (state) => state.hiddenElements ?? []);
+
+/**
+ * @internal
+ */
 export const selectAttributeFilterDisplayForm = createSelector(selectState, (state) => state.displayForm);
 
 /**
@@ -48,7 +53,7 @@ export const selectAttributeFilterElements = createSelector(
     selectAttributeFilterElementsForm,
     selectCommitedSelection,
     (elementsForm, selection): IAttributeElements =>
-        elementsForm === "uris" ? { uris: selection } : { values: selection },
+        elementsForm === "uris" ? { uris: selection } : { values: selection }, // TODO: DHO take hidden elements into account
 );
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/state.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/internal/store/state.ts
@@ -41,6 +41,7 @@ export interface AttributeFilterState {
     limitingAttributeFilters?: IElementsQueryAttributeFilter[];
     limitingMeasures?: IMeasure[];
     limitingDateFilters?: IRelativeDateFilter[];
+    hiddenElements?: string[];
 }
 
 /**

--- a/libs/sdk-ui-filters/src/AttributeFilterLoader/types/loader/index.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterLoader/types/loader/index.ts
@@ -1,4 +1,5 @@
 // (C) 2022 GoodData Corporation
+import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 import { IAttributeFilter } from "@gooddata/sdk-model";
 import { CallbackRegistration } from "../common";
 import { IAttributeLoader } from "./attribute";
@@ -24,4 +25,14 @@ export interface IAttributeFilterLoader extends IAttributeLoader, IAttributeElem
     onInitSuccess: CallbackRegistration;
     onInitError: CallbackRegistration<{ error: Error }>;
     onInitCancel: CallbackRegistration;
+}
+
+/**
+ * @internal
+ */
+export interface IAttributeFilterHandlerConfig {
+    readonly backend: IAnalyticalBackend;
+    readonly workspace: string;
+    readonly filter: IAttributeFilter;
+    readonly hiddenElements?: string[];
 }

--- a/libs/sdk-ui-filters/src/index.ts
+++ b/libs/sdk-ui-filters/src/index.ts
@@ -96,13 +96,18 @@ export {
     IAttributeLoader,
     IAttributeElementLoader,
     IAttributeFilterLoader,
+    // Options
+    IAttributeFilterHandlerOptions,
+    IAttributeFilterHandlerOptionsBase,
     // Single selection
     ISingleSelectionHandler,
     IStagedSingleSelectionHandler,
+    ISingleSelectAttributeFilterHandlerOptions,
     // Multi selection
     InvertableSelection,
     IInvertableSelectionHandler,
     IStagedInvertableSelectionHandler,
+    IMultiSelectAttributeFilterHandlerOptions,
     // Handlers
     InvertableAttributeElementSelection,
     IAttributeFilterHandler,


### PR DESCRIPTION
This allows the user to deny-list certain elements from the filter.
These will not be available in the loaded elements and will also be excluded in the resulting filter.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
