### PR TITLE
RAIL-4159 Migrate Insight configuration panel

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -5385,12 +5385,18 @@ payload: ObjRef;
 type: string;
 }>;
 clearWidgetSelection: CaseReducer<UiState, AnyAction>;
+setConfigurationPanelOpened: CaseReducer<UiState, {
+payload: boolean;
+type: string;
+}>;
 }>;
 
 // @alpha (undocumented)
 export interface UiState {
     // (undocumented)
     activeHeaderIndex: number | null;
+    // (undocumented)
+    configurationPanelOpened: boolean;
     // (undocumented)
     deleteDialog: {
         open: boolean;

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiReducers.ts
@@ -105,6 +105,10 @@ const clearWidgetSelection: UiReducer = (state) => {
     state.selectedWidgetRef = undefined;
 };
 
+const setConfigurationPanelOpened: UiReducer<PayloadAction<boolean>> = (state, action) => {
+    state.configurationPanelOpened = action.payload;
+};
+
 export const uiReducers = {
     openScheduleEmailDialog,
     closeScheduleEmailDialog,
@@ -130,4 +134,5 @@ export const uiReducers = {
     setActiveHeaderIndex,
     selectWidget,
     clearWidgetSelection,
+    setConfigurationPanelOpened,
 };

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiSelectors.ts
@@ -156,3 +156,11 @@ export const selectActiveHeaderIndex = createSelector(selectSelf, (state) => sta
  * @internal
  */
 export const selectSelectedWidgetRef = createSelector(selectSelf, (state) => state.selectedWidgetRef);
+
+/**
+ * @internal
+ */
+export const selectConfigurationPanelOpened = createSelector(
+    selectSelf,
+    (state) => state.configurationPanelOpened,
+);

--- a/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/ui/uiState.ts
@@ -37,6 +37,7 @@ export interface UiState {
     renderMode: RenderMode;
     activeHeaderIndex: number | null;
     selectedWidgetRef: ObjRef | undefined;
+    configurationPanelOpened: boolean;
 }
 
 export const uiInitialState: UiState = {
@@ -70,4 +71,5 @@ export const uiInitialState: UiState = {
     renderMode: "view",
     activeHeaderIndex: null,
     selectedWidgetRef: undefined,
+    configurationPanelOpened: true,
 };

--- a/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
+++ b/libs/sdk-ui-dashboard/src/presentation/localization/bundles/en-US.json
@@ -1278,6 +1278,11 @@
         "comment": "Label of widget configuration section",
         "limit": 0
     },
+    "configurationPanel.interactions": {
+        "value": "Interactions",
+        "comment": "",
+        "limit": 0
+    },
     "configurationPanel.comparison": {
         "value": "Comparison",
         "comment": "",
@@ -1453,6 +1458,16 @@
     },
     "configurationPanel.unlistedDashboardTab": {
         "value": "Unlisted dashboard",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.sectionTitle": {
+        "value": "Title",
+        "comment": "",
+        "limit": 0
+    },
+    "configurationPanel.visualprops.hideTitle": {
+        "value": "Hide title",
         "comment": "",
         "limit": 0
     },

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
@@ -55,10 +55,6 @@ export const ConfigurationBubble: React.FC<IConfigurationBubbleProps> = (props) 
             arrowDirections={arrowDirections}
         >
             {children}
-            {/* <ConfigurationPanel
-                onWidgetDelete={props.onWidgetDelete}
-                // handleSetConfigMenuDisplay={setConfigMenuDisplay}
-            /> */}
         </Bubble>
     );
 };

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ScrollContext.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ScrollContext.tsx
@@ -1,0 +1,15 @@
+// (C) 2019-2022 GoodData Corporation
+import React, { useContext } from "react";
+
+export const useScrollContext = () => useContext(ScrollContext);
+export type isElementInvisibleType = (element: HTMLElement, container: HTMLElement) => boolean;
+
+export const scrollContextDefault = {
+    scrollIntoView: (
+        _element: HTMLElement,
+        _bottomMargin?: number,
+        _isElementInvisibleCheck?: isElementInvisibleType,
+    ) => {},
+};
+
+export const ScrollContext = React.createContext(scrollContextDefault);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ScrollablePanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ScrollablePanel.tsx
@@ -1,0 +1,67 @@
+// (C) 2019-2022 GoodData Corporation
+import React, { useRef, useImperativeHandle, useMemo } from "react";
+
+import { ScrollContext, isElementInvisibleType } from "./ScrollContext";
+
+export interface IScrollablePanelProps extends React.HTMLAttributes<HTMLDivElement> {
+    scrollToVisible?: (element: HTMLElement, container: HTMLElement, bottomMargin: number) => void;
+    tagName?: React.ReactType;
+}
+
+const DEFAULT_BOTTOM_MARGIN = 5;
+
+const scrollToVisibleDefault = (element: HTMLElement, container: HTMLElement, bottomMargin: number) => {
+    container.scrollTop = element.offsetTop - container.offsetTop - bottomMargin;
+};
+
+const isElementInvisibleCheckDefault: isElementInvisibleType = (
+    element: HTMLElement,
+    container: HTMLElement,
+): boolean => {
+    if (element && container) {
+        const offset = element.offsetTop - container.offsetTop;
+        const itemHeight = element.clientHeight;
+        const parentHeight = container.clientHeight;
+        return parentHeight < offset + itemHeight;
+    }
+    return false;
+};
+
+// eslint-disable-next-line react/display-name
+export const ScrollablePanel = React.forwardRef<HTMLDivElement | undefined, IScrollablePanelProps>(
+    (props, ref) => {
+        const {
+            tagName: TagName = "div",
+            scrollToVisible = scrollToVisibleDefault,
+            children,
+            ...divProps
+        } = props;
+        const containerRef = useRef<HTMLDivElement>();
+        useImperativeHandle(ref, () => containerRef.current);
+
+        const memoizeContext = useMemo(() => {
+            return {
+                scrollIntoView: (
+                    element: HTMLElement,
+                    bottomMargin = DEFAULT_BOTTOM_MARGIN,
+                    isElementInvisibleCheck = isElementInvisibleCheckDefault,
+                ) => {
+                    if (containerRef.current) {
+                        const container = containerRef.current;
+                        if (isElementInvisibleCheck(element, container)) {
+                            scrollToVisible(element, container, bottomMargin);
+                        }
+                    }
+                },
+            };
+        }, [scrollToVisible, containerRef]);
+
+        return (
+            <ScrollContext.Provider value={memoizeContext}>
+                <TagName {...divProps} ref={containerRef}>
+                    {children}
+                </TagName>
+            </ScrollContext.Provider>
+        );
+    },
+);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/types.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/types.ts
@@ -1,0 +1,3 @@
+// (C) 2022 GoodData Corporation
+
+export type SelectedItemType = "configuration" | "interactions" | undefined;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
@@ -37,6 +37,7 @@ export function useWidgetSelection(widgetRef: ObjRef | undefined): IUseWidgetSel
     const onSelected = useCallback(() => {
         if (isSelectable && widgetRef) {
             dispatch(uiActions.selectWidget(widgetRef));
+            dispatch(uiActions.setConfigurationPanelOpened(true));
         }
     }, [isSelectable, widgetRef, dispatch]);
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfiguration.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfiguration.tsx
@@ -1,0 +1,72 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { InsightConfigurationHeader } from "./InsightConfigurationHeader";
+import { IInsightWidget, isInsightWidget, objRefToString } from "@gooddata/sdk-model";
+import { stringUtils } from "@gooddata/util";
+import cx from "classnames";
+import debounce from "lodash/debounce";
+import { InsightTitleConfig } from "./InsightTitleConfig";
+import InsightFilters from "./InsightFilters";
+import { ScrollablePanel } from "../../common/configuration/ScrollablePanel";
+import { SelectedItemType } from "../../common/configuration/types";
+
+interface IInsightConfigurationProps {
+    widget: IInsightWidget;
+    selectedItemType: SelectedItemType;
+    handleConfigurationHeaderClick: () => void;
+    onCloseButtonClick: () => void;
+}
+
+export const InsightConfiguration: React.FC<IInsightConfigurationProps> = ({
+    widget,
+    selectedItemType,
+    handleConfigurationHeaderClick,
+    onCloseButtonClick,
+}) => {
+    const widgetRefSuffix = isInsightWidget(widget)
+        ? stringUtils.simplifyText(objRefToString(widget.ref))
+        : "";
+
+    const classes = cx("configuration-panel", `s-visualization-${widgetRefSuffix}`);
+    const node = React.createRef<HTMLDivElement>();
+
+    const isNotOnInput = (event: React.UIEvent<HTMLDivElement>) => {
+        const target = event.target as HTMLElement;
+        return target.tagName !== "INPUT";
+    };
+
+    const onScroll = debounce(() => {
+        if (node?.current) {
+            // fireGoodstrapScrollEvent(node.current, window); // TODO: what should this do?
+        }
+    }, 20);
+
+    const onPanelScroll = (event: React.UIEvent<HTMLDivElement>) => {
+        if (isNotOnInput(event)) {
+            onScroll();
+        }
+    };
+
+    return (
+        <>
+            <InsightConfigurationHeader
+                selectedItemType={selectedItemType}
+                handleConfigurationHeaderClick={handleConfigurationHeaderClick}
+                onCloseButtonClick={onCloseButtonClick}
+            />
+            <ScrollablePanel className={classes} ref={node} onScroll={onPanelScroll}>
+                {selectedItemType === "configuration" && (
+                    <>
+                        <InsightTitleConfig
+                            isHidingOfWidgetTitleEnabled={true} // TODO
+                            hideTitle={false}
+                            // resetTitle={() => handleResetTitle(widgetOriginalTitle)} // TODO
+                        />
+                        <InsightFilters widget={widget} />
+                    </>
+                )}
+                {/*{selectedItemType === INTERACTIONS && TODO}*/}
+            </ScrollablePanel>
+        </>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationHeader.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationHeader.tsx
@@ -1,0 +1,38 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import { Button, Typography } from "@gooddata/sdk-ui-kit";
+import { FormattedMessage } from "react-intl";
+import { SelectedItemType } from "../../common/configuration/types";
+
+interface IInsightConfigurationProps {
+    selectedItemType: SelectedItemType;
+    handleConfigurationHeaderClick: () => void;
+    onCloseButtonClick: () => void;
+}
+
+export const InsightConfigurationHeader: React.FC<IInsightConfigurationProps> = ({
+    selectedItemType,
+    handleConfigurationHeaderClick,
+    onCloseButtonClick,
+}) => {
+    return (
+        <div className="configuration-panel-header">
+            <Typography
+                tagName="h3"
+                className="configuration-panel-header-title clickable"
+                onClick={handleConfigurationHeaderClick}
+            >
+                <i className="gd-icon-navigateleft" />
+                {selectedItemType === "configuration" ? (
+                    <FormattedMessage id="configurationPanel.title" />
+                ) : (
+                    <FormattedMessage id="configurationPanel.interactions" />
+                )}
+            </Typography>
+            <Button
+                className="gd-button-link gd-button-icon-only gd-icon-cross configuration-panel-header-close-button s-configuration-panel-header-close-button"
+                onClick={onCloseButtonClick}
+            />
+        </div>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationItems.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationItems.tsx
@@ -1,0 +1,93 @@
+// (C) 2020-2022 GoodData Corporation
+import { IInsightWidget, insightIsLocked } from "@gooddata/sdk-model";
+import React from "react";
+import { Item, ItemsWrapper } from "@gooddata/sdk-ui-kit";
+
+import { selectInsightByRef, useDashboardSelector } from "../../../../model";
+import InsightConfigurationWrapper from "./InsightConfigurationWrapper";
+import { useIntl } from "react-intl";
+
+interface IInsightConfigurationItemsProps {
+    selectedWidget: IInsightWidget;
+    // showInteractionItem: boolean;
+    handleConfigurationItemClick: () => void;
+    // handleInteractionsItemClick: () => void;
+    onCloseButtonClick: () => void;
+    // onWidgetDelete: (e: React.MouseEvent<HTMLDivElement>) => void;
+    // handleRenderInsightConfiguration: (isRender: boolean) => void;
+    // isHidingOfWidgetTitleEnabled: boolean;
+}
+
+export default function InsightConfigurationItems(props: IInsightConfigurationItemsProps) {
+    const {
+        handleConfigurationItemClick,
+        // handleInteractionsItemClick,
+        // handleRenderInsightConfiguration,
+        // showInteractionItem,
+        // onWidgetDelete,
+        ...restProps
+    } = props;
+
+    const intl = useIntl();
+
+    // useEffect(() => {
+    //     handleRenderInsightConfiguration(true);
+    // }, [handleRenderInsightConfiguration]);
+    //
+    // const onEditItemClick = () => {
+    //     if (!canEditInsight) {
+    //         return;
+    //     }
+    //     handleOpenEditInsightOverlay(true, widgetRef);
+    // };
+
+    const insight = useDashboardSelector(selectInsightByRef(props.selectedWidget?.insight));
+
+    const isLocked = insight && insightIsLocked(insight);
+
+    return (
+        <InsightConfigurationWrapper canEditInsight isLocked={isLocked} {...restProps}>
+            <ItemsWrapper style={{ width: "100%" }} smallItemsSpacing>
+                <Item subMenu onClick={handleConfigurationItemClick}>
+                    <span>
+                        <i className="gd-icon-settings" />
+                        {intl.formatMessage({ id: "configurationPanel.title" })}
+                    </span>
+                </Item>
+                {/*{showInteractionItem && (*/}
+                {/*    <Item subMenu onClick={handleInteractionsItemClick}>*/}
+                {/*        <Icon.Interaction className="item-icon" color={theme?.palette?.complementary?.c5} />*/}
+                {/*        <span className="item-label">*/}
+                {/*            {intl.formatMessage({ id: "configurationPanel.interactions" })}*/}
+                {/*        </span>*/}
+                {/*    </Item>*/}
+                {/*)}*/}
+                {/*<Separator />*/}
+                {/*{canEditInsight && (*/}
+                {/*    <React.Fragment>*/}
+                {/*        <Item*/}
+                {/*            className={cx(*/}
+                {/*                "gd-list-item",*/}
+                {/*                "gd-menu-item",*/}
+                {/*                "options-menu-edit-insight s-options-menu-edit-insight",*/}
+                {/*            )}*/}
+                {/*            onClick={onEditItemClick}*/}
+                {/*        >*/}
+                {/*            <span>*/}
+                {/*                <i className="gd-icon-pencil" />*/}
+                {/*                {intl.formatMessage({ id: "controlButtons.edit.value" })}*/}
+                {/*            </span>*/}
+                {/*        </Item>*/}
+                {/*        <Separator />*/}
+                {/*    </React.Fragment>*/}
+                {/*)}*/}
+                {/*<Item className="gd-list-item gd-menu-item s-delete-insight-item" onClick={onWidgetDelete}>*/}
+                {/*    <span>*/}
+                {/*        <i className="gd-icon-trash" />*/}
+                {/*        {intl.formatMessage({ id: "configurationPanel.remove.form.dashboard" })}*/}
+                {/*    </span>*/}
+                {/*</Item>*/}
+            </ItemsWrapper>
+        </InsightConfigurationWrapper>
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationPanel.tsx
@@ -1,0 +1,91 @@
+// (C) 2007-2022 GoodData Corporation
+import { isInsightWidget } from "@gooddata/sdk-model";
+import React, { useState } from "react";
+
+import {
+    selectSelectedWidgetRef,
+    selectWidgetByRef,
+    useDashboardSelector,
+    useDashboardDispatch,
+    uiActions,
+} from "../../../../model";
+import { SelectedItemType } from "../../common/configuration/types";
+import { InsightConfiguration } from "./InsightConfiguration";
+import InsightConfigurationItems from "./InsightConfigurationItems";
+import invariant from "ts-invariant";
+
+export interface IConfigurationPanelProps {
+    handleSetConfigMenuDisplay?: (value: boolean) => void;
+}
+
+export default function InsightConfigurationPanel(props: IConfigurationPanelProps) {
+    const widgetRef = useDashboardSelector(selectSelectedWidgetRef);
+    const widget = useDashboardSelector(selectWidgetByRef(widgetRef));
+
+    invariant(widget && isInsightWidget(widget), "must have insight widget selected");
+
+    const dispatch = useDashboardDispatch();
+    const [selectedItemType, setSelectedItemType] = useState<SelectedItemType>();
+
+    const selectInsightMenuItem = (menuItemType?: SelectedItemType) => {
+        props.handleSetConfigMenuDisplay?.(menuItemType === undefined);
+        setSelectedItemType(menuItemType);
+    };
+
+    const onCloseButtonClick = () => {
+        dispatch(uiActions.setConfigurationPanelOpened(false));
+    };
+
+    if (selectedItemType === "configuration" || selectedItemType === "interactions") {
+        return (
+            <InsightConfiguration
+                widget={widget}
+                selectedItemType={selectedItemType}
+                handleConfigurationHeaderClick={selectInsightMenuItem}
+                onCloseButtonClick={onCloseButtonClick}
+            />
+        );
+    } else {
+        // const isDrillingEnabled = [
+        //     this.props.isEnableKPIDashboardDrillToDashboard,
+        //     this.props.isEnableKPIDashboardDrillToInsight,
+        //     this.props.isEnableKPIDashboardDrillToUrl,
+        // ].some((isEnabled) => isEnabled === true);
+
+        return (
+            <InsightConfigurationItems
+                onCloseButtonClick={onCloseButtonClick}
+                // onWidgetDelete={onWidgetDelete}
+                selectedWidget={widget}
+                // handleInteractionsItemClick={this.onInteractionsItemClick}// TODO other interactions
+                handleConfigurationItemClick={() => selectInsightMenuItem("configuration")}
+                // handleRenderInsightConfiguration={handleSetConfigMenuDisplay}
+                // showInteractionItem={isDrillingEnabled && hasSupportedDrillItems}
+                // isHidingOfWidgetTitleEnabled={isHidingOfWidgetTitleEnabled}
+            />
+        );
+    }
+    //
+    // private onInteractionsItemClick = () => {
+    //     this.selectInsightMenuItem(INTERACTIONS);
+    // };
+    //
+    // private isEnableDrilling() {
+    //     return (
+    //         this.props.isEnableKPIDashboardDrillToInsight ||
+    //         this.props.isEnableKPIDashboardDrillToDashboard ||
+    //         this.props.isEnableKPIDashboardDrillToUrl
+    //     );
+    // }
+    //
+    //
+    // private renderInteractionSection() {
+    //     const { isEnableKDZooming, widgetRef } = this.props;
+    //     return (
+    //         <React.Fragment>
+    //             {isEnableKDZooming && <ZoomInsightConfiguration widgetRef={widgetRef} />}
+    //             {this.isEnableDrilling() && <DrillConfigPanel />}
+    //         </React.Fragment>
+    //     );
+    // }
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationWrapper.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightConfigurationWrapper.tsx
@@ -1,0 +1,133 @@
+// (C) 2020-2022 GoodData Corporation
+import React from "react";
+import { Button, Typography } from "@gooddata/sdk-ui-kit";
+
+import { IInsightWidget } from "@gooddata/sdk-model";
+import { selectInsightByRef, useDashboardSelector } from "../../../../model";
+
+export interface InsightConfigurationWrapperProps {
+    selectedWidget: IInsightWidget;
+    canEditInsight: boolean;
+    isLocked?: boolean;
+    // projectId: string;
+    // insightId: string;
+    // exploreMode?: boolean;
+    onCloseButtonClick: () => void;
+    // theme?: ITheme;
+    children?: React.ReactNode;
+}
+
+export default function InsightConfigurationWrapper(props: InsightConfigurationWrapperProps) {
+    const renderTitle = (title: string | undefined) => {
+        // const {
+        //     canEditInsight,
+        //     isLocked,
+        //     // canOpenInsightUrl,
+        //     // projectId,
+        //     // insightId,
+        //     // exploreMode,
+        //     // theme,
+        // } = this.props;
+
+        // if (canEditInsight && canOpenInsightUrl && !exploreMode) {
+        //     const insightDirectUrl = `/analyze/#/${projectId}/${insightId}/edit`;
+        //     const goToInsight = () => {
+        //         window.open(insightDirectUrl, "_blank");
+        //     };
+        //
+        //     return (
+        //         <Typography
+        //             tagName="p"
+        //             className="insight-title s-insight-title s-insight-title-clickable"
+        //             onClick={goToInsight}
+        //         >
+        //             {isLocked && (
+        //                 <BubbleHoverTrigger
+        //                     eventsOnBubble={true}
+        //                     className="gd-bubble-locked s-locked-insight-bubble-trigger"
+        //                 >
+        //                     <Icon.Lock
+        //                         className="gd-icon-locked"
+        //                         width={14}
+        //                         height={14}
+        //                         color={theme?.palette?.complementary?.c5 ?? "#8A99A5"}
+        //                     />
+        //                     {
+        //                         <Bubble alignPoints={[{ align: "tc bc", offset: { x: -2, y: -10 } }]}>
+        //                             <FormattedMessage
+        //                                 // TODO: TIGER-HACK - inherited insights are locked and cannot be edited; we need to give slightly different tooltip.
+        //                                 id={
+        //                                     isTigerBackend()
+        //                                         ? "configurationPanel.title.inheritedInsight"
+        //                                         : "configurationPanel.title.lockedInsight"
+        //                                 }
+        //                             />
+        //                         </Bubble>
+        //                     }
+        //                 </BubbleHoverTrigger>
+        //             )}
+        //             <span className="original-insight-title" title={title}>
+        //                 {title}
+        //             </span>
+        //             <Icon.ExternalLink
+        //                 className="gd-icon-link"
+        //                 width={14}
+        //                 height={14}
+        //                 color={theme?.palette?.complementary?.c5 ?? "#8A99A5"}
+        //             />
+        //         </Typography>
+        //     );
+        // }
+
+        return (
+            <span title={title} className="insight-title s-insight-title s-insight-title-simple">
+                {title}
+            </span>
+        );
+    };
+
+    const { selectedWidget } = props;
+    const insight = useDashboardSelector(selectInsightByRef(selectedWidget?.insight));
+
+    const renderHeader = () => {
+        const widgetTitle = selectedWidget.title;
+        const widgetOriginalTitle = insight?.insight.title;
+        const originalTitleComponent = renderTitle(widgetOriginalTitle);
+
+        if (!widgetTitle || widgetTitle === widgetOriginalTitle) {
+            return (
+                <Typography tagName="h3" className="widget-title s-widget-title">
+                    {originalTitleComponent}
+                </Typography>
+            );
+        }
+
+        return (
+            <React.Fragment>
+                <Typography tagName="h3" className="widget-title s-widget-title">
+                    <span
+                        title={widgetTitle}
+                        className="insight-title s-insight-title s-insight-title-simple"
+                    >
+                        {widgetTitle}
+                    </span>
+                </Typography>
+                {originalTitleComponent}
+            </React.Fragment>
+        );
+    };
+
+    const { onCloseButtonClick } = props;
+    return (
+        <div className="insight-configuration">
+            <div className="insight-configuration-panel-header">
+                {renderHeader()}
+                <Button
+                    className="gd-button-link gd-button-icon-only gd-icon-cross configuration-panel-header-close-button s-configuration-panel-header-close-button"
+                    onClick={onCloseButtonClick}
+                />
+            </div>
+            {props.children}
+        </div>
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -1,0 +1,53 @@
+// (C) 2007-2022 GoodData Corporation
+// import { connect } from "react-redux";
+// import { getRecommendedDateDataset } from "@gooddata/sdk-ui-kit";
+//
+// import DateDataSetFilter, {
+//     IDateDataSetFilterDispatchProps,
+//     IDateDataSetFilterStateProps,
+// } from "../common/DateDataSetFilter";
+// import { getSelectedWidgetRef } from "../../modules/Core/services/DashboardService";
+// import { autoOpenChanged } from "../../modules/Core/actions/VisualizationActions";
+// import { dateDataSetFilterEnabled, dateDataSetSelected } from "../../modules/Core/actions/EditModeActions";
+// import {
+//     areDateDataSetsLoading,
+//     getRelatedDateDataSets,
+//     getSelectedDateDataSet,
+// } from "../../modules/VisualizationsCache";
+// import { AppState } from "../../modules/Core/typings/state";
+// import { IProcessedDateDataset } from "../../modules/Core/typings/DateDataSets";
+// import {
+//     getDateFilterCheckboxDisabled,
+//     getWidgetByRef,
+//     getWidgetType,
+//     getDateFilterEnabled,
+//     getDateFilterLoading,
+//     getDateFilterAutoOpen,
+//     getVisualizationDateDataSet,
+// } from "../../modules/Widgets";
+import React from "react";
+import { useInsightWidgetRelatedDateDatasets } from "../../../widget/common/useWidgetRelatedDateDatasets";
+import { IInsightWidget, isInsightWidget } from "@gooddata/sdk-model";
+import { DateDatasetFilter } from "../../common/configuration/DateDatasetFilter";
+
+export interface IConfigurationPanelProps {
+    widget: IInsightWidget;
+}
+
+export default function InsightDateDataSetFilter({ widget }: IConfigurationPanelProps) {
+    const { status, result } = useInsightWidgetRelatedDateDatasets(widget);
+
+    if (isInsightWidget(widget)) {
+        return (
+            <DateDatasetFilter
+                widget={widget}
+                isFilterLoading={false} // TODO
+                dateFilterCheckboxDisabled={false}
+                isDropdownLoading={status === "loading" || status === "pending"}
+                relatedDateDatasets={result}
+            />
+        );
+    }
+
+    return null;
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightFilters.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightFilters.tsx
@@ -1,0 +1,23 @@
+// (C) 2007-2022 GoodData Corporation
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { Typography } from "@gooddata/sdk-ui-kit";
+import InsightDateDataSetFilter from "./InsightDateDataSetFilter";
+import { IInsightWidget } from "@gooddata/sdk-model";
+import { AttributeFilterConfiguration } from "../../common/configuration/AttributeFilterConfiguration";
+
+interface IInsightFiltersProps {
+    widget: IInsightWidget;
+}
+
+export default function InsightFilters({ widget }: IInsightFiltersProps) {
+    return (
+        <div className="s-viz-filters-panel configuration-category">
+            <Typography tagName="h3" className="s-viz-filters-headline">
+                <FormattedMessage id="configurationPanel.filterBy" />
+            </Typography>
+            <InsightDateDataSetFilter widget={widget} />
+            <AttributeFilterConfiguration widget={widget} />
+        </div>
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightTitleConfig.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightTitleConfig.tsx
@@ -1,0 +1,50 @@
+// (C) 2007-2022 GoodData Corporation
+import React, { useState } from "react";
+import { FormattedMessage, useIntl } from "react-intl";
+import { Typography, Checkbox } from "@gooddata/sdk-ui-kit";
+
+interface IVisualizationTitleConfigProps {
+    // resetTitle: () => void;
+    isHidingOfWidgetTitleEnabled: boolean;
+    hideTitle: boolean;
+    // setVisualPropsConfigurationTitle: (
+    //     widgetRef: ObjRef,
+    //     hideTitle: boolean,
+    // ) => IVisualPropsConfigurationAction;
+}
+
+export function InsightTitleConfig(props: IVisualizationTitleConfigProps) {
+    const {
+        hideTitle,
+        // widget,
+        // setVisualPropsConfigurationTitle,
+        isHidingOfWidgetTitleEnabled,
+    } = props;
+
+    const intl = useIntl();
+
+    const [widgetTitleState, setWidgetTitleState] = useState(hideTitle);
+
+    const handleHideTitleChange = (isChecked: boolean) => {
+        setWidgetTitleState(isChecked);
+        // setVisualPropsConfigurationTitle(widget, isChecked);
+    };
+
+    return (
+        <>
+            {isHidingOfWidgetTitleEnabled && (
+                <div className="configuration-category s-hide-title-configuration">
+                    <Typography tagName="h3" className="s-viz-title-headline">
+                        <FormattedMessage id="configurationPanel.visualprops.sectionTitle" />
+                    </Typography>
+                    <Checkbox
+                        onChange={handleHideTitleChange}
+                        value={widgetTitleState}
+                        text={intl.formatMessage({ id: "configurationPanel.visualprops.hideTitle" })}
+                        labelSize="small"
+                    />
+                </div>
+            )}
+        </>
+    );
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -17,6 +17,8 @@ import {
     isCustomWidget,
     useDashboardScheduledEmails,
     selectCanExportReport,
+    useDashboardDispatch,
+    uiActions,
 } from "../../../model";
 import {
     DashboardItem,
@@ -30,6 +32,8 @@ import { useInsightExport } from "../common/useInsightExport";
 import { useDashboardComponentsContext } from "../../dashboardContexts";
 import { useInsightMenu } from "./useInsightMenu";
 import { useWidgetSelection } from "../common/useWidgetSelection";
+import { ConfigurationBubble } from "../common";
+import InsightConfigurationPanel from "../insight/configuration/InsightConfigurationPanel";
 
 interface IDefaultDashboardInsightWidgetProps {
     widget: IInsightWidget;
@@ -134,6 +138,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         [InsightMenuComponentProvider, insight, widget],
     );
 
+    const dispatch = useDashboardDispatch();
     const { isSelectable, isSelected, onSelected } = useWidgetSelection(widget.ref);
 
     return (
@@ -157,13 +162,26 @@ const DefaultDashboardInsightWidgetCore: React.FC<
                     )
                 }
                 renderBeforeVisualization={() => (
-                    <InsightMenuButtonComponent
-                        insight={insight}
-                        widget={widget}
-                        isOpen={isMenuOpen}
-                        onClick={openMenu}
-                        items={menuItems}
-                    />
+                    <>
+                        {isSelected && (
+                            <>
+                                <ConfigurationBubble widget={widget}>
+                                    <InsightConfigurationPanel />
+                                </ConfigurationBubble>
+                                <div
+                                    className="dash-item-action dash-item-action-lw-options"
+                                    onClick={() => dispatch(uiActions.setConfigurationPanelOpened(true))}
+                                />
+                            </>
+                        )}
+                        <InsightMenuButtonComponent
+                            insight={insight}
+                            widget={widget}
+                            isOpen={isMenuOpen}
+                            onClick={openMenu}
+                            items={menuItems}
+                        />
+                    </>
                 )}
                 renderAfterContent={() => {
                     if (!isMenuOpen) {


### PR DESCRIPTION
Migrate parts of the Insight config panel. Missing interactions, but to keep it small.

Missing
- interaction section
- drilling

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
