### PR TITLE
NAS-3989 - WS earlyAccess string is not evaluated

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -146,16 +146,25 @@ function getEarlyAccessValue<T>(
     strategies: StrategiesDef[],
     earlyAccessValue: string = "",
 ): T {
-    const earlyAccessStrategy = strategies.find((item) => item.attributes.find(findEarlyAccess));
-    const earlyAccess = earlyAccessStrategy ? earlyAccessStrategy.attributes.find(findEarlyAccess) : null;
+    const earlyAccessStrategies = strategies.filter((item) => item.attributes.find(findEarlyAccess));
 
-    if (earlyAccessStrategy && earlyAccess) {
-        const values = (earlyAccess.values || [earlyAccess.value]).filter(Boolean) as Array<string>;
-        if (earlyAccess.conditional === "EQUALS" && values.includes(earlyAccessValue)) {
-            return earlyAccessStrategy.value;
-        }
-        if (earlyAccess.conditional === "NOT_EQUALS" && !values.includes(earlyAccessValue)) {
-            return earlyAccessStrategy.value;
+    if (earlyAccessStrategies.length > 0) {
+        for (let s = 0; s < earlyAccessStrategies.length; s++) {
+            const earlyAccessStrategy = earlyAccessStrategies[s];
+            const earlyAccesses = earlyAccessStrategy
+                ? earlyAccessStrategy.attributes.filter(findEarlyAccess)
+                : [];
+
+            for (let i = 0; i < earlyAccesses.length; i++) {
+                const earlyAccess = earlyAccesses[i];
+                const values = (earlyAccess.values || [earlyAccess.value]).filter(Boolean) as Array<string>;
+                if (earlyAccess.conditional === "EQUALS" && values.includes(earlyAccessValue)) {
+                    return earlyAccessStrategy.value;
+                }
+                if (earlyAccess.conditional === "NOT_EQUALS" && !values.includes(earlyAccessValue)) {
+                    return earlyAccessStrategy.value;
+                }
+            }
         }
     }
     return defaultValue;

--- a/libs/sdk-backend-tiger/src/backend/features/hub.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/hub.ts
@@ -22,7 +22,6 @@ export async function getFeatureHubFeatures(
     try {
         const data = await loadHubFeatures(configuration, state);
         const featuresMap = data.reduce((prev, item) => ({ ...prev, [item.key]: item }), {} as FeaturesMap);
-
         return mapFeatures(featuresMap, context);
     } catch (err) {
         // eslint-disable-next-line no-console

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -187,4 +187,47 @@ describe("live features", () => {
             dashboardEditModeDevRollout: false,
         });
     });
+
+    describe("full definition - BOOLEAN - with more definitions", () => {
+        beforeEach(() => {
+            mockReturn([
+                createFeature("ADmeasureValueFilterNullAsZeroOption", "STRING", "Disabled", [
+                    createStrategy("EnabledCheckedByDefault", [
+                        createAttr("earlyAccess", ["alpha", "beta"], "STRING", "EQUALS"),
+                    ]),
+                    createStrategy("EnabledUncheckedByDefault", [
+                        createAttr("earlyAccess", ["gamma"], "STRING", "EQUALS"),
+                    ]),
+                ]),
+            ]);
+        });
+
+        it("for none", async () => {
+            const results = await getFeatureHubFeatures(createFeatures("none"));
+            expect(results).toEqual({
+                ADmeasureValueFilterNullAsZeroOption: "Disabled",
+            });
+        });
+
+        it("for alpha", async () => {
+            const results = await getFeatureHubFeatures(createFeatures("alpha"));
+            expect(results).toEqual({
+                ADmeasureValueFilterNullAsZeroOption: "EnabledCheckedByDefault",
+            });
+        });
+
+        it("for gamma", async () => {
+            const results = await getFeatureHubFeatures(createFeatures("gamma"));
+            expect(results).toEqual({
+                ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            });
+        });
+
+        it("for omega", async () => {
+            const results = await getFeatureHubFeatures(createFeatures("omega"));
+            expect(results).toEqual({
+                ADmeasureValueFilterNullAsZeroOption: "Disabled",
+            });
+        });
+    });
 });


### PR DESCRIPTION
JIRA: NAS-3989

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
