### PR TITLE
RELATED: RAIL-4158 fix widget selection

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5122,9 +5122,10 @@ payload: number | null;
 type: string;
 }>;
 selectWidget: CaseReducer<UiState, {
-payload: UriRef | IdentifierRef | undefined;
+payload: ObjRef;
 type: string;
 }>;
+clearWidgetSelection: CaseReducer<UiState, AnyAction>;
 }>;
 
 // @alpha (undocumented)

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/dashboard/common/stateInitializers.ts
@@ -175,6 +175,6 @@ export function* actionsToInitializeExistingDashboard(
         metaActions.setMeta({
             dashboard,
         }),
-        uiActions.selectWidget(undefined),
+        uiActions.clearWidgetSelection(),
     ];
 }

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -89,8 +89,12 @@ const setActiveHeaderIndex: UiReducer<PayloadAction<number | null>> = (state, ac
     state.activeHeaderIndex = action.payload;
 };
 
-const selectWidget: UiReducer<PayloadAction<ObjRef | undefined>> = (state, action) => {
+const selectWidget: UiReducer<PayloadAction<ObjRef>> = (state, action) => {
     state.selectedWidgetRef = action.payload;
+};
+
+const clearWidgetSelection: UiReducer = (state) => {
+    state.selectedWidgetRef = undefined;
 };
 
 export const uiReducers = {
@@ -115,4 +119,5 @@ export const uiReducers = {
     setRenderMode,
     setActiveHeaderIndex,
     selectWidget,
+    clearWidgetSelection,
 };

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -21,7 +21,7 @@ export const DashboardInner: React.FC<IDashboardProps> = () => {
 
     const unselectWidget = useCallback(() => {
         if (selectedWidget) {
-            dispatch(uiActions.selectWidget(undefined));
+            dispatch(uiActions.clearWidgetSelection());
         }
     }, [dispatch, selectedWidget]);
 

--- a/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dashboard/components/DashboardInner.tsx
@@ -1,7 +1,13 @@
 // (C) 2022 GoodData Corporation
-import React from "react";
+import React, { useCallback } from "react";
 import { IntlWrapper } from "../../localization";
-import { useDashboardSelector, selectLocale } from "../../../model";
+import {
+    useDashboardSelector,
+    selectLocale,
+    uiActions,
+    useDashboardDispatch,
+    selectSelectedWidgetRef,
+} from "../../../model";
 import { DashboardHeader } from "../DashboardHeader/DashboardHeader";
 import { IDashboardProps } from "../types";
 import { DashboardMainContent } from "./DashboardMainContent";
@@ -10,10 +16,18 @@ import { RenderModeAwareDashboardLayoutSectionHeaderRenderer } from "../Dashboar
 
 export const DashboardInner: React.FC<IDashboardProps> = () => {
     const locale = useDashboardSelector(selectLocale);
+    const dispatch = useDashboardDispatch();
+    const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
+
+    const unselectWidget = useCallback(() => {
+        if (selectedWidget) {
+            dispatch(uiActions.selectWidget(undefined));
+        }
+    }, [dispatch, selectedWidget]);
 
     return (
         <IntlWrapper locale={locale}>
-            <div className="gd-dashboards-root gd-flex-container">
+            <div className="gd-dashboards-root gd-flex-container" onClick={unselectWidget}>
                 <DashboardSidebar DefaultSidebar={RenderModeAwareDashboardLayoutSectionHeaderRenderer} />
                 <div className="gd-dash-content">
                     <div className="gd-dash-header-wrapper">

--- a/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/presentationComponents/DashboardItems/DashboardItemContent.tsx
@@ -1,5 +1,5 @@
 // (C) 2020-2022 GoodData Corporation
-import React, { forwardRef } from "react";
+import React, { forwardRef, useCallback } from "react";
 import cx from "classnames";
 
 interface IDashboardItemContentProps {
@@ -12,6 +12,15 @@ interface IDashboardItemContentProps {
 
 export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemContentProps>(
     function DashboardItemContent({ children, className, isSelectable, isSelected, onSelected }, ref) {
+        const handleClick = useCallback(
+            (e: React.MouseEvent) => {
+                if (onSelected) {
+                    e.stopPropagation();
+                    onSelected();
+                }
+            },
+            [onSelected],
+        );
         return (
             <div
                 className={cx("dash-item-content", className, {
@@ -19,7 +28,7 @@ export const DashboardItemContent = forwardRef<HTMLDivElement, IDashboardItemCon
                     "is-selected": isSelected,
                 })}
                 ref={ref}
-                onClick={onSelected}
+                onClick={handleClick}
             >
                 {children}
             </div>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
@@ -1,0 +1,46 @@
+// (C) 2022 GoodData Corporation
+import { useCallback } from "react";
+import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
+import {
+    selectIsInEditMode,
+    selectSelectedWidgetRef,
+    uiActions,
+    useDashboardDispatch,
+    useDashboardSelector,
+} from "../../../model";
+
+export interface IUseWidgetSelectionResult {
+    /**
+     * Flag indicating the given item can be selected.
+     */
+    isSelectable: boolean;
+    /**
+     * Flag indicating the given item is selected.
+     */
+    isSelected: boolean;
+    /**
+     * Callback to call when an item is selected.
+     */
+    onSelected: () => void;
+}
+
+export function useWidgetSelection(widgetRef: ObjRef): IUseWidgetSelectionResult {
+    const dispatch = useDashboardDispatch();
+
+    const isSelectable = useDashboardSelector(selectIsInEditMode);
+
+    const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
+    const isSelected = isSelectable && !!selectedWidget && areObjRefsEqual(selectedWidget, widgetRef);
+
+    const onSelected = useCallback(() => {
+        if (isSelectable && widgetRef) {
+            dispatch(uiActions.selectWidget(widgetRef));
+        }
+    }, [isSelectable, widgetRef, dispatch]);
+
+    return {
+        isSelectable,
+        isSelected,
+        onSelected,
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/DashboardItemWithKpiAlert.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/DashboardItemWithKpiAlert.tsx
@@ -54,6 +54,19 @@ export interface IDashboardItemWithKpiAlertProps {
 
     isReadOnlyMode?: boolean;
 
+    /**
+     * Flag indicating the given item can be selected.
+     */
+    isSelectable?: boolean;
+    /**
+     * Flag indicating the given item is selected.
+     */
+    isSelected?: boolean;
+    /**
+     * Callback to call when an item is selected.
+     */
+    onSelected?: () => void;
+
     // Callbacks
     onAlertDialogOpenClick: () => void;
 
@@ -312,6 +325,9 @@ export class DashboardItemWithKpiAlert extends Component<
                         {this.props.renderHeadline(clientHeight)}
                     </>
                 )}
+                isSelectable={this.props.isSelectable}
+                isSelected={this.props.isSelected}
+                onSelected={this.props.onSelected}
             >
                 {this.props.children}
             </DashboardItemKpi>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -64,6 +64,7 @@ import { DashboardItemWithKpiAlert, evaluateAlertTriggered } from "./KpiAlerts";
 import { dashboardFilterToFilterContextItem, stripDateDatasets } from "./utils/filterUtils";
 import { useWidgetBrokenAlertsQuery } from "../../common/useWidgetBrokenAlertsQuery";
 import { invariant } from "ts-invariant";
+import { useWidgetSelection } from "../../common/useWidgetSelection";
 
 interface IKpiExecutorProps {
     dashboardRef?: ObjRef;
@@ -233,6 +234,8 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
             ? "error"
             : "idle";
 
+    const { isSelectable, isSelected, onSelected } = useWidgetSelection(kpiWidget.ref);
+
     return (
         <DashboardItemWithKpiAlert
             kpi={kpiWidget}
@@ -365,6 +368,9 @@ const KpiExecutorCore: React.FC<IKpiProps> = (props) => {
             )}
             alertDeletingStatus={kpiAlertOperations.removingStatus}
             alertSavingStatus={alertSavingStatus}
+            isSelectable={isSelectable}
+            isSelected={isSelected}
+            onSelected={onSelected}
         >
             {() => {
                 return (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -8,7 +8,6 @@ import {
     IInsightWidget,
     widgetTitle,
     ScreenSize,
-    areObjRefsEqual,
 } from "@gooddata/sdk-model";
 import { OnError, OnExportReady, OnLoadingChanged, VisType } from "@gooddata/sdk-ui";
 
@@ -18,10 +17,6 @@ import {
     isCustomWidget,
     useDashboardScheduledEmails,
     selectCanExportReport,
-    selectIsInEditMode,
-    selectSelectedWidgetRef,
-    useDashboardDispatch,
-    uiActions,
 } from "../../../model";
 import {
     DashboardItem,
@@ -34,6 +29,7 @@ import { DashboardInsight } from "../insight/DashboardInsight";
 import { useInsightExport } from "../common/useInsightExport";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import { useInsightMenu } from "./useInsightMenu";
+import { useWidgetSelection } from "../common/useWidgetSelection";
 
 interface IDefaultDashboardInsightWidgetProps {
     widget: IInsightWidget;
@@ -138,17 +134,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         [InsightMenuComponentProvider, insight, widget],
     );
 
-    const isSelectable = useDashboardSelector(selectIsInEditMode);
-
-    const selectedWidget = useDashboardSelector(selectSelectedWidgetRef);
-    const isSelected = isSelectable && selectedWidget && areObjRefsEqual(selectedWidget, widget.ref);
-
-    const dispatch = useDashboardDispatch();
-    const onSelected = useCallback(() => {
-        if (isSelectable && widget.ref) {
-            dispatch(uiActions.selectWidget(widget.ref));
-        }
-    }, [isSelectable, widget.ref, dispatch]);
+    const { isSelectable, isSelected, onSelected } = useWidgetSelection(widget.ref);
 
     return (
         <DashboardItem


### PR DESCRIPTION
* Make KPIs selectable as well
* Extract selection utils into a hook
* Deselect widget on outside click

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
