### PR TITLE
RELATED: RAIL-4330 Fix column sizing for empty values on tiger

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
@@ -25,6 +25,11 @@ import {
 import { createDateValueFormatter } from "../dateFormatting/dateValueFormatter";
 import { toSdkGranularity } from "../dateGranularityConversions";
 
+// Tiger can return nulls for empty values but SPI needs strings always, so convert nulls to empty strings
+function coalesceNulls(value: string | null): string {
+    return value ?? "";
+}
+
 const supportedSuffixes: string[] = Object.keys(JsonApiAttributeOutAttributesGranularityEnum)
     .filter((item) => isNaN(Number(item)))
     .map(
@@ -97,10 +102,12 @@ function attributeMeasureItem(
 ): IResultAttributeHeader {
     return {
         attributeHeaderItem: {
-            uri: header.attributeHeader.primaryLabelValue,
-            name: granularity
-                ? dateValueFormatter(header.attributeHeader.labelValue, granularity)
-                : header.attributeHeader.labelValue,
+            uri: coalesceNulls(header.attributeHeader.primaryLabelValue),
+            name: coalesceNulls(
+                granularity
+                    ? dateValueFormatter(header.attributeHeader.labelValue, granularity)
+                    : header.attributeHeader.labelValue,
+            ),
         },
     };
 }

--- a/libs/sdk-model/src/execution/results/index.ts
+++ b/libs/sdk-model/src/execution/results/index.ts
@@ -147,7 +147,7 @@ export interface IAttributeHeaderFormOf {
 }
 
 /**
- * Attribute descriptior header.
+ * Attribute descriptor header.
  *
  * @public
  */
@@ -275,7 +275,7 @@ export interface IResultAttributeHeaderItem {
      * into multiple workspaces, it is up to the backend whether the URIs of the elements will be same across
      * all workspaces or not.
      *
-     * Recommendation for the consumers: URI is safe to use if you obtain in programatically from this header
+     * Recommendation for the consumers: URI is safe to use if you obtain in programmatically from this header
      * and then use it in the same workspace for instance for filtering. It is not safe to hardcode URIs
      * and use them in a solution which should operate on top of different workspaces.
      */
@@ -293,7 +293,7 @@ export interface IResultAttributeHeader {
 }
 
 /**
- * Measure header specifes name of the measure to which the calculated values in the particular data view slice belong.
+ * Measure header specifies name of the measure to which the calculated values in the particular data view slice belong.
  *
  * @remarks
  * Measure header also specifies 'order' - this is essentially an index into measure group descriptor's item array; it
@@ -319,7 +319,7 @@ export interface IResultMeasureHeaderItem {
 }
 
 /**
- * Measure header specifes name of the measure to which the calculated values in the particular data view slice belong.
+ * Measure header specifies name of the measure to which the calculated values in the particular data view slice belong.
  *
  * @remarks
  * Measure header also specifies 'order' - this is essentially an index into measure group descriptor's item array; it

--- a/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
@@ -1,4 +1,5 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
+import isNil from "lodash/isNil";
 import {
     DataCol,
     ScopeCol,
@@ -61,7 +62,7 @@ export function searchForLocatorMatch(
             // while the attribute locator has element optional (for wildcard match), all the remaining code always populates
             // the attribute element.
             // TODO: revise the API, it may be that it really should not be optional in the interface.
-            invariant(elementToMatch);
+            invariant(!isNil(elementToMatch));
 
             if (col.header.attributeHeaderItem.uri === elementToMatch) {
                 if (locators.length === 1) {


### PR DESCRIPTION
Tiger now returns nulls for empty values (api-client-tiger will be regenerated in a separate commit, the OpenAPI spec is not ready).
Also pivot table needs to handle empty strings in its column resizing.
Finally, fixed some typos encountered along the way.

JIRA: RAIL-4330

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
