### PR TITLE
RELATED: TNT-888 Fixing default decimal separator for percentFormatter

### DIFF
--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartCreators/customConfiguration.ts
@@ -386,11 +386,7 @@ export function percentageDataLabelFormatter(config?: IChartConfig): string {
     //  * left or right axis on single axis chart, or
     //  * primary axis on dual axis chart
     if (this.percentage && (isSingleAxis || isPrimaryAxis)) {
-        return percentFormatter(
-            this.percentage,
-            this.series?.data?.length > 0 && this.series.data[0].format,
-            config?.separators,
-        );
+        return percentFormatter(this.percentage, this.series?.data?.length > 0 && this.series.data[0].format);
     }
 
     return labelFormatter.call(this, config);

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/tooltip.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_chartOptions/tooltip.ts
@@ -25,5 +25,5 @@ export function getFormattedValueForTooltip(
         stackMeasuresToPercent === false || isNil(percentageValue) || isDualChartWithRightAxis;
     return isNotStackToPercent
         ? formatValueForTooltip(target ?? y, format, separators)
-        : percentFormatter(percentageValue, format, separators);
+        : percentFormatter(percentageValue, format);
 }

--- a/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
+++ b/libs/sdk-ui-charts/src/highcharts/chartTypes/_util/common.ts
@@ -3,13 +3,14 @@ import clone from "lodash/clone";
 import includes from "lodash/includes";
 import isNil from "lodash/isNil";
 import setWith from "lodash/setWith";
-import { ISeparators, numberFormat } from "@gooddata/numberjs";
+import { numberFormat } from "@gooddata/numberjs";
 import escape from "lodash/escape";
 import isEqual from "lodash/fp/isEqual";
 import unescape from "lodash/unescape";
 import { VisualizationTypes } from "@gooddata/sdk-ui";
 import { IChartOptions, ISeriesItem } from "../../typings/unsafe";
 import { IChartConfig } from "../../../interfaces";
+import { DEFAULT_DECIMAL_SEPARATOR } from "../../constants/format";
 
 export function parseValue(value: string): number | null {
     const parsedValue = parseFloat(value);
@@ -169,8 +170,9 @@ export const unwrap = (wrappedObject: unknown): any => {
 const getNumberWithGivenDecimals = (value: number, decimalNumbers: number) =>
     decimalNumbers === 0 ? `${Math.round(value)}%` : `${parseFloat(value.toFixed(decimalNumbers))}%`;
 
-const getNumberOfFormatDecimals = (format: string, decimalSeparator: string): number => {
-    const splittedFormat = format.split(decimalSeparator);
+// it calculates number of decimals from default format that contains ',' and '.' as separators
+const getNumberOfDecimalsFromDefaultFormat = (format: string): number => {
+    const splittedFormat = format.split(DEFAULT_DECIMAL_SEPARATOR);
 
     if (splittedFormat.length !== 2) {
         return 0;
@@ -182,13 +184,13 @@ const getNumberOfFormatDecimals = (format: string, decimalSeparator: string): nu
     );
 };
 
-export function percentFormatter(value: number, format?: string, separators?: ISeparators): string {
+export function percentFormatter(value: number, format?: string): string {
     if (isNil(value)) {
         return "";
     }
 
-    const isPercentageFormat = format && format.trim().slice(-1) === "%" && separators;
-    const numberOfDecimals = isPercentageFormat ? getNumberOfFormatDecimals(format, separators.decimal) : 2;
+    const isPercentageFormat = format && format.trim().slice(-1) === "%";
+    const numberOfDecimals = isPercentageFormat ? getNumberOfDecimalsFromDefaultFormat(format) : 2;
 
     return getNumberWithGivenDecimals(value, numberOfDecimals);
 }

--- a/libs/sdk-ui-charts/src/highcharts/constants/format.ts
+++ b/libs/sdk-ui-charts/src/highcharts/constants/format.ts
@@ -1,0 +1,2 @@
+// (C) 2022 GoodData Corporation
+export const DEFAULT_DECIMAL_SEPARATOR = ".";


### PR DESCRIPTION
JIRA: TNT-888

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
