### PR TITLE
RAIL-4354 - 'InsightView' cannot be used as a JSX component

### DIFF
--- a/examples/sdk-examples/src/components/SourceDropdown.tsx
+++ b/examples/sdk-examples/src/components/SourceDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { SourceContainer } from "../components/SourceContainer";
 
@@ -23,7 +23,7 @@ export class SourceDropdown extends React.Component<ISourceDropdownProps, ISourc
         this.setState((state) => ({ ...state, viewJS: isJS }));
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { hidden, viewJS } = this.state;
         const { sourceJS, source } = this.props;
 

--- a/examples/sdk-examples/src/examples/advanced/chartConfiguration/ConfigurationColumnChartExample.tsx
+++ b/examples/sdk-examples/src/examples/advanced/chartConfiguration/ConfigurationColumnChartExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 import { InsightView } from "@gooddata/sdk-ui-ext";
 import * as Md from "../../../md/full";
@@ -71,7 +71,7 @@ export class ConfigurationColumnChartExample extends Component<
         });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { config } = this.state;
 
         return (

--- a/examples/sdk-examples/src/examples/advanced/chartConfiguration/InsightViewDualAxisBarChartExample.tsx
+++ b/examples/sdk-examples/src/examples/advanced/chartConfiguration/InsightViewDualAxisBarChartExample.tsx
@@ -1,11 +1,11 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 
 import { InsightView } from "@gooddata/sdk-ui-ext";
 import * as Md from "../../../md/full";
 
 export class InsightViewDualAxisBarChartExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         const config = {
             secondary_xaxis: {
                 visible: true,

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeElementsExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeElementsExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 import { AttributeElements } from "@gooddata/sdk-ui-filters";
 import { attributeDisplayFormRef } from "@gooddata/sdk-model";
@@ -16,7 +16,7 @@ export class AttributeFilterItem extends Component<IItem> {
             console.log("AttributeFilterItem onChange", uri, event.target.value === "on");
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { title, uri } = this.props;
         return (
             <label className="gd-list-item s-attribute-filter-list-item" style={{ display: "inline-flex" }}>
@@ -34,7 +34,7 @@ export class AttributeElementsExample extends Component {
         return <AttributeFilterItem key={uri} uri={uri} title={title} />;
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div style={{ minHeight: 500 }}>
                 <AttributeElements displayForm={attributeDisplayFormRef(Md.EmployeeName.Default)} limit={20}>

--- a/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterComponentExample.tsx
+++ b/examples/sdk-examples/src/examples/attributeFilter/AttributeFilterComponentExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 import { AttributeFilter } from "@gooddata/sdk-ui-filters";
 import { idRef, newPositiveAttributeFilter, newNegativeAttributeFilter, uriRef } from "@gooddata/sdk-model";
@@ -13,7 +13,7 @@ export class AttributeFilterComponentExample extends Component {
         console.log("AttributeFilterComponentExample onApply", ...params);
     };
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div>
                 <div>attribute defined by identifier</div>

--- a/examples/sdk-examples/src/examples/basic/BulletChartExample.tsx
+++ b/examples/sdk-examples/src/examples/basic/BulletChartExample.tsx
@@ -10,7 +10,7 @@ const FranchiseFees = modifyMeasure(Md.$FranchiseFees, (m) => m.format("#,##0").
 const FranchiseFeesOngoingRoyalty = modifyMeasure(Md.$FranchiseFeesOngoingRoyalty, (m) => m.format("#,##0"));
 
 export class BulletChartExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div style={{ height: 300 }} className="s-bullet-chart">
                 <BulletChart

--- a/examples/sdk-examples/src/examples/basic/HeadlineExample.tsx
+++ b/examples/sdk-examples/src/examples/basic/HeadlineExample.tsx
@@ -19,7 +19,7 @@ export class HeadlineExample extends Component {
         return console.log("ColumnChartExample onError", ...params);
     };
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div className="s-headline" style={{ display: "flex" }}>
                 <style jsx>

--- a/examples/sdk-examples/src/examples/drill/GeoPushpinChartDrillExample.tsx
+++ b/examples/sdk-examples/src/examples/drill/GeoPushpinChartDrillExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
 
@@ -21,7 +21,7 @@ export class GeoPushpinChartDrillExample extends React.Component<unknown, State>
         drillEvent: null,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div className="s-geo-pushpin-chart-on-drill">
                 <div style={{ height: 500, position: "relative" }} className="s-geo-pushpin-chart">

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartClusteringExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartClusteringExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
@@ -8,7 +8,7 @@ import { MAPBOX_TOKEN } from "../../constants/fixtures";
 import * as Md from "../../md/full";
 
 export class GeoPushpinChartClusteringExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div style={{ height: "500px", position: "relative" }} className="s-geo-pushpin-chart-clustering">
                 <GeoPushpinChart

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationColorMappingExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationColorMappingExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
@@ -35,7 +35,7 @@ const colorMapping: IColorMapping[] = [
 ];
 
 export class GeoPushpinChartConfigurationColorMappingExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         const geoConfig = {
             tooltipText: tooltipTextAttribute,
             mapboxToken: MAPBOX_TOKEN,

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
@@ -14,7 +14,7 @@ import {
 } from "../../md/geoModel";
 
 export class GeoPushpinChartConfigurationExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         const geoConfig = {
             center: {
                 lat: 39,

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationLegendExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationLegendExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
@@ -8,7 +8,7 @@ import { GeoPushpinChart, IGeoConfig } from "@gooddata/sdk-ui-geo";
 import { locationAttribute, segmentByAttribute, sizeMeasure } from "../../md/geoModel";
 
 export class GeoPushpinChartConfigurationLegendExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         const geoConfig: IGeoConfig = {
             mapboxToken: MAPBOX_TOKEN,
             legend: {

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationPointsGroupNearbyExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationPointsGroupNearbyExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
@@ -16,7 +16,7 @@ export class GeoPushpinChartConfigurationPointsGroupNearbyExample extends Compon
         groupNearbyPoints: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { groupNearbyPoints } = this.state;
         const geoConfig = {
             mapboxToken: MAPBOX_TOKEN,

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationPointsSizeExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationPointsSizeExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 
 import "@gooddata/sdk-ui-geo/styles/css/main.css";
@@ -20,7 +20,7 @@ export class GeoPushpinChartConfigurationPointsSizeExample extends Component<unk
         maxSize: "default",
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { minSize, maxSize } = this.state;
         const geoConfig: IGeoConfig = {
             mapboxToken: MAPBOX_TOKEN,

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationViewportExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartConfigurationViewportExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
@@ -8,7 +8,7 @@ import { MAPBOX_TOKEN } from "../../constants/fixtures";
 import { locationAttribute } from "../../md/geoModel";
 
 export class GeoPushpinChartConfigurationViewportExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div
                 style={{ height: "500px", position: "relative" }}

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartWithCategoryLegendExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartWithCategoryLegendExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2020-2021 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React, { Component } from "react";
 import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
@@ -8,7 +8,7 @@ import { MAPBOX_TOKEN } from "../../constants/fixtures";
 import { locationAttribute, sizeMeasure, colorMeasure, segmentByAttribute } from "../../md/geoModel";
 
 export class GeoPushpinChartWithCategoryLegendExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div style={{ height: "500px", position: "relative" }} className="s-geo-pushpin-chart-category">
                 <GeoPushpinChart

--- a/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartWithColorLegendExample.tsx
+++ b/examples/sdk-examples/src/examples/geoPushpin/GeoPushpinChartWithColorLegendExample.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component } from "react";
 import { GeoPushpinChart } from "@gooddata/sdk-ui-geo";
 
@@ -8,7 +8,7 @@ import { MAPBOX_TOKEN } from "../../constants/fixtures";
 import { locationAttribute, sizeMeasure, colorMeasure } from "../../md/geoModel";
 
 export class GeoPushpinChartWithColorLegendExample extends Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div style={{ height: "500px", position: "relative" }} className="s-geo-pushpin-chart-color">
                 <GeoPushpinChart

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterExample.tsx
@@ -41,7 +41,7 @@ export class FilterByValueExample extends Component<unknown, IMeasureValueFilter
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <div>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterFormattedInPercentageExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterFormattedInPercentageExample.tsx
@@ -39,7 +39,7 @@ export class MeasureValueFilterExample extends Component<unknown, IMeasureValueF
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <div>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterShownInPercentageExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterShownInPercentageExample.tsx
@@ -42,7 +42,7 @@ export class MeasureValueFilterExample extends Component<unknown, IMeasureValueF
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <div>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterStackedToHundredPercentExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterByValue/MeasureValueFilterStackedToHundredPercentExample.tsx
@@ -42,7 +42,7 @@ export class MeasureValueFilterExample extends Component<unknown, IMeasureValueF
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <div>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentExample.tsx
@@ -28,7 +28,7 @@ export class MeasureValueFilterComponentExample extends React.PureComponent {
         this.setState({ filters: [filter ?? defaultFilter] });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <React.Fragment>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentPercentageExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentPercentageExample.tsx
@@ -31,7 +31,7 @@ export class MeasureValueFilterComponentPercentageExample extends React.PureComp
         this.setState({ filters: [filter ?? defaultFilter] });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
 
         return (

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentRatioExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterComponentRatioExample.tsx
@@ -34,7 +34,7 @@ export class MeasureValueFilterComponentRatioExample extends React.PureComponent
         this.setState({ filters: [filter ?? defaultFilter] });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters } = this.state;
         return (
             <React.Fragment>

--- a/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterDropdownComponentExample.tsx
+++ b/examples/sdk-examples/src/examples/measureValueFilter/measureValueFilterComponent/MeasureValueFilterDropdownComponentExample.tsx
@@ -69,7 +69,7 @@ export class MeasureValueFilterComponentExample extends React.PureComponent<
         this.setState((state) => ({ ...state, displayDropdown: !state.displayDropdown }));
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { filters, displayDropdown } = this.state;
 
         return (

--- a/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
+++ b/examples/sdk-examples/src/examples/pivotTable/PivotTableManualResizingExample.tsx
@@ -54,7 +54,7 @@ export class PivotTableManualResizingExample extends Component {
         this.setState({ columnWidths });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div>
                 <div>

--- a/examples/sdk-examples/src/examples/timeOverTimeComparison/PreviousPeriodHeadlineExample.tsx
+++ b/examples/sdk-examples/src/examples/timeOverTimeComparison/PreviousPeriodHeadlineExample.tsx
@@ -21,7 +21,7 @@ export class PreviousPeriodHeadlineExample extends Component {
         return console.log("PreviousPeriodHeadlineExample onError", ...params);
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const primaryMeasure = TotalSales;
         const secondaryMeasure = newPreviousPeriodMeasure(
             TotalSales,

--- a/libs/sdk-ui-charts/src/charts/areaChart/CoreAreaChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/areaChart/CoreAreaChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreAreaChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="area" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/barChart/CoreBarChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/barChart/CoreBarChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreBarChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="bar" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/bubbleChart/CoreBubbleChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/bubbleChart/CoreBubbleChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { ICoreChartProps } from "../../interfaces";
 import { BaseChart } from "../_base/BaseChart";
 
 export class CoreBubbleChart extends React.Component<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="bubble" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/bulletChart/CoreBulletChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/bulletChart/CoreBulletChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreBulletChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="bullet" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/columnChart/CoreColumnChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/columnChart/CoreColumnChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreColumnChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="column" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/comboChart/CoreComboChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/comboChart/CoreComboChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { ICoreChartProps } from "../../interfaces";
 import { BaseChart } from "../_base/BaseChart";
 
 export class CoreComboChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="combo" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/donutChart/CoreDonutChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/donutChart/CoreDonutChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { ICoreChartProps } from "../../interfaces";
 import { BaseChart } from "../_base/BaseChart";
 
 export class CoreDonutChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="donut" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/funnelChart/CoreFunnelChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/funnelChart/CoreFunnelChart.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { visualizationIsBetaWarning } from "@gooddata/sdk-ui";
 import { BaseChart } from "../_base/BaseChart";
@@ -10,7 +10,7 @@ export class CoreFunnelChart extends React.PureComponent<ICoreChartProps> {
         visualizationIsBetaWarning();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="funnel" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
+++ b/libs/sdk-ui-charts/src/charts/headline/internal/Headline.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { createRef } from "react";
 import Measure from "react-measure";
 import { ResponsiveText } from "@gooddata/sdk-ui-kit";
@@ -59,7 +59,7 @@ export default class Headline extends React.Component<IHeadlineVisualizationProp
 
     private secondaryItemTitleWrapperRef = createRef<HTMLDivElement>();
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <Measure client>
                 {({ measureRef, contentRect }) => {

--- a/libs/sdk-ui-charts/src/charts/heatmap/CoreHeatmap.tsx
+++ b/libs/sdk-ui-charts/src/charts/heatmap/CoreHeatmap.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreHeatmap extends React.PureComponent<ICoreChartProps, null> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="heatmap" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/lineChart/CoreLineChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/lineChart/CoreLineChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreLineChart extends React.PureComponent<ICoreChartProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="line" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/pieChart/CorePieChart.tsx
+++ b/libs/sdk-ui-charts/src/charts/pieChart/CorePieChart.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { ICoreChartProps } from "../../interfaces";
 import { BaseChart } from "../_base/BaseChart";
 
 export class CorePieChart extends React.PureComponent<ICoreChartProps, null> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="pie" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/scatterPlot/CoreScatterPlot.tsx
+++ b/libs/sdk-ui-charts/src/charts/scatterPlot/CoreScatterPlot.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreScatterPlot extends React.PureComponent<ICoreChartProps, null> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="scatter" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/treemap/CoreTreemap.tsx
+++ b/libs/sdk-ui-charts/src/charts/treemap/CoreTreemap.tsx
@@ -1,10 +1,10 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { BaseChart } from "../_base/BaseChart";
 import { ICoreChartProps } from "../../interfaces";
 
 export class CoreTreemap extends React.PureComponent<ICoreChartProps, null> {
-    public render(): React.ReactNode {
+    public render() {
         return <BaseChart type="treemap" {...this.props} />;
     }
 }

--- a/libs/sdk-ui-charts/src/charts/withJsxExport.tsx
+++ b/libs/sdk-ui-charts/src/charts/withJsxExport.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import isFunction from "lodash/isFunction";
 import isString from "lodash/isString";
@@ -29,7 +29,7 @@ export const withJsxExport = <T extends object>(
             return `<${getDisplayName(Component)}\n${paddedPropDeclarations}\n/>`;
         };
 
-        public render(): React.ReactNode {
+        public render() {
             return <Component {...this.props} />;
         }
     };

--- a/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
+++ b/libs/sdk-ui-charts/src/charts/xirr/internal/XirrTransformation.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import noop from "lodash/noop";
@@ -38,7 +38,7 @@ class XirrTransformation extends React.Component<IXirrTransformationProps & Wrap
         onAfterRender: noop,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { drillableItems, config, onAfterRender, dataView } = this.props;
 
         const drillablePredicates = convertDrillableItemsToPredicates(drillableItems);

--- a/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/Chart.tsx
@@ -89,7 +89,7 @@ export class Chart extends React.Component<IChartProps> {
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return <div {...this.props.domProps} ref={this.setChartRef} />;
     }
 }

--- a/libs/sdk-ui-charts/src/highcharts/adapter/HighChartsRenderer.tsx
+++ b/libs/sdk-ui-charts/src/highcharts/adapter/HighChartsRenderer.tsx
@@ -418,7 +418,7 @@ export class HighChartsRenderer extends React.PureComponent<
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return this.renderVisualization();
     }
 

--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4769,7 +4769,7 @@ export const selectDashboardShareInfo: OutputSelector<DashboardState, IAccessCon
 export const selectDashboardShareStatus: OutputSelector<DashboardState, ShareStatus, (res: DashboardDescriptor) => ShareStatus>;
 
 // @public
-export const selectDashboardTags: OutputSelector<DashboardState, string[] | undefined, (res: DashboardDescriptor) => string[] | undefined>;
+export const selectDashboardTags: OutputSelector<DashboardState, string[], (res: DashboardDescriptor) => string[]>;
 
 // @public
 export const selectDashboardTitle: OutputSelector<DashboardState, string, (res: DashboardDescriptor) => string>;
@@ -4862,7 +4862,7 @@ export const selectEnableKPIDashboardImplicitDrillDown: OutputSelector<Dashboard
 export const selectEnableKPIDashboardSaveAsNew: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @public
-export const selectEnableKPIDashboardSchedule: OutputSelector<DashboardState, boolean | undefined, (res: ResolvedDashboardConfig) => boolean | undefined>;
+export const selectEnableKPIDashboardSchedule: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;
 
 // @public
 export const selectEnableKPIDashboardScheduleRecipients: OutputSelector<DashboardState, boolean, (res: ResolvedDashboardConfig) => boolean>;

--- a/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
+++ b/libs/sdk-ui-dashboard/src/model/react/useDashboardScheduledEmails.ts
@@ -35,7 +35,7 @@ export const useDashboardScheduledEmails = () => {
     const isReadOnly = useDashboardSelector(selectIsReadOnly);
     const isInViewMode = useDashboardSelector(selectIsInViewMode);
     const canCreateScheduledMail = useDashboardSelector(selectCanCreateScheduledMail);
-    const isScheduledEmailingEnabled = !!useDashboardSelector(selectEnableKPIDashboardSchedule);
+    const isScheduledEmailingEnabled = useDashboardSelector(selectEnableKPIDashboardSchedule);
     const menuButtonItemsVisibility = useDashboardSelector(selectMenuButtonItemsVisibility);
 
     const openScheduleEmailingDialog = () => dispatch(uiActions.openScheduleEmailDialog());

--- a/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/config/configSelectors.ts
@@ -33,7 +33,7 @@ export const selectConfig = createSelector(selectSelf, (configState) => {
  * @public
  */
 export const selectDateFilterConfig = createSelector(selectConfig, (state) => {
-    return state.dateFilterConfig;
+    return state.dateFilterConfig ?? undefined;
 });
 
 /**
@@ -42,7 +42,7 @@ export const selectDateFilterConfig = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectSettings = createSelector(selectConfig, (state) => {
-    return state.settings;
+    return state.settings ?? undefined;
 });
 
 /**
@@ -51,7 +51,7 @@ export const selectSettings = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectLocale = createSelector(selectConfig, (state) => {
-    return state.locale;
+    return state.locale ?? undefined;
 });
 
 /**
@@ -60,7 +60,7 @@ export const selectLocale = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectSeparators = createSelector(selectConfig, (state) => {
-    return state.separators;
+    return state.separators ?? undefined;
 });
 
 /**
@@ -69,7 +69,7 @@ export const selectSeparators = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectColorPalette = createSelector(selectConfig, (state) => {
-    return state.colorPalette;
+    return state.colorPalette ?? undefined;
 });
 
 /**
@@ -82,7 +82,7 @@ export const selectColorPalette = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectObjectAvailabilityConfig = createSelector(selectConfig, (state) => {
-    return state.objectAvailability;
+    return state.objectAvailability ?? undefined;
 });
 
 /**
@@ -91,7 +91,7 @@ export const selectObjectAvailabilityConfig = createSelector(selectConfig, (stat
  * @internal
  */
 export const selectMapboxToken = createSelector(selectConfig, (state) => {
-    return state.mapboxToken;
+    return state.mapboxToken ?? undefined;
 });
 
 /**
@@ -103,7 +103,7 @@ export const selectMapboxToken = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectIsReadOnly = createSelector(selectConfig, (state) => {
-    return state.isReadOnly;
+    return state.isReadOnly ?? false;
 });
 
 /**
@@ -115,7 +115,7 @@ export const selectIsReadOnly = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectIsEmbedded = createSelector(selectConfig, (state) => {
-    return state.isEmbedded;
+    return state.isEmbedded ?? false;
 });
 
 /**
@@ -125,7 +125,7 @@ export const selectIsEmbedded = createSelector(selectConfig, (state) => {
  * @internal
  */
 export const selectIsExport = createSelector(selectConfig, (state) => {
-    return state.isExport;
+    return state.isExport ?? false;
 });
 
 /**
@@ -134,7 +134,7 @@ export const selectIsExport = createSelector(selectConfig, (state) => {
  * @internal
  */
 export const selectIsWhiteLabeled = createSelector(selectConfig, (state) => {
-    return state.isWhiteLabeled;
+    return state.isWhiteLabeled ?? false;
 });
 
 /**
@@ -175,7 +175,7 @@ export const selectIsSaveAsNewButtonHidden = createSelector(selectConfig, (state
  * @public
  */
 export const selectDateFormat = createSelector(selectConfig, (state) => {
-    return state.settings?.responsiveUiDateFormat;
+    return state.settings?.responsiveUiDateFormat ?? undefined;
 });
 
 /**
@@ -184,7 +184,7 @@ export const selectDateFormat = createSelector(selectConfig, (state) => {
  * @public
  */
 export const selectEnableKPIDashboardSchedule = createSelector(selectConfig, (state) => {
-    return state.settings?.enableKPIDashboardSchedule;
+    return state.settings?.enableKPIDashboardSchedule ?? false;
 });
 
 /**
@@ -301,7 +301,7 @@ export const selectEnableInsightExportScheduling = createSelector(selectConfig, 
  * @internal
  */
 export const selectDashboardEditModeDevRollout = createSelector(selectConfig, (state) => {
-    return !!state.settings?.dashboardEditModeDevRollout;
+    return !!state.settings?.dashboardEditModeDevRollout ?? false;
 });
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/dateFilterConfig/dateFilterConfigSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/dateFilterConfig/dateFilterConfigSelectors.ts
@@ -27,7 +27,7 @@ const selectSelf = createSelector(
  * @alpha
  */
 export const selectDateFilterConfigOverrides = createSelector(selectSelf, (dateFilterConfigState) => {
-    return dateFilterConfigState.dateFilterConfig;
+    return dateFilterConfigState.dateFilterConfig ?? undefined;
 });
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/meta/metaSelectors.ts
@@ -46,7 +46,7 @@ export const selectDashboardDescriptor = createSelector(selectSelf, (state) => {
  * @internal
  */
 export const selectPersistedDashboard = createSelector(selectSelf, (state) => {
-    return state.persistedDashboard;
+    return state.persistedDashboard ?? undefined;
 });
 
 /**
@@ -58,7 +58,7 @@ export const selectPersistedDashboard = createSelector(selectSelf, (state) => {
  * been persisted (typically newly created dashboard being edited).
  */
 export const selectPersistedDashboardFilterContext = createSelector(selectSelf, (state) => {
-    return state.persistedDashboard?.filterContext;
+    return state.persistedDashboard?.filterContext ?? undefined;
 });
 
 /**
@@ -101,7 +101,7 @@ export const selectPersistedDashboardFilterContextAsFilterContextDefinition = cr
  * @public
  */
 export const selectDashboardRef = createSelector(selectPersistedDashboard, (state) => {
-    return state?.ref;
+    return state?.ref ?? undefined;
 });
 
 /**
@@ -114,7 +114,7 @@ export const selectDashboardRef = createSelector(selectPersistedDashboard, (stat
  * @public
  */
 export const selectDashboardId = createSelector(selectPersistedDashboard, (state) => {
-    return state?.identifier;
+    return state?.identifier ?? undefined;
 });
 
 /**
@@ -127,7 +127,7 @@ export const selectDashboardId = createSelector(selectPersistedDashboard, (state
  * @public
  */
 export const selectDashboardUri = createSelector(selectPersistedDashboard, (state) => {
-    return state?.uri;
+    return state?.uri ?? undefined;
 });
 
 /**
@@ -191,7 +191,7 @@ export const selectDashboardDescription = createSelector(selectDashboardDescript
  * @public
  */
 export const selectDashboardTags = createSelector(selectDashboardDescriptor, (state) => {
-    return state.tags;
+    return state.tags ?? [];
 });
 
 /**
@@ -218,7 +218,7 @@ export const selectIsDashboardPrivate = createSelector(selectDashboardShareStatu
  * @alpha
  */
 export const selectDashboardLockStatus = createSelector(selectDashboardDescriptor, (state) => {
-    return state.isLocked || false;
+    return state.isLocked ?? false;
 });
 
 /**

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -24,7 +24,7 @@ export const selectIsScheduleEmailDialogOpen = createSelector(
  */
 export const selectScheduleEmailDialogDefaultAttachment = createSelector(
     selectSelf,
-    (state) => state.scheduleEmailDialog.defaultAttachmentRef,
+    (state) => state.scheduleEmailDialog.defaultAttachmentRef ?? undefined,
 );
 
 /**
@@ -65,7 +65,10 @@ const selectHighlightedKpiWidgetRef = createSelector(
     (state) => state.kpiAlerts.highlightedWidgetRef,
 );
 
-const selectOpenedKpiWidgetRef = createSelector(selectSelf, (state) => state.kpiAlerts.openedWidgetRef);
+const selectOpenedKpiWidgetRef = createSelector(
+    selectSelf,
+    (state) => state.kpiAlerts.openedWidgetRef ?? undefined,
+);
 
 /**
  * @alpha
@@ -147,7 +150,7 @@ export const selectIsInEditMode = createSelector(selectSelf, (state) => state.re
 /**
  * @internal
  */
-export const selectActiveHeaderIndex = createSelector(selectSelf, (state) => state.activeHeaderIndex);
+export const selectActiveHeaderIndex = createSelector(selectSelf, (state) => state.activeHeaderIndex ?? null);
 
 /**
  * @internal

--- a/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/useSaveAs.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/saveAs/DefaultSaveAsDialog/useSaveAs.ts
@@ -61,7 +61,7 @@ export const useSaveAs = (props: UseSaveAsProps): UseSaveAsResult => {
     const { onSubmit, onSubmitSuccess, onSubmitError } = props;
     const locale = useDashboardSelector(selectLocale);
     const dashboardTitle = useDashboardSelector(selectDashboardTitle);
-    const isScheduleEmailsEnabled = useDashboardSelector(selectEnableKPIDashboardSchedule) ?? false;
+    const isScheduleEmailsEnabled = useDashboardSelector(selectEnableKPIDashboardSchedule);
     const capabilities = useDashboardSelector(selectBackendCapabilities);
     const isDashboardSaving = useDashboardSelector(selectIsDashboardSaving);
 

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/DateTime.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/DateTime.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 import { Datepicker, Timepicker } from "@gooddata/sdk-ui-kit";
 
@@ -20,7 +20,7 @@ interface IDateTimeOwnProps {
 export type IDateTimeProps = IDateTimeOwnProps;
 
 export class DateTime extends React.PureComponent<IDateTimeProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { date, dateFormat, label, locale, timezone, onDateChange } = this.props;
 
         return (

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RecipientsSelect/RecipientsSelectRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RecipientsSelect/RecipientsSelectRenderer.tsx
@@ -122,7 +122,7 @@ export class RecipientsSelectRenderer extends React.PureComponent<IRecipientsSel
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { isMulti, options, value } = this.props;
         const creatableSelectComponent: SelectComponentsConfig<
             IScheduleEmailRecipient,

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatPeriodSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatPeriodSelect.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 
 interface IRepeatPeriodSelectData {
@@ -24,7 +24,7 @@ export class RepeatPeriodSelect extends React.PureComponent<
         };
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div className="gd-schedule-email-dialog-repeat-period">
                 <input

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatSelect.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/RepeatSelect/RepeatSelect.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 
@@ -39,7 +39,7 @@ class RepeatSelectRender extends React.PureComponent<IRepeatSelectProps, IRepeat
         };
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { label, startDate } = this.props;
         const { repeatType } = this.state;
         return (

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/ScheduledMailDialogRenderer.tsx
@@ -332,7 +332,7 @@ export class ScheduledMailDialogRendererUI extends React.PureComponent<
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { intl, onCancel, editSchedule, enableWidgetExportScheduling } = this.props;
         const { alignment, isValidScheduleEmailData } = this.state;
         const alignPoints = [

--- a/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Textarea.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/scheduledEmail/DefaultScheduledEmailDialog/ScheduledMailDialogRenderer/Textarea.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import * as React from "react";
 import cx from "classnames";
 
@@ -35,7 +35,7 @@ export class Textarea extends React.PureComponent<ITextareaProps, ITextareaState
         };
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { className, label, maxlength, placeholder, value } = this.props;
         const { rows } = this.state;
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/InsightDrillDialog/DrillDialogInsight.tsx
@@ -46,7 +46,7 @@ const selectChartConfig = createSelector(
     (mapboxToken, separators, drillableItems, isExport) => ({
         mapboxToken,
         separators,
-        forceDisableDrillOnAxes: !drillableItems?.length, // to keep in line with KD, enable axes drilling only if using explicit drills
+        forceDisableDrillOnAxes: !drillableItems.length, // to keep in line with KD, enable axes drilling only if using explicit drills
         isExportMode: isExport,
     }),
 );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiAlerts/KpiAlertDialog/KpiAlertDialog.tsx
@@ -151,7 +151,7 @@ export class KpiAlertDialog extends Component<
         }
     }
 
-    render(): React.ReactNode {
+    render() {
         return (
             <KpiAlertDialogWrapper>
                 {(isMobile) => {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiContent/KpiContent.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiContent/KpiContent.tsx
@@ -121,7 +121,7 @@ class KpiContent extends Component<IKpiContentProps & WrappedComponentProps> {
         return kpiValue;
     }
 
-    render(): React.ReactNode {
+    render() {
         return (
             <div className="gd-kpi-widget-content">
                 <div className="visualization-content">

--- a/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
+++ b/libs/sdk-ui-ext/api/sdk-ui-ext.api.md
@@ -198,7 +198,7 @@ export const InsightRenderer: React_2.FC<IInsightRendererProps>;
 // @public
 export class InsightView extends React_2.Component<IInsightViewProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @beta

--- a/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightRenderer.tsx
@@ -236,7 +236,7 @@ class InsightRendererCore extends React.PureComponent<IInsightRendererProps & Wr
         this.unmountVisualization();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             // never ever dynamically change the props of this div, otherwise bad things will happen
             // e.g. visualization being rendered multiple times, etc.

--- a/libs/sdk-ui-ext/src/insightView/InsightView.tsx
+++ b/libs/sdk-ui-ext/src/insightView/InsightView.tsx
@@ -255,7 +255,7 @@ export const IntlInsightView = withContexts(injectIntl(InsightViewCore));
  * @public
  */
 export class InsightView extends React.Component<IInsightViewProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <IntlInsightView {...this.props} />

--- a/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/BaseVisualization.tsx
@@ -165,7 +165,7 @@ export class BaseVisualization extends React.PureComponent<IBaseVisualizationPro
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return <div key={this.visElementId} style={{ height: "100%" }} className={this.getClassName()} />;
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/DisabledBubbleMessage.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/DisabledBubbleMessage.tsx
@@ -14,7 +14,7 @@ export interface IBubbleMessageOwnProps {
 export type IBubbleMessageProps = IBubbleMessageOwnProps & WrappedComponentProps;
 
 export class DisabledBubbleMessage extends React.PureComponent<IBubbleMessageProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { className, children, intl } = this.props;
         return (
             <BubbleHoverTrigger className={className}>

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/ConfigSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/ConfigSection.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import cx from "classnames";
@@ -63,7 +63,7 @@ export class ConfigSection extends React.Component<IConfigSectionProps, IConfigS
         this.setState({ collapsed });
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { collapsed } = this.state;
         const { title, intl, subtitle, className } = this.props;
         const configSectionClassName = `adi-bucket-configuration ${className}`;

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/InputControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/InputControl.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps, injectIntl } from "react-intl";
 import noop from "lodash/noop";
@@ -75,7 +75,7 @@ export class InputControl extends React.Component<
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { disabled, labelText, placeholder, showDisabledMessage, intl, type } = this.props;
 
         return (

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/UnsupportedProperties.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/UnsupportedProperties.tsx
@@ -1,10 +1,10 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 
 export default class UnsupportedProperties extends React.Component {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div className={this.getClassNames()}>
                 <FormattedMessage id="properties.unsupported" />

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelRotationControl.tsx
@@ -18,7 +18,7 @@ export interface ILabelRotationControl {
 }
 
 class LabelRotationControl extends React.PureComponent<ILabelRotationControl & WrappedComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { axisVisible, axisLabelsEnabled, axisRotation } = this.getControlProperties();
 
         const isDisabled = this.props.disabled || !axisVisible || !axisLabelsEnabled;

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelSubsection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/LabelSubsection.tsx
@@ -19,7 +19,7 @@ export interface ILabelSubsection {
 }
 
 class LabelSubsection extends React.PureComponent<ILabelSubsection & WrappedComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { axisVisible, axisLabelsEnabled } = this.getControlProperties();
 
         return (

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NamePositionControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NamePositionControl.tsx
@@ -10,7 +10,7 @@ import { IVisualizationProperties } from "../../../interfaces/Visualization";
 import { messages } from "../../../../locales";
 
 class NamePositionControl extends React.PureComponent<IConfigItemSubsection & WrappedComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { axisVisible, axisNameVisible, namePosition } = this.getControlProperties();
         const { axis, properties, pushData, disabled, configPanelDisabled, intl } = this.props;
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NameSubsection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/axis/NameSubsection.tsx
@@ -8,7 +8,7 @@ import { IVisualizationProperties } from "../../../interfaces/Visualization";
 import { messages } from "../../../../locales";
 
 class NameSubsection extends React.PureComponent<IConfigItemSubsection & WrappedComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { axisVisible, axisNameVisible } = this.getControlProperties();
         const { axis, properties, pushData, disabled, configPanelDisabled } = this.props;
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorOverlay.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorOverlay.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { Overlay } from "@gooddata/sdk-ui-kit";
 
@@ -59,7 +59,7 @@ export default class ColorOverlay extends React.PureComponent<IColorOverlayProps
         this.startScrollingPropagation();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <Overlay
                 alignTo={this.props.alignTo}

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorPalette.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorPalette.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import ColorPaletteItem from "./ColorPaletteItem";
@@ -13,7 +13,7 @@ export interface IColorPaletteProps {
 }
 
 export default class ColorPalette extends React.PureComponent<IColorPaletteProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <div className={this.getClassNames()}>{this.renderItems()}</div>;
     }
 

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorPaletteItem.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/colorDropdown/ColorPaletteItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { IColor, IColorFromPalette, IColorPaletteItem } from "@gooddata/sdk-model";
 import cx from "classnames";
@@ -19,7 +19,7 @@ export default class ColorPaletteItem extends React.PureComponent<IColorPaletteI
         this.itemRef = (React as any).createRef();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div
                 ref={this.itemRef}

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/colors/coloredItemsList/ColoredItemContent.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import { IRgbColorValue } from "@gooddata/sdk-model";
@@ -10,7 +10,7 @@ export interface IColoredItemContentProps extends ISelectableChild {
 }
 
 export default class ColoredItemContent extends React.PureComponent<IColoredItemContentProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div className={this.getClassName()}>
                 <div className={this.getIconStyle()} style={{ backgroundColor: this.getBackgroundColor() }} />

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendPositionControl.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendPositionControl.tsx
@@ -17,7 +17,7 @@ export interface ILegendPositionControl {
 }
 
 class LegendPositionControl extends React.PureComponent<ILegendPositionControl & WrappedComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <DropdownControl
                 value={this.props.value}

--- a/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendSection.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationControls/legend/LegendSection.tsx
@@ -13,7 +13,7 @@ export interface ILegendSection {
 }
 
 class LegendSection extends React.PureComponent<ILegendSection> {
-    public render(): React.ReactNode {
+    public render() {
         const { controlsDisabled, properties, pushData } = this.props;
 
         const legendEnabled = this.props.properties?.controls?.legend?.enabled ?? true;

--- a/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
+++ b/libs/sdk-ui-ext/src/internal/components/configurationPanels/ConfigurationPanelContent.tsx
@@ -47,7 +47,7 @@ export default abstract class ConfigurationPanelContent<
 
     protected supportedPropertiesList: string[];
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div key={`config-${this.props.type}`}>
                 <InternalIntlWrapper locale={this.props.locale}>

--- a/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
+++ b/libs/sdk-ui-filters/api/sdk-ui-filters.api.md
@@ -60,7 +60,7 @@ export class DateFilter extends React_2.PureComponent<IDateFilterProps, IDateFil
     // (undocumented)
     static getDerivedStateFromProps(nextProps: IDateFilterProps, prevState: IDateFilterState): IDateFilterState;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @beta (undocumented)
@@ -529,7 +529,7 @@ export class MeasureValueFilter extends React_2.PureComponent<IMeasureValueFilte
     // (undocumented)
     static defaultProps: Partial<IMeasureValueFilterProps>;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     state: IMeasureValueFilterState;
 }
@@ -539,7 +539,7 @@ export class MeasureValueFilterDropdown extends React_2.PureComponent<IMeasureVa
     // (undocumented)
     static defaultProps: Pick<IMeasureValueFilterDropdownProps, "displayTreatNullAsZeroOption" | "treatNullAsZeroDefaultValue" | "enableOperatorSelection">;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @beta (undocumented)

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeDropdown.tsx
@@ -280,7 +280,7 @@ export class AttributeDropdownCore extends React.PureComponent<
         return title;
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { FilterLoading, fullscreenOnMobile } = this.props;
         const customizedTitle = this.getTitle();
         const classes = cx(

--- a/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeFilterItem.tsx
+++ b/libs/sdk-ui-filters/src/AttributeFilter/AttributeDropdown/AttributeFilterItem.tsx
@@ -19,7 +19,7 @@ export interface IAttributeFilterItemProps {
 }
 
 export class AttributeFilterItem extends React.PureComponent<IAttributeFilterItemProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { item } = this.props;
 
         if (!item || item.source.empty) {

--- a/libs/sdk-ui-filters/src/DateFilter/AbsoluteDateFilterForm/AbsoluteDateFilterForm.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/AbsoluteDateFilterForm/AbsoluteDateFilterForm.tsx
@@ -28,7 +28,7 @@ const dayPickerProps = {
  * @internal
  */
 export class AbsoluteDateFilterForm extends React.Component<IAbsoluteDateFilterFormProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { dateFormat, isMobile, selectedFilterOption, errors, isTimeEnabled } = this.props;
         return (
             <DateRangePicker

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilter.tsx
@@ -154,7 +154,7 @@ export class DateFilter extends React.PureComponent<IDateFilterProps, IDateFilte
         DateFilter.checkInitialFilterOption(this.props.selectedFilterOption);
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             customFilterName,
             dateFilterMode,

--- a/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateFilterBody/DateFilterBody.tsx
@@ -88,7 +88,7 @@ export class DateFilterBody extends React.Component<IDateFilterBodyProps, IDateF
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             isExcludeCurrentPeriodEnabled,
             isMobile,

--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePicker.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePicker.tsx
@@ -31,7 +31,7 @@ class DateRangePickerComponent extends React.Component<IDateRangePickerProps & W
     private fromInputRef = React.createRef<DayPickerInput>();
     private toInputRef = React.createRef<DayPickerInput>();
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             dateFormat,
             range: { from, to },

--- a/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputFieldBody.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DateRangePicker/DateRangePickerInputFieldBody.tsx
@@ -26,7 +26,7 @@ export class DateRangePickerInputFieldBody extends React.Component<
         return "";
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { className } = this.props;
         return (
             <span className={cx(className)}>

--- a/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/DynamicSelect/DynamicSelect.tsx
@@ -96,7 +96,7 @@ export class DynamicSelect extends React.Component<IDynamicSelectProps, IDynamic
         }
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             initialIsOpen,
             placeholder,

--- a/libs/sdk-ui-filters/src/DateFilter/NumericInput/NumericInput.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/NumericInput/NumericInput.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import isNumber from "lodash/isNumber";
 import defaultTo from "lodash/defaultTo";
@@ -23,7 +23,7 @@ export class NumericInput extends React.Component<{
     min?: number;
     max?: number;
 }> {
-    public render(): React.ReactNode {
+    public render() {
         const {
             props,
             handleChange,

--- a/libs/sdk-ui-filters/src/DateFilter/RelativeRangePicker/RelativeRangePicker.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/RelativeRangePicker/RelativeRangePicker.tsx
@@ -19,7 +19,7 @@ class RelativeRangePickerComponent extends React.Component<
 > {
     private toFieldRef = React.createRef<DynamicSelect>();
 
-    public render(): React.ReactNode {
+    public render() {
         const { handleFromChange, handleToChange } = this;
         const { selectedFilterOption, intl, isMobile } = this.props;
 

--- a/libs/sdk-ui-filters/src/DateFilter/Select/VirtualizedSelectMenu.tsx
+++ b/libs/sdk-ui-filters/src/DateFilter/Select/VirtualizedSelectMenu.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { VariableSizeList as List, ListChildComponentProps } from "react-window";
 import cx from "classnames";
@@ -97,7 +97,7 @@ export class VirtualizedSelectMenu<V> extends React.Component<ISelectMenuProps<V
 
     private listRef = React.createRef<List>();
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             items,
             selectedItem,

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/Dropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { IntlWrapper, ISeparators } from "@gooddata/sdk-ui";
@@ -102,7 +102,7 @@ class DropdownWrapped extends React.PureComponent<IDropdownProps, IDropdownState
 export const DropdownWithIntl = injectIntl(DropdownWrapped);
 
 export class Dropdown extends React.PureComponent<IDropdownOwnProps, IDropdownState> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <DropdownWithIntl {...this.props} />

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/DropdownBody.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/DropdownBody.tsx
@@ -284,7 +284,7 @@ class DropdownBodyWrapped extends React.PureComponent<IDropdownBodyProps, IDropd
 export const DropdownBodyWithIntl = injectIntl(DropdownBodyWrapped);
 
 export class DropdownBody extends React.PureComponent<IDropdownBodyOwnProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <DropdownBodyWithIntl {...this.props} />

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilter.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilter.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { IMeasureValueFilter } from "@gooddata/sdk-model";
 import noop from "lodash/noop";
@@ -39,7 +39,7 @@ export class MeasureValueFilter extends React.PureComponent<
 
     private buttonRef = React.createRef<HTMLDivElement>();
 
-    public render(): React.ReactNode {
+    public render() {
         const { displayDropdown } = this.state;
         const {
             filter,

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/MeasureValueFilterDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import {
     IMeasureValueFilter,
@@ -67,7 +67,7 @@ export class MeasureValueFilterDropdown extends React.PureComponent<IMeasureValu
         enableOperatorSelection: true,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             filter,
             onCancel,

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdown.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import cx from "classnames";
@@ -27,7 +27,7 @@ export class OperatorDropdown extends React.PureComponent<IOperatorDropdownProps
         opened: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <>
                 {this.renderDropdownButton()}

--- a/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdownItem.tsx
+++ b/libs/sdk-ui-filters/src/MeasureValueFilter/OperatorDropdownItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import cx from "classnames";
@@ -26,7 +26,7 @@ export class OperatorDropdownItem extends React.PureComponent<IOperatorDropdownI
         bubbleText: null,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { intl, operator, selectedOperator, bubbleText } = this.props;
 
         const className = cx(

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartOptionsWrapper.tsx
@@ -34,7 +34,7 @@ export class GeoChartOptionsWrapper extends React.Component<IGeoChartInnerProps>
         this.errorMap = newErrorMapping(props.intl);
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { dataView, error, isLoading } = this.props;
 
         // if explicitly null, do not default the components to allow them to be disabled

--- a/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/GeoChartRenderer.tsx
@@ -168,7 +168,7 @@ class GeoChartRenderer extends React.Component<IGeoChartRendererProps> {
         });
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             config: { isExportMode = false },
         } = this.props;

--- a/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
+++ b/libs/sdk-ui-kit/api/sdk-ui-kit.api.md
@@ -70,7 +70,7 @@ export class AutoSize extends Component<IAutoSizeProps> {
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     state: {
         width: number;
@@ -114,7 +114,7 @@ export class Bubble extends React_2.Component<IBubbleProps, IBubbleState> {
     // (undocumented)
     onAlign: (alignment: IAlignPoint) => void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     shouldComponentUpdate(nextProps: IBubbleProps, nextState: IBubbleState): boolean;
 }
@@ -151,7 +151,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React_2.PureCo
     // (undocumented)
     protected eventListeners(): any;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     readonly state: Readonly<IBubbleTriggerState>;
 }
@@ -174,7 +174,7 @@ export class Button extends React_2.Component<IButtonProps> {
         iconRight: string;
     };
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -223,7 +223,7 @@ export class Checkbox extends React_2.PureComponent<CheckboxProps> {
     // (undocumented)
     onChange: (e: React_2.ChangeEvent<HTMLInputElement>) => void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -305,7 +305,7 @@ export const DateDatasetsListItem: React_2.FC<IDateDatasetsListItemProps>;
 // @internal (undocumented)
 export class Datepicker extends React_2.PureComponent<IDatePickerOwnProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -447,7 +447,7 @@ export enum ENUM_KEY_CODE {
 // @internal (undocumented)
 export class ErrorOverlay extends React_2.PureComponent<IErrorOverlayProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -2527,7 +2527,7 @@ export class Input extends React_2.PureComponent<InputPureProps, InputState> {
     // (undocumented)
     onChange: (value: string | number) => void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     UNSAFE_componentWillReceiveProps(nextProps: InputPureProps): void;
     // (undocumented)
@@ -2583,7 +2583,7 @@ export class InputPure extends React_2.PureComponent<InputPureProps> implements 
     // (undocumented)
     onKeyPress: (e: React_2.KeyboardEvent) => void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     renderClearIcon(clearOnEsc: boolean): React_2.ReactNode;
     // (undocumented)
@@ -2686,7 +2686,7 @@ export class InputWithNumberFormat extends React_2.PureComponent<InputWithNumber
     // (undocumented)
     onFocus: (e: React_2.FocusEvent<HTMLInputElement>) => void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     UNSAFE_componentWillReceiveProps({ value: newValue }: InputWithNumberFormatProps): void;
 }
@@ -3391,7 +3391,7 @@ export const LoadingSpinner: React_2.FC<ILoadingSpinner>;
 // @internal (undocumented)
 export class MeasureNumberFormat extends React_2.PureComponent<IMeasureNumberFormatOwnProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -3465,7 +3465,7 @@ export class Overlay<T = HTMLElement> extends React_2.Component<IOverlayProps<T>
     // (undocumented)
     onDocumentMouseDown(e: React_2.MouseEvent): void;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     shouldComponentUpdate(nextProps: IOverlayProps<T>, nextState: IOverlayState): boolean;
     // (undocumented)
@@ -3673,7 +3673,7 @@ export class Tabs extends Component<ITabsProps, ITabsState> {
 // @internal (undocumented)
 export class Timepicker extends React_2.PureComponent<ITimepickerOwnProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)

--- a/libs/sdk-ui-kit/src/AutoSize/AutoSize.tsx
+++ b/libs/sdk-ui-kit/src/AutoSize/AutoSize.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { Component, createRef } from "react";
 import throttle from "lodash/throttle";
 import { elementRegion } from "../utils/domUtilities";
@@ -39,7 +39,7 @@ export class AutoSize extends Component<IAutoSizeProps> {
     private throttledUpdateSize = throttle(this.updateSize, 250, { leading: false });
     private wrapperRef = createRef<HTMLDivElement>();
 
-    public render(): React.ReactNode {
+    public render() {
         const { children } = this.props;
         const { width, height } = this.state;
         return (

--- a/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/Bubble.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import keys from "lodash/keys";
 import cloneDeep from "lodash/cloneDeep";
@@ -174,7 +174,7 @@ export class Bubble extends React.Component<IBubbleProps, IBubbleState> {
         }, this);
     }
 
-    render(): React.ReactNode {
+    render() {
         const arrowStyle = result(this.props, "arrowStyle", {});
 
         return (

--- a/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
+++ b/libs/sdk-ui-kit/src/Bubble/BubbleTrigger.tsx
@@ -53,7 +53,7 @@ export class BubbleTrigger<P extends IBubbleTriggerProps> extends React.PureComp
         this.setState({ isBubbleVisible: active });
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { children, eventsOnBubble, className, tagName, ...others } = this.props;
         const dataAttributes = pickBy(others, (_, key) => key.startsWith("data-"));
 

--- a/libs/sdk-ui-kit/src/Button/Button.tsx
+++ b/libs/sdk-ui-kit/src/Button/Button.tsx
@@ -24,7 +24,7 @@ export class Button extends React.Component<IButtonProps> {
 
     public buttonNode: HTMLElement;
 
-    public render(): React.ReactNode {
+    public render() {
         const { id, tagName, title, value, tabIndex, type, iconLeft, iconRight } = this.props;
         const TagName = tagName as any;
 

--- a/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
+++ b/libs/sdk-ui-kit/src/Datepicker/Datepicker.tsx
@@ -263,7 +263,7 @@ export class WrappedDatePicker extends React.PureComponent<DatePickerProps, IDat
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { dateFormat } = this.props;
         const classNamesProps = {
             overlay: "gd-datepicker-picker",
@@ -318,7 +318,7 @@ const DatePickerWithIntl = injectIntl(WrappedDatePicker);
  * @internal
  */
 export class Datepicker extends React.PureComponent<IDatePickerOwnProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <DatePickerWithIntl {...this.props} />

--- a/libs/sdk-ui-kit/src/Form/Checkbox.tsx
+++ b/libs/sdk-ui-kit/src/Form/Checkbox.tsx
@@ -38,7 +38,7 @@ export class Checkbox extends React.PureComponent<CheckboxProps> {
         this.props.onChange(e.target.checked);
     };
 
-    render(): React.ReactNode {
+    render() {
         const { disabled, name, text, title, value, labelSize } = this.props;
 
         const labelClasses = cx("input-label-text", {

--- a/libs/sdk-ui-kit/src/Form/Input.tsx
+++ b/libs/sdk-ui-kit/src/Form/Input.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import isNumber from "lodash/isNumber";
 import isString from "lodash/isString";
@@ -57,7 +57,7 @@ export class Input extends React.PureComponent<InputPureProps, InputState> {
         }
     }
 
-    render(): React.ReactNode {
+    render() {
         return (
             <InputPure
                 {...this.props}

--- a/libs/sdk-ui-kit/src/Form/InputPure.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputPure.tsx
@@ -158,7 +158,7 @@ export class InputPure extends React.PureComponent<InputPureProps> implements ID
         );
     }
 
-    render(): React.ReactNode {
+    render() {
         const {
             className,
             clearOnEsc,

--- a/libs/sdk-ui-kit/src/Form/InputWithNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/Form/InputWithNumberFormat.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import memoize from "lodash/memoize";
 import { InputPure, InputPureProps } from "./InputPure";
@@ -174,7 +174,7 @@ export class InputWithNumberFormat extends React.PureComponent<
         });
     }
 
-    render(): React.ReactNode {
+    render() {
         return (
             <InputPure
                 {...this.props}

--- a/libs/sdk-ui-kit/src/Menu/ControlledMenu.tsx
+++ b/libs/sdk-ui-kit/src/Menu/ControlledMenu.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 
 import { OpenAction, IMenuPositionConfig, OnOpenedChange } from "./MenuSharedTypes";
@@ -38,7 +38,7 @@ export class ControlledMenu extends React.Component<IControlledMenuProps> {
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <MenuOpener
                 opened={this.props.opened}

--- a/libs/sdk-ui-kit/src/Menu/MenuState.tsx
+++ b/libs/sdk-ui-kit/src/Menu/MenuState.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 
 import { OnOpenedChange, IOnOpenedChangeParams } from "./MenuSharedTypes";
@@ -36,7 +36,7 @@ export class MenuState extends React.Component<IMenuStateProps, IMenuStateState>
         };
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return this.props.children({
             opened: (this.isControlled() ? this.props.opened : this.state.opened) ?? false,
             onOpenedChange: this.onOpenedChange,

--- a/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpenedByHover.tsx
+++ b/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpenedByHover.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 
 import { MenuPosition } from "../positioning/MenuPosition";
@@ -14,7 +14,7 @@ export class MenuOpenedByHover extends React.Component<IMenuOpenedBySharedProps>
         this.clearCloseDelayTimer();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <MenuPosition
                 toggler={

--- a/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpener.tsx
+++ b/libs/sdk-ui-kit/src/Menu/menuOpener/MenuOpener.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 
 import { OpenAction, IMenuPositionConfig, OnOpenedChange } from "../MenuSharedTypes";
@@ -31,7 +31,7 @@ export class MenuOpener extends React.Component<IMenuOpenerProps> {
         portalTarget: document.querySelector("body"),
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const Component = this.getComponentByOpenAction() as React.ElementType;
 
         return (

--- a/libs/sdk-ui-kit/src/Menu/positioning/MenuPosition.tsx
+++ b/libs/sdk-ui-kit/src/Menu/positioning/MenuPosition.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { PositionedMenuContent } from "./PositionedMenuContent";
 import { IMenuPositionConfig } from "../MenuSharedTypes";
@@ -54,7 +54,7 @@ export class MenuPosition extends React.Component<IMenuPositionProps, IMenuPosit
     // positions from React Measure were outdated. To solve this we do the
     // measurements manually in PositionedMenuContent at the correct time.
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             portalTarget,
             topLevelMenu,

--- a/libs/sdk-ui-kit/src/Menu/positioning/PositionedMenuContent.tsx
+++ b/libs/sdk-ui-kit/src/Menu/positioning/PositionedMenuContent.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { createRef } from "react";
 
 import { IMenuPositionConfig } from "../MenuSharedTypes";
@@ -54,7 +54,7 @@ export class PositionedMenuContent extends React.Component<
         this.removeEventListeners();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return (
             <div
                 style={{

--- a/libs/sdk-ui-kit/src/Menu/utils/OutsideClickHandler.tsx
+++ b/libs/sdk-ui-kit/src/Menu/utils/OutsideClickHandler.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React, { createRef } from "react";
 
 export interface IOutsideClickHandlerProps {
@@ -34,7 +34,7 @@ export class OutsideClickHandler extends React.Component<IOutsideClickHandlerPro
         this.removeListeners();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return <div ref={this.wrapperElRef}>{this.props.children}</div>;
     }
 

--- a/libs/sdk-ui-kit/src/Menu/utils/RenderChildrenInPortal.tsx
+++ b/libs/sdk-ui-kit/src/Menu/utils/RenderChildrenInPortal.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import ReactDOM from "react-dom";
 
@@ -28,7 +28,7 @@ export class RenderChildrenInPortal extends React.Component<IRenderChildrenInPor
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         return ReactDOM.createPortal(this.props.children, this.portalContentWrapperEl);
     }
 }

--- a/libs/sdk-ui-kit/src/Overlay/ErrorOverlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/ErrorOverlay.tsx
@@ -81,7 +81,7 @@ const ErrorOverlayWithIntl = injectIntl(ErrorOverlayCore);
  * @internal
  */
 export class ErrorOverlay extends React.PureComponent<IErrorOverlayProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <ErrorOverlayWithIntl {...this.props} />

--- a/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
+++ b/libs/sdk-ui-kit/src/Overlay/Overlay.tsx
@@ -175,7 +175,7 @@ export class Overlay<T = HTMLElement> extends React.Component<IOverlayProps<T>, 
         afterOverlayClosed();
     }
 
-    public render(): React.ReactNode {
+    public render() {
         // Need stop propagation of events from Portal thats new behavior of react 16
         // https://github.com/facebook/react/issues/11387
         return (

--- a/libs/sdk-ui-kit/src/ShortenedText/ShortenedText.tsx
+++ b/libs/sdk-ui-kit/src/ShortenedText/ShortenedText.tsx
@@ -174,7 +174,7 @@ export class ShortenedText extends PureComponent<IShortenedTextProps, IShortened
         );
     }
 
-    render(): React.ReactNode {
+    render() {
         if (this.state.customTitle && this.props.displayTooltip) {
             return this.renderTextWithBubble();
         }

--- a/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
+++ b/libs/sdk-ui-kit/src/Timepicker/Timepicker.tsx
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import moment from "moment";
@@ -124,7 +124,7 @@ export class WrappedTimepicker extends React.PureComponent<TimePickerProps, ITim
         this.setState({ selectedTime }, () => this.props.onChange(selectedTime));
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { overlayPositionType, maxVisibleItemsCount, overlayZIndex } = this.props;
         const { dropdownWidth, selectedTime } = this.state;
         const time = {
@@ -184,7 +184,7 @@ const TimePickerWithIntl = injectIntl(WrappedTimepicker);
  * @internal
  */
 export class Timepicker extends React.PureComponent<ITimepickerOwnProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <TimePickerWithIntl {...this.props} />

--- a/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/MeasureNumberFormat.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { ISeparators, IntlWrapper } from "@gooddata/sdk-ui";
@@ -183,7 +183,7 @@ const MeasureNumberFormatWithIntl = injectIntl(WrappedMeasureNumberFormat);
  * @internal
  */
 export class MeasureNumberFormat extends React.PureComponent<IMeasureNumberFormatOwnProps> {
-    public render(): React.ReactNode {
+    public render() {
         return (
             <IntlWrapper locale={this.props.locale}>
                 <MeasureNumberFormatWithIntl {...this.props} />

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/CustomFormatDialog.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps } from "react-intl";
 import { ISeparators } from "@gooddata/sdk-ui";
@@ -46,7 +46,7 @@ export class CustomFormatDialog extends React.PureComponent<
         format: this.props.formatString || "",
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { anchorEl, positioning, onCancel, separators, templates, documentationLink, intl } =
             this.props;
         const { format } = this.state;

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/DropdownItem.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/DropdownItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import { stringUtils } from "@gooddata/util";
@@ -30,7 +30,7 @@ export default class DropdownItem extends React.Component<
         displayHelp: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { template, separators } = this.props;
         const { displayHelp } = this.state;
         return (

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/formatTemplatesDropdown/FormatTemplatesDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { ISeparators } from "@gooddata/sdk-ui";
 import DropdownItem from "./DropdownItem";
@@ -26,7 +26,7 @@ export class FormatTemplatesDropdown extends React.Component<
         isOpened: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { isOpened } = this.state;
         const { templates, separators } = this.props;
         return (

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/ExtendedPreview.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/ExtendedPreview.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import { FormattedMessage } from "react-intl";
@@ -20,7 +20,7 @@ export class ExtendedPreview extends React.Component<IExtendedPreviewProps, IExt
         expanded: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { expanded } = this.state;
         const { format, separators } = this.props;
 

--- a/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/Preview.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/customFormatDialog/previewSection/Preview.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { injectIntl, WrappedComponentProps } from "react-intl";
 import { ISeparators } from "@gooddata/sdk-ui";
@@ -25,7 +25,7 @@ export class Preview extends React.PureComponent<ICustomFormatPreviewProps, ICus
         preview: DEFAULT_PREVIEW_VALUE,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { format, separators, intl } = this.props;
 
         return (

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdown.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { WrappedComponentProps } from "react-intl";
 import { ISeparators } from "@gooddata/sdk-ui";
@@ -30,7 +30,7 @@ export class PresetsDropdown extends React.PureComponent<IMeasureNumberFormatDro
         ],
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { presets, anchorEl, onClose, positioning } = this.props;
 
         return (

--- a/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdownItem.tsx
+++ b/libs/sdk-ui-kit/src/measureNumberFormat/presetsDropdown/PresetsDropdownItem.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import { ISeparators } from "@gooddata/sdk-ui";
@@ -19,7 +19,7 @@ export class PresetsDropdownItem extends React.PureComponent<IMeasureNumberForma
         isSelected: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { preset, separators, isSelected } = this.props;
         const { localIdentifier, name, previewNumber, format } = preset;
 

--- a/libs/sdk-ui-pivot/src/CorePivotTable.tsx
+++ b/libs/sdk-ui-pivot/src/CorePivotTable.tsx
@@ -470,7 +470,7 @@ export class CorePivotTableAgImpl extends React.Component<ICorePivotTableProps, 
         );
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { ErrorComponent } = this.props;
         const { desiredHeight, error } = this.state;
 

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsMenu.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsMenu.tsx
@@ -67,7 +67,7 @@ const MenuToggler = () => {
 };
 
 export default class AggregationsMenu extends React.Component<IAggregationsMenuProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { intl, colId, getTableDescriptor, isMenuOpened, onMenuOpenedChange } = this.props;
 
         if (!colId) {

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsSubMenu.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/AggregationsSubMenu.tsx
@@ -49,7 +49,7 @@ export default class AggregationsSubMenu extends React.Component<IAggregationsSu
         isMenuOpened: false,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { toggler, isMenuOpened, intl } = this.props;
         const menuOpenedProp = isMenuOpened ? { opened: true } : {};
 

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnGroupHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnGroupHeader.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IHeaderGroupParams } from "@ag-grid-community/all-modules";
 import React from "react";
 
@@ -12,7 +12,7 @@ export interface IProps extends ICommonHeaderParams, IHeaderGroupParams {
 }
 
 export default class ColumnGroupHeader extends React.Component<IProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { menu, intl } = this.props;
         const colGroupDef = this.props.columnGroup.getColGroupDef()!;
         const colId = agColId(colGroupDef);

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnHeader.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/ColumnHeader.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { IHeaderParams } from "@ag-grid-community/all-modules";
 import React from "react";
 import { IMenu } from "../../../publicTypes";
@@ -47,7 +47,7 @@ class ColumnHeader extends React.Component<IColumnHeaderProps, IColumnHeaderStat
         this.props.setSort(sortDir, multiSort);
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { displayName, enableSorting, menu, column } = this.props;
         const col = this.getColDescriptor();
         const textAlign = isSliceCol(col) || isEmptyScopeCol(col) ? ALIGN_LEFT : ALIGN_RIGHT;

--- a/libs/sdk-ui-pivot/src/impl/structure/headers/HeaderCell.tsx
+++ b/libs/sdk-ui-pivot/src/impl/structure/headers/HeaderCell.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { IntlShape } from "react-intl";
 import cx from "classnames";
@@ -90,7 +90,7 @@ export default class HeaderCell extends React.Component<IHeaderCellProps, IHeade
         }
     }
 
-    public render(): React.ReactNode {
+    public render() {
         const { menuPosition, className } = this.props;
 
         return (

--- a/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
+++ b/libs/sdk-ui-vis-commons/api/sdk-ui-vis-commons.api.md
@@ -80,7 +80,7 @@ export const FLUID_LEGEND_THRESHOLD = 768;
 // @internal (undocumented)
 export class FluidLegend extends React_2.PureComponent<IFluidLegendProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     renderPaging: () => React_2.ReactNode;
     // (undocumented)
@@ -138,7 +138,7 @@ export const HeadlinePagination: React_2.FC<IHeadlinePaginationProps>;
 // @internal (undocumented)
 export class HeatmapLegend extends React_2.PureComponent<IHeatmapLegendProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @internal (undocumented)
@@ -504,7 +504,7 @@ export class StaticLegend extends React_2.PureComponent<IStaticLegendProps> {
     // (undocumented)
     static defaultProps: Pick<IStaticLegendProps, "buttonOrientation" | "paginationHeight" | "onPageChanged">;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
     // (undocumented)
     renderPaging: (pagesCount: number) => React_2.ReactNode;
     // (undocumented)

--- a/libs/sdk-ui-vis-commons/src/legend/FluidLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/FluidLegend.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2018 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import noop from "lodash/noop";
@@ -60,7 +60,7 @@ export class FluidLegend extends React.PureComponent<IFluidLegendProps> {
         );
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { series, containerWidth } = this.props;
         const { itemWidth, hasPaging, visibleItemsCount } = calculateFluidLegend(
             series.length,

--- a/libs/sdk-ui-vis-commons/src/legend/HeatmapLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/HeatmapLegend.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import { IColorLegendSize, IHeatmapLegendItem, IColorLegendItem } from "./types";
 import { ColorLegend } from "./ColorLegend";
@@ -19,7 +19,7 @@ export interface IHeatmapLegendProps {
  * @internal
  */
 export class HeatmapLegend extends React.PureComponent<IHeatmapLegendProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { title, series, format, numericSymbols, size, position } = this.props;
         const data = series.map((item: IHeatmapLegendItem): IColorLegendItem => {
             const { range, color } = item;

--- a/libs/sdk-ui-vis-commons/src/legend/Legend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/Legend.tsx
@@ -151,7 +151,7 @@ export class Legend extends React.PureComponent<ILegendProps> {
         );
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { contentDimensions, responsive, heatmapLegend, showFluidLegend, maximumRows } = this.props;
 
         if (heatmapLegend) {

--- a/libs/sdk-ui-vis-commons/src/legend/LegendAxisIndicator.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/LegendAxisIndicator.tsx
@@ -12,7 +12,7 @@ export interface ILegendAxisIndicatorProps {
 export class LegendAxisIndicatorClass extends React.PureComponent<
     ILegendAxisIndicatorProps & WrappedComponentProps
 > {
-    public render(): React.ReactNode {
+    public render() {
         const { labelKey, width, data, intl } = this.props;
         const style = width ? { width: `${width}px` } : {};
         const values = (data || []).reduce(

--- a/libs/sdk-ui-vis-commons/src/legend/LegendItem.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/LegendItem.tsx
@@ -15,7 +15,7 @@ interface ILegendItemProps {
 }
 
 class LegendItem extends React.Component<ILegendItemProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { item, width, enableBorderRadius = false, theme } = this.props;
         const disabledColor = theme?.palette?.complementary?.c5 ?? DEFAULT_DISABLED_COLOR;
 

--- a/libs/sdk-ui-vis-commons/src/legend/LegendList.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/LegendList.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2019 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import LegendItem from "./LegendItem";
 import { LegendAxisIndicator } from "./LegendAxisIndicator";
@@ -15,7 +15,7 @@ export interface ILegendListProps {
 export const LegendSeparator = (): JSX.Element => <div className="legend-separator" />;
 
 export class LegendList extends React.PureComponent<ILegendListProps> {
-    public render(): React.ReactNode {
+    public render() {
         const { series, enableBorderRadius, onItemClick, width } = this.props;
 
         return series.map((item: any, index: number) => {

--- a/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
+++ b/libs/sdk-ui-vis-commons/src/legend/StaticLegend.tsx
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import React from "react";
 import cx from "classnames";
 import noop from "lodash/noop";
@@ -71,7 +71,7 @@ export class StaticLegend extends React.PureComponent<IStaticLegendProps> {
         );
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const {
             enableBorderRadius,
             containerHeight,

--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -396,7 +396,7 @@ export class ErrorComponent extends React_2.Component<IErrorProps> {
     // (undocumented)
     static defaultProps: Partial<IErrorProps>;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @public
@@ -1449,7 +1449,7 @@ export class LoadingComponent extends React_2.Component<ILoadingProps> {
     // (undocumented)
     static defaultProps: Partial<ILoadingProps>;
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
 
 // @public
@@ -1616,7 +1616,7 @@ export const TranslationsCustomizationProvider: React_2.FC<ITranslationsCustomiz
 // @internal (undocumented)
 export class TranslationsProvider extends React_2.PureComponent<ITranslationsProviderProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): any;
 }
 
 // @public

--- a/libs/sdk-ui/src/base/localization/TranslationsProvider.tsx
+++ b/libs/sdk-ui/src/base/localization/TranslationsProvider.tsx
@@ -34,7 +34,7 @@ export type ITranslationsProviderProps = ITranslationsProviderOwnProps & Wrapped
  * @internal
  */
 export class TranslationsProvider extends React.PureComponent<ITranslationsProviderProps> {
-    public render(): React.ReactNode {
+    public render() {
         const props: ITranslationsComponentProps = {
             numericSymbols: getNumericSymbols(this.props.intl),
             emptyHeaderString: this.getEmptyHeaderString(),

--- a/libs/sdk-ui/src/base/react/ErrorComponent.tsx
+++ b/libs/sdk-ui/src/base/react/ErrorComponent.tsx
@@ -76,7 +76,7 @@ export class ErrorComponent extends React.Component<IErrorProps> {
         },
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { className, style, width, height, message, description, icon, clientHeight } = this.props;
 
         const customHeight = getCustomHeight(clientHeight);

--- a/libs/sdk-ui/src/base/react/LoadingComponent.tsx
+++ b/libs/sdk-ui/src/base/react/LoadingComponent.tsx
@@ -38,7 +38,7 @@ export class LoadingComponent extends React.Component<ILoadingProps> {
         imageWidth: undefined,
     };
 
-    public render(): React.ReactNode {
+    public render() {
         const { inline, width, height, imageWidth, imageHeight, color, speed = 1, className } = this.props;
         const duration = baseAnimationDuration / speed;
         const delay = duration / -5;

--- a/skel/sdk-skel-tsx/api/sdk-skel-tsx.api.md
+++ b/skel/sdk-skel-tsx/api/sdk-skel-tsx.api.md
@@ -15,9 +15,8 @@ export interface ISdkComponentProps {
 // @public (undocumented)
 export class SdkComponent extends React_2.Component<ISdkComponentProps> {
     // (undocumented)
-    render(): React_2.ReactNode;
+    render(): JSX.Element;
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/skel/sdk-skel-tsx/src/sdkComponent/SdkComponent.tsx
+++ b/skel/sdk-skel-tsx/src/sdkComponent/SdkComponent.tsx
@@ -1,4 +1,4 @@
-// (C) 2019 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import React from "react";
 
 /**
@@ -12,7 +12,7 @@ export interface ISdkComponentProps {
  * @public
  */
 export class SdkComponent extends React.Component<ISdkComponentProps> {
-    public render(): React.ReactNode {
+    public render() {
         return <p>{this.props.message}</p>;
     }
 }


### PR DESCRIPTION
JIRA: RAIL-4354

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
