### PR TITLE
RELATED:  CAL-512 Make fixLocatorItem more robust

### DIFF
--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/fixLegacyElementUris.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/fixLegacyElementUris.ts
@@ -94,7 +94,8 @@ function fixSortItems(sortItems: ISortItem[] = []) {
 
 function fixLocatorItem(locator: ILocatorItem): ILocatorItem {
     if (isAttributeLocator(locator)) {
-        const [uri, labelValue] = locator.attributeLocatorItem.element.match(FAKE_ELEMENT_URI_REGEX) ?? [];
+        // element can be null even though the OpenAPI spec says it cannot (that will be fixed in CAL-515)
+        const [uri, labelValue] = locator.attributeLocatorItem.element?.match(FAKE_ELEMENT_URI_REGEX) ?? [];
 
         if (uri) {
             return {


### PR DESCRIPTION
Currently, the OpenAPI spec is not correct for parts of Tiger so some
items can now be null even though the spec says they can't.

This is a symptomatic fix, we will revisit this once CAL-515 is done.

JIRA: CAL-512

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
