### PR TITLE
RELATED: RAIL-4328 Fix init_hotfix_branch

### DIFF
--- a/common/scripts/ci/init_hotfix_branch.sh
+++ b/common/scripts/ci/init_hotfix_branch.sh
@@ -62,7 +62,7 @@ if [ -z "$existing_branch" ]; then
 else
   # in case there is only the first branch for a hotfix, that ends with -fix, assume the existing fix number is 0
   # otherwise parse the number from the branch name
-  if [[ $existing_branch =~ '-fix$' ]]; then
+  if [[ $existing_branch =~ -fix$ ]]; then
     existing_fix_number=0
   else
     existing_fix_number=$(echo "$existing_branch" | sed 's/.*fix-\([0-9]*\)$/\1/')


### PR DESCRIPTION
The regular expression must not be in quotes.

JIRA: RAIL-4328

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
