### PR TITLE
Fix header countdown render logic

### DIFF
--- a/libs/sdk-ui-kit/src/Header/Header.tsx
+++ b/libs/sdk-ui-kit/src/Header/Header.tsx
@@ -214,7 +214,7 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
     });
 
     private getTrialCountdown = (expiredDate: string) => {
-        const trialDaysLeft = differenceInCalendarDays(new Date(expiredDate), new Date()) + 1; // include expired date.
+        const trialDaysLeft = differenceInCalendarDays(new Date(expiredDate), new Date());
         if (trialDaysLeft === 1) {
             return <FormattedMessage id="gs.header.countdown.lastDay" />;
         }
@@ -229,7 +229,8 @@ class AppHeaderCore extends Component<IAppHeaderProps & WrappedComponentProps, I
                 />
             );
         }
-        if (trialDaysLeft > 30 && trialDaysLeft < 90) {
+        if (trialDaysLeft > 30 && trialDaysLeft <= 91) {
+            // expiredDate is one day after the last day that user can use the service
             const currentDateWithoutTime = format(new Date(), "yyyy-MM-dd");
             const trialMonthsLeft = differenceInMonths(
                 new Date(expiredDate),


### PR DESCRIPTION
<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
