### PR TITLE
HOTFIX: NAS-3939 Remove subtotals in pivot table when it's not sorted by the first att…

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2997,6 +2997,9 @@ export function resultHeaderName(header: IResultHeader): string;
 // @public (undocumented)
 export type RgbType = "rgb";
 
+// @internal
+export function sanitizeBucketTotals(bucket: IBucket, sortItems: ISortItem[]): ITotal[];
+
 // @alpha
 export type ScheduledMailAttachment = IDashboardAttachment | IWidgetAttachment;
 

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -390,7 +390,7 @@ export {
 
 export { newInsightDefinition, InsightDefinitionBuilder, InsightModifications } from "./insight/factory";
 
-export { insightSanitize } from "./insight/sanitization";
+export { insightSanitize, sanitizeBucketTotals } from "./insight/sanitization";
 
 export { factoryNotationFor } from "./execution/objectFactoryNotation";
 

--- a/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/dataSource.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IntlShape } from "react-intl";
 import { IDataView, IExecutionResult, IPreparedExecution } from "@gooddata/sdk-backend-spi";
 import { ColDef, GridApi, IDatasource, IGetRowsParams } from "@ag-grid-community/all-modules";
@@ -165,7 +165,7 @@ export class AgGridDatasource implements IDatasource {
                     .then((data) => {
                         const dataView = this.config.dataViewTransform(data);
                         const dv = DataViewFacade.for(dataView);
-                        this.gridApiProvider()?.setInfiniteRowCount(dataView.totalCount[0]);
+                        this.gridApiProvider()?.setRowCount(dataView.totalCount[0]);
                         this.currentSorts = dv.meta().effectiveSortItems();
 
                         // Table descriptors contain information about effective totals (e.g. totals set for the
@@ -262,7 +262,7 @@ export class AgGridDatasource implements IDatasource {
 function isSortedByFirstAttribute(tableDescriptor: TableDescriptor, sortingCols: ColDef[]): boolean {
     if (!sortingCols.length) {
         // this is somewhat dangerous assumption: no explicit sort == sorted by first col
-        //  (bear backend behaves thusly)
+        //  (bear and tiger backend behaves thusly)
         return true;
     }
 
@@ -277,7 +277,7 @@ function isDataViewSortedByFirstAttribute(dv: DataViewFacade): boolean {
     const { sortBy } = dv.definition;
     if (!sortBy || !sortBy.length) {
         // this is somewhat dangerous assumption: no explicit sort == sorted by first col
-        //  (bear backend behaves thusly)
+        //  (bear and tiger backend behaves thusly)
         return true;
     }
 

--- a/libs/sdk-ui-pivot/src/impl/utils.ts
+++ b/libs/sdk-ui-pivot/src/impl/utils.ts
@@ -1,5 +1,13 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import once from "lodash/once";
+import {
+    bucketsFind,
+    IExecutionDefinition,
+    ISortItem,
+    ITotal,
+    sanitizeBucketTotals,
+} from "@gooddata/sdk-model";
+import { BucketNames } from "@gooddata/sdk-ui";
 
 function getScrollbarWidthBody(): number {
     const outer = document.createElement("div");
@@ -34,4 +42,16 @@ export async function sleep(delay: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, delay);
     });
+}
+
+/**
+ * Remove invalid totals from an execution definition given a list of sort items
+ *
+ * @param definition - an execution definition to sanitize
+ * @param sortItems - a specification of the sort, if not provided definition.sortBy will be used
+ */
+export function sanitizeDefTotals(definition: IExecutionDefinition, sortItems?: ISortItem[]): ITotal[] {
+    const { buckets, sortBy } = definition;
+    const attributeBucket = bucketsFind(buckets, BucketNames.ATTRIBUTE);
+    return attributeBucket ? sanitizeBucketTotals(attributeBucket, sortItems ?? sortBy) : [];
 }


### PR DESCRIPTION
…ribute

- Bear does not return subtotals in such cases, however Tiger has no problem with those
- As the vizualization is the not sufficiently readable, simply remove the subtotals

JIRA: NAS-3940 and NAS-3397

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
