### PR TITLE
Fix scss rules to make it work with `dart-sass`

### DIFF
--- a/libs/sdk-ui-kit/styles/scss/dialog.scss
+++ b/libs/sdk-ui-kit/styles/scss/dialog.scss
@@ -40,8 +40,8 @@
      */
     .row {
         width: auto;
-        margin-left: -$column-gutter/2;
-        margin-right: -$column-gutter/2;
+        margin-left: calc(-#{$column-gutter} / 2);
+        margin-right: calc(-#{$column-gutter} / 2);
     }
 
     .gd-dialog-close,

--- a/libs/sdk-ui-kit/styles/scss/loadingMask.scss
+++ b/libs/sdk-ui-kit/styles/scss/loadingMask.scss
@@ -44,7 +44,7 @@
     $step-increment-progress: 1 / $steps;
     $step-increment-deg: 360 / $steps;
 
-    #{0} {
+    0% {
         transform: rotate(0deg) translateZ(-0.1px);
     }
 


### PR DESCRIPTION
FET: 932 Preparation for AD/KD

Update scss rules to fix errors/warnings for `dart-sass` migration on AD/KD

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
