### PR TITLE
BUGFIX: NAS-3939 Subtotals are no longer added by pivot table aggregation menu when sorted

### DIFF
--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -2999,7 +2999,7 @@ export function resultHeaderName(header: IResultHeader): string;
 export type RgbType = "rgb";
 
 // @internal
-export function sanitizeBucketTotals(bucket: IBucket, sortItems: ISortItem[]): ITotal[];
+export function sanitizeBucketTotals(bucket: IBucket, sortItems: ISortItem[], totals?: ITotal[]): ITotal[];
 
 // @alpha
 export type ScheduledMailAttachment = IDashboardAttachment | IWidgetAttachment;

--- a/libs/sdk-model/src/insight/sanitization.ts
+++ b/libs/sdk-model/src/insight/sanitization.ts
@@ -37,18 +37,20 @@ function removeInvalidTotalsFromInsight<T extends IInsightDefinition>(insight: T
 }
 
 /**
- * Takes totals from a bucket and removes all subtotals if the bucket is sorted on a different than the first attribute.
+ * Takes totals from a bucket and removes all subtotals if the bucket is sorted on other than the first attribute.
  *
  * @param bucket - a grouping of attributes, measures and totals to sanitize
  * @param sortItems - a specification of the sort
- * @returns totals - sanitized totals
+ * @param totals - if specified these totals instead of the bucket totals will be sanitized in regard to the bucket
+ * @returns sanitized totals
  * @internal
  */
-export function sanitizeBucketTotals(bucket: IBucket, sortItems: ISortItem[]): ITotal[] {
+export function sanitizeBucketTotals(bucket: IBucket, sortItems: ISortItem[], totals?: ITotal[]): ITotal[] {
+    const originalTotals = totals ?? bucketTotals(bucket);
     if (isSortedOnDifferentThanFirstAttributeInBucket(bucket, sortItems)) {
-        return getBucketTotalsWithoutSubtotals(bucket);
+        return getTotalsWithoutSubtotals(originalTotals, bucket);
     } else {
-        return bucketTotals(bucket);
+        return originalTotals;
     }
 }
 
@@ -67,8 +69,6 @@ function isSortedOnDifferentThanFirstAttributeInBucket(bucket: IBucket, sortItem
     });
 }
 
-function getBucketTotalsWithoutSubtotals(bucket: IBucket): ITotal[] {
-    return bucketTotals(bucket).filter(
-        (total) => bucketAttributeIndex(bucket, total.attributeIdentifier) === 0,
-    );
+function getTotalsWithoutSubtotals(totals: ITotal[], bucket: IBucket): ITotal[] {
+    return totals.filter((total) => bucketAttributeIndex(bucket, total.attributeIdentifier) === 0);
 }

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -724,7 +724,12 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
     };
 
     private onMenuAggregationClick = (menuAggregationClickConfig: IMenuAggregationClickConfig) => {
-        const newColumnTotals = getUpdatedColumnTotals(this.getColumnTotals(), menuAggregationClickConfig);
+        const sortItems = this.internal.table?.getSortItems();
+        const newColumnTotals = sanitizeDefTotals(
+            this.getExecutionDefinition(),
+            sortItems,
+            getUpdatedColumnTotals(this.getColumnTotals(), menuAggregationClickConfig),
+        );
 
         this.pushDataGuard({
             properties: {

--- a/libs/sdk-ui-pivot/src/impl/tableFacade.ts
+++ b/libs/sdk-ui-pivot/src/impl/tableFacade.ts
@@ -735,6 +735,10 @@ export class TableFacade {
         return this.tableDescriptor.createSortItems(columns, this.currentResult.definition.sortBy);
     };
 
+    public getSortItems = (): ISortItem[] => {
+        return this.currentResult.definition.sortBy;
+    };
+
     /**
      * Tests whether the provided prepared execution matches the execution that is used to obtain data for this
      * table facade.

--- a/libs/sdk-ui-pivot/src/impl/utils.ts
+++ b/libs/sdk-ui-pivot/src/impl/utils.ts
@@ -2,6 +2,7 @@
 import once from "lodash/once";
 import {
     bucketsFind,
+    bucketTotals,
     IExecutionDefinition,
     ISortItem,
     ITotal,
@@ -45,13 +46,20 @@ export async function sleep(delay: number): Promise<void> {
 }
 
 /**
- * Remove invalid totals from an execution definition given a list of sort items
+ * Get only valid totals from an execution definition given a list of sort items
  *
  * @param definition - an execution definition to sanitize
  * @param sortItems - a specification of the sort, if not provided definition.sortBy will be used
+ * @param totals - totals to be sanitized, if not provided ATTRIBUTE bucket totals will be used
  */
-export function sanitizeDefTotals(definition: IExecutionDefinition, sortItems?: ISortItem[]): ITotal[] {
+export function sanitizeDefTotals(
+    definition: IExecutionDefinition,
+    sortItems?: ISortItem[],
+    totals?: ITotal[],
+): ITotal[] {
     const { buckets, sortBy } = definition;
     const attributeBucket = bucketsFind(buckets, BucketNames.ATTRIBUTE);
-    return attributeBucket ? sanitizeBucketTotals(attributeBucket, sortItems ?? sortBy) : [];
+    return attributeBucket
+        ? sanitizeBucketTotals(attributeBucket, sortItems ?? sortBy, totals ?? bucketTotals(attributeBucket))
+        : [];
 }


### PR DESCRIPTION
Subtotals are no longer added by pivot table aggregation menu when sorted by other than the first attribute.

After clicking on a item in menu a check is first rhow the table is sorted. If the subtotals would be incompatible they are simply not added.

Side effect: Nothing happens except a reload on aggregation menu click in these cases.

JIRA: NAS-3939

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
