### PR TITLE
RELATED: RAIL-4158 Add SPI support for legacy dashboards

### DIFF
--- a/libs/sdk-backend-base/src/customBackend/workspace.ts
+++ b/libs/sdk-backend-base/src/customBackend/workspace.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import {
     IAnalyticalWorkspace,
@@ -19,6 +19,7 @@ import {
     IWorkspaceDescriptor,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import { CustomExecutionFactory } from "./execution";
 import { CustomBackendConfig, CustomBackendState } from "./config";
@@ -109,5 +110,9 @@ export class CustomWorkspace implements IAnalyticalWorkspace {
 
     public accessControl(): IWorkspaceAccessControlService {
         throw new NotSupported("access control is not supported");
+    }
+
+    public legacyDashboards(): IWorkspaceLegacyDashboardsService {
+        throw new NotSupported("legacy dashboards are not supported");
     }
 }

--- a/libs/sdk-backend-base/src/decoratedBackend/index.ts
+++ b/libs/sdk-backend-base/src/decoratedBackend/index.ts
@@ -28,6 +28,7 @@ import {
     IOrganizations,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import { IOrganizationDescriptor } from "@gooddata/sdk-model";
 import isEmpty from "lodash/isEmpty";
@@ -200,6 +201,10 @@ class AnalyticalWorkspaceDecorator implements IAnalyticalWorkspace {
 
     public accessControl(): IWorkspaceAccessControlService {
         return this.decorated.accessControl();
+    }
+
+    public legacyDashboards(): IWorkspaceLegacyDashboardsService {
+        return this.decorated.legacyDashboards();
     }
 }
 

--- a/libs/sdk-backend-base/src/dummyBackend/index.ts
+++ b/libs/sdk-backend-base/src/dummyBackend/index.ts
@@ -41,6 +41,7 @@ import {
     IMeasureReferencing,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -267,6 +268,9 @@ function dummyWorkspace(workspace: string, config: DummyBackendConfig): IAnalyti
             throw new NotSupported("not supported");
         },
         accessControl(): IWorkspaceAccessControlService {
+            throw new NotSupported("not supported");
+        },
+        legacyDashboards(): IWorkspaceLegacyDashboardsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-bear/src/backend/index.ts
+++ b/libs/sdk-backend-bear/src/backend/index.ts
@@ -73,6 +73,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsTimeGranularities: false,
     supportsHierarchicalWorkspaces: false,
     supportsCustomColorPalettes: true,
+    supportsLegacyDashboards: true,
 };
 
 /**
@@ -111,6 +112,9 @@ type BearLegacyFunctions = {
         workspace: string,
         postMessageData: IDrillableItemsCommandBody,
     ): Promise<IDrillableItemsCommandBody>;
+    /**
+     * @deprecated use the {@link @gooddata/sdk-backend-spi#IAnalyticalWorkspace.legacyDashboards} instead
+     */
     getProjectDashboards?(workspace: string): Promise<GdcProjectDashboard.IWrappedProjectDashboard[]>;
     getUrisFromIdentifiers?(
         workspace: string,

--- a/libs/sdk-backend-bear/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/index.ts
@@ -1,4 +1,4 @@
-// (C) 2019-2021 GoodData Corporation
+// (C) 2019-2022 GoodData Corporation
 
 import {
     IAnalyticalWorkspace,
@@ -18,6 +18,7 @@ import {
     IWorkspaceDescriptor,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import { BearExecution } from "./execution/executionFactory";
 import { BearWorkspaceMeasures } from "./measures";
@@ -35,6 +36,7 @@ import { BearWorkspaceAttributes } from "./attributes/index";
 import { BearWorkspaceFacts } from "./facts";
 import { BearWorkspaceUserGroupsQuery } from "./userGroups";
 import { BearWorkspaceAccessControlService } from "./accessControl";
+import { BearWorkspaceLegacyDashboards } from "./legacyDashboards";
 
 export class BearWorkspace implements IAnalyticalWorkspace {
     constructor(
@@ -123,5 +125,9 @@ export class BearWorkspace implements IAnalyticalWorkspace {
 
     public accessControl(): IWorkspaceAccessControlService {
         return new BearWorkspaceAccessControlService(this.authCall, this.workspace);
+    }
+
+    public legacyDashboards(): IWorkspaceLegacyDashboardsService {
+        return new BearWorkspaceLegacyDashboards(this.authCall, this.workspace);
     }
 }

--- a/libs/sdk-backend-bear/src/backend/workspace/legacyDashboards/convertors.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/legacyDashboards/convertors.ts
@@ -1,0 +1,23 @@
+// (C) 2022 GoodData Corporation
+import { GdcProjectDashboard } from "@gooddata/api-model-bear";
+import { ILegacyDashboard, uriRef, ILegacyDashboardTab } from "@gooddata/sdk-model";
+
+export function projectDashboardToLegacyDashboard(
+    data: GdcProjectDashboard.IWrappedProjectDashboard[],
+): ILegacyDashboard[] {
+    return data.map((item) => {
+        const { content, meta } = item.projectDashboard;
+        return {
+            identifier: meta.identifier!,
+            uri: meta.uri!,
+            ref: uriRef(meta.uri!),
+            title: meta.title,
+            tabs: content.tabs.map((tab): ILegacyDashboardTab => {
+                return {
+                    identifier: tab.identifier,
+                    title: tab.title,
+                };
+            }),
+        };
+    });
+}

--- a/libs/sdk-backend-bear/src/backend/workspace/legacyDashboards/index.ts
+++ b/libs/sdk-backend-bear/src/backend/workspace/legacyDashboards/index.ts
@@ -1,0 +1,16 @@
+// (C) 2022 GoodData Corporation
+import { IWorkspaceLegacyDashboardsService } from "@gooddata/sdk-backend-spi";
+import { ILegacyDashboard } from "@gooddata/sdk-model";
+
+import { BearAuthenticatedCallGuard } from "../../../types/auth";
+
+import { projectDashboardToLegacyDashboard } from "./convertors";
+
+export class BearWorkspaceLegacyDashboards implements IWorkspaceLegacyDashboardsService {
+    constructor(private readonly authCall: BearAuthenticatedCallGuard, public readonly workspace: string) {}
+
+    public getLegacyDashboards = async (): Promise<ILegacyDashboard[]> => {
+        const data = await this.authCall((sdk) => sdk.md.getProjectDashboards(this.workspace));
+        return projectDashboardToLegacyDashboard(data);
+    };
+}

--- a/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/legacyRecordedBackend/index.ts
@@ -32,6 +32,7 @@ import {
     IOrganizations,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import {
     defFingerprint,
@@ -224,6 +225,10 @@ function recordedWorkspace(
         },
 
         accessControl(): IWorkspaceAccessControlService {
+            throw new NotSupported("not supported");
+        },
+
+        legacyDashboards(): IWorkspaceLegacyDashboardsService {
             throw new NotSupported("not supported");
         },
     };

--- a/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
+++ b/libs/sdk-backend-mockingbird/src/recordedBackend/index.ts
@@ -33,6 +33,7 @@ import {
     IDateFilterConfigsQueryResult,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import {
     IColorPalette,
@@ -84,6 +85,7 @@ export const defaultRecordedBackendCapabilities: IBackendCapabilities = {
     allowsInconsistentRelations: false,
     supportsHierarchicalWorkspaces: false,
     supportsCustomColorPalettes: true,
+    supportsLegacyDashboards: false,
 };
 
 /**
@@ -229,6 +231,9 @@ function recordedWorkspace(
         },
         accessControl(): IWorkspaceAccessControlService {
             return recordedAccessControlFactory(implConfig);
+        },
+        legacyDashboards(): IWorkspaceLegacyDashboardsService {
+            throw new NotSupported("not supported");
         },
     };
 }

--- a/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
+++ b/libs/sdk-backend-spi/api/sdk-backend-spi.api.md
@@ -57,6 +57,7 @@ import { IKpiWithComparison } from '@gooddata/sdk-model';
 import { IKpiWithoutComparison } from '@gooddata/sdk-model';
 import { IKpiWithPopComparison } from '@gooddata/sdk-model';
 import { IKpiWithPreviousPeriodComparison } from '@gooddata/sdk-model';
+import { ILegacyDashboard } from '@gooddata/sdk-model';
 import { IListedDashboard as IListedDashboard_2 } from '@gooddata/sdk-model';
 import { IMeasure } from '@gooddata/sdk-model';
 import { IMeasureMetadataObject as IMeasureMetadataObject_2 } from '@gooddata/sdk-model';
@@ -279,6 +280,7 @@ export interface IAnalyticalWorkspace {
     getDescriptor(): Promise<IWorkspaceDescriptor>;
     getParentWorkspace(): Promise<IAnalyticalWorkspace | undefined>;
     insights(): IWorkspaceInsightsService;
+    legacyDashboards(): IWorkspaceLegacyDashboardsService;
     measures(): IWorkspaceMeasuresService;
     permissions(): IWorkspacePermissionsService;
     settings(): IWorkspaceSettingsService;
@@ -366,6 +368,7 @@ export interface IBackendCapabilities {
     supportsHierarchicalWorkspaces?: boolean;
     supportsHyperlinkAttributeLabels?: boolean;
     supportsKpiWidget?: boolean;
+    supportsLegacyDashboards?: boolean;
     supportsObjectUris?: boolean;
     supportsOwners?: boolean;
     supportsRankingFilter?: boolean;
@@ -1690,6 +1693,11 @@ export interface IWorkspaceInsightsService {
     getVisualizationClass(ref: ObjRef): Promise<IVisualizationClass>;
     getVisualizationClasses(options?: IGetVisualizationClassesOptions): Promise<IVisualizationClass[]>;
     updateInsight(insight: IInsight): Promise<IInsight>;
+}
+
+// @alpha
+export interface IWorkspaceLegacyDashboardsService {
+    getLegacyDashboards(): Promise<ILegacyDashboard[]>;
 }
 
 // @public

--- a/libs/sdk-backend-spi/src/backend/capabilities.ts
+++ b/libs/sdk-backend-spi/src/backend/capabilities.ts
@@ -162,6 +162,11 @@ export interface IBackendCapabilities {
     supportsCustomColorPalettes?: boolean;
 
     /**
+     * Indicates whether backend supports Legacy Dashboards (a.k.a. PP Dashboards).
+     */
+    supportsLegacyDashboards?: boolean;
+
+    /**
      * Catchall for additional capabilities
      */
     [key: string]: undefined | boolean | number | string;

--- a/libs/sdk-backend-spi/src/index.ts
+++ b/libs/sdk-backend-spi/src/index.ts
@@ -175,6 +175,8 @@ export {
 
 export { IWorkspaceAccessControlService } from "./workspace/accessControl";
 
+export { IWorkspaceLegacyDashboardsService } from "./workspace/legacyDashboards";
+
 // Moved to @gooddata/sdk-model
 export {
     IDateFilterConfig,

--- a/libs/sdk-backend-spi/src/workspace/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/index.ts
@@ -15,6 +15,7 @@ import { IWorkspaceMeasuresService } from "./measures";
 import { IWorkspaceFactsService } from "./facts";
 import { IWorkspaceAccessControlService } from "./accessControl";
 import { IWorkspaceUserGroupsQuery } from "./userGroups";
+import { IWorkspaceLegacyDashboardsService } from "./legacyDashboards";
 
 /**
  * Represents an analytical workspace hosted on a backend.
@@ -115,6 +116,12 @@ export interface IAnalyticalWorkspace {
      * Returns service that can be used to manage access control records for the workspace.
      */
     accessControl(): IWorkspaceAccessControlService;
+
+    /**
+     * Returns service that can be used to list Legacy Dashboards on backends that support them (see the supportsLegacyDashboards capability).
+     * See {@link IAnalyticalWorkspace.dashboards} for the non-legacy dashboards that are most likely a better choice.
+     */
+    legacyDashboards(): IWorkspaceLegacyDashboardsService;
 }
 
 /**

--- a/libs/sdk-backend-spi/src/workspace/legacyDashboards/index.ts
+++ b/libs/sdk-backend-spi/src/workspace/legacyDashboards/index.ts
@@ -1,0 +1,16 @@
+// (C) 2022 GoodData Corporation
+import { ILegacyDashboard } from "@gooddata/sdk-model";
+
+/**
+ * Service to list legacy dashboards
+ *
+ * @alpha
+ */
+export interface IWorkspaceLegacyDashboardsService {
+    /**
+     * Gets all legacy dashboards available in current workspace.
+     *
+     * @returns promise of list of the dashboards
+     */
+    getLegacyDashboards(): Promise<ILegacyDashboard[]>;
+}

--- a/libs/sdk-backend-tiger/src/backend/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/index.ts
@@ -73,6 +73,7 @@ const CAPABILITIES: IBackendCapabilities = {
     supportsTimeGranularities: true,
     supportsHierarchicalWorkspaces: true,
     supportsCustomColorPalettes: false,
+    supportsLegacyDashboards: false,
 };
 
 /**

--- a/libs/sdk-backend-tiger/src/backend/workspace/index.ts
+++ b/libs/sdk-backend-tiger/src/backend/workspace/index.ts
@@ -19,6 +19,7 @@ import {
     IWorkspaceDescriptor,
     IWorkspaceUserGroupsQuery,
     IWorkspaceAccessControlService,
+    IWorkspaceLegacyDashboardsService,
 } from "@gooddata/sdk-backend-spi";
 import { TigerExecution } from "./execution/executionFactory";
 import { TigerWorkspaceCatalogFactory } from "./catalog/factory";
@@ -123,5 +124,8 @@ export class TigerWorkspace implements IAnalyticalWorkspace {
     }
     public dateFilterConfigs(): IDateFilterConfigsQuery {
         return new TigerWorkspaceDateFilterConfigsQuery();
+    }
+    public legacyDashboards(): IWorkspaceLegacyDashboardsService {
+        throw new NotSupported("Not supported");
     }
 }

--- a/libs/sdk-model/api/sdk-model.api.md
+++ b/libs/sdk-model/api/sdk-model.api.md
@@ -1265,6 +1265,21 @@ export interface IKpiWithPreviousPeriodComparison extends IKpiBase {
 }
 
 // @alpha
+export interface ILegacyDashboard {
+    readonly identifier: string;
+    readonly ref: ObjRef;
+    readonly tabs: ILegacyDashboardTab[];
+    readonly title: string;
+    readonly uri: string;
+}
+
+// @alpha
+export interface ILegacyDashboardTab {
+    readonly identifier: string;
+    readonly title: string;
+}
+
+// @alpha
 export interface IListedDashboard extends Readonly<Required<IAuditableDates>>, Readonly<IAuditableUsers>, IAccessControlAware {
     readonly availability: ListedDashboardAvailability;
     readonly description: string;

--- a/libs/sdk-model/src/index.ts
+++ b/libs/sdk-model/src/index.ts
@@ -738,3 +738,5 @@ export {
 } from "./accessControl";
 
 export { IOrganizationDescriptor } from "./organization";
+
+export { ILegacyDashboard, ILegacyDashboardTab } from "./legacyDashboard";

--- a/libs/sdk-model/src/legacyDashboard/index.ts
+++ b/libs/sdk-model/src/legacyDashboard/index.ts
@@ -1,0 +1,53 @@
+// (C) 2022 GoodData Corporation
+import { ObjRef } from "../objRef";
+
+/**
+ * Legacy Dashboard (a.k.a. PP Dashboard) tab.
+ *
+ * @alpha
+ */
+export interface ILegacyDashboardTab {
+    /**
+     * Title of the tab
+     */
+    readonly title: string;
+    /**
+     * Unique identifier of the tab
+     */
+    readonly identifier: string;
+}
+
+/**
+ * Legacy Dashboard (a.k.a. PP Dashboard).
+ *
+ * @remarks
+ * Use this only if you are certain you need this, for vast majority of use cases the {@link IDashboard} is a much better fit.
+ *
+ * @alpha
+ */
+export interface ILegacyDashboard {
+    /**
+     * Object ref
+     */
+    readonly ref: ObjRef;
+
+    /**
+     * Object uri
+     */
+    readonly uri: string;
+
+    /**
+     * Object identifier
+     */
+    readonly identifier: string;
+
+    /**
+     * Title of the legacy dashboard
+     */
+    readonly title: string;
+
+    /**
+     * Tabs included in the legacy dashboard
+     */
+    readonly tabs: ILegacyDashboardTab[];
+}

--- a/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
+++ b/libs/sdk-ui-dashboard/src/model/queryServices/tests/__snapshots__/queryWidgetFilters.test.ts.snap
@@ -232,6 +232,7 @@ Object {
         "supportsCustomColorPalettes": true,
         "supportsHierarchicalWorkspaces": false,
         "supportsKpiWidget": true,
+        "supportsLegacyDashboards": false,
         "supportsOwners": true,
         "supportsWidgetEntity": true,
       },


### PR DESCRIPTION
Since we reference these in the DrillToLegacyDashboard, we must provide
a way to get the data in a backend agnostic way (not bear specific
function).

The relevant backend agnostic function was deprecated and will be
removed in a follow-up commit once gdc-dashboards are ready.

JIRA: RAIL-4158

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
