### PR TITLE
RELATED: RAIL-4158 optimize KPI with config

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -4865,6 +4865,9 @@ export const selectColorPalette: OutputSelector<DashboardState, IColorPalette, (
 export const selectConfig: OutputSelector<DashboardState, ResolvedDashboardConfig, (res: ConfigState) => ResolvedDashboardConfig>;
 
 // @internal (undocumented)
+export const selectConfigurationPanelOpened: OutputSelector<DashboardState, boolean, (res: UiState) => boolean>;
+
+// @internal (undocumented)
 export const selectConfiguredAndImplicitDrillsByWidgetRef: (ref: ObjRef) => OutputSelector<DashboardState, IImplicitDrillWithPredicates[], (res1: IImplicitDrillWithPredicates[], res2: IImplicitDrillWithPredicates[], res3: IImplicitDrillWithPredicates[]) => IImplicitDrillWithPredicates[]>;
 
 // @internal (undocumented)

--- a/libs/sdk-ui-dashboard/src/_staging/metadata/safeSerializeObjRef.ts
+++ b/libs/sdk-ui-dashboard/src/_staging/metadata/safeSerializeObjRef.ts
@@ -1,0 +1,11 @@
+// (C) 2022 GoodData Corporation
+import { ObjRefInScope, serializeObjRef } from "@gooddata/sdk-model";
+
+/**
+ * Wrapper around {@link @gooddata/sdk-model#serializeObjRef} that can handle undefined values.
+ *
+ * @param ref - ref to serialize
+ */
+export function safeSerializeObjRef(ref: ObjRefInScope | undefined): string {
+    return ref ? serializeObjRef(ref) : "";
+}

--- a/libs/sdk-ui-dashboard/src/model/store/index.ts
+++ b/libs/sdk-ui-dashboard/src/model/store/index.ts
@@ -206,6 +206,7 @@ export {
     selectIsInEditMode,
     selectIsInViewMode,
     selectSelectedWidgetRef,
+    selectConfigurationPanelOpened,
 } from "./ui/uiSelectors";
 export { uiActions } from "./ui";
 export { LegacyDashboardsState } from "./legacyDashboards/legacyDashboardsState";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetFilters.ts
@@ -25,6 +25,7 @@ import {
     useDashboardQueryProcessing,
     useDashboardSelector,
 } from "../../../model";
+import { safeSerializeObjRef } from "../../../_staging/metadata/safeSerializeObjRef";
 
 /**
  * Hook for obtaining the effective filters for a widget.
@@ -91,10 +92,10 @@ export function useWidgetFilters(
 
     // only run the "full" filters query if any of the non-ignored filters has changed
     useEffect(() => {
-        if (widget && nonIgnoredFiltersStatus === "success") {
-            runFiltersQuery(widget, insight);
+        if (widget?.ref && nonIgnoredFiltersStatus === "success") {
+            runFiltersQuery(widget.ref, insight);
         }
-    }, [widget, stringify(nonIgnoredFilters), insight, nonIgnoredFiltersStatus]);
+    }, [safeSerializeObjRef(widget?.ref), stringify(nonIgnoredFilters), insight, nonIgnoredFiltersStatus]);
 
     return {
         result: effectiveFiltersState.filters,
@@ -140,11 +141,11 @@ function useNonIgnoredFilters(widget: ExtendedDashboardWidget | undefined) {
     });
 
     useEffect(() => {
-        if (widget) {
+        if (widget?.ref) {
             // force ignore the insight -> this way we get only the dashboard level filters even for InsightWidgets
-            run(widget, null);
+            run(widget.ref, null);
         }
-    }, [widget, filtersDigest(dashboardFilters, widgetIgnoresDateFilter)]);
+    }, [safeSerializeObjRef(widget?.ref), filtersDigest(dashboardFilters, widgetIgnoresDateFilter)]);
 
     const nonIgnoredFilters = useMemo(
         () =>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
@@ -2,6 +2,7 @@
 import { useCallback } from "react";
 import { areObjRefsEqual, ObjRef } from "@gooddata/sdk-model";
 import {
+    selectConfigurationPanelOpened,
     selectIsInEditMode,
     selectSelectedWidgetRef,
     uiActions,
@@ -22,10 +23,16 @@ export interface IUseWidgetSelectionResult {
      * Callback to call when an item is selected.
      */
     onSelected: () => void;
+    /**
+     * Flag indicating the given item has its config panel open.
+     */
+    hasConfigPanelOpen: boolean;
 }
 
 export function useWidgetSelection(widgetRef: ObjRef | undefined): IUseWidgetSelectionResult {
     const dispatch = useDashboardDispatch();
+
+    const isConfigPanelOpen = useDashboardSelector(selectConfigurationPanelOpened);
 
     const isSelectable = useDashboardSelector(selectIsInEditMode);
 
@@ -45,5 +52,6 @@ export function useWidgetSelection(widgetRef: ObjRef | undefined): IUseWidgetSel
         isSelectable,
         isSelected,
         onSelected,
+        hasConfigPanelOpen: isConfigPanelOpen && isSelected,
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/DashboardKpiCore.tsx
@@ -49,12 +49,7 @@ export const DashboardKpiCore = (props: IDashboardKpiProps): JSX.Element => {
     const separators = useDashboardSelector(selectSeparators);
     const isReadOnly = useDashboardSelector(selectIsReadOnly);
 
-    const kpiData = useKpiData({
-        kpiWidget,
-        backend,
-        dashboardFilters,
-        workspace,
-    });
+    const kpiData = useKpiData({ kpiWidget, dashboardFilters });
 
     if (kpiData.status === "loading" || kpiData.status === "pending") {
         return <LoadingComponent />;

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -114,34 +114,26 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
 
     const kpiWidgetRef = widgetRef(kpiWidget);
 
-    const { error, result, status } = useExecutionDataView(
-        {
-            backend,
-            workspace,
-            execution: {
-                seriesBy: compact([primaryMeasure, secondaryMeasure]),
-                filters: effectiveFilters,
-            },
+    const { error, result, status } = useExecutionDataView({
+        backend,
+        workspace,
+        execution: {
+            seriesBy: compact([primaryMeasure, secondaryMeasure]),
+            filters: effectiveFilters,
         },
-        [primaryMeasure, secondaryMeasure, effectiveFilters, backend, workspace],
-    );
+    });
     const isLoading = status === "loading" || status === "pending";
 
     const {
         error: alertExecutionError,
         result: alertExecutionResult,
         status: alertExecutionStatus,
-    } = useExecutionDataView(
-        {
-            backend,
-            workspace,
-            execution: {
-                seriesBy: [primaryMeasure],
-                filters: effectiveFilters,
-            },
+    } = useExecutionDataView({
+        execution: {
+            seriesBy: [primaryMeasure],
+            filters: effectiveFilters,
         },
-        [primaryMeasure, effectiveFilters, backend, workspace],
-    );
+    });
     const isAlertExecutionLoading = alertExecutionStatus === "loading" || alertExecutionStatus === "pending";
 
     const currentUser = useDashboardSelector(selectCurrentUser);

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
@@ -89,7 +89,9 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
         kpiDataStatus === "pending";
 
     const executionsHandler = useWidgetExecutionsHandler(widgetRef(kpiWidget));
-    const { isSelectable, isSelected, onSelected } = useWidgetSelection(widgetRef(kpiWidget));
+    const { isSelectable, isSelected, onSelected, hasConfigPanelOpen } = useWidgetSelection(
+        widgetRef(kpiWidget),
+    );
 
     useEffect(() => {
         if (error) {
@@ -106,7 +108,7 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
                 "content-loaded": !isLoading,
             })}
             renderBeforeContent={() => {
-                if (isSelected) {
+                if (isSelected && hasConfigPanelOpen) {
                     return (
                         <ConfigurationBubble widget={kpiWidget}>
                             <KpiConfigurationPanel widget={kpiWidget} />
@@ -115,14 +117,17 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
                 }
                 return null;
             }}
-            renderAfterContent={() =>
-                isSelected ? (
-                    <div
-                        className="dash-item-action dash-item-action-delete gd-icon-trash"
-                        onClick={onWidgetDelete}
-                    />
-                ) : null
-            }
+            renderAfterContent={() => {
+                if (isSelected) {
+                    return (
+                        <div
+                            className="dash-item-action dash-item-action-delete gd-icon-trash"
+                            onClick={onWidgetDelete}
+                        />
+                    );
+                }
+                return null;
+            }}
             renderHeadline={(clientHeight) => (
                 <DashboardItemHeadline title={kpiWidget.title} clientHeight={clientHeight} />
             )}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
@@ -75,20 +75,17 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
         dispatch(eagerRemoveSectionItem(coordinates.sectionIndex, coordinates.itemIndex));
     }, [dispatch, coordinates.sectionIndex, coordinates.itemIndex]);
 
-    const { error, result, status } = useExecutionDataView(
-        {
-            backend,
-            workspace,
-            execution:
-                kpiDataStatus === "success"
-                    ? {
-                          seriesBy: compact([primaryMeasure, secondaryMeasure]),
-                          filters: effectiveFilters,
-                      }
-                    : undefined,
-        },
-        [kpiDataStatus, primaryMeasure, secondaryMeasure, effectiveFilters, backend, workspace],
-    );
+    const { error, result, status } = useExecutionDataView({
+        backend,
+        workspace,
+        execution:
+            kpiDataStatus === "success"
+                ? {
+                      seriesBy: compact([primaryMeasure, secondaryMeasure]),
+                      filters: effectiveFilters,
+                  }
+                : undefined,
+    });
 
     const isLoading =
         status === "loading" ||

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
@@ -55,12 +55,7 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
         error: kpiDataError,
         result: kpiDataResult,
         status: kpiDataStatus,
-    } = useKpiData({
-        kpiWidget,
-        backend,
-        dashboardFilters,
-        workspace,
-    });
+    } = useKpiData({ kpiWidget, dashboardFilters });
 
     const { primaryMeasure, secondaryMeasure, effectiveFilters } = kpiDataResult ?? {};
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiConfigurationPanel.tsx
@@ -2,8 +2,8 @@
 import React from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
-import { IKpiWidget, widgetRef } from "@gooddata/sdk-model";
-import { useBackendStrict, useWorkspaceStrict, useCancelablePromise } from "@gooddata/sdk-ui";
+import { IKpiWidget, serializeObjRef, widgetRef } from "@gooddata/sdk-model";
+import { useBackendStrict, useCancelablePromise, useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { Typography } from "@gooddata/sdk-ui-kit";
 import noop from "lodash/noop";
 
@@ -21,6 +21,8 @@ interface IKpiConfigurationPanelProps {
 
 export const KpiConfigurationPanel: React.FC<IKpiConfigurationPanelProps> = (props) => {
     const { widget } = props;
+
+    const ref = widgetRef(widget);
     const metric = widget.kpi.metric;
 
     const backend = useBackendStrict();
@@ -28,18 +30,18 @@ export const KpiConfigurationPanel: React.FC<IKpiConfigurationPanelProps> = (pro
 
     const { result: numberOfAlerts, status } = useCancelablePromise(
         {
-            promise: widgetRef(widget)
+            promise: ref
                 ? async () => {
                       const res = await backend
                           .workspace(workspace)
                           .dashboards()
-                          .getWidgetAlertsCountForWidgets([widgetRef(widget)]);
+                          .getWidgetAlertsCountForWidgets([ref]);
 
                       return res[0]?.alertCount;
                   }
                 : null,
         },
-        [backend, workspace, widget],
+        [backend, workspace, serializeObjRef(ref)],
     );
 
     const isNumOfAlertsLoaded = status === "success";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiConfigurationPanel.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiConfigurationPanel.tsx
@@ -1,11 +1,10 @@
 // (C) 2022 GoodData Corporation
-import React from "react";
+import React, { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import cx from "classnames";
 import { IKpiWidget, serializeObjRef, widgetRef } from "@gooddata/sdk-model";
 import { useBackendStrict, useCancelablePromise, useWorkspaceStrict } from "@gooddata/sdk-ui";
 import { Typography } from "@gooddata/sdk-ui-kit";
-import noop from "lodash/noop";
 
 import { AttributeFilterConfiguration } from "../../../common";
 import { KpiComparison } from "./KpiComparison/KpiComparison";
@@ -14,6 +13,7 @@ import { KpiMetricDropdown } from "./KpiMetricDropdown/KpiMetricDropdown";
 import { KpiConfigurationPanelHeader } from "./KpiConfigurationPanelHeader";
 import { KpiConfigurationMessages } from "./KpiConfigurationMessages";
 import { KpiDrillConfiguration } from "./KpiDrill/KpiDrillConfiguration";
+import { uiActions, useDashboardDispatch } from "../../../../../model";
 
 interface IKpiConfigurationPanelProps {
     widget: IKpiWidget;
@@ -27,6 +27,12 @@ export const KpiConfigurationPanel: React.FC<IKpiConfigurationPanelProps> = (pro
 
     const backend = useBackendStrict();
     const workspace = useWorkspaceStrict();
+    const dispatch = useDashboardDispatch();
+
+    const closeConfigPanel = useCallback(
+        () => dispatch(uiActions.setConfigurationPanelOpened(false)),
+        [dispatch],
+    );
 
     const { result: numberOfAlerts, status } = useCancelablePromise(
         {
@@ -54,11 +60,7 @@ export const KpiConfigurationPanel: React.FC<IKpiConfigurationPanelProps> = (pro
 
     return (
         <>
-            <KpiConfigurationPanelHeader
-                onCloseButtonClick={
-                    noop // TODO
-                }
-            />
+            <KpiConfigurationPanelHeader onCloseButtonClick={closeConfigPanel} />
             <div className="configuration-panel">
                 <div className={configurationCategoryClasses}>
                     <KpiConfigurationMessages numberOfAlerts={numberOfAlerts} />

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardWidget.tsx
@@ -17,6 +17,7 @@ import { IDashboardWidgetProps } from "./types";
 import { DashboardKpi } from "../kpi/DashboardKpi";
 import { DefaultDashboardInsightWidget } from "./DefaultDashboardInsightWidget";
 import { useWidgetSelection } from "../common/useWidgetSelection";
+import { safeSerializeObjRef } from "../../../_staging/metadata/safeSerializeObjRef";
 
 /**
  * @internal
@@ -71,7 +72,7 @@ export const DefaultDashboardWidget = (props: IDashboardWidgetProps): JSX.Elemen
                 onError(error, executionId);
             },
         });
-    }, [effectiveBackend, dispatchEvent, widgetRef]);
+    }, [effectiveBackend, dispatchEvent, safeSerializeObjRef(widgetRef)]);
 
     if (!isDashboardWidget(widget)) {
         throw new UnexpectedError(


### PR DESCRIPTION
Prevents unnecessary network requests and reloads in both View and Edit KPIs.
Some of the changes should even make insights better (the useWidgetFilters optimization).

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
