### PR TITLE
RELATED: SD-2249 Handle getOrganizationPermissions errors better

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -303,7 +303,11 @@ export const buildTigerSpecificFunctions = (
                 return result.data.data?.meta?.permissions || [];
             });
         } catch (error) {
-            if ([404, 403].includes(error?.response?.status)) {
+            const toleratedCodes = [404, 403];
+            if (
+                toleratedCodes.includes(error?.response?.status) ||
+                toleratedCodes.includes(error?.cause?.response?.status) // the error might be wrapped by an UnexpectedResponseError so check for it too
+            ) {
                 // temporary - 404 gets returned if you are not org admin
                 return [];
             }


### PR DESCRIPTION
We need to handle also the cases when the error is wrapped
in and UnexpectedResponseError object.

JIRA: SD-2249

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
