### PR TITLE
RELATED: RAIL-4360 Partially prepare for null AttributeResultHeaders

### DIFF
--- a/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/attributes/elements/index.ts
@@ -141,12 +141,16 @@ class BearWorkspaceElementsQuery implements IElementsQuery {
         );
 
         const urisToUse = elements?.uris ?? uris;
+        invariant(
+            !urisToUse || urisToUse.every((item) => item !== null),
+            "Nulls are not supported as attribute element uris on bear",
+        );
 
         return ServerPaging.for(
             async ({ limit, offset }) => {
                 const params: GdcMetadata.IValidElementsParams = {
                     ...restOptions,
-                    ...{ uris: urisToUse },
+                    ...{ uris: urisToUse as string[] | undefined },
                     limit,
                     offset,
                     afm: this.limitingAfm,

--- a/libs/sdk-backend-bear/src/convertors/dateFormatting/dateFormatter.ts
+++ b/libs/sdk-backend-bear/src/convertors/dateFormatting/dateFormatter.ts
@@ -39,7 +39,7 @@ export function transformDateFormat(
     }
     const resultHeaderUri = resultHeader.attributeHeaderItem.uri;
     const foundUri = dateAttributeUris.some((dateAttributeUri) =>
-        resultHeaderUri.startsWith(dateAttributeUri),
+        resultHeaderUri?.startsWith(dateAttributeUri),
     );
     if (!foundUri) {
         return resultHeader;

--- a/libs/sdk-backend-bear/src/convertors/dateFormatting/dateValueParser.ts
+++ b/libs/sdk-backend-bear/src/convertors/dateFormatting/dateValueParser.ts
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import parse from "date-fns/parse";
 import { UnexpectedError } from "@gooddata/sdk-backend-spi";
 
@@ -19,11 +19,14 @@ export const DEFAULT_DATE_FORMAT: DateFormat = "MM/dd/yyyy";
  * @param dateFormat - dateFormat to assume when parsing the value.
  * @internal
  */
-export const parseDateValue = (value: string, dateFormat: DateFormat = DEFAULT_DATE_FORMAT): Date => {
+export const parseDateValue = (value: string | null, dateFormat: DateFormat = DEFAULT_DATE_FORMAT): Date => {
     if (!dateFormats.includes(dateFormat)) {
         throw new UnexpectedError(
             `Unsupported date format "${dateFormat}". Supported date formats are ${dateFormats}`,
         );
+    }
+    if (value === null) {
+        throw new UnexpectedError("Unsupported date value null. Nulls are not supported as date values");
     }
     return parse(value, dateFormat, new Date());
 };

--- a/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/DashboardConverter.ts
@@ -73,6 +73,7 @@ import { convertUrisToReferences } from "../fromBackend/ReferenceConverter";
 import isEmpty from "lodash/isEmpty";
 import omitBy from "lodash/omitBy";
 import { serializeProperties } from "../fromBackend/PropertiesConverter";
+import { assertNoNulls } from "./utils";
 
 const refToUri = (ref: ObjRef) => {
     invariant(isUriRef(ref));
@@ -234,10 +235,12 @@ export const convertFilterContextItem = (
         );
     }
 
+    assertNoNulls(attributeElements);
+
     return {
         attributeFilter: {
             negativeSelection,
-            attributeElements: attributeElements.uris,
+            attributeElements: attributeElements.uris as string[], // checked above so the cast is ok
             displayForm: displayFormUri,
             localIdentifier,
             filterElementsBy: convertedAttributeFilterParents,

--- a/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/FilterConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 import { GdcVisualizationObject } from "@gooddata/api-model-bear";
 import {
     IFilter,
@@ -25,6 +25,7 @@ import {
     ObjRefInScope,
 } from "@gooddata/sdk-model";
 import { toBearRef } from "./ObjRefConverter";
+import { assertNoNulls } from "./utils";
 
 const convertObjRefInScopeToRefWithoutIdentifier = (ref: ObjRefInScope) => {
     if (isIdentifierRef(ref)) {
@@ -89,10 +90,11 @@ const convertNegativeAttributeFilter = (
     filter: INegativeAttributeFilter,
 ): GdcVisualizationObject.INegativeAttributeFilter => {
     const elements = filterAttributeElements(filter);
+    assertNoNulls(elements);
     return {
         negativeAttributeFilter: {
             displayForm: toBearRef(filterObjRef(filter)),
-            notIn: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
+            notIn: (isAttributeElementsByRef(elements) ? elements.uris : elements.values) as string[], // checked above so the cast is ok
         },
     };
 };
@@ -101,10 +103,11 @@ const convertPositiveAttributeFilter = (
     filter: IPositiveAttributeFilter,
 ): GdcVisualizationObject.IPositiveAttributeFilter => {
     const elements = filterAttributeElements(filter);
+    assertNoNulls(elements);
     return {
         positiveAttributeFilter: {
             displayForm: toBearRef(filterObjRef(filter)),
-            in: isAttributeElementsByRef(elements) ? elements.uris : elements.values,
+            in: (isAttributeElementsByRef(elements) ? elements.uris : elements.values) as string[], // checked above so the cast is ok
         },
     };
 };

--- a/libs/sdk-backend-bear/src/convertors/toBackend/afm/FilterConverter.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/afm/FilterConverter.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2020 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { GdcExecuteAFM } from "@gooddata/api-model-bear";
 import {
     filterIsEmpty,
@@ -20,6 +20,7 @@ import {
 import isNil from "lodash/isNil";
 import { toBearRef, toScopedBearRef } from "../ObjRefConverter";
 import compact from "lodash/compact";
+import { assertNoNulls } from "../utils";
 
 function convertAttributeFilter(filter: IAttributeFilter): GdcExecuteAFM.FilterItem | null {
     /*
@@ -32,18 +33,20 @@ function convertAttributeFilter(filter: IAttributeFilter): GdcExecuteAFM.FilterI
     }
 
     if (!isPositiveAttributeFilter(filter)) {
+        assertNoNulls(filter.negativeAttributeFilter.notIn);
         return {
             negativeAttributeFilter: {
                 displayForm: toBearRef(filter.negativeAttributeFilter.displayForm),
-                notIn: filter.negativeAttributeFilter.notIn,
+                notIn: filter.negativeAttributeFilter.notIn as GdcExecuteAFM.AttributeElements, // checked above so the cast is ok
             },
         };
     }
 
+    assertNoNulls(filter.positiveAttributeFilter.in);
     return {
         positiveAttributeFilter: {
             displayForm: toBearRef(filter.positiveAttributeFilter.displayForm),
-            in: filter.positiveAttributeFilter.in,
+            in: filter.positiveAttributeFilter.in as GdcExecuteAFM.AttributeElements, // checked above so the cast is ok
         },
     };
 }

--- a/libs/sdk-backend-bear/src/convertors/toBackend/utils.ts
+++ b/libs/sdk-backend-bear/src/convertors/toBackend/utils.ts
@@ -1,0 +1,11 @@
+// (C) 2022 GoodData Corporation
+import invariant from "ts-invariant";
+import { IAttributeElements, isAttributeElementsByRef } from "@gooddata/sdk-model";
+
+export function assertNoNulls(elements: IAttributeElements): void {
+    const rawData = isAttributeElementsByRef(elements) ? elements.uris : elements.values;
+    invariant(
+        rawData.every((item) => item !== null),
+        "Nulls are not supported as attribute element values or uris on bear",
+    );
+}

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/elementsUtils.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/elementsUtils.ts
@@ -112,7 +112,7 @@ export const resolveStringFilter =
     (filter: string | undefined) =>
     (elements: IAttributeElement[]): IAttributeElement[] => {
         return filter
-            ? elements.filter((item) => item.title.toLowerCase().includes(filter.toLowerCase()))
+            ? elements.filter((item) => item.title?.toLowerCase().includes(filter.toLowerCase()))
             : elements;
     };
 

--- a/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
+++ b/libs/sdk-backend-tiger/src/convertors/toBackend/afm/DimensionsConverter.ts
@@ -69,10 +69,10 @@ function convertAttributeSortType(sortItem: ISortItem): SortKeyAttributeAttribut
  * This function caters for the dirty trick + in case the sorts were created 'normally', programmatically by the
  * user who specified primaryLabelValue directly, it has logic to fall back to using the uri as-is.
  */
-function extractItemValueFromElement(elementUri: string): string {
+function extractItemValueFromElement(elementUri: string | null): string | null {
     // no reasonable way to avoid the super-linear backtracking right now
     // eslint-disable-next-line regexp/no-super-linear-backtracking
-    const parsedUri = elementUri.match(/obj\/([^/]*)(\/elements\?id=)?(.*)$/);
+    const parsedUri = elementUri?.match(/obj\/([^/]*)(\/elements\?id=)?(.*)$/);
 
     if (parsedUri?.[3]) {
         return parsedUri[3];
@@ -81,8 +81,8 @@ function extractItemValueFromElement(elementUri: string): string {
     return elementUri;
 }
 
-function convertMeasureLocators(locators: ILocatorItem[]): { [key: string]: string } {
-    const dataColumnLocators = locators.map<{ [key: string]: string }>((locator) => {
+function convertMeasureLocators(locators: ILocatorItem[]): { [key: string]: string | null } {
+    const dataColumnLocators = locators.map<{ [key: string]: string | null }>((locator) => {
         if (isAttributeLocator(locator)) {
             return {
                 [locator.attributeLocatorItem.attributeIdentifier]: extractItemValueFromElement(

--- a/libs/sdk-model/src/execution/base/sort.ts
+++ b/libs/sdk-model/src/execution/base/sort.ts
@@ -113,6 +113,10 @@ export interface IAttributeLocatorItemBody {
     attributeIdentifier: Identifier;
     /**
      * Value of the attribute element; TODO: make sure bear is ready for this
+     * @remarks
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     element: string;
 }

--- a/libs/sdk-model/src/execution/results/index.ts
+++ b/libs/sdk-model/src/execution/results/index.ts
@@ -258,7 +258,12 @@ export interface IDimensionDescriptor {
  */
 export interface IResultAttributeHeaderItem {
     /**
-     * Human readable name of the attribute element
+     * Human readable name of the attribute element.
+     *
+     * @remarks
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     name: string;
 
@@ -278,6 +283,10 @@ export interface IResultAttributeHeaderItem {
      * Recommendation for the consumers: URI is safe to use if you obtain in programmatically from this header
      * and then use it in the same workspace for instance for filtering. It is not safe to hardcode URIs
      * and use them in a solution which should operate on top of different workspaces.
+     *
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     uri: string;
 }
@@ -472,6 +481,11 @@ export function isResultTotalHeader(obj: unknown): obj is IResultTotalHeader {
 
 /**
  * Returns item name contained within a result header.
+ *
+ * @remarks
+ * Note that this can actually be null on some backends if your data contains NULL values.
+ * We will change the type of this to string | null in the next major (since it is a breaking change),
+ * but for now, if you expect NULLs in your data, treat this as string | null already.
  *
  * @param header - header of any type
  * @public

--- a/libs/sdk-model/src/ldm/attributeElement.ts
+++ b/libs/sdk-model/src/ldm/attributeElement.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2020 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 /**
  * Attribute element represented by concrete display form
@@ -8,11 +8,21 @@
 export interface IAttributeElement {
     /**
      * Title of the attribute element for the given display form
+     *
+     * @remarks
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     readonly title: string;
 
     /**
      * Uri of the attribute element
+     *
+     * @remarks
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     readonly uri: string;
 }

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/DrillSelectDropdown.tsx
@@ -104,7 +104,7 @@ export const createDrillSelectItems = (
 
             return {
                 type: DrillType.DRILL_DOWN,
-                name: title,
+                name: title ?? "NULL", // TODO localize this? drilldown is currently only on bear and that does not support nulls anyway
                 drillDefinition,
                 id: stringify(drillDefinition),
             };

--- a/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/drill/DrillSelect/types.ts
@@ -1,4 +1,4 @@
-// (C) 2021 GoodData Corporation
+// (C) 2021-2022 GoodData Corporation
 import { DashboardDrillDefinition, DashboardDrillContext, IDashboardDrillEvent } from "../../../types";
 
 /**
@@ -16,7 +16,7 @@ export interface DrillSelectItem {
     id: string;
     name: string;
     drillDefinition: DashboardDrillDefinition;
-    attributeValue?: string;
+    attributeValue?: string | null;
 }
 
 export interface DrillSelectContext {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightWithDrillDialog.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/DefaultDashboardInsight/DashboardInsightWithDrillDialog.tsx
@@ -27,11 +27,12 @@ export const DashboardInsightWithDrillDialog = (props: IDashboardInsightProps): 
         () =>
             drillSteps
                 .filter((s) => isDrillDownDefinition(s.drillDefinition))
-                .map((s) =>
-                    getDrillDownAttributeTitle(
-                        getDrillOriginLocalIdentifier(s.drillDefinition as IDrillDownDefinition),
-                        s.drillEvent,
-                    ),
+                .map(
+                    (s) =>
+                        getDrillDownAttributeTitle(
+                            getDrillOriginLocalIdentifier(s.drillDefinition as IDrillDownDefinition),
+                            s.drillEvent,
+                        ) ?? "NULL", // TODO localize this? drilldown is currently only on bear and that does not support nulls anyway
                 ),
         [drillSteps],
     );

--- a/libs/sdk-ui-geo/src/core/geoChart/geoChartColor.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/geoChartColor.ts
@@ -12,7 +12,6 @@ import { getColorPalette, rgbToRgba } from "./helpers/geoChart/colors";
 import { isAttributeDescriptor, isResultAttributeHeader } from "@gooddata/sdk-model";
 import { getMinMax } from "./helpers/geoChart/common";
 import { IColorLegendItem, IColorStrategy } from "@gooddata/sdk-ui-vis-commons";
-import { IColorAssignment } from "@gooddata/sdk-ui";
 
 const DEFAULT_SEGMENT_ITEM = "default_segment_item";
 const DEFAULT_COLOR_INDEX_IN_PALETTE = DEFAULT_PUSHPIN_COLOR_SCALE - 1;
@@ -39,28 +38,25 @@ export function getColorIndexInPalette(value: number | null, min: number, max: n
 type ColorPaletteMapping = { [itemName: string]: string[] };
 
 export function getColorPaletteMapping(colorStrategy: IColorStrategy): ColorPaletteMapping {
-    const colorAssignment: IColorAssignment[] = colorStrategy.getColorAssignment();
+    const colorAssignment = colorStrategy.getColorAssignment();
 
-    return colorAssignment.reduce(
-        (result: ColorPaletteMapping, item: IColorAssignment, index: number): ColorPaletteMapping => {
-            const color = colorStrategy.getColorByIndex(index);
-            const colorPalette = getColorPalette(color, DEFAULT_PUSHPIN_COLOR_OPACITY);
-            // color base on Location
-            if (isAttributeDescriptor(item.headerItem)) {
-                return {
-                    [DEFAULT_SEGMENT_ITEM]: colorPalette,
-                };
-            }
-            // color base on SegmentBy
-            const name: string = isResultAttributeHeader(item.headerItem)
-                ? item.headerItem.attributeHeaderItem.name
-                : DEFAULT_SEGMENT_ITEM;
+    return colorAssignment.reduce((result: ColorPaletteMapping, item, index): ColorPaletteMapping => {
+        const color = colorStrategy.getColorByIndex(index);
+        const colorPalette = getColorPalette(color, DEFAULT_PUSHPIN_COLOR_OPACITY);
+        // color base on Location
+        if (isAttributeDescriptor(item.headerItem)) {
+            return {
+                [DEFAULT_SEGMENT_ITEM]: colorPalette,
+            };
+        }
+        // color base on SegmentBy
+        const name = isResultAttributeHeader(item.headerItem)
+            ? item.headerItem.attributeHeaderItem.name
+            : DEFAULT_SEGMENT_ITEM;
 
-            result[name] = colorPalette;
-            return result;
-        },
-        {},
-    );
+        result[name ?? DEFAULT_SEGMENT_ITEM] = colorPalette;
+        return result;
+    }, {});
 }
 
 /**

--- a/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
+++ b/libs/sdk-ui-geo/src/core/geoChart/helpers/geoChart/data.ts
@@ -37,7 +37,7 @@ interface ISegmentData {
     data: string[];
 }
 
-export function getLocation(latlng: string): IGeoLngLat | null {
+export function getLocation(latlng: string | null): IGeoLngLat | null {
     if (!latlng) {
         return null;
     }
@@ -66,7 +66,7 @@ export function getGeoData(dv: DataViewFacade): IGeoData {
     const colorIndex = geoData?.color?.index;
 
     if (locationIndex !== undefined) {
-        const locationData: string[] = getAttributeData(attributeHeaderItems, locationIndex);
+        const locationData = getAttributeData(attributeHeaderItems, locationIndex);
         geoData[BucketNames.LOCATION].data = locationData.map(getLocation);
     }
 

--- a/libs/sdk-ui-geo/src/core/geoChart/tests/GeoChartInner.test.tsx
+++ b/libs/sdk-ui-geo/src/core/geoChart/tests/GeoChartInner.test.tsx
@@ -1,4 +1,4 @@
-// (C) 2020 GoodData Corporation
+// (C) 2020-2022 GoodData Corporation
 import React from "react";
 import { ShallowWrapper, shallow } from "enzyme";
 import { GeoChartInner, IGeoChartInnerProps, IGeoChartInnerOptions } from "../GeoChartInner";
@@ -13,7 +13,7 @@ const { dv, geoData } = RecShortcuts.AllAndSmall;
 
 function buildGeoChartOptions(): IGeoChartInnerOptions {
     const colorStrategy = getColorStrategy(DefaultColorPalette, [], geoData, dv);
-    const categoryItems = createCategoryLegendItems(colorStrategy, "(empty)");
+    const categoryItems = createCategoryLegendItems(colorStrategy, "(empty)", "(null)");
 
     return {
         geoData,

--- a/libs/sdk-ui-pivot/src/columnWidths.ts
+++ b/libs/sdk-ui-pivot/src/columnWidths.ts
@@ -177,6 +177,11 @@ export interface IAttributeColumnLocatorBody {
 
     /**
      * Attribute element URI / primary key.
+     *
+     * @remarks
+     * Note that this can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     element?: string;
 }

--- a/libs/sdk-ui-pivot/src/impl/data/rowGroupingProvider.ts
+++ b/libs/sdk-ui-pivot/src/impl/data/rowGroupingProvider.ts
@@ -83,7 +83,7 @@ class AttributeGroupingProvider implements IGroupingProvider {
                 this.itemUris[columnId] = [];
             }
 
-            pageRows.forEach((row: IGridRow, rowIndex: number) => {
+            pageRows.forEach((row, rowIndex) => {
                 const headerItem = row.headerItemMap[columnId];
                 if (isResultAttributeHeader(headerItem)) {
                     const attributeItemUri = headerItem.attributeHeaderItem.uri;

--- a/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colDefFactory.ts
@@ -1,4 +1,4 @@
-// (C) 2007-2021 GoodData Corporation
+// (C) 2007-2022 GoodData Corporation
 import { ColDef, ColGroupDef } from "@ag-grid-community/all-modules";
 import findIndex from "lodash/findIndex";
 import {
@@ -74,7 +74,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
         const colDef: ColDef = {
             type: COLUMN_ATTRIBUTE_COLUMN,
             colId: col.id,
-            headerName: col.header.attributeHeaderItem.name,
+            headerName: col.header.attributeHeaderItem.name ?? "NULL", // TODO RAIL-4360 localize this when the null strings are available
         };
 
         state.allColDefs.push(colDef);
@@ -84,7 +84,7 @@ function createColumnGroupColDef(col: ScopeCol, state: TransformState): ColDef |
     } else {
         const colGroup: ColGroupDef = {
             groupId: col.id,
-            headerName: col.header.attributeHeaderItem.name,
+            headerName: col.header.attributeHeaderItem.name ?? "NULL", // TODO RAIL-4360 localize this when the null strings are available
             children,
         };
 

--- a/libs/sdk-ui/src/base/results/dataAccess.ts
+++ b/libs/sdk-ui/src/base/results/dataAccess.ts
@@ -108,6 +108,11 @@ export type DataSeriesDescriptorMethods = {
     measureFormat(): string;
 
     /**
+     * @remarks
+     * Note that the values can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
+     *
      * @returns - titles of attribute elements that are used to scope all data points in this series
      */
     scopeTitles(): string[];
@@ -303,6 +308,11 @@ export type DataSliceHeaders = {
 export type DataSliceDescriptorMethods = {
     /**
      * @returns titles of attribute elements to which this data slice belongs
+     *
+     * @remarks
+     * Note that the values can actually be null on some backends if your data contains NULL values.
+     * We will change the type of this to string | null in the next major (since it is a breaking change),
+     * but for now, if you expect NULLs in your data, treat this as string | null already.
      */
     readonly sliceTitles: () => string[];
 };

--- a/tools/mock-handling/src/codegen/dataSample.ts
+++ b/tools/mock-handling/src/codegen/dataSample.ts
@@ -14,7 +14,7 @@ function generateRecordingForDataSample(entries: DataSampleRecording[]): string 
         .map(([_, entryRecording]) => {
             return entryRecording.getAttributeElements().map((element, index) => {
                 return `${createUniqueVariableName(
-                    element.title,
+                    element.title ?? "NULL",
                 )} : ${entryRecording.getRecordingName()}[${index}]`;
             });
         })


### PR DESCRIPTION
Conservatively prepare the codebase and TSDocs for nulls in
AttributeResultHeaders.

Done so to avoid hard breaking change for now, we will really change the
types in the next major, this is to prepare the users for this change
and also prevent some runtime errors.

JIRA: RAIL-4360

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
