### PR TITLE
RELATED: RAIL-4342 Ui actions and meta selectors

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4933,6 +4933,9 @@ export const selectInsightsMap: OutputSelector<DashboardState, ObjRefMap<IInsigh
 // @internal
 export const selectIsCircularDependency: (currentFilterLocalId: string, neighborFilterLocalid: string) => OutputSelector<DashboardState, boolean, (res: string[]) => boolean>;
 
+// @internal (undocumented)
+export const selectIsDashboardLoading: OutputSelector<DashboardState, boolean, (res: LoadingState) => boolean>;
+
 // @public (undocumented)
 export const selectIsDashboardSaving: OutputSelector<DashboardState, boolean, (res: SavingState) => boolean>;
 
@@ -4965,6 +4968,9 @@ export const selectIsKpiAlertOpenedByWidgetRef: (ref: ObjRef | undefined) => (st
 
 // @alpha
 export const selectIsLayoutEmpty: OutputSelector<DashboardState, boolean, (res: ExtendedDashboardWidget[]) => boolean>;
+
+// @internal
+export const selectIsNewDashboard: OutputSelector<DashboardState, boolean, (res: UriRef | IdentifierRef | undefined) => boolean>;
 
 // @public
 export const selectIsReadOnly: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
@@ -5201,6 +5207,8 @@ setRenderMode: CaseReducer<UiState, {
 payload: RenderMode;
 type: string;
 }>;
+setEditRenderMode: CaseReducer<UiState, AnyAction>;
+setViewRenderMode: CaseReducer<UiState, AnyAction>;
 setActiveHeaderIndex: CaseReducer<UiState, {
 payload: number | null;
 type: string;

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -1,7 +1,7 @@
 // (C) 2021-2022 GoodData Corporation
 export { DashboardDispatch, DashboardState, DashboardSelector, DashboardSelectorEvaluator } from "./types";
 
-export { selectDashboardLoading } from "./loading/loadingSelectors";
+export { selectDashboardLoading, selectIsDashboardLoading } from "./loading/loadingSelectors";
 export { LoadingState } from "./loading/loadingState";
 export { selectDashboardSaving, selectIsDashboardSaving } from "./saving/savingSelectors";
 export { SavingState } from "./saving/savingState";
@@ -162,6 +162,7 @@ export {
     selectDashboardShareInfo,
     selectPersistedDashboard,
     selectDashboardLockStatus,
+    selectIsNewDashboard,
 } from "./meta/metaSelectors";
 export {
     selectListedDashboards,

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -85,6 +85,14 @@ const setRenderMode: UiReducer<PayloadAction<RenderMode>> = (state, action) => {
     state.renderMode = action.payload;
 };
 
+const setEditRenderMode: UiReducer = (state) => {
+    state.renderMode = "edit";
+};
+
+const setViewRenderMode: UiReducer = (state) => {
+    state.renderMode = "view";
+};
+
 const setActiveHeaderIndex: UiReducer<PayloadAction<number | null>> = (state, action) => {
     state.activeHeaderIndex = action.payload;
 };
@@ -117,6 +125,8 @@ export const uiReducers = {
     closeDeleteDialog,
     setMenuButtonItemsVisibility,
     setRenderMode,
+    setEditRenderMode,
+    setViewRenderMode,
     setActiveHeaderIndex,
     selectWidget,
     clearWidgetSelection,


### PR DESCRIPTION
- export selectors needed for postMessageAPI
- add new actions to set render mode without handing over the param.

JIRA: RAIL-4342

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
