### PR TITLE
RELATED: RAIL-4336 avoid some injectIntl calls

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/AttributeDropdownListItem.tsx
@@ -3,11 +3,11 @@ import React from "react";
 import isEmpty from "lodash/isEmpty";
 import { v4 as uuid } from "uuid";
 import cx from "classnames";
-import { FormattedMessage, injectIntl } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import { IAttributeDropdownListItemProps } from "@gooddata/sdk-ui-filters";
 import { stringUtils } from "@gooddata/util";
 
-const AttributeDropdownListItem: React.FC<IAttributeDropdownListItemProps> = (props) => {
+const AttributeDropdownListItem: React.FC<Omit<IAttributeDropdownListItemProps, "intl">> = (props) => {
     const { source } = props;
     if (isEmpty(source)) {
         return <div />;
@@ -62,4 +62,4 @@ const AttributeDropdownListItem: React.FC<IAttributeDropdownListItemProps> = (pr
     );
 };
 
-export default injectIntl(AttributeDropdownListItem);
+export default AttributeDropdownListItem;

--- a/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/DropdownConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/filterBar/attributeFilter/dashboardDropdownBody/configuration/DropdownConfiguration.tsx
@@ -1,7 +1,7 @@
 // (C) 2021-2022 GoodData Corporation
 import React, { useCallback, useState } from "react";
 import { Button, Typography } from "@gooddata/sdk-ui-kit";
-import { FormattedMessage, injectIntl, WrappedComponentProps } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { ConfigurationParentItems } from "./ConfigurationParentItems";
 import { areObjRefsEqual, ObjRef, IAttributeDisplayFormMetadataObject } from "@gooddata/sdk-model";
 import { IAttributeFilterParent, IAttributeFiltersMetaState } from "../types";
@@ -38,8 +38,7 @@ interface IAttributeFilterDropdownConfigurationDispatchProps {
     attributeFilterDisplayFormChanged: (payload: any) => void;
 }
 
-export type IAttributeFilterDropdownConfigurationProps = WrappedComponentProps &
-    IAttributeFilterDropdownConfigurationOwnProps &
+export type IAttributeFilterDropdownConfigurationProps = IAttributeFilterDropdownConfigurationOwnProps &
     IAttributeFilterDropdownConfigurationStateProps &
     IAttributeFilterDropdownConfigurationDispatchProps;
 
@@ -76,7 +75,6 @@ const isFilterDisplayFormChanged = (currentDisplayForm: ObjRef, originalDisplayF
 
 const DropdownConfiguration: React.FC<IAttributeFilterDropdownConfigurationProps> = (props) => {
     const {
-        intl,
         isDependentFiltersEnabled,
         allAttributeFilters,
         attributeFilterTitle,
@@ -90,6 +88,7 @@ const DropdownConfiguration: React.FC<IAttributeFilterDropdownConfigurationProps
         onChange,
     } = props;
 
+    const intl = useIntl();
     const [items, setItems] = useItems();
     const [currentDisplayFormRef, setCurrentDisplayFormRef] = useState(attributeFilterRef);
 
@@ -166,4 +165,4 @@ const DropdownConfiguration: React.FC<IAttributeFilterDropdownConfigurationProps
     );
 };
 
-export default injectIntl(DropdownConfiguration);
+export default DropdownConfiguration;

--- a/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/EmptyDashboardError.tsx
@@ -1,16 +1,14 @@
 // (C) 2020-2022 GoodData Corporation
 import React from "react";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import { useIntl } from "react-intl";
 import { IErrorProps } from "@gooddata/sdk-ui";
 
 interface IEmptyDashboardErrorProps {
     ErrorComponent: React.ComponentType<IErrorProps>;
 }
 
-const EmptyDashboardErrorCore: React.FC<IEmptyDashboardErrorProps & WrappedComponentProps> = ({
-    ErrorComponent,
-    intl,
-}) => {
+export const EmptyDashboardError: React.FC<IEmptyDashboardErrorProps> = ({ ErrorComponent }) => {
+    const intl = useIntl();
     return (
         <ErrorComponent
             className="s-layout-error"
@@ -19,5 +17,3 @@ const EmptyDashboardErrorCore: React.FC<IEmptyDashboardErrorProps & WrappedCompo
         />
     );
 };
-
-export const EmptyDashboardError = injectIntl(EmptyDashboardErrorCore);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentNoWidgets.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentNoWidgets.tsx
@@ -1,23 +1,22 @@
 // (C) 2019-2022 GoodData Corporation
 import * as React from "react";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import { useIntl } from "react-intl";
 import { Icon } from "@gooddata/sdk-ui-kit";
 import { ITheme } from "@gooddata/sdk-model";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 
 import { isMobileView } from "../../utils/responsive";
 
-export interface IAttachmentNoWidgetsOwnProps {
+export interface IAttachmentProps {
     className?: string;
     label: string;
     fileName: string;
     theme?: ITheme;
 }
 
-export type IAttachmentProps = IAttachmentNoWidgetsOwnProps & WrappedComponentProps;
-
 const AttachmentNoWidgetsComponent = (props: IAttachmentProps) => {
-    const { className = "", fileName, intl, label, theme } = props;
+    const { className = "", fileName, label, theme } = props;
+    const intl = useIntl();
     const classNames = `gd-input-component gd-attachment-component ${className}`;
 
     const nameOfAttachment = isMobileView() ? "PDF" : fileName;
@@ -34,4 +33,4 @@ const AttachmentNoWidgetsComponent = (props: IAttachmentProps) => {
     );
 };
 
-export const AttachmentNoWidgets = injectIntl(withTheme(AttachmentNoWidgetsComponent));
+export const AttachmentNoWidgets = withTheme(AttachmentNoWidgetsComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/Attachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/Attachments.tsx
@@ -1,7 +1,7 @@
 // (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 
-import { FormattedMessage, injectIntl, WrappedComponentProps } from "react-intl";
+import { FormattedMessage } from "react-intl";
 import identity from "lodash/identity";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 
@@ -11,7 +11,7 @@ import { IWidgetExportConfiguration, IWidgetsSelection } from "../../interfaces"
 import { objRefToString, ITheme } from "@gooddata/sdk-model";
 import { IInsightWidgetExtended } from "../../useScheduledEmail";
 
-export interface IAttachmentsOwnProps {
+export interface IAttachmentsProps {
     theme?: ITheme;
     dashboardTitle: string;
     insightWidgets: IInsightWidgetExtended[];
@@ -29,8 +29,6 @@ const AttachmentItem: React.FC<{ format: string }> = ({ format, children }) => (
         <span className="gd-dashboard-attachment-name">{children}</span>
     </div>
 );
-
-export type IAttachmentsProps = IAttachmentsOwnProps & WrappedComponentProps;
 
 const AttachmentsComponent = (props: IAttachmentsProps) => {
     const {
@@ -95,4 +93,4 @@ const AttachmentsComponent = (props: IAttachmentsProps) => {
     );
 };
 
-export const Attachments = injectIntl(withTheme(AttachmentsComponent));
+export const Attachments = withTheme(AttachmentsComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentsSelectionDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentsSelectionDropdown.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useCallback, useState } from "react";
-import { injectIntl, WrappedComponentProps, FormattedMessage } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import identity from "lodash/identity";
 
 import { Icon, InsightIcon, Typography } from "@gooddata/sdk-ui-kit";
@@ -13,7 +13,7 @@ import { IWidgetsSelection } from "../../interfaces";
 import { ObjRef, objRefToString, ITheme } from "@gooddata/sdk-model";
 import { IInsightWidgetExtended } from "../../useScheduledEmail";
 
-export interface IAttachmentsSelectionDropdownOwnProps {
+export interface IAttachmentsSelectionDropdownProps {
     dashboardTitle: string;
     dashboardSelected: boolean;
     insightWidgets: IInsightWidgetExtended[];
@@ -22,17 +22,15 @@ export interface IAttachmentsSelectionDropdownOwnProps {
     theme?: ITheme;
 }
 
-export type IAttachmentsSelectionDropdownProps = IAttachmentsSelectionDropdownOwnProps &
-    WrappedComponentProps;
-
 const AttachmentsSelectionDropdownComponent: React.FC<IAttachmentsSelectionDropdownProps> = (props) => {
-    const { intl, theme, dashboardTitle, insightWidgets = [], onApply } = props;
+    const { theme, dashboardTitle, insightWidgets = [], onApply } = props;
     const ICON_COLOR = theme?.palette?.complementary?.c5;
     const ICON_SIZE_BUTTON = 18;
     const ICON_PROPS = { color: ICON_COLOR, height: 19, width: 26 };
 
     const [dashboardSelected, setDashboardSelected] = useState(props.dashboardSelected);
     const [widgetsSelected, setWidgetsSelected] = useState(props.widgetsSelected);
+    const intl = useIntl();
 
     const handleWidgetSelectedChange = useCallback(
         (widgetRef: ObjRef) => {
@@ -117,4 +115,4 @@ const AttachmentsSelectionDropdownComponent: React.FC<IAttachmentsSelectionDropd
     );
 };
 
-export const AttachmentsSelectionDropdown = injectIntl(withTheme(AttachmentsSelectionDropdownComponent));
+export const AttachmentsSelectionDropdown = withTheme(AttachmentsSelectionDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/FormatOptionsDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/FormatOptionsDropdown.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import { useCallback, useState } from "react";
 import { Dropdown, DropdownButton, DropdownList, SingleSelectListItem, Icon } from "@gooddata/sdk-ui-kit";
-import { FormattedMessage, injectIntl, WrappedComponentProps } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { ScheduleDropdown } from "./ScheduleDropdown";
 import { ITheme } from "@gooddata/sdk-model";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
@@ -12,7 +12,7 @@ import { DEFAULT_DROPDOWN_ALIGN_POINTS, DEFAULT_DROPDOWN_ZINDEX } from "../../co
 const ICON_SIZE_BUTTON = 18;
 const DROPDOWN_WIDTH = 70;
 
-export interface IFormatOptionsDropdownOwnProps {
+export interface IFormatOptionsDropdownProps {
     theme?: ITheme;
     format: WidgetExportFileFormat;
     mergeHeaders: boolean;
@@ -20,10 +20,9 @@ export interface IFormatOptionsDropdownOwnProps {
     onApply: (result: IWidgetExportConfiguration) => void;
 }
 
-export type IFormatOptionsDropdownProps = IFormatOptionsDropdownOwnProps & WrappedComponentProps;
-
 const FormatOptionsDropdownComponent: React.FC<IFormatOptionsDropdownProps> = (props) => {
-    const { intl, theme, onApply } = props;
+    const { theme, onApply } = props;
+    const intl = useIntl();
 
     const FORMAT_VALUES: WidgetExportFileFormat[] = ["csv", "xlsx"];
 
@@ -43,7 +42,7 @@ const FormatOptionsDropdownComponent: React.FC<IFormatOptionsDropdownProps> = (p
                 mergeHeaders,
                 includeFilters,
             }),
-        [format, mergeHeaders, includeFilters],
+        [format, mergeHeaders, includeFilters, onApply],
     );
 
     const handleOnCancel = useCallback(() => {
@@ -154,4 +153,4 @@ const FormatOptionsDropdownComponent: React.FC<IFormatOptionsDropdownProps> = (p
     );
 };
 
-export const FormatOptionsDropdown = injectIntl(withTheme(FormatOptionsDropdownComponent));
+export const FormatOptionsDropdown = withTheme(FormatOptionsDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/ScheduleDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/ScheduleDropdown.tsx
@@ -2,7 +2,7 @@
 import * as React from "react";
 import cx from "classnames";
 import { Bubble, BubbleHoverTrigger, Dropdown, Button } from "@gooddata/sdk-ui-kit";
-import { FormattedMessage, injectIntl, WrappedComponentProps } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { ITheme } from "@gooddata/sdk-model";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 import { DEFAULT_DROPDOWN_ALIGN_POINTS, DEFAULT_DROPDOWN_ZINDEX } from "../../constants";
@@ -12,7 +12,7 @@ const ALIGN_POINTS = [
     { align: "tc bc", offset: { x: 0, y: 0 } },
 ];
 
-export interface IScheduleDropdownOwnProps {
+export interface IScheduleDropdownProps {
     title: string;
     applyDisabled?: boolean;
     theme?: ITheme;
@@ -25,13 +25,10 @@ export interface IScheduleDropdownOwnProps {
     buttonDisabled?: boolean;
 }
 
-type IScheduleDropdownProps = IScheduleDropdownOwnProps & WrappedComponentProps;
-
 export const ScheduleDropdownComponent: React.FC<IScheduleDropdownProps> = (props) => {
     const {
         title,
         applyDisabled,
-        intl,
         onApply,
         onCancel,
         iconComponent,
@@ -40,6 +37,8 @@ export const ScheduleDropdownComponent: React.FC<IScheduleDropdownProps> = (prop
         bodyClassName,
         buttonDisabled,
     } = props;
+
+    const intl = useIntl();
 
     const renderBody = (closeDropdown: () => void) => {
         return (
@@ -128,4 +127,4 @@ export const ScheduleDropdownComponent: React.FC<IScheduleDropdownProps> = (prop
     );
 };
 
-export const ScheduleDropdown = injectIntl(withTheme(ScheduleDropdownComponent));
+export const ScheduleDropdown = withTheme(ScheduleDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/test/AttachmentNoWidgets.test.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/test/AttachmentNoWidgets.test.tsx
@@ -2,12 +2,12 @@
 import React from "react";
 import { mount, ReactWrapper } from "enzyme";
 
-import { AttachmentNoWidgets, IAttachmentNoWidgetsOwnProps } from "../AttachmentNoWidgets";
+import { AttachmentNoWidgets, IAttachmentProps } from "../AttachmentNoWidgets";
 import { IntlWrapper } from "../../../../../localization/IntlWrapper";
 
 describe("AttachmentNoWidgets", () => {
     const FILE_NAME = "ABC.pdf";
-    function renderComponent(customProps: Partial<IAttachmentNoWidgetsOwnProps> = {}): ReactWrapper {
+    function renderComponent(customProps: Partial<IAttachmentProps> = {}): ReactWrapper {
         const defaultProps = {
             includeFilterContext: false,
             isMobile: false,

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatExecuteOnSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatExecuteOnSelect.tsx
@@ -1,6 +1,6 @@
 // (C) 2019-2022 GoodData Corporation
-import * as React from "react";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import React, { useMemo } from "react";
+import { useIntl } from "react-intl";
 import { Dropdown, DropdownList, DropdownButton, SingleSelectListItem } from "@gooddata/sdk-ui-kit";
 import invariant from "ts-invariant";
 
@@ -11,75 +11,58 @@ import { messages } from "../../../../../locales";
 
 const DROPDOWN_WIDTH = 154;
 
-interface IRepeatExecuteOnSelectOwnProps {
+export interface IRepeatExecuteOnSelectProps {
     repeatExecuteOn: string;
     startDate: Date;
     onChange: (repeatExecuteOn: string) => void;
 }
 
-export type IRepeatExecuteOnSelectProps = IRepeatExecuteOnSelectOwnProps & WrappedComponentProps;
+export const RepeatExecuteOnSelect: React.FC<IRepeatExecuteOnSelectProps> = (props) => {
+    const { onChange, repeatExecuteOn, startDate } = props;
+    const intl = useIntl();
 
-class RenderRepeatExecuteOnSelect extends React.PureComponent<IRepeatExecuteOnSelectProps> {
-    public render(): React.ReactNode {
-        const repeatExecuteOnItems = this.getRepeatExecuteOnItems();
-        const repeatExecuteOnItem = repeatExecuteOnItems.find(this.isRepeatExecuteOnItemSelected);
-        invariant(repeatExecuteOnItem, "Inconsistent state in RepeatExecuteOnSelect");
+    const repeatExecuteOnItems = useMemo(() => {
+        return [REPEAT_EXECUTE_ON.DAY_OF_MONTH, REPEAT_EXECUTE_ON.DAY_OF_WEEK].map((id): IDropdownItem => {
+            return {
+                id,
+                title: intl.formatMessage(messages[`scheduleDialogEmailRepeatsExecuteOn_${id}`], {
+                    date: getDate(startDate),
+                    day: getIntlDayName(intl, startDate),
+                    week: getWeek(startDate),
+                }),
+            };
+        });
+    }, [intl, startDate]);
 
-        return (
-            <Dropdown
-                alignPoints={DEFAULT_DROPDOWN_ALIGN_POINTS}
-                className="gd-schedule-email-dialog-repeat-execute-on s-gd-schedule-email-dialog-repeat-execute-on"
-                renderBody={({ closeDropdown, isMobile }) => (
-                    <DropdownList
-                        width={DROPDOWN_WIDTH}
-                        items={repeatExecuteOnItems}
-                        isMobile={isMobile}
-                        renderItem={({ item }) => (
-                            <SingleSelectListItem
-                                title={item.title}
-                                onClick={() => {
-                                    this.onRepeatExecuteOnChange(item);
-                                    closeDropdown();
-                                }}
-                                isSelected={repeatExecuteOnItem.id === item.id}
-                            />
-                        )}
-                    />
-                )}
-                renderButton={({ toggleDropdown }) => (
-                    <DropdownButton value={repeatExecuteOnItem.title} onClick={toggleDropdown} />
-                )}
-                overlayPositionType="sameAsTarget"
-                overlayZIndex={DEFAULT_DROPDOWN_ZINDEX}
-            />
-        );
-    }
+    const repeatExecuteOnItem = repeatExecuteOnItems.find((item) => item.id === repeatExecuteOn);
+    invariant(repeatExecuteOnItem, "Inconsistent state in RepeatExecuteOnSelect");
 
-    private isRepeatExecuteOnItemSelected = (item: IDropdownItem): boolean => {
-        return item.id === this.props.repeatExecuteOn;
-    };
-
-    private getRepeatExecuteOnItem = (repeatExecuteOn: string): IDropdownItem => {
-        const { intl, startDate } = this.props;
-        return {
-            id: repeatExecuteOn,
-            title: intl.formatMessage(messages[`scheduleDialogEmailRepeatsExecuteOn_${repeatExecuteOn}`], {
-                date: getDate(startDate),
-                day: getIntlDayName(intl, startDate),
-                week: getWeek(startDate),
-            }),
-        };
-    };
-
-    private getRepeatExecuteOnItems = (): IDropdownItem[] => {
-        return [REPEAT_EXECUTE_ON.DAY_OF_MONTH, REPEAT_EXECUTE_ON.DAY_OF_WEEK].map(
-            this.getRepeatExecuteOnItem,
-        );
-    };
-
-    private onRepeatExecuteOnChange = (item: IDropdownItem) => {
-        this.props.onChange(item.id);
-    };
-}
-
-export const RepeatExecuteOnSelect = injectIntl(RenderRepeatExecuteOnSelect);
+    return (
+        <Dropdown
+            alignPoints={DEFAULT_DROPDOWN_ALIGN_POINTS}
+            className="gd-schedule-email-dialog-repeat-execute-on s-gd-schedule-email-dialog-repeat-execute-on"
+            renderBody={({ closeDropdown, isMobile }) => (
+                <DropdownList
+                    width={DROPDOWN_WIDTH}
+                    items={repeatExecuteOnItems}
+                    isMobile={isMobile}
+                    renderItem={({ item }) => (
+                        <SingleSelectListItem
+                            title={item.title}
+                            onClick={() => {
+                                onChange(item.id);
+                                closeDropdown();
+                            }}
+                            isSelected={repeatExecuteOnItem.id === item.id}
+                        />
+                    )}
+                />
+            )}
+            renderButton={({ toggleDropdown }) => (
+                <DropdownButton value={repeatExecuteOnItem.title} onClick={toggleDropdown} />
+            )}
+            overlayPositionType="sameAsTarget"
+            overlayZIndex={DEFAULT_DROPDOWN_ZINDEX}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatFrequencySelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatFrequencySelect.tsx
@@ -1,6 +1,6 @@
 // (C) 2019-2022 GoodData Corporation
-import * as React from "react";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import React, { useMemo } from "react";
+import { useIntl } from "react-intl";
 import { Dropdown, DropdownList, DropdownButton, SingleSelectListItem } from "@gooddata/sdk-ui-kit";
 import invariant from "ts-invariant";
 
@@ -10,71 +10,57 @@ import { messages } from "../../../../../locales";
 
 const DROPDOWN_WIDTH = 100;
 
-interface IRepeatFrequencySelectOwnProps {
+export interface IRepeatFrequencySelectProps {
     repeatFrequency: string;
     repeatPeriod: number;
     onChange: (repeatFrequency: string) => void;
 }
 
-export type IRepeatFrequencySelectProps = IRepeatFrequencySelectOwnProps & WrappedComponentProps;
+export const RepeatFrequencySelect: React.FC<IRepeatFrequencySelectProps> = (props) => {
+    const { onChange, repeatFrequency, repeatPeriod } = props;
+    const intl = useIntl();
 
-class RenderRepeatFrequencySelect extends React.PureComponent<IRepeatFrequencySelectProps> {
-    public render(): React.ReactNode {
-        const repeatFrequencyItems = this.getRepeatFrequencyItems();
-        const repeatFrequencyItem = repeatFrequencyItems.find(this.isRepeatFrequencyItemSelected);
-        invariant(repeatFrequencyItem, "Inconsistent state in RepeatFrequencySelect");
+    const repeatFrequencyItems = useMemo(() => {
+        return FREQUENCY_TYPE.map((id): IDropdownItem => {
+            return {
+                id,
+                title: intl.formatMessage(messages[`scheduleDialogEmailRepeatsFrequencies_${id}`], {
+                    n: repeatPeriod,
+                }),
+            };
+        });
+    }, [intl, repeatPeriod]);
 
-        return (
-            <Dropdown
-                alignPoints={DEFAULT_DROPDOWN_ALIGN_POINTS}
-                className="gd-schedule-email-dialog-repeat-frequency s-gd-schedule-email-dialog-repeat-frequency"
-                renderButton={({ toggleDropdown }) => (
-                    <DropdownButton value={repeatFrequencyItem.title} onClick={toggleDropdown} />
-                )}
-                renderBody={({ closeDropdown, isMobile }) => (
-                    <DropdownList
-                        width={DROPDOWN_WIDTH}
-                        items={repeatFrequencyItems}
-                        isMobile={isMobile}
-                        renderItem={({ item }) => (
-                            <SingleSelectListItem
-                                title={item.title}
-                                onClick={() => {
-                                    this.onRepeatFrequencyChange(item);
-                                    closeDropdown();
-                                }}
-                                isSelected={repeatFrequencyItem.id === item.id}
-                            />
-                        )}
-                    />
-                )}
-                overlayPositionType="sameAsTarget"
-                overlayZIndex={DEFAULT_DROPDOWN_ZINDEX}
-            />
-        );
-    }
+    const repeatFrequencyItem = repeatFrequencyItems.find((item) => item.id === repeatFrequency);
 
-    private isRepeatFrequencyItemSelected = (item: IDropdownItem): boolean => {
-        return item.id === this.props.repeatFrequency;
-    };
+    invariant(repeatFrequencyItem, "Inconsistent state in RepeatFrequencySelect");
 
-    private getRepeatFrequencyItem = (repeatFrequency: string): IDropdownItem => {
-        const { intl, repeatPeriod } = this.props;
-        return {
-            id: repeatFrequency,
-            title: intl.formatMessage(messages[`scheduleDialogEmailRepeatsFrequencies_${repeatFrequency}`], {
-                n: repeatPeriod,
-            }),
-        };
-    };
-
-    private getRepeatFrequencyItems = (): IDropdownItem[] => {
-        return FREQUENCY_TYPE.map(this.getRepeatFrequencyItem);
-    };
-
-    private onRepeatFrequencyChange = (item: IDropdownItem) => {
-        this.props.onChange(item.id);
-    };
-}
-
-export const RepeatFrequencySelect = injectIntl(RenderRepeatFrequencySelect);
+    return (
+        <Dropdown
+            alignPoints={DEFAULT_DROPDOWN_ALIGN_POINTS}
+            className="gd-schedule-email-dialog-repeat-frequency s-gd-schedule-email-dialog-repeat-frequency"
+            renderButton={({ toggleDropdown }) => (
+                <DropdownButton value={repeatFrequencyItem.title} onClick={toggleDropdown} />
+            )}
+            renderBody={({ closeDropdown, isMobile }) => (
+                <DropdownList
+                    width={DROPDOWN_WIDTH}
+                    items={repeatFrequencyItems}
+                    isMobile={isMobile}
+                    renderItem={({ item }) => (
+                        <SingleSelectListItem
+                            title={item.title}
+                            onClick={() => {
+                                onChange(item.id);
+                                closeDropdown();
+                            }}
+                            isSelected={repeatFrequencyItem.id === item.id}
+                        />
+                    )}
+                />
+            )}
+            overlayPositionType="sameAsTarget"
+            overlayZIndex={DEFAULT_DROPDOWN_ZINDEX}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyInsightMenu/LegacyInsightMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyInsightMenu/LegacyInsightMenuButton.tsx
@@ -3,7 +3,7 @@ import React, { useCallback } from "react";
 import { insightVisualizationUrl, objRefToString, widgetRef } from "@gooddata/sdk-model";
 import { stringUtils } from "@gooddata/util";
 import cx from "classnames";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import { useIntl } from "react-intl";
 import { Bubble, BubbleHoverTrigger, IAlignPoint } from "@gooddata/sdk-ui-kit";
 import { VisType } from "@gooddata/sdk-ui";
 
@@ -17,13 +17,13 @@ function isExportableVisualization(visType: VisType): boolean {
 
 const bubbleAlignPoints: IAlignPoint[] = [{ align: "tc bc" }, { align: "tc br" }];
 
-const LegacyInsightMenuButtonCore: React.FC<IDashboardInsightMenuButtonProps & WrappedComponentProps> = ({
+export const LegacyInsightMenuButton: React.FC<IDashboardInsightMenuButtonProps> = ({
     onClick,
     widget,
     insight,
-    intl,
     isOpen,
 }) => {
+    const intl = useIntl();
     const onOptionsMenuClick = useCallback(() => {
         onClick();
     }, [onClick]);
@@ -69,5 +69,3 @@ const LegacyInsightMenuButtonCore: React.FC<IDashboardInsightMenuButtonProps & W
         </div>
     );
 };
-
-export const LegacyInsightMenuButton = injectIntl(LegacyInsightMenuButtonCore);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlertDialogWrapper.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlertDialogWrapper.tsx
@@ -1,6 +1,6 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React, { useMemo } from "react";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import { useIntl } from "react-intl";
 import { IAnalyticalBackend } from "@gooddata/sdk-backend-spi";
 
 import {
@@ -12,16 +12,15 @@ import {
 import { enrichBrokenAlertsInfo, IKpiAlertDialogProps, KpiAlertDialog } from "./KpiAlerts";
 import { useBrokenAlertFiltersMeta } from "./useBrokenAlertFiltersMeta";
 
-interface IKpiAlertDialogWrapperProps
-    extends WrappedComponentProps,
-        Omit<IKpiAlertDialogProps, "brokenAlertFilters" | "intl"> {
+interface IKpiAlertDialogWrapperProps extends Omit<IKpiAlertDialogProps, "brokenAlertFilters" | "intl"> {
     brokenAlertFiltersBasicInfo: IBrokenAlertFilterBasicInfo[];
     backend: IAnalyticalBackend;
     workspace: string;
 }
 
-const KpiAlertDialogWrapperCore: React.FC<IKpiAlertDialogWrapperProps> = (props) => {
-    const { brokenAlertFiltersBasicInfo, backend, workspace, intl, ...restProps } = props;
+export const KpiAlertDialogWrapper: React.FC<IKpiAlertDialogWrapperProps> = (props) => {
+    const { brokenAlertFiltersBasicInfo, backend, workspace, ...restProps } = props;
+    const intl = useIntl();
     const dateDatasets = useDashboardSelector(selectCatalogDateDatasets);
 
     const { result: brokenAlertFiltersMeta, status } = useBrokenAlertFiltersMeta({
@@ -43,7 +42,7 @@ const KpiAlertDialogWrapperCore: React.FC<IKpiAlertDialogWrapperProps> = (props)
             brokenAlertFiltersMeta.dateDatasets,
             brokenAlertFiltersMeta.attributeFiltersMeta,
         );
-    }, [brokenAlertFiltersMeta, restProps.dateFormat]);
+    }, [brokenAlertFiltersBasicInfo, brokenAlertFiltersMeta, intl, restProps.dateFormat]);
 
     return (
         <KpiAlertDialog
@@ -53,5 +52,3 @@ const KpiAlertDialogWrapperCore: React.FC<IKpiAlertDialogWrapperProps> = (props)
         />
     );
 };
-
-export const KpiAlertDialogWrapper = injectIntl(KpiAlertDialogWrapperCore);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialogDateRange.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialogDateRange.tsx
@@ -1,6 +1,6 @@
 // (C) 2019-2022 GoodData Corporation
 import React from "react";
-import { FormattedMessage, injectIntl, WrappedComponentProps } from "react-intl";
+import { FormattedMessage, useIntl } from "react-intl";
 import { IDateFilter, IDashboardDateFilter, ITheme } from "@gooddata/sdk-model";
 import { Icon } from "@gooddata/sdk-ui-kit";
 import { withTheme } from "@gooddata/sdk-ui-theme-provider";
@@ -13,12 +13,12 @@ interface IKpiAlertDialogDateRangeProps {
     theme?: ITheme;
 }
 
-const KpiAlertDialogDateRangeComponent: React.FC<IKpiAlertDialogDateRangeProps & WrappedComponentProps> = ({
+const KpiAlertDialogDateRangeComponent: React.FC<IKpiAlertDialogDateRangeProps> = ({
     filter,
-    intl,
     dateFormat,
     theme,
 }) => {
+    const intl = useIntl();
     const translationData = getKpiAlertTranslationData(filter, intl, dateFormat);
     if (!translationData) {
         return null;
@@ -38,4 +38,4 @@ const KpiAlertDialogDateRangeComponent: React.FC<IKpiAlertDialogDateRangeProps &
     );
 };
 
-export const KpiAlertDialogDateRange = injectIntl(withTheme(KpiAlertDialogDateRangeComponent));
+export const KpiAlertDialogDateRange = withTheme(KpiAlertDialogDateRangeComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -220,7 +220,6 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
     const isDrillable =
         (kpiResult?.measureDescriptor &&
             result &&
-            status !== "error" &&
             isSomeHeaderPredicateMatched(predicates, kpiResult.measureDescriptor, result)) ||
         widgetDrills.length > 0;
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -1,7 +1,7 @@
 // (C) 2020-2022 GoodData Corporation
 import React, { useMemo, useCallback } from "react";
 import cx from "classnames";
-import { injectIntl, WrappedComponentProps } from "react-intl";
+import { useIntl } from "react-intl";
 import {
     IInsight,
     insightVisualizationUrl,
@@ -47,9 +47,7 @@ interface IDefaultDashboardInsightWidgetProps {
 // Sometimes this component is rendered even before insights are ready, which blows up.
 // Since the behavior is nearly impossible to replicate reliably, let's be defensive here and not render
 // anything until the insights "catch up".
-const DefaultDashboardInsightWidgetWrapper: React.FC<
-    IDefaultDashboardInsightWidgetProps & WrappedComponentProps
-> = (props) => {
+export const DefaultDashboardInsightWidget: React.FC<IDefaultDashboardInsightWidgetProps> = (props) => {
     const {
         widget,
         // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
@@ -80,7 +78,7 @@ const DefaultDashboardInsightWidgetWrapper: React.FC<
  * @internal
  */
 const DefaultDashboardInsightWidgetCore: React.FC<
-    IDefaultDashboardInsightWidgetProps & WrappedComponentProps & { insight: IInsight }
+    IDefaultDashboardInsightWidgetProps & { insight: IInsight }
 > = ({
     widget,
     insight,
@@ -88,10 +86,10 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     onError,
     onExportReady,
     onLoadingChanged,
-    intl,
     // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
     index,
 }) => {
+    const intl = useIntl();
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
     const { ref: widgetRef } = widget;
 
@@ -213,5 +211,3 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         </DashboardItem>
     );
 };
-
-export const DefaultDashboardInsightWidget = injectIntl(DefaultDashboardInsightWidgetWrapper);

--- a/tools/i18n-toolkit/src/utils/console.ts
+++ b/tools/i18n-toolkit/src/utils/console.ts
@@ -136,7 +136,7 @@ function resultToDetail(cwd: string, { identifier, files, data }: UsageResult) {
 
 function table(data: string[][]) {
     const max = data.reduce((prev, columns) => {
-        columns.map((colum, i) => {
+        columns.forEach((colum, i) => {
             prev[i] = Math.max(prev[i], realLength(colum));
         });
         return prev;


### PR DESCRIPTION
This makes sure that useIntl is used instead of injectIntl where practically possible. This makes the React tree smaller as there are less components. This in turn makes debugging slightly easier.

Also fix one SonarQube-reported bug and remove a useless condition.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
