### PR TITLE
Convert api error when scanning data source

### DIFF
--- a/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
+++ b/libs/sdk-backend-tiger/src/backend/tigerSpecificFunctions.ts
@@ -442,17 +442,18 @@ export const buildTigerSpecificFunctions = (
         }
     },
     scanDataSource: async (dataSourceId: string, scanRequest: ScanRequest) => {
-        return await authApiCall(async (sdk) => {
-            // TODO replace sdk.axios call with sdk.actions when API is regenerated for Tiger 1.7
-            return await sdk.axios
-                .post(`/api/v1/actions/dataSources/${dataSourceId}/scan`, scanRequest)
-                .then((res: AxiosResponse) => {
-                    return res?.data;
-                })
-                .catch((err) => {
-                    return Promise.reject(`scan error=${JSON.stringify(err.response.data)}`);
-                });
-        });
+        try {
+            return await authApiCall(async (sdk) => {
+                // TODO replace sdk.axios call with sdk.actions when API is regenerated for Tiger 1.7
+                return await sdk.axios
+                    .post(`/api/v1/actions/dataSources/${dataSourceId}/scan`, scanRequest)
+                    .then((res: AxiosResponse) => {
+                        return res?.data;
+                    });
+            });
+        } catch (error) {
+            throw convertApiError(error);
+        }
     },
     publishPdm: async (dataSourceId: string, declarativePdm: DeclarativePdm) => {
         return await authApiCall(async (sdk) => {


### PR DESCRIPTION
Without proper error conversion, auth call is not able to call not authenticated handler.

JIRA: TNT-904

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
