### PR TITLE
NAS-3989 - WS earlyAccess string is not evaluated

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/features/feature.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/feature.ts
@@ -25,10 +25,10 @@ export function mapFeatures(features: FeaturesMap): Partial<ITigerFeatureFlags> 
         ),
         ...loadFeature(
             features,
-            TigerFeaturesNames.ADmeasureValueFilterNullAsZeroOption,
-            "ADmeasureValueFilterNullAsZeroOption",
+            TigerFeaturesNames.ADMeasureValueFilterNullAsZeroOption,
+            "ADMeasureValueFilterNullAsZeroOption",
             "STRING",
-            FeatureFlagsValues.ADmeasureValueFilterNullAsZeroOption,
+            FeatureFlagsValues.ADMeasureValueFilterNullAsZeroOption,
         ),
         ...loadFeature(
             features,

--- a/libs/sdk-backend-tiger/src/backend/features/hub.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/hub.ts
@@ -1,5 +1,5 @@
 // (C) 2020-2022 GoodData Corporation
-import { ILiveFeatures } from "@gooddata/api-client-tiger";
+import { ILiveFeatures, FeatureContext } from "@gooddata/api-client-tiger";
 import axios, { AxiosResponse } from "axios";
 
 import { ITigerFeatureFlags } from "../uiFeatures";
@@ -17,10 +17,11 @@ const state: HubServiceState = {};
 
 export async function getFeatureHubFeatures(
     features: ILiveFeatures["live"],
+    wsContext: Partial<FeatureContext> = {},
 ): Promise<Partial<ITigerFeatureFlags>> {
     const { configuration, context } = features;
     try {
-        const data = await loadHubFeatures(configuration, context, state);
+        const data = await loadHubFeatures(configuration, { ...context, ...wsContext }, state);
         const featuresMap = data.reduce((prev, item) => ({ ...prev, [item.key]: item }), {} as FeaturesMap);
         return mapFeatures(featuresMap);
     } catch (err) {
@@ -34,7 +35,7 @@ export async function getFeatureHubFeatures(
 // - more info in ticket RAIL-4279
 async function loadHubFeatures(
     configuration: ILiveFeatures["live"]["configuration"],
-    context: ILiveFeatures["live"]["context"],
+    context: FeatureContext,
     state: HubServiceState,
 ): Promise<FeatureHubResponse[number]["features"]> {
     const { host, key } = configuration;
@@ -84,7 +85,7 @@ export type FeatureHubResponse = {
 async function getFeatureHubData(
     host: string,
     key: string,
-    context: ILiveFeatures["live"]["context"],
+    context: FeatureContext,
     state?: HubServiceState[string],
 ): Promise<AxiosResponse<FeatureHubResponse>> {
     return axios.get("/features", {

--- a/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/hub.test.ts
@@ -4,6 +4,7 @@ import axios, { AxiosResponse } from "axios";
 import { ILiveFeatures } from "@gooddata/api-client-tiger";
 import { getFeatureHubFeatures, FeatureHubResponse } from "../hub";
 import { FeatureDef } from "../feature";
+import { pickContext } from "../index";
 
 jest.mock("axios");
 
@@ -53,6 +54,23 @@ describe("live features", () => {
         });
     });
 
+    it("call axios with ws context", async () => {
+        mockReturn([]);
+
+        await getFeatureHubFeatures(createFeatures(), pickContext({ earlyAccess: "omega" }));
+        expect(axios.get).toHaveBeenCalledWith("/features", {
+            baseURL: "/",
+            headers: {
+                "Content-type": "application/json",
+                "X-FeatureHub": "earlyAccess=omega",
+                "if-none-match": expect.anything(),
+            },
+            method: "GET",
+            params: { sdkUrl: "" },
+            validateStatus: expect.anything(),
+        });
+    });
+
     it("call axios with context filled", async () => {
         mockReturn([]);
 
@@ -70,6 +88,23 @@ describe("live features", () => {
         });
     });
 
+    it("call axios with context and ws context filled", async () => {
+        mockReturn([]);
+
+        await getFeatureHubFeatures(createFeatures("beta"), pickContext({ earlyAccess: "omega" }));
+        expect(axios.get).toHaveBeenCalledWith("/features", {
+            baseURL: "/",
+            headers: {
+                "Content-type": "application/json",
+                "X-FeatureHub": "earlyAccess=omega",
+                "if-none-match": expect.anything(),
+            },
+            method: "GET",
+            params: { sdkUrl: "" },
+            validateStatus: expect.anything(),
+        });
+    });
+
     it("empty definition", async () => {
         mockReturn([]);
 
@@ -79,7 +114,7 @@ describe("live features", () => {
 
     it("full definition - BOOLEAN", async () => {
         mockReturn([
-            createFeature("ADmeasureValueFilterNullAsZeroOption", "BOOLEAN", true),
+            createFeature("ADMeasureValueFilterNullAsZeroOption", "BOOLEAN", true),
             createFeature("dashboardEditModeDevRollout", "BOOLEAN", true),
             createFeature("enableKPIDashboardDeleteFilterButton", "BOOLEAN", true),
             createFeature("enableMultipleDates", "BOOLEAN", true),
@@ -88,7 +123,7 @@ describe("live features", () => {
 
         const results = await getFeatureHubFeatures(createFeatures());
         expect(results).toEqual({
-            ADmeasureValueFilterNullAsZeroOption: true,
+            ADMeasureValueFilterNullAsZeroOption: true,
             dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
@@ -98,7 +133,7 @@ describe("live features", () => {
 
     it("full definition - STRING", async () => {
         mockReturn([
-            createFeature("ADmeasureValueFilterNullAsZeroOption", "STRING", "EnabledUncheckedByDefault"),
+            createFeature("ADMeasureValueFilterNullAsZeroOption", "STRING", "EnabledUncheckedByDefault"),
             createFeature("dashboardEditModeDevRollout", "STRING", "ENABLED"),
             createFeature("enableKPIDashboardDeleteFilterButton", "STRING", "ENABLED"),
             createFeature("enableMultipleDates", "STRING", "ENABLED"),
@@ -107,7 +142,7 @@ describe("live features", () => {
 
         const results = await getFeatureHubFeatures(createFeatures());
         expect(results).toEqual({
-            ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
             dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,

--- a/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
+++ b/libs/sdk-backend-tiger/src/backend/features/test/static.test.ts
@@ -17,7 +17,7 @@ describe("static features", () => {
     it("full definition", async () => {
         const results = await getStaticFeatures(
             createFeatures({
-                [TigerFeaturesNames.ADmeasureValueFilterNullAsZeroOption]: "EnabledUncheckedByDefault",
+                [TigerFeaturesNames.ADMeasureValueFilterNullAsZeroOption]: "EnabledUncheckedByDefault",
                 [TigerFeaturesNames.EnableSortingByTotalGroup]: "ENABLED",
                 [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                 [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
@@ -25,7 +25,7 @@ describe("static features", () => {
             }),
         );
         expect(results).toEqual({
-            ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
             dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,
@@ -37,7 +37,7 @@ describe("static features", () => {
         const results = await getStaticFeatures(
             createFeatures(
                 {
-                    [TigerFeaturesNames.ADmeasureValueFilterNullAsZeroOption]: "EnabledUncheckedByDefault",
+                    [TigerFeaturesNames.ADMeasureValueFilterNullAsZeroOption]: "EnabledUncheckedByDefault",
                     [TigerFeaturesNames.EnableSortingByTotalGroup]: "ENABLED",
                     [TigerFeaturesNames.EnableMultipleDates]: "ENABLED",
                     [TigerFeaturesNames.EnableKPIDashboardDeleteFilterButton]: "ENABLED",
@@ -47,7 +47,7 @@ describe("static features", () => {
             ),
         );
         expect(results).toEqual({
-            ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+            ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
             dashboardEditModeDevRollout: true,
             enableKPIDashboardDeleteFilterButton: true,
             enableMultipleDates: true,

--- a/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
+++ b/libs/sdk-backend-tiger/src/backend/uiFeatures.ts
@@ -4,7 +4,7 @@ export enum TigerFeaturesNames {
     //boolean + possible values: enabled, disabled
     EnableSortingByTotalGroup = "enableSortingByTotalGroup",
     //string, possible values: disabled, enabledCheckedByDefault, enabledUncheckedByDefault
-    ADmeasureValueFilterNullAsZeroOption = "ADmeasureValueFilterNullAsZeroOption",
+    ADMeasureValueFilterNullAsZeroOption = "ADMeasureValueFilterNullAsZeroOption",
     //boolean + possible values: enabled, disabled
     EnableMultipleDates = "enableMultipleDates",
     //boolean + possible values: enabled, disabled
@@ -15,7 +15,7 @@ export enum TigerFeaturesNames {
 
 export type ITigerFeatureFlags = {
     enableSortingByTotalGroup: typeof FeatureFlagsValues["enableSortingByTotalGroup"][number];
-    ADmeasureValueFilterNullAsZeroOption: typeof FeatureFlagsValues["ADmeasureValueFilterNullAsZeroOption"][number];
+    ADMeasureValueFilterNullAsZeroOption: typeof FeatureFlagsValues["ADMeasureValueFilterNullAsZeroOption"][number];
     enableMultipleDates: typeof FeatureFlagsValues["enableMultipleDates"][number];
     enableKPIDashboardDeleteFilterButton: typeof FeatureFlagsValues["enableKPIDashboardDeleteFilterButton"][number];
     dashboardEditModeDevRollout: typeof FeatureFlagsValues["dashboardEditModeDevRollout"][number];
@@ -23,7 +23,7 @@ export type ITigerFeatureFlags = {
 
 export const DefaultFeatureFlags: ITigerFeatureFlags = {
     enableSortingByTotalGroup: false,
-    ADmeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
+    ADMeasureValueFilterNullAsZeroOption: "EnabledUncheckedByDefault",
     enableMultipleDates: true,
     enableKPIDashboardDeleteFilterButton: false,
     // disable edit mode in gdc-dashboards during development
@@ -32,7 +32,7 @@ export const DefaultFeatureFlags: ITigerFeatureFlags = {
 
 export const FeatureFlagsValues = {
     enableSortingByTotalGroup: [true, false] as const,
-    ADmeasureValueFilterNullAsZeroOption: [
+    ADMeasureValueFilterNullAsZeroOption: [
         "Disabled",
         "EnabledCheckedByDefault",
         "EnabledUncheckedByDefault",

--- a/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/settings/index.ts
@@ -5,7 +5,7 @@ import {
     IUserWorkspaceSettings,
 } from "@gooddata/sdk-backend-spi";
 import { TigerAuthenticatedCallGuard } from "../../../types";
-import { TigerFeaturesService } from "../../features";
+import { TigerFeaturesService, pickContext } from "../../features";
 import { DefaultUiSettings, DefaultUserSettings } from "../../uiSettings";
 
 export class TigerWorkspaceSettings implements IWorkspaceSettingsService {
@@ -32,16 +32,19 @@ export class TigerWorkspaceSettings implements IWorkspaceSettingsService {
 
     public getSettingsForCurrentUser(): Promise<IUserWorkspaceSettings> {
         return this.authCall(async (client) => {
-            const profile = await client.profile.getCurrent();
-            const features = await new TigerFeaturesService(this.authCall).getFeatures(profile);
             const {
-                data: { meta: config },
+                data: { meta: config, attributes },
             } = (
                 await client.entities.getEntityWorkspaces({
                     id: this.workspace,
                     metaInclude: ["config"],
                 })
             ).data;
+            const profile = await client.profile.getCurrent();
+            const features = await new TigerFeaturesService(this.authCall).getFeatures(
+                profile,
+                pickContext(attributes),
+            );
 
             return {
                 ...DefaultUserSettings,


### PR DESCRIPTION
JIRA: NAS-3978, NAS-3989

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
