### PR TITLE
RELATED: RAIL-4159 fix DashboardItemContent

### DIFF
--- a/libs/sdk-ui-dashboard/.dependency-cruiser.js
+++ b/libs/sdk-ui-dashboard/.dependency-cruiser.js
@@ -8,11 +8,7 @@ options = {
 
         depCruiser.isolatedSubmodule("constants", "src/presentation/constants"),
         depCruiser.isolatedSubmodule("localization", "src/presentation/localization"),
-        depCruiser.moduleWithDependencies(
-            "presentationComponents",
-            "src/presentation/presentationComponents",
-            ["src/model"],
-        ),
+        depCruiser.isolatedSubmodule("presentationComponents", "src/presentation/presentationComponents"),
 
         // TODO: RAIL-3611
         // depCruiser.moduleWithDependencies("_staging", "src/_staging",["src/types.ts"]),

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutSection.tsx
@@ -37,7 +37,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
         sectionRenderer = DashboardLayoutSectionRenderer,
         sectionHeaderRenderer = DashboardLayoutSectionHeaderRenderer,
         itemKeyGetter = ({ item }) => item.index(),
-        gridRowRenderer = ({ children }) => children,
+        gridRowRenderer,
         itemRenderer,
         widgetRenderer,
         screen,
@@ -64,7 +64,7 @@ export function DashboardLayoutSection<TWidget>(props: IDashboardLayoutSectionPr
         DefaultSectionRenderer: DashboardLayoutSectionRenderer,
         children: (
             <>
-                {sectionHeaderRenderer?.({
+                {sectionHeaderRenderer({
                     section,
                     screen,
                     DefaultSectionHeaderRenderer: DashboardLayoutSectionHeaderRenderer,

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutWidgetRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutWidgetRenderer.tsx
@@ -1,5 +1,5 @@
 // (C) 2007-2022 GoodData Corporation
-import React, { CSSProperties } from "react";
+import React, { CSSProperties, useMemo } from "react";
 import cx from "classnames";
 import { IDashboardLayoutWidgetRenderProps } from "./interfaces";
 
@@ -19,7 +19,7 @@ export function DashboardLayoutWidgetRenderer(props: IDashboardLayoutWidgetRende
 
     const { heightAsRatio, gridHeight } = item.size()[screen]!;
 
-    const style = React.useMemo(() => {
+    const style = useMemo(() => {
         const computedStyle: CSSProperties = {
             minHeight,
             height,
@@ -43,14 +43,14 @@ export function DashboardLayoutWidgetRenderer(props: IDashboardLayoutWidgetRende
         return computedStyle;
     }, [minHeight, height, allowOverflow, debug, heightAsRatio, isResizedByLayoutSizingStrategy]);
 
-    const getClassNames = () => {
-        return cx("gd-fluidlayout-column-container", className, {
-            "custom-height": !!gridHeight,
-        });
-    };
-
     return (
-        <div ref={contentRef} className={getClassNames()} style={style}>
+        <div
+            ref={contentRef}
+            className={cx("gd-fluidlayout-column-container", className, {
+                "custom-height": !!gridHeight,
+            })}
+            style={style}
+        >
             {children}
         </div>
     );

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemBase.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemBase.tsx
@@ -3,7 +3,6 @@ import React from "react";
 
 import { DashboardItemContent } from "./DashboardItemContent";
 import { DashboardItemContentWrapper } from "./DashboardItemContentWrapper";
-import { ObjRef } from "@gooddata/sdk-model";
 
 export interface IDashboardItemBaseProps {
     /**
@@ -42,9 +41,18 @@ export interface IDashboardItemBaseProps {
      * Ref forwarded to the main content container.
      */
     contentRef?: React.Ref<HTMLDivElement>;
-
+    /**
+     * Flag indicating the given item can be selected.
+     */
     isSelectable?: boolean;
-    objRef?: ObjRef;
+    /**
+     * Flag indicating the given item is selected.
+     */
+    isSelected?: boolean;
+    /**
+     * Callback to call when an item is selected.
+     */
+    onSelected?: () => void;
 }
 
 const noopRender = () => null;
@@ -60,7 +68,8 @@ export const DashboardItemBase: React.FC<IDashboardItemBaseProps> = ({
     renderAfterContent = noopRender,
     contentRef,
     isSelectable = false,
-    objRef,
+    isSelected = false,
+    onSelected,
 }) => {
     return (
         <DashboardItemContentWrapper>
@@ -71,7 +80,8 @@ export const DashboardItemBase: React.FC<IDashboardItemBaseProps> = ({
                         className={contentClassName}
                         ref={contentRef}
                         isSelectable={isSelectable}
-                        objRef={objRef}
+                        isSelected={isSelected}
+                        onSelected={onSelected}
                     >
                         {renderBeforeVisualization()}
                         <div className={visualizationClassName}>

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
@@ -1,15 +1,13 @@
 // (C) 2020-2022 GoodData Corporation
-import React, { forwardRef } from "react";
-import isEqual from "lodash/isEqual";
-import noop from "lodash/noop";
+import React, { forwardRef, useCallback } from "react";
 import cx from "classnames";
+import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import {
     useDashboardDispatch,
     useDashboardSelector,
     uiActions,
     selectSelectedWidgetRef,
 } from "../../../model";
-import { ObjRef } from "@gooddata/sdk-model";
 
 interface IDashboardItemContentProps {
     className?: string;
@@ -22,14 +20,17 @@ export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemCon
     function DashboardItemContent({ children, className, isSelectable, objRef }, ref) {
         const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
         const dispatch = useDashboardDispatch();
-
-        const onClick = isSelectable ? () => objRef && dispatch(uiActions.selectWidget(objRef)) : noop;
+        const onClick = useCallback(() => {
+            if (isSelectable && objRef) {
+                dispatch(uiActions.selectWidget(objRef));
+            }
+        }, [isSelectable, objRef, dispatch]);
 
         return (
             <div
                 className={cx("dash-item-content", className, {
                     "is-selectable": isSelectable,
-                    "is-selected": isEqual(selectedWidget, objRef),
+                    "is-selected": isSelectable && selectedWidget && areObjRefsEqual(selectedWidget, objRef),
                 })}
                 ref={ref}
                 onClick={onClick}

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
@@ -1,39 +1,25 @@
 // (C) 2020-2022 GoodData Corporation
-import React, { forwardRef, useCallback } from "react";
+import React, { forwardRef } from "react";
 import cx from "classnames";
-import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
-import {
-    useDashboardDispatch,
-    useDashboardSelector,
-    uiActions,
-    selectSelectedWidgetRef,
-} from "../../../model";
 
 interface IDashboardItemContentProps {
     className?: string;
     children?: React.ReactNode;
     isSelectable?: boolean;
-    objRef?: ObjRef;
+    isSelected?: boolean;
+    onSelected?: () => void;
 }
 
 export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemContentProps>(
-    function DashboardItemContent({ children, className, isSelectable, objRef }, ref) {
-        const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
-        const dispatch = useDashboardDispatch();
-        const onClick = useCallback(() => {
-            if (isSelectable && objRef) {
-                dispatch(uiActions.selectWidget(objRef));
-            }
-        }, [isSelectable, objRef, dispatch]);
-
+    function DashboardItemContent({ children, className, isSelectable, isSelected, onSelected }, ref) {
         return (
             <div
                 className={cx("dash-item-content", className, {
                     "is-selectable": isSelectable,
-                    "is-selected": isSelectable && selectedWidget && areObjRefsEqual(selectedWidget, objRef),
+                    "is-selected": isSelected,
                 })}
                 ref={ref}
-                onClick={onClick}
+                onClick={onSelected}
             >
                 {children}
             </div>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -8,6 +8,7 @@ import {
     IInsightWidget,
     widgetTitle,
     ScreenSize,
+    areObjRefsEqual,
 } from "@gooddata/sdk-model";
 import { OnError, OnExportReady, OnLoadingChanged, VisType } from "@gooddata/sdk-ui";
 
@@ -18,6 +19,9 @@ import {
     useDashboardScheduledEmails,
     selectCanExportReport,
     selectIsInEditMode,
+    selectSelectedWidgetRef,
+    useDashboardDispatch,
+    uiActions,
 } from "../../../model";
 import {
     DashboardItem,
@@ -136,7 +140,17 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         [InsightMenuComponentProvider, insight, widget],
     );
 
-    const isEditMode = useDashboardSelector(selectIsInEditMode);
+    const isSelectable = useDashboardSelector(selectIsInEditMode);
+
+    const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
+    const isSelected = isSelectable && selectedWidget && areObjRefsEqual(selectedWidget, widget.ref);
+
+    const dispatch = useDashboardDispatch();
+    const onSelected = useCallback(() => {
+        if (isSelectable && widget.ref) {
+            dispatch(uiActions.selectWidget(widget.ref));
+        }
+    }, [isSelectable, widget.ref, dispatch]);
 
     return (
         <DashboardItem
@@ -149,8 +163,9 @@ const DefaultDashboardInsightWidgetCore: React.FC<
             screen={screen}
         >
             <DashboardItemVisualization
-                isSelectable={isEditMode}
-                objRef={widget.ref}
+                isSelectable={isSelectable}
+                isSelected={isSelected}
+                onSelected={onSelected}
                 renderHeadline={(clientHeight) =>
                     !widget.configuration?.hideTitle && (
                         <DashboardItemHeadline title={widget.title} clientHeight={clientHeight} />


### PR DESCRIPTION
Fix invalid store access in DashboardItemContent: This component needs to be pure to be usable even outside of SDK dashboard context (e.g. legacy edit mode in gdc-dashboards).

Also made some small clean ups encountered along the way.

JIRA: RAIL-4159

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
