### PR TITLE
RELATED: RAIL-4293 Fix loadNextElementsPage in AttributeFilterHandler

### DIFF
--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/bridge.ts
@@ -73,7 +73,7 @@ import {
     selectIsWorkingSelectionChanged,
     selectIsWorkingSelectionEmpty,
     selectOffset,
-    isLoadElementsOptionsChanged,
+    selectIsLoadElementsOptionsChanged,
 } from "./redux";
 import { newAttributeFilterCallbacks } from "./callbacks";
 import { AttributeFilterHandlerConfig } from "./types";
@@ -501,6 +501,6 @@ export class AttributeFilterReduxBridge {
     };
 
     isLoadElementsOptionsChanged = (): boolean => {
-        return this.redux.select(isLoadElementsOptionsChanged);
+        return this.redux.select(selectIsLoadElementsOptionsChanged);
     };
 }

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsSelectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/elements/elementsSelectors.ts
@@ -2,7 +2,6 @@
 import { IAttributeElement } from "@gooddata/sdk-model";
 import { createSelector } from "@reduxjs/toolkit";
 import invariant from "ts-invariant";
-import isEqual from "lodash/isEqual";
 
 import { ILoadElementsOptions } from "../../../types";
 import { selectState } from "../common/selectors";
@@ -133,14 +132,3 @@ export const selectLoadElementsOptions = createSelector(
 export const selectLastLoadedElementsOptions = createSelector(selectState, (state): ILoadElementsOptions => {
     return state.elements.lastLoadedOptions;
 });
-
-/**
- * @internal
- */
-export const isLoadElementsOptionsChanged = createSelector(
-    selectLoadElementsOptions,
-    selectLastLoadedElementsOptions,
-    (loadOptions, lastLoadedOptions) => {
-        return !isEqual(loadOptions, lastLoadedOptions);
-    },
-);

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initSelectionSaga.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/init/initSelectionSaga.ts
@@ -22,6 +22,8 @@ export function* initSelectionSaga(correlation: Correlation): SagaIterator<void>
         return;
     }
 
+    const initSelectionCorrelation = `initSelection_${correlation}`;
+
     yield fork(
         loadCustomElementsSaga,
         actions.loadCustomElementsRequest({
@@ -31,7 +33,7 @@ export function* initSelectionSaga(correlation: Correlation): SagaIterator<void>
                 limit: 550,
                 search: undefined,
             },
-            correlation,
+            correlation: initSelectionCorrelation,
         }),
     );
 
@@ -44,15 +46,18 @@ export function* initSelectionSaga(correlation: Correlation): SagaIterator<void>
     } = yield race({
         success: take(
             (a: AnyAction) =>
-                actions.loadCustomElementsSuccess.match(a) && a.payload.correlation === correlation,
+                actions.loadCustomElementsSuccess.match(a) &&
+                a.payload.correlation === initSelectionCorrelation,
         ),
         error: take(
             (a: AnyAction) =>
-                actions.loadCustomElementsError.match(a) && a.payload.correlation === correlation,
+                actions.loadCustomElementsError.match(a) &&
+                a.payload.correlation === initSelectionCorrelation,
         ),
         cancel: take(
             (a: AnyAction) =>
-                actions.loadCustomElementsCancel.match(a) && a.payload.correlation === correlation,
+                actions.loadCustomElementsCancel.match(a) &&
+                a.payload.correlation === initSelectionCorrelation,
         ),
     });
 

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageReducers.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageReducers.ts
@@ -30,9 +30,7 @@ const loadNextElementsPageSuccess: AttributeFilterReducer<
         }
     });
     state.elements.data = state.elements.data.concat(action.payload.elements.map((data) => data.uri));
-    state.elements.currentOptions.offset =
-        state.elements.currentOptions.offset + state.elements.currentOptions.limit;
-    state.elements.lastLoadedOptions = state.elements.currentOptions;
+    state.elements.lastLoadedOptions = action.payload.options;
 };
 
 const loadNextElementsPageError: AttributeFilterReducer<

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageSaga.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageSaga.ts
@@ -4,7 +4,7 @@ import { put, call, takeLatest, select, cancelled } from "redux-saga/effects";
 
 import { elementsSaga } from "../elements/elementsSaga";
 import { actions } from "../store/slice";
