### PR TITLE
NAS-3998 - server-evaluated key for FH must be used in frontend SDK

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/static.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/static.ts
@@ -6,9 +6,9 @@ import { FeatureDef, FeaturesMap, mapFeatures } from "./feature";
 export async function getStaticFeatures(
     features: IStaticFeatures["static"],
 ): Promise<Partial<ITigerFeatureFlags>> {
-    const { items, context } = features;
+    const { items } = features;
 
-    return mapFeatures(remapStaticFeatures(items), context);
+    return mapFeatures(remapStaticFeatures(items));
 }
 
 function remapStaticFeatures(features: IStaticFeatures["static"]["items"]): FeaturesMap {

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -3,7 +3,7 @@
 import axios, { AxiosResponse } from "axios";
 import { ILiveFeatures } from "@gooddata/api-client-tiger";
 import { getFeatureHubFeatures, FeatureHubResponse } from "../hub";
-import { FeatureDef, StrategiesDef, AttributeDef } from "../feature";
+import { FeatureDef } from "../feature";
 
 jest.mock("axios");
 
@@ -12,42 +12,14 @@ describe("live features", () => {
         return { configuration: { host: "/", key: "" }, context: { earlyAccess } };
     }
 
-    function createFeature(
-        key: string,
-        type: FeatureDef["type"],
-        value: any,
-        strategies: StrategiesDef[] = [],
-    ): FeatureDef {
+    function createFeature(key: string, type: FeatureDef["type"], value: any): FeatureDef {
         return {
             id: Math.random().toString(),
             key,
             type,
             value,
-            strategies,
             l: false,
             version: "1",
-        };
-    }
-
-    function createStrategy(value: any, attributes: AttributeDef[]): StrategiesDef {
-        return {
-            id: Math.random().toString(),
-            value,
-            attributes,
-        };
-    }
-
-    function createAttr(
-        fieldName: string,
-        values: string[],
-        type: AttributeDef["type"],
-        conditional: AttributeDef["conditional"],
-    ): AttributeDef {
-        return {
-            values,
-            type,
-            conditional,
-            fieldName,
         };
     }
 
@@ -71,7 +43,27 @@ describe("live features", () => {
         await getFeatureHubFeatures(createFeatures());
         expect(axios.get).toHaveBeenCalledWith("/features", {
             baseURL: "/",
-            headers: { "Content-type": "application/json" },
+            headers: {
+                "Content-type": "application/json",
+                "X-FeatureHub": "earlyAccess=",
+            },
+            method: "GET",
+            params: { sdkUrl: "" },
+            validateStatus: expect.anything(),
+        });
+    });
+
+    it("call axios with context filled", async () => {
+        mockReturn([]);
+
+        await getFeatureHubFeatures(createFeatures("beta"));
+        expect(axios.get).toHaveBeenCalledWith("/features", {
+            baseURL: "/",
+            headers: {
+                "Content-type": "application/json",
+                "X-FeatureHub": "earlyAccess=beta",
+                "if-none-match": expect.anything(),
+            },
             method: "GET",
             params: { sdkUrl: "" },
             validateStatus: expect.anything(),
@@ -120,114 +112,6 @@ describe("live features", () => {
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
             enableSortingByTotalGroup: true,
-        });
-    });
-
-    it("full definition - BOOLEAN - with valid strategy EQUAL that matched", async () => {
-        mockReturn([
-            createFeature("dashboardEditModeDevRollout", "BOOLEAN", false, [
-                createStrategy(true, [createAttr("earlyAccess", ["beta"], "STRING", "EQUALS")]),
-            ]),
-        ]);
-
-        const results = await getFeatureHubFeatures(createFeatures("beta"));
-        expect(results).toEqual({
-            dashboardEditModeDevRollout: true,
-        });
-    });
-
-    it("full definition - BOOLEAN - with valid strategy EQUAL that not matched", async () => {
-        mockReturn([
-            createFeature("dashboardEditModeDevRollout", "BOOLEAN", false, [
-                createStrategy(true, [createAttr("earlyAccess", ["beta"], "STRING", "EQUALS")]),
-            ]),
-        ]);
-
-        const results = await getFeatureHubFeatures(createFeatures("alpha"));
-        expect(results).toEqual({
-            dashboardEditModeDevRollout: false,
-        });
-    });
-
-    it("full definition - BOOLEAN - with valid strategy NOT_EQUAL that matched", async () => {
-        mockReturn([
-            createFeature("dashboardEditModeDevRollout", "BOOLEAN", false, [
-                createStrategy(true, [createAttr("earlyAccess", ["beta"], "STRING", "NOT_EQUALS")]),
-            ]),
-        ]);
-
-        const results = await getFeatureHubFeatures(createFeatures("beta"));
-        expect(results).toEqual({
-            dashboardEditModeDevRollout: false,
-        });
-    });
-
-    it("full definition - BOOLEAN - with valid strategy NOT_EQUAL that not matched", async () => {
-        mockReturn([
-            createFeature("dashboardEditModeDevRollout", "BOOLEAN", false, [
-                createStrategy(true, [createAttr("earlyAccess", ["beta"], "STRING", "NOT_EQUALS")]),
-            ]),
-        ]);
-
-        const results = await getFeatureHubFeatures(createFeatures("alpha"));
-        expect(results).toEqual({
-            dashboardEditModeDevRollout: true,
-        });
-    });
-
-    it("full definition - BOOLEAN - with invalid strategy EQUAL that matched", async () => {
-        mockReturn([
-            createFeature("dashboardEditModeDevRollout", "BOOLEAN", false, [
-                createStrategy(true, [createAttr("earlyAccess", ["beta"], "STRING", "ENDS_WITH")]),
-            ]),
-        ]);
-
-        const results = await getFeatureHubFeatures(createFeatures("beta"));
-        expect(results).toEqual({
-            dashboardEditModeDevRollout: false,
-        });
-    });
-
-    describe("full definition - BOOLEAN - with more definitions", () => {
-        beforeEach(() => {
-            mockReturn([
-                createFeature("ADmeasureValueFilterNullAsZeroOption", "STRING", "Disabled", [
-                    createStrategy("EnabledCheckedByDefault", [
-                        createAttr("earlyAccess", ["alpha", "beta"], "STRING", "EQUALS"),
-                    ]),
-                    createStrategy("EnabledUncheckedByDefault", [
-                        createAttr("earlyAccess", ["gamma"], "STRING", "EQUALS"),
-                    ]),
-                ]),
-            ]);
-        });
-
-        it("for none", async () => {
-            const results = await getFeatureHubFeatures(createFeatures("none"));
-            expect(results).toEqual({
-                ADmeasureValueFilterNullAsZeroOption: "Disabled",
-            });
-        });
-
-        it("for alpha", async () => {
-            const results = await getFeatureHubFeatures(createFeatures("alpha"));
-            expect(results).toEqual({
-                ADmeasureValueFilterNullAsZeroOption: "EnabledCheckedByDefault",
-            });
-        });
-
-        it("for gamma", async () => {
-            const results = await getFeatureHubFeatures(createFeatures("gamma"));
-            expect(results).toEqual({
-                ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
-            });
-        });
-
-        it("for omega", async () => {
-            const results = await getFeatureHubFeatures(createFeatures("omega"));
-            expect(results).toEqual({
-                ADmeasureValueFilterNullAsZeroOption: "Disabled",
-            });
         });
     });
 });


### PR DESCRIPTION
JIRA: NAS-3998
(cherry picked from commit 6873f54a065110e4276f6b65a981f28783a4e5ac)

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
