### PR TITLE
RELATED: RAIL-4382 Use side effects properly

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useCustomWidgetInsightDataView.ts
@@ -1,5 +1,5 @@
 // (C) 2022 GoodData Corporation
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { IInsightDefinition, insightSetFilters, isInsight, ObjRef } from "@gooddata/sdk-model";
 import {
     DataViewFacade,
@@ -121,6 +121,12 @@ export function useCustomWidgetInsightDataView({
         onSuccess,
     });
 
+    useEffect(() => {
+        if (filterQueryTask.status === "error") {
+            onError?.(filterQueryTask.error);
+        }
+    }, [filterQueryTask.error, filterQueryTask.status, onError]);
+
     // insight non-success status has precedence, other things cannot run without an insight
     if (
         effectiveInsightTask.status === "error" ||
@@ -151,9 +157,6 @@ export function useCustomWidgetInsightDataView({
     }
 
     if (filterQueryTask.status === "error" || dataViewTask.status === "error") {
-        if (filterQueryTask.status === "error") {
-            onError?.(filterQueryTask.error);
-        }
         return {
             error: (dataViewTask.error ?? filterQueryTask.error)!,
             result: undefined,


### PR DESCRIPTION
The side effect needs to be in useEffect, not called directly
in the hook body.

JIRA: RAIL-4382

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
