### PR TITLE
RELATED: RAIL-4377 Fix handling of KPIs with empty response format

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/DefaultDashboardKpi/KpiExecutor.tsx
@@ -1,7 +1,6 @@
 // (C) 2020-2022 GoodData Corporation
 import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useIntl } from "react-intl";
-import compact from "lodash/compact";
 import { IAnalyticalBackend, IDataView, IUserWorkspaceSettings } from "@gooddata/sdk-backend-spi";
 import {
     IMeasure,
@@ -22,7 +21,6 @@ import {
     isSomeHeaderPredicateMatched,
     NoDataSdkError,
     OnError,
-    useExecutionDataView,
 } from "@gooddata/sdk-ui";
 
 import { filterContextItemsToDashboardFiltersByWidget } from "../../../../converters";
@@ -59,6 +57,7 @@ import {
     getKpiResult,
     KpiRenderer,
     stripDateDatasets,
+    useKpiExecutionDataView,
 } from "../common";
 
 interface IKpiExecutorProps {
@@ -114,13 +113,13 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
 
     const kpiWidgetRef = widgetRef(kpiWidget);
 
-    const { error, result, status } = useExecutionDataView({
+    const { error, result, status } = useKpiExecutionDataView({
         backend,
         workspace,
-        execution: {
-            seriesBy: compact([primaryMeasure, secondaryMeasure]),
-            filters: effectiveFilters,
-        },
+        primaryMeasure,
+        secondaryMeasure,
+        effectiveFilters,
+        shouldLoad: true,
     });
     const isLoading = status === "loading" || status === "pending";
 
@@ -128,11 +127,12 @@ const KpiExecutorCore: React.FC<IKpiExecutorProps> = (props) => {
         error: alertExecutionError,
         result: alertExecutionResult,
         status: alertExecutionStatus,
-    } = useExecutionDataView({
-        execution: {
-            seriesBy: [primaryMeasure],
-            filters: effectiveFilters,
-        },
+    } = useKpiExecutionDataView({
+        backend,
+        workspace,
+        primaryMeasure,
+        effectiveFilters,
+        shouldLoad: true,
     });
     const isAlertExecutionLoading = alertExecutionStatus === "loading" || alertExecutionStatus === "pending";
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/EditableDashboardKpi.tsx
@@ -2,10 +2,9 @@
 import React, { useCallback, useEffect } from "react";
 import cx from "classnames";
 import { useIntl } from "react-intl";
-import compact from "lodash/compact";
 import noop from "lodash/noop";
 import { widgetRef } from "@gooddata/sdk-model";
-import { useBackendStrict, useExecutionDataView, useWorkspaceStrict } from "@gooddata/sdk-ui";
+import { useBackendStrict, useWorkspaceStrict } from "@gooddata/sdk-ui";
 
 import {
     useDashboardSelector,
@@ -24,7 +23,7 @@ import { useDashboardComponentsContext } from "../../../dashboardContexts";
 import { useWidgetSelection } from "../../common/useWidgetSelection";
 import { ConfigurationBubble } from "../../common";
 import { KpiConfigurationPanel } from "./KpiConfigurationPanel/KpiConfigurationPanel";
-import { getKpiResult, KpiRenderer, useKpiData } from "../common";
+import { getKpiResult, KpiRenderer, useKpiData, useKpiExecutionDataView } from "../common";
 import { IDashboardKpiProps } from "../types";
 
 export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
@@ -70,16 +69,13 @@ export const EditableDashboardKpi = (props: IDashboardKpiProps) => {
         dispatch(eagerRemoveSectionItem(coordinates.sectionIndex, coordinates.itemIndex));
     }, [dispatch, coordinates.sectionIndex, coordinates.itemIndex]);
 
-    const { error, result, status } = useExecutionDataView({
+    const { error, result, status } = useKpiExecutionDataView({
         backend,
         workspace,
-        execution:
-            kpiDataStatus === "success"
-                ? {
-                      seriesBy: compact([primaryMeasure, secondaryMeasure]),
-                      filters: effectiveFilters,
-                  }
-                : undefined,
+        primaryMeasure,
+        secondaryMeasure,
+        effectiveFilters,
+        shouldLoad: kpiDataStatus === "success",
     });
 
     const isLoading =

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/index.ts
@@ -4,3 +4,4 @@ export { KpiRenderer } from "./KpiRenderer";
 export * from "./resultUtils";
 export * from "./types";
 export { useKpiData } from "./useKpiData";
+export { useKpiExecutionDataView } from "./useKpiExecutionDataView";

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiExecutionDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiExecutionDataView.ts
@@ -1,0 +1,67 @@
+// (C) 2022 GoodData Corporation
+import { useMemo } from "react";
+import { IAnalyticalBackend, isNoDataError } from "@gooddata/sdk-backend-spi";
+import { IMeasure, IPoPMeasureDefinition, IPreviousPeriodMeasureDefinition } from "@gooddata/sdk-model";
+import {
+    DataViewFacade,
+    GoodDataSdkError,
+    isNoDataSdkError,
+    UseCancelablePromiseState,
+    useExecutionDataView,
+} from "@gooddata/sdk-ui";
+import compact from "lodash/compact";
+
+import { IDashboardFilter } from "../../../../types";
+
+interface IUseKpiExecutionDataViewConfig {
+    backend?: IAnalyticalBackend;
+    workspace?: string;
+    primaryMeasure?: IMeasure;
+    secondaryMeasure?: IMeasure<IPoPMeasureDefinition> | IMeasure<IPreviousPeriodMeasureDefinition>;
+    effectiveFilters?: IDashboardFilter[];
+    /**
+     * If false, the loading will not be attempted. This is useful for when you want to wait for some other load first.
+     */
+    shouldLoad: boolean;
+}
+
+/**
+ * Wrapper around useExecutionDataView that does not treat no data errors as errors.
+ * This allows formats for empty values to come into play when no data is returned.
+ */
+export function useKpiExecutionDataView(
+    config: IUseKpiExecutionDataViewConfig,
+): UseCancelablePromiseState<DataViewFacade, GoodDataSdkError> {
+    const { primaryMeasure, backend, effectiveFilters, secondaryMeasure, workspace, shouldLoad } = config;
+
+    const response = useExecutionDataView({
+        backend,
+        workspace,
+        execution: shouldLoad
+            ? {
+                  seriesBy: compact([primaryMeasure, secondaryMeasure]),
+                  filters: effectiveFilters,
+              }
+            : undefined,
+    });
+
+    return useMemo<UseCancelablePromiseState<DataViewFacade, GoodDataSdkError>>(() => {
+        // do not treat no data as error here to give the user a chance to decide if no data is ok or not
+        // instead return facade for the empty dataView provided by the error (it still has useful info
+        // like measure format, name, etc.)
+        if (
+            response.status === "error" &&
+            isNoDataSdkError(response.error) &&
+            isNoDataError(response.error.cause) &&
+            response.error.cause.dataView
+        ) {
+            return {
+                result: DataViewFacade.for(response.error.cause.dataView!),
+                error: undefined,
+                status: "success",
+            };
+        }
+
+        return response;
+    }, [response]);
+}


### PR DESCRIPTION
This mimics what the withExecution HOC does.

JIRA: RAIL-4377

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
