### PR TITLE
RELATED: RAIL-4379 Allow passing only slicesBy to Execute

### DIFF
--- a/libs/sdk-ui/api/sdk-ui.api.md
+++ b/libs/sdk-ui/api/sdk-ui.api.md
@@ -951,7 +951,7 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
     LoadingComponent?: IExecuteLoadingComponent;
     loadOnMount?: boolean;
     placeholdersResolutionContext?: any;
-    seriesBy: AttributesMeasuresOrPlaceholders;
+    seriesBy?: AttributesMeasuresOrPlaceholders;
     slicesBy?: AttributesOrPlaceholders;
     sortBy?: SortsOrPlaceholders;
     totals?: TotalsOrPlaceholders;

--- a/libs/sdk-ui/src/execution/Execute.tsx
+++ b/libs/sdk-ui/src/execution/Execute.tsx
@@ -13,6 +13,7 @@ import {
     TotalsOrPlaceholders,
     NullableFiltersOrPlaceholders,
     SortsOrPlaceholders,
+    UnexpectedSdkError,
 } from "../base";
 import { createExecution } from "./createExecution";
 import { IExecuteErrorComponent, IExecuteLoadingComponent } from "./interfaces";
@@ -44,7 +45,7 @@ export interface IExecuteProps extends IWithLoadingEvents<IExecuteProps> {
      * Data series will be built using the provided measures that are further scoped for
      * elements of the specified attributes.
      */
-    seriesBy: AttributesMeasuresOrPlaceholders;
+    seriesBy?: AttributesMeasuresOrPlaceholders;
 
     /**
      * Slice all data series by elements of these attributes.
@@ -182,6 +183,12 @@ const WrappedExecute = withContexts(
         exportTitle,
         execution: (props) => {
             const { seriesBy, slicesBy, totals, filters, sortBy } = props;
+            if (!seriesBy?.length && !slicesBy?.length) {
+                throw new UnexpectedSdkError(
+                    "In the Execute component, either seriesBy or slicesBy must be defined and must contain at least one item",
+                );
+            }
+
             return createExecution({
                 ...props,
                 componentName: componentName(props),

--- a/libs/sdk-ui/src/execution/createExecution.ts
+++ b/libs/sdk-ui/src/execution/createExecution.ts
@@ -41,7 +41,7 @@ export type CreateExecutionOptions = {
      * Data series will be built using the provided measures that are further scoped for
      * elements of the specified attributes.
      */
-    seriesBy: IAttributeOrMeasure[];
+    seriesBy?: IAttributeOrMeasure[];
 
     /**
      * Slice all data series by elements of these attributes.
@@ -123,7 +123,7 @@ export function createExecution(options: CreateExecutionOptions): IPreparedExecu
     const {
         backend,
         workspace,
-        seriesBy,
+        seriesBy = [],
         slicesBy = [],
         filters = [],
         sortBy = [],

--- a/libs/sdk-ui/src/execution/tests/Execute.test.tsx
+++ b/libs/sdk-ui/src/execution/tests/Execute.test.tsx
@@ -216,6 +216,25 @@ describe("Execute", () => {
             }),
         );
     });
+
+    it("should throw if neither seriesBy not slicesBy have any elements", async () => {
+        const mounted = mount(
+            <Execute backend={DummyBackendEmptyData} workspace={"testWorkspace"}>
+                {({ error }) => {
+                    if (error) {
+                        return <div className="my-error">ERROR</div>;
+                    }
+                    return null;
+                }}
+            </Execute>,
+        );
+
+        await createDummyPromise({ delay: 100 });
+
+        mounted.update();
+
+        expect(mounted).toContainMatchingElement(".my-error");
+    });
 });
 
 describe("createExecution", () => {


### PR DESCRIPTION
This aligns it to ExecuteInsight that can already process insights without measures. This is useful for example for tables that only have rows and columns defined.

JIRA: RAIL-4379

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
