### PR TITLE
RELATED: RAIL-4336 Use useTheme instead of withTheme

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3852,7 +3852,7 @@ export interface LoadingState {
 }
 
 // @alpha (undocumented)
-export const LockedStatusIndicator: React_2.ComponentType<Pick<ILockedStatusProps, "isLocked">>;
+export const LockedStatusIndicator: (props: ILockedStatusProps) => JSX.Element | null;
 
 // @alpha
 export interface MeasureDateDatasets {

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/ThemedLoadingEqualizer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/ThemedLoadingEqualizer.tsx
@@ -1,10 +1,10 @@
 // (C) 2021 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import { useTheme, withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 import { LoadingSpinner } from "@gooddata/sdk-ui-kit";
 
-const LoadingEqualizer: React.FC = () => {
+export const ThemedLoadingEqualizer: React.FC = () => {
     const theme = useTheme();
 
     return (
@@ -19,8 +19,3 @@ const LoadingEqualizer: React.FC = () => {
         </div>
     );
 };
-
-/**
- * @internal
- */
-export const ThemedLoadingEqualizer = withTheme(LoadingEqualizer);

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/index.ts
@@ -1,3 +1,3 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 export * from "./DashboardItems";
-export { ThemedLoadingEqualizer } from "./LoadingEqualizer";
+export { ThemedLoadingEqualizer } from "./ThemedLoadingEqualizer";

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentNoWidgets.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentNoWidgets.tsx
@@ -2,8 +2,7 @@
 import * as React from "react";
 import { useIntl } from "react-intl";
 import { Icon } from "@gooddata/sdk-ui-kit";
-import { ITheme } from "@gooddata/sdk-model";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 
 import { isMobileView } from "../../utils/responsive";
 
@@ -11,12 +10,12 @@ export interface IAttachmentProps {
     className?: string;
     label: string;
     fileName: string;
-    theme?: ITheme;
 }
 
-const AttachmentNoWidgetsComponent = (props: IAttachmentProps) => {
-    const { className = "", fileName, label, theme } = props;
+export const AttachmentNoWidgets = (props: IAttachmentProps) => {
+    const { className = "", fileName, label } = props;
     const intl = useIntl();
+    const theme = useTheme();
     const classNames = `gd-input-component gd-attachment-component ${className}`;
 
     const nameOfAttachment = isMobileView() ? "PDF" : fileName;
@@ -32,5 +31,3 @@ const AttachmentNoWidgetsComponent = (props: IAttachmentProps) => {
         </div>
     );
 };
-
-export const AttachmentNoWidgets = withTheme(AttachmentNoWidgetsComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/Attachments.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/Attachments.tsx
@@ -1,18 +1,15 @@
 // (C) 2019-2022 GoodData Corporation
 import * as React from "react";
-
 import { FormattedMessage } from "react-intl";
 import identity from "lodash/identity";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { objRefToString } from "@gooddata/sdk-model";
 
 import { AttachmentsSelectionDropdown } from "./AttachmentsSelectionDropdown";
 import { FormatOptionsDropdown } from "./FormatOptionsDropdown";
 import { IWidgetExportConfiguration, IWidgetsSelection } from "../../interfaces";
-import { objRefToString, ITheme } from "@gooddata/sdk-model";
 import { IInsightWidgetExtended } from "../../useScheduledEmail";
 
 export interface IAttachmentsProps {
-    theme?: ITheme;
     dashboardTitle: string;
     insightWidgets: IInsightWidgetExtended[];
     dashboardSelected: boolean;
@@ -30,7 +27,7 @@ const AttachmentItem: React.FC<{ format: string }> = ({ format, children }) => (
     </div>
 );
 
-const AttachmentsComponent = (props: IAttachmentsProps) => {
+export const Attachments = (props: IAttachmentsProps) => {
     const {
         dashboardTitle,
         dashboardSelected,
@@ -92,5 +89,3 @@ const AttachmentsComponent = (props: IAttachmentsProps) => {
         </div>
     );
 };
-
-export const Attachments = withTheme(AttachmentsComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentsSelectionDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/AttachmentsSelectionDropdown.tsx
@@ -4,14 +4,13 @@ import * as React from "react";
 import { useCallback, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
 import identity from "lodash/identity";
-
 import { Icon, InsightIcon, Typography } from "@gooddata/sdk-ui-kit";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
-import { ScheduleDropdown } from "./ScheduleDropdown";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
+import { ObjRef, objRefToString } from "@gooddata/sdk-model";
 
 import { IWidgetsSelection } from "../../interfaces";
-import { ObjRef, objRefToString, ITheme } from "@gooddata/sdk-model";
 import { IInsightWidgetExtended } from "../../useScheduledEmail";
+import { ScheduleDropdown } from "./ScheduleDropdown";
 
 export interface IAttachmentsSelectionDropdownProps {
     dashboardTitle: string;
@@ -19,18 +18,18 @@ export interface IAttachmentsSelectionDropdownProps {
     insightWidgets: IInsightWidgetExtended[];
     widgetsSelected: { [widgetUri: string]: boolean };
     onApply(dashboardSelected: boolean, widgetsSelected: IWidgetsSelection): void;
-    theme?: ITheme;
 }
 
-const AttachmentsSelectionDropdownComponent: React.FC<IAttachmentsSelectionDropdownProps> = (props) => {
-    const { theme, dashboardTitle, insightWidgets = [], onApply } = props;
+export const AttachmentsSelectionDropdown: React.FC<IAttachmentsSelectionDropdownProps> = (props) => {
+    const { dashboardTitle, insightWidgets = [], onApply } = props;
+    const intl = useIntl();
+    const theme = useTheme();
     const ICON_COLOR = theme?.palette?.complementary?.c5;
     const ICON_SIZE_BUTTON = 18;
     const ICON_PROPS = { color: ICON_COLOR, height: 19, width: 26 };
 
     const [dashboardSelected, setDashboardSelected] = useState(props.dashboardSelected);
     const [widgetsSelected, setWidgetsSelected] = useState(props.widgetsSelected);
-    const intl = useIntl();
 
     const handleWidgetSelectedChange = useCallback(
         (widgetRef: ObjRef) => {
@@ -114,5 +113,3 @@ const AttachmentsSelectionDropdownComponent: React.FC<IAttachmentsSelectionDropd
         />
     );
 };
-
-export const AttachmentsSelectionDropdown = withTheme(AttachmentsSelectionDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/FormatOptionsDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/FormatOptionsDropdown.tsx
@@ -4,8 +4,7 @@ import { useCallback, useState } from "react";
 import { Dropdown, DropdownButton, DropdownList, SingleSelectListItem, Icon } from "@gooddata/sdk-ui-kit";
 import { FormattedMessage, useIntl } from "react-intl";
 import { ScheduleDropdown } from "./ScheduleDropdown";
-import { ITheme } from "@gooddata/sdk-model";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 import { IWidgetExportConfiguration, WidgetExportFileFormat } from "../../interfaces";
 import { DEFAULT_DROPDOWN_ALIGN_POINTS, DEFAULT_DROPDOWN_ZINDEX } from "../../constants";
 
@@ -13,16 +12,16 @@ const ICON_SIZE_BUTTON = 18;
 const DROPDOWN_WIDTH = 70;
 
 export interface IFormatOptionsDropdownProps {
-    theme?: ITheme;
     format: WidgetExportFileFormat;
     mergeHeaders: boolean;
     includeFilters: boolean;
     onApply: (result: IWidgetExportConfiguration) => void;
 }
 
-const FormatOptionsDropdownComponent: React.FC<IFormatOptionsDropdownProps> = (props) => {
-    const { theme, onApply } = props;
+export const FormatOptionsDropdown: React.FC<IFormatOptionsDropdownProps> = (props) => {
+    const { onApply } = props;
     const intl = useIntl();
+    const theme = useTheme();
 
     const FORMAT_VALUES: WidgetExportFileFormat[] = ["csv", "xlsx"];
 
@@ -152,5 +151,3 @@ const FormatOptionsDropdownComponent: React.FC<IFormatOptionsDropdownProps> = (p
         />
     );
 };
-
-export const FormatOptionsDropdown = withTheme(FormatOptionsDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/ScheduleDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Attachments/ScheduleDropdown.tsx
@@ -3,8 +3,6 @@ import * as React from "react";
 import cx from "classnames";
 import { Bubble, BubbleHoverTrigger, Dropdown, Button } from "@gooddata/sdk-ui-kit";
 import { FormattedMessage, useIntl } from "react-intl";
-import { ITheme } from "@gooddata/sdk-model";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 import { DEFAULT_DROPDOWN_ALIGN_POINTS, DEFAULT_DROPDOWN_ZINDEX } from "../../constants";
 
 const ALIGN_POINTS = [
@@ -15,7 +13,6 @@ const ALIGN_POINTS = [
 export interface IScheduleDropdownProps {
     title: string;
     applyDisabled?: boolean;
-    theme?: ITheme;
     iconComponent?: React.ReactNode;
     onApply?: () => void;
     onCancel?: () => void;
@@ -25,7 +22,7 @@ export interface IScheduleDropdownProps {
     buttonDisabled?: boolean;
 }
 
-export const ScheduleDropdownComponent: React.FC<IScheduleDropdownProps> = (props) => {
+export const ScheduleDropdown: React.FC<IScheduleDropdownProps> = (props) => {
     const {
         title,
         applyDisabled,
@@ -126,5 +123,3 @@ export const ScheduleDropdownComponent: React.FC<IScheduleDropdownProps> = (prop
         />
     );
 };
-
-export const ScheduleDropdown = withTheme(ScheduleDropdownComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/ScheduledEmails.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailManagementDialog/ScheduledEmails.tsx
@@ -1,10 +1,11 @@
 // (C) 2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
-import { IScheduledMail, ITheme } from "@gooddata/sdk-model";
+import { IScheduledMail } from "@gooddata/sdk-model";
 import { LoadingSpinner } from "@gooddata/sdk-ui-kit";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
+
 import { ScheduledEmail } from "./ScheduledEmail";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
 
 interface IScheduledEmailsProps {
     onDelete: (scheduledEmail: IScheduledMail) => void;
@@ -12,22 +13,21 @@ interface IScheduledEmailsProps {
     isLoading: boolean;
     scheduledEmails: IScheduledMail[];
     currentUserEmail?: string;
-    theme?: ITheme;
     noSchedulesMessageId: string;
     canManageScheduledMail: boolean;
 }
 
-const ScheduledEmailsComponent: React.FC<IScheduledEmailsProps> = (props) => {
+export const ScheduledEmails: React.FC<IScheduledEmailsProps> = (props) => {
     const {
         isLoading,
         scheduledEmails,
         currentUserEmail,
         onDelete,
         onEdit,
-        theme,
         noSchedulesMessageId,
         canManageScheduledMail,
     } = props;
+    const theme = useTheme();
 
     if (isLoading) {
         return (
@@ -65,5 +65,3 @@ const ScheduledEmailsComponent: React.FC<IScheduledEmailsProps> = (props) => {
         </>
     );
 };
-
-export const ScheduledEmails = withTheme(ScheduledEmailsComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/lockedStatus/LockedStatusIndicator.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/topBar/shareIndicators/lockedStatus/LockedStatusIndicator.tsx
@@ -1,12 +1,16 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import React from "react";
 import { BubbleHoverTrigger, Bubble, Icon } from "@gooddata/sdk-ui-kit";
 import { FormattedMessage } from "react-intl";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 import { ILockedStatusProps } from "./types";
 import { gdColorStateBlank } from "../../../constants/colors";
 
-const LockedStatusComponent = (props: ILockedStatusProps): JSX.Element | null => {
+/**
+ * @alpha
+ */
+export const LockedStatusIndicator = (props: ILockedStatusProps): JSX.Element | null => {
+    const theme = useTheme();
     if (!props.isLocked) {
         return null;
     }
@@ -17,7 +21,7 @@ const LockedStatusComponent = (props: ILockedStatusProps): JSX.Element | null =>
                     className="gd-icon-locked"
                     width={25}
                     height={24}
-                    color={props.theme?.palette?.complementary?.c6 ?? gdColorStateBlank}
+                    color={theme?.palette?.complementary?.c6 ?? gdColorStateBlank}
                 />
                 <Bubble alignPoints={[{ align: "bc tl" }]} alignTo={`.gd-icon-locked`}>
                     <FormattedMessage
@@ -29,8 +33,3 @@ const LockedStatusComponent = (props: ILockedStatusProps): JSX.Element | null =>
         </div>
     );
 };
-
-/**
- * @alpha
- */
-export const LockedStatusIndicator = withTheme(LockedStatusComponent);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialogDateRange.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialogDateRange.tsx
@@ -1,24 +1,20 @@
 // (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage, useIntl } from "react-intl";
-import { IDateFilter, IDashboardDateFilter, ITheme } from "@gooddata/sdk-model";
+import { IDateFilter, IDashboardDateFilter } from "@gooddata/sdk-model";
 import { Icon } from "@gooddata/sdk-ui-kit";
-import { withTheme } from "@gooddata/sdk-ui-theme-provider";
+import { useTheme } from "@gooddata/sdk-ui-theme-provider";
 
 import { getKpiAlertTranslationData } from "../utils/translationUtils";
 
 interface IKpiAlertDialogDateRangeProps {
     filter: IDateFilter | IDashboardDateFilter | undefined;
     dateFormat: string;
-    theme?: ITheme;
 }
 
-const KpiAlertDialogDateRangeComponent: React.FC<IKpiAlertDialogDateRangeProps> = ({
-    filter,
-    dateFormat,
-    theme,
-}) => {
+export const KpiAlertDialogDateRange: React.FC<IKpiAlertDialogDateRangeProps> = ({ filter, dateFormat }) => {
     const intl = useIntl();
+    const theme = useTheme();
     const translationData = getKpiAlertTranslationData(filter, intl, dateFormat);
     if (!translationData) {
         return null;
@@ -37,5 +33,3 @@ const KpiAlertDialogDateRangeComponent: React.FC<IKpiAlertDialogDateRangeProps> 
         />
     );
 };
-
-export const KpiAlertDialogDateRange = withTheme(KpiAlertDialogDateRangeComponent);


### PR DESCRIPTION
This makes the component tree smaller and avoids connecting to
the themeIsLoading context none of the components cares about.

JIRA: RAIL-4336

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
