### PR TITLE
RAIL-4356 - Cannot drill at empty value with JS error

### DIFF
--- a/libs/sdk-ui/src/base/vis/drilling.ts
+++ b/libs/sdk-ui/src/base/vis/drilling.ts
@@ -4,6 +4,7 @@ import {
     isTotalDescriptor,
     isMeasureDescriptor,
     isResultAttributeHeader,
+    IResultAttributeHeader,
 } from "@gooddata/sdk-model";
 import CustomEventPolyfill from "custom-event";
 import findIndex from "lodash/findIndex";
@@ -82,7 +83,7 @@ export function getDrillIntersection(drillItems: IMappingHeader[]): IDrillEventI
                 if (attributeItem && isResultAttributeHeader(attributeItem)) {
                     drillIntersection.push({
                         header: {
-                            ...attributeItem,
+                            ...convertToEmpty(attributeItem),
                             ...drillItem,
                         },
                     });
@@ -127,4 +128,24 @@ export function fireDrillEvent(
             }),
         );
     }
+}
+
+function convertToEmpty(attributeItem: IResultAttributeHeader) {
+    const { attributeHeaderItem } = attributeItem;
+
+    // This is special behaviour for tiger when we allowed empty string or null
+    // In this case if uri is one of these special value, set on same value also name
+    // because there is now some special ui value (from example "(empty value)") which is not
+    // valid for this case
+    const values = ["", null] as Array<any>;
+    const isEmpty = values.indexOf(attributeHeaderItem.uri) >= 0;
+
+    return {
+        ...attributeItem,
+        attributeHeaderItem: {
+            ...attributeHeaderItem,
+            // Send empty string for not, need to be updated for NULL in future
+            name: isEmpty ? "" : attributeHeaderItem.name,
+        },
+    };
 }


### PR DESCRIPTION
JIRA: RAIL-4356

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
