### PR TITLE
RELATED: RAIL-4158 filter config fixes

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetFilter.tsx
@@ -8,13 +8,14 @@ import { useDashboardSelector, selectAllCatalogDateDatasetsMap } from "../../../
 import { DateDatasetPicker } from "./DateDatasetPicker";
 import { getUnrelatedDateDataset } from "./utils";
 import { useDateFilterConfigurationHandling } from "./useDateFilterConfigurationHandling";
+import { useIsSelectedDatasetHidden } from "./useIsSelectedDatasetHidden";
 
 const CONFIG_PANEL_DATE_FILTER_WIDTH = 159;
 
 interface IDateDatasetFilterProps {
     widget: IWidget;
     relatedDateDatasets: ICatalogDateDataset[] | undefined;
-    isDropdownLoading: boolean;
+    isDatasetsLoading: boolean;
 
     dateFromVisualization?: ICatalogDateDataset;
     dateFilterCheckboxDisabled: boolean;
@@ -26,12 +27,14 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
         widget,
         dateFilterCheckboxDisabled,
         dateFromVisualization,
-        isDropdownLoading,
+        isDatasetsLoading,
     } = props;
 
     const catalogDatasetsMap = useDashboardSelector(selectAllCatalogDateDatasetsMap);
     const selectedDateDataset = widget.dateDataSet && catalogDatasetsMap.get(widget.dateDataSet);
-    const selectedDateDatasetHiddenByObjectAvailability = false; // TODO we need to resolve tags here, but ICatalogDateDataset has no tags...
+
+    const { selectedDateDatasetHiddenByObjectAvailability, status: visibleDateDatasetsStatus } =
+        useIsSelectedDatasetHidden(selectedDateDataset?.dataSet.ref);
 
     const [isDateFilterEnabled, setIsDateFilterEnabled] = useState(!!widget.dateDataSet);
 
@@ -42,6 +45,7 @@ export const DateDatasetFilter: React.FC<IDateDatasetFilterProps> = (props) => {
     );
 
     const isFilterLoading = status === "loading";
+    const isDropdownLoading = isDatasetsLoading || visibleDateDatasetsStatus === "loading";
 
     const shouldRenderDateDataSetsDropdown =
         !dateFilterCheckboxDisabled &&

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/DateDatasetPicker.tsx
@@ -48,7 +48,7 @@ export const DateDatasetPicker: React.FC<IDateDatasetPickerProps> = (props) => {
                 widgetRef={widget.ref}
                 className="s-filter-date-dropdown"
                 relatedDateDatasets={relatedDateDatasets ?? []}
-                activeDateDataset={selectedDateDataset}
+                activeDateDataset={selectedDateDatasetHidden ? undefined : selectedDateDataset}
                 unrelatedDateDataset={unrelatedDateDataset}
                 dateFromVisualization={dateFromVisualization}
                 onDateDatasetChange={onDateDatasetChange}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/useIsSelectedDatasetHidden.ts
@@ -1,0 +1,59 @@
+// (C) 2022 GoodData Corporation
+import { useMemo } from "react";
+import { areObjRefsEqual, idRef, ObjRef } from "@gooddata/sdk-model";
+
+import {
+    useDashboardSelector,
+    selectObjectAvailabilityConfig,
+    selectCatalogDateDatasets,
+} from "../../../../model";
+import { useBackendStrict, useCancelablePromise, useWorkspaceStrict } from "@gooddata/sdk-ui";
+import { safeSerializeObjRef } from "../../../../_staging/metadata/safeSerializeObjRef";
+
+export function useIsSelectedDatasetHidden(selectedDateDatasetRef: ObjRef | undefined) {
+    const backend = useBackendStrict();
+    const workspace = useWorkspaceStrict();
+
+    const allDateDatasets = useDashboardSelector(selectCatalogDateDatasets);
+    const objectAvailability = useDashboardSelector(selectObjectAvailabilityConfig);
+
+    const hasObjectAvailability = !!(
+        objectAvailability.excludeObjectsWithTags?.length || objectAvailability.includeObjectsWithTags?.length
+    );
+
+    const { result: visibleDateDatasets, status } = useCancelablePromise(
+        {
+            promise: hasObjectAvailability
+                ? async () => {
+                      const catalog = await backend
+                          .workspace(workspace)
+                          .catalog()
+                          .forTypes(["dateDataset"])
+                          .excludeTags(
+                              (objectAvailability.excludeObjectsWithTags ?? []).map((tag) => idRef(tag)),
+                          )
+                          .includeTags(
+                              (objectAvailability.includeObjectsWithTags ?? []).map((tag) => idRef(tag)),
+                          )
+                          .load();
+
+                      return catalog.dateDatasets();
+                  }
+                : () => Promise.resolve(allDateDatasets),
+        },
+        [backend, workspace, objectAvailability],
+    );
+
+    const selectedDateDatasetHiddenByObjectAvailability = useMemo(() => {
+        if (!visibleDateDatasets) {
+            return false;
+        }
+
+        return !visibleDateDatasets.some((ds) => areObjRefsEqual(selectedDateDatasetRef, ds.dataSet.ref));
+    }, [safeSerializeObjRef(selectedDateDatasetRef), visibleDateDatasets]);
+
+    return {
+        selectedDateDatasetHiddenByObjectAvailability,
+        status,
+    };
+}

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insight/configuration/InsightDateDataSetFilter.tsx
@@ -42,7 +42,7 @@ export default function InsightDateDataSetFilter({ widget }: IConfigurationPanel
             <DateDatasetFilter
                 widget={widget}
                 dateFilterCheckboxDisabled={false}
-                isDropdownLoading={status === "loading" || status === "pending"}
+                isDatasetsLoading={status === "loading" || status === "pending"}
                 relatedDateDatasets={result}
             />
         );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/EditableDashboardKpi/KpiConfigurationPanel/KpiWidgetDateDatasetFilter.tsx
@@ -14,7 +14,7 @@ export const KpiWidgetDateDatasetFilter: React.FC<{
             <DateDatasetFilter
                 widget={widget}
                 dateFilterCheckboxDisabled={false} // for KPI date checkbox is always enabled
-                isDropdownLoading={status === "loading" || status === "pending"}
+                isDatasetsLoading={status === "loading" || status === "pending"}
                 relatedDateDatasets={result}
             />
         </div>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiData.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/kpi/common/useKpiData.ts
@@ -106,25 +106,15 @@ function getSecondaryMeasure(
         !effectiveFilters ||
         !effectiveFilters.some((filter) => isDateFilter(filter) && !isAllTimeDateFilter(filter));
 
-    if (comparison === "none" || isAllTime) {
+    if (comparison === "none" || isAllTime || !kpiWidget.dateDataSet) {
         return undefined;
     }
 
     if (comparison === "previousPeriod") {
-        invariant(
-            kpiWidget.dateDataSet,
-            "Inconsistent KPI in useKpiData, it has comparison but not dateDataset",
-        );
-
         return newPreviousPeriodMeasure(primaryMeasure, [{ dataSet: kpiWidget.dateDataSet, periodsAgo: 1 }]);
     }
 
     if (comparison === "lastYear") {
-        invariant(
-            kpiWidget.dateDataSet,
-            "Inconsistent KPI in useKpiData, it has comparison but not dateDataset",
-        );
-
         const relevantDateDataset = dateDatasetsMap.get(kpiWidget.dateDataSet);
 
         invariant(relevantDateDataset, "Cannot find relevant date dataset in useKpiData");


### PR DESCRIPTION
* respect object visibility for date datasets
* allow changes to config that is already invalid
* fix useKpiData hook

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
