### PR TITLE
RAIL-4359 - Repair of bugs related to NULL value

### DIFF
--- a/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
+++ b/libs/sdk-ui-pivot/src/impl/structure/colLocatorMatching.ts
@@ -1,5 +1,4 @@
 // (C) 2021-2022 GoodData Corporation
-import isNil from "lodash/isNil";
 import {
     DataCol,
     ScopeCol,
@@ -9,13 +8,7 @@ import {
     isRootCol,
     LeafDataCol,
 } from "./tableDescriptorTypes";
-import {
-    ColumnLocator,
-    IAttributeColumnLocator,
-    isAttributeColumnLocator,
-    isMeasureColumnLocator,
-} from "../../columnWidths";
-import invariant from "ts-invariant";
+import { ColumnLocator, isAttributeColumnLocator, isMeasureColumnLocator } from "../../columnWidths";
 import { colMeasureLocalId } from "./colAccessors";
 
 /**
@@ -51,19 +44,14 @@ export function searchForLocatorMatch(
                 );
             });
 
-            if (!matchingLocator) {
+            if (!isAttributeColumnLocator(matchingLocator)) {
                 // if there is no matching attribute locator yet code is on scope col, then it
                 // means there are less attributes in the table than there are attribute locators. the
                 // table has changed yet some sort items hang around. bail out immediately with no match.
                 return undefined;
             }
 
-            const elementToMatch = (matchingLocator as IAttributeColumnLocator).attributeLocatorItem.element;
-            // while the attribute locator has element optional (for wildcard match), all the remaining code always populates
-            // the attribute element.
-            // TODO: revise the API, it may be that it really should not be optional in the interface.
-            invariant(!isNil(elementToMatch));
-
+            const elementToMatch = matchingLocator.attributeLocatorItem.element;
             if (col.header.attributeHeaderItem.uri === elementToMatch) {
                 if (locators.length === 1) {
                     // elements match; see if all locators exhausted. if so, it means the width item does


### PR DESCRIPTION
 - Get `UNKNOWN ERROR` page when Manual resizing column with "NULL" value
 - Get warning message ”Sorry we cann't display this insight” when sorting with "Null" value on header

JIRA: CAL-531, RAIL-4359

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
