### PR TITLE
RELATED: RAIL-4299 ui-sdk-pivot: fix js error on adding totals

### DIFF
--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -439,10 +439,10 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
         }
     }
 
-    private handleMouseDown(e: React.MouseEvent<HTMLDivElement>): void {
+    private handleMouseDown(e: React.MouseEvent): void {
         // Do not propagate event when it originates from the table resizer.
         // This means for example that we can resize columns without triggering drag in the application.
-        if ((e.target as HTMLDivElement).className.includes("ag-header-cell-resize")) {
+        if ((e.target as Element)?.className?.includes?.("ag-header-cell-resize")) {
             e.stopPropagation();
         }
     }


### PR DESCRIPTION
When adding totals in table, this is via the svg icon placed in table.
This svg does not have className as string and fails with javascript
error when trying to query this.
So be defensive when looking for table resizer (which is not an svg)

JIRA: RAIL-4299


<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)