### PR TITLE
RELATED: CAL-519 Partially revert changes related to null attribute headers

### DIFF
--- a/libs/api-client-tiger/api/api-client-tiger.api.md
+++ b/libs/api-client-tiger/api/api-client-tiger.api.md
@@ -506,8 +506,8 @@ export interface AttributeItem {
 
 // @public
 export interface AttributeResultHeader {
-    labelValue: string | null;
-    primaryLabelValue: string | null;
+    labelValue: string;
+    primaryLabelValue: string;
 }
 
 // @public

--- a/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/api.ts
@@ -611,13 +611,13 @@ export interface AttributeResultHeader {
      * @type {string}
      * @memberof AttributeResultHeader
      */
-    labelValue: string | null;
+    labelValue: string;
     /**
      * A value of the primary attribute label.
      * @type {string}
      * @memberof AttributeResultHeader
      */
-    primaryLabelValue: string | null;
+    primaryLabelValue: string;
 }
 /**
  * Filter the result by comparing specified metric to given constant value, using given comparison operator.

--- a/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
+++ b/libs/api-client-tiger/src/generated/afm-rest-api/openapi-spec.json
@@ -1723,13 +1723,11 @@
                     "labelValue": {
                         "type": "string",
                         "description": "A value of the current attribute label.",
-                        "nullable": true,
                         "example": "East Coast"
                     },
                     "primaryLabelValue": {
                         "type": "string",
                         "description": "A value of the primary attribute label.",
-                        "nullable": true,
                         "example": "1225"
                     }
                 },

--- a/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/fromBackend/afm/DimensionHeaderConverter.ts
@@ -25,11 +25,6 @@ import {
 import { createDateValueFormatter } from "../dateFormatting/dateValueFormatter";
 import { toSdkGranularity } from "../dateGranularityConversions";
 
-// Tiger can return nulls for empty values but SPI needs strings always, so convert nulls to empty strings
-function coalesceNulls(value: string | null): string {
-    return value ?? "";
-}
-
 const supportedSuffixes: string[] = Object.keys(JsonApiAttributeOutAttributesGranularityEnum)
     .filter((item) => isNaN(Number(item)))
     .map(
@@ -102,12 +97,10 @@ function attributeMeasureItem(
 ): IResultAttributeHeader {
     return {
         attributeHeaderItem: {
-            uri: coalesceNulls(header.attributeHeader.primaryLabelValue),
-            name: coalesceNulls(
-                granularity
-                    ? dateValueFormatter(header.attributeHeader.labelValue, granularity)
-                    : header.attributeHeader.labelValue,
-            ),
+            uri: header.attributeHeader.primaryLabelValue,
+            name: granularity
+                ? dateValueFormatter(header.attributeHeader.labelValue, granularity)
+                : header.attributeHeader.labelValue,
         },
     };
 }

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToDashboardHandler.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/drill/drillToDashboardHandler.ts
@@ -176,8 +176,7 @@ export function convertIntersectionToAttributeFilters(
         .filter((i: DrillEventIntersectionElementHeader) => filterIntersection(i, dateDataSetsAttributesRefs))
         .filter(isDrillIntersectionAttributeItem)
         .map((h: IDrillIntersectionAttributeItem): IAttributeFilter => {
-            // on tiger, empty values have uri: "" and name: "(empty value)" so we need to detect this special case here
-            if (backendSupportsElementUris || h.attributeHeaderItem.uri === "") {
+            if (backendSupportsElementUris) {
                 return newPositiveAttributeFilter(h.attributeHeader.ref, {
                     uris: [h.attributeHeaderItem.uri],
                 });

--- a/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
+++ b/libs/sdk-ui-ext/src/internal/components/pluggableVisualizations/drillDownUtil.ts
@@ -125,8 +125,7 @@ export function convertIntersectionToFilters(
         .map((intersection) => intersection.header)
         .filter(isDrillIntersectionAttributeItem)
         .map((header) => {
-            // on tiger, empty values have uri: "" and name: "(empty value)" so we need to detect this special case here
-            if (backendSupportsElementUris || header.attributeHeaderItem.uri === "") {
+            if (backendSupportsElementUris) {
                 return newPositiveAttributeFilter(header.attributeHeader.ref, {
                     uris: [header.attributeHeaderItem.uri],
                 });


### PR DESCRIPTION
* Partially revert 040e318ad1aa4fa24a8db43b063a735b6281c6d7
* Partially revert afa98bc98a06904d4f3e31e7ae5ad1131d9eb5f1
* Revert changes to the api-client-tiger

JIRA: CAL-519

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