-import { selectLoadNextElementsPageOptions } from "./loadNextElementsPageSelectors";
+import { selectHasNextPage, selectLoadNextElementsPageOptions } from "./loadNextElementsPageSelectors";
 
 /**
  * @internal
@@ -40,6 +40,12 @@ export function* loadNextElementsPageSaga(
     const {
         payload: { correlation },
     } = action;
+
+    const hasNextPage: ReturnType<typeof selectHasNextPage> = yield select(selectHasNextPage);
+
+    if (!hasNextPage) {
+        return;
+    }
 
     try {
         yield put(actions.loadNextElementsPageStart({ correlation }));

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageSelectors.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/internal/redux/loadNextElementsPage/loadNextElementsPageSelectors.ts
@@ -1,8 +1,14 @@
 // (C) 2021-2022 GoodData Corporation
 import { createSelector } from "@reduxjs/toolkit";
+import isEqual from "lodash/isEqual";
+import omit from "lodash/omit";
 
 import { selectState } from "../common/selectors";
-import { selectLoadElementsOptions } from "../elements/elementsSelectors";
+import {
+    selectElementsTotalCount,
+    selectLastLoadedElementsOptions,
+    selectLoadElementsOptions,
+} from "../elements/elementsSelectors";
 import { ILoadElementsOptions } from "../../../types";
 
 /**
@@ -31,5 +37,27 @@ export const selectLoadNextElementsPageOptions = createSelector(
             ...options,
             offset: options.offset + options.limit,
         };
+    },
+);
+
+/**
+ * @internal
+ */
+export const selectHasNextPage = createSelector(
+    selectLastLoadedElementsOptions,
+    selectElementsTotalCount,
+    (lastLoadedOptions, totalCount) => {
+        return lastLoadedOptions.offset + lastLoadedOptions.limit < totalCount;
+    },
+);
+
+/**
+ * @internal
+ */
+export const selectIsLoadElementsOptionsChanged = createSelector(
+    selectLoadElementsOptions,
+    selectLastLoadedElementsOptions,
+    (loadOptions, lastLoadedOptions) => {
+        return !isEqual(omit(loadOptions, "offset"), omit(lastLoadedOptions, "offset"));
     },
 );

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadNextElementsPage.test.ts.snap
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/test/__snapshots__/loadNextElementsPage.test.ts.snap
@@ -67,13 +67,22 @@ exports[`AttributeFilterHandler loadNextElementsPage() that was successful shoul
 Array [
   Object {
     "correlation": "success",
-    "elements": Array [],
+    "elements": Array [
+      Object {
+        "title": "Explorer",
+        "uri": "/gdc/md/referenceworkspace/obj/1054/elements?id=342345",
+      },
+      Object {
+        "title": "Grammar Plus",
+        "uri": "/gdc/md/referenceworkspace/obj/1054/elements?id=168737",
+      },
+    ],
     "options": Object {
-      "limit": 550,
+      "limit": 2,
       "limitingAttributeFilters": undefined,
       "limitingDateFilters": undefined,
       "limitingMeasures": undefined,
-      "offset": 550,
+      "offset": 2,
       "order": undefined,
       "search": "",
     },

--- a/libs/sdk-ui-filters/src/AttributeFilterHandler/test/loadNextElementsPage.test.ts
+++ b/libs/sdk-ui-filters/src/AttributeFilterHandler/test/loadNextElementsPage.test.ts
@@ -14,6 +14,7 @@ describe("AttributeFilterHandler", () => {
         const onLoadNextElementsPageStart = jest.fn();
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 
@@ -26,10 +27,26 @@ describe("AttributeFilterHandler", () => {
         expect(onLoadNextElementsPageStart.mock.calls[0]).toMatchSnapshot("with parameters");
     });
 
+    it("loadNextElementsPage() should not trigger onLoadNextElementsPageStart() callback, when all elements are loaded", async () => {
+        const onLoadNextElementsPageStart = jest.fn();
+        const attributeFilterHandler = newTestAttributeFilterHandler("positive");
+
+        attributeFilterHandler.init();
+        await waitForAsync();
+
+        attributeFilterHandler.onLoadNextElementsPageStart(onLoadNextElementsPageStart);
+        attributeFilterHandler.loadNextElementsPage();
+
+        await waitForAsync();
+
+        expect(onLoadNextElementsPageStart).toHaveBeenCalledTimes(0);
+    });
+
     it("loadNextElementsPage() that was successful should trigger onLoadNextElementsPageSuccess() callback", async () => {
         const onLoadNextElementsPageSuccess = jest.fn();
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 
@@ -46,6 +63,7 @@ describe("AttributeFilterHandler", () => {
         const onLoadNextElementsPageError = jest.fn();
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 
@@ -63,6 +81,7 @@ describe("AttributeFilterHandler", () => {
         const onLoadNextElementsPageCancel = jest.fn();
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 
@@ -80,6 +99,7 @@ describe("AttributeFilterHandler", () => {
         const onLoadNextElementsPageCancel = jest.fn();
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 
@@ -201,6 +221,7 @@ describe("AttributeFilterHandler", () => {
     it("getNextElementsPageError() should return error", async () => {
         const attributeFilterHandler = newTestAttributeFilterHandler("positive");
 
+        attributeFilterHandler.setLimit(2);
         attributeFilterHandler.init();
         await waitForAsync();
 


### PR DESCRIPTION
- Correct paging logic
- Do not fire load when all elements are loaded
- Fix validation of the changed elements load options
- Fix clashing init correlations

RAIL-4231

<!--

Description of changes.

-->

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
