### PR TITLE
RELATED: RAIL-4391 fix insight menu, partially refine widget definitions

### DIFF
--- a/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
+++ b/libs/sdk-ui-dashboard/api/sdk-ui-dashboard.api.md
@@ -3992,10 +3992,10 @@ export interface LayoutState extends UndoEnhancedState<DashboardLayoutCommands> 
 }
 
 // @internal (undocumented)
-export const LegacyDashboardInsightMenu: (props: IDashboardInsightMenuProps) => JSX.Element;
+export const LegacyDashboardInsightMenu: ComponentType<PropsWithChildren<IDashboardInsightMenuProps> | (IDashboardInsightMenuProps & RefAttributes<Component<IDashboardInsightMenuProps, any, any>>)>;
 
 // @internal (undocumented)
-export const LegacyDashboardInsightMenuButton: (props: IDashboardInsightMenuButtonProps) => JSX.Element;
+export const LegacyDashboardInsightMenuButton: ComponentType<PropsWithChildren<IDashboardInsightMenuButtonProps> | (IDashboardInsightMenuButtonProps & RefAttributes<Component<IDashboardInsightMenuButtonProps, any, any>>)>;
 
 // @alpha (undocumented)
 export interface LegacyDashboardsState {

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/configuration/ConfigurationBubble.tsx
@@ -6,6 +6,8 @@ import { ArrowDirections, ArrowOffsets, Bubble, IAlignPoint } from "@gooddata/sd
 
 interface IConfigurationBubbleProps {
     widget: IWidget;
+    classNames?: string;
+    onClose?: () => void;
 }
 
 const alignPoints: IAlignPoint[] = [
@@ -30,29 +32,27 @@ const arrowDirections: ArrowDirections = {
 };
 
 export const ConfigurationBubble: React.FC<IConfigurationBubbleProps> = (props) => {
-    const { children } = props;
+    const { children, classNames, onClose } = props;
     // const [configMenuDisplay, setConfigMenuDisplay] = useState(false);
-
-    const classNames = cx(
-        "bubble-light gd-configuration-bubble s-gd-configuration-bubble",
-        // getEditInsightClassNames(widget, !configMenuDisplay),
-        {
-            // "is-sticky": props.isSticky,
-        },
-    );
-
-    const overlayClassNames = cx("gd-configuration-bubble-wrapper", {
-        // "is-sticky": props.isSticky,
-    });
 
     return (
         <Bubble
-            className={classNames}
-            overlayClassName={overlayClassNames}
+            className={cx(
+                "bubble-light gd-configuration-bubble s-gd-configuration-bubble",
+                classNames,
+                // getEditInsightClassNames(widget, !configMenuDisplay),
+                {
+                    // "is-sticky": props.isSticky,
+                },
+            )}
+            overlayClassName={cx("gd-configuration-bubble-wrapper", {
+                // "is-sticky": props.isSticky,
+            })}
             alignTo={".s-dash-item.is-selected"}
             alignPoints={alignPoints}
             arrowOffsets={arrowOffsets}
             arrowDirections={arrowDirections}
+            onClose={onClose}
         >
             {children}
         </Bubble>

--- a/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/common/useWidgetSelection.tsx
@@ -24,6 +24,10 @@ export interface IUseWidgetSelectionResult {
      */
     onSelected: () => void;
     /**
+     * Callback to call when you want to close the config panel.
+     */
+    closeConfigPanel: () => void;
+    /**
      * Flag indicating the given item has its config panel open.
      */
     hasConfigPanelOpen: boolean;
@@ -41,6 +45,10 @@ export function useWidgetSelection(widgetRef: ObjRef | undefined): IUseWidgetSel
         isSelectable && selectedWidget && widgetRef && areObjRefsEqual(selectedWidget, widgetRef),
     );
 
+    const closeConfigPanel = useCallback(() => {
+        dispatch(uiActions.setConfigurationPanelOpened(false));
+    }, [dispatch]);
+
     const onSelected = useCallback(() => {
         if (isSelectable && widgetRef) {
             dispatch(uiActions.selectWidget(widgetRef));
@@ -53,5 +61,6 @@ export function useWidgetSelection(widgetRef: ObjRef | undefined): IUseWidgetSel
         isSelected,
         onSelected,
         hasConfigPanelOpen: isConfigPanelOpen && isSelected,
+        closeConfigPanel,
     };
 }

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/DashboardInsightMenuBubble.tsx
@@ -1,0 +1,57 @@
+// (C) 2021-2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+import { stringUtils } from "@gooddata/util";
+
+import { IWidget, objRefToString, widgetRef } from "@gooddata/sdk-model";
+import { ArrowDirections, ArrowOffsets, Bubble, IAlignPoint } from "@gooddata/sdk-ui-kit";
+
+const alignPoints: IAlignPoint[] = [
+    { align: "tr tl" },
+    { align: "br bl" },
+    { align: "tl tr" },
+    { align: "tr tr" },
+    { align: "br br" },
+];
+
+const arrowDirections: ArrowDirections = {
+    "tr tr": "right",
+    "br br": "right",
+};
+
+const arrowOffsets: ArrowOffsets = {
+    "tr tl": [20, 0],
+    "tl tr": [-20, 0],
+};
+
+interface IDashboardInsightMenuBubbleProps {
+    widget: IWidget;
+    onClose: () => void;
+}
+
+export const DashboardInsightMenuBubble: React.FC<IDashboardInsightMenuBubbleProps> = (props) => {
+    const { onClose, widget, children } = props;
+    const widgetRefAsString = objRefToString(widgetRef(widget));
+
+    return (
+        <Bubble
+            alignTo={`.dash-item-action-widget-options-${stringUtils.simplifyText(widgetRefAsString)}`}
+            alignPoints={alignPoints}
+            arrowDirections={arrowDirections}
+            arrowOffsets={arrowOffsets}
+            className={cx(
+                "bubble-light",
+                "gd-configuration-bubble",
+                "edit-insight-config",
+                "s-edit-insight-config",
+                "edit-insight-config-arrow-color",
+                "edit-insight-config-title-1-line",
+            )}
+            closeOnOutsideClick
+            onClose={onClose}
+            overlayClassName="gd-configuration-bubble-wrapper"
+        >
+            {children}
+        </Bubble>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/DefaultDashboardInsightMenu/DashboardInsightMenu/index.tsx
@@ -1,70 +1,56 @@
 // (C) 2021-2022 GoodData Corporation
 import React, { useState } from "react";
 import cx from "classnames";
-import { stringUtils } from "@gooddata/util";
+import { Separator } from "@gooddata/sdk-ui-kit";
 
 import { IDashboardInsightMenuProps, IInsightMenuSubmenu, IInsightMenuItem } from "../../types";
-import { objRefToString, widgetRef } from "@gooddata/sdk-model";
-import { ArrowDirections, ArrowOffsets, Bubble, IAlignPoint, Separator } from "@gooddata/sdk-ui-kit";
 import { DashboardInsightMenuContainer } from "./DashboardInsightMenuContainer";
 import { DashboardInsightMenuItemButton } from "./DashboardInsightMenuItemButton";
 import { DashboardInsightSubmenuContainer } from "./DashboardInsightSubmenuContainer";
+import { selectIsInEditMode, useDashboardSelector } from "../../../../../model";
+import { ConfigurationBubble } from "../../../common";
+import { DashboardInsightMenuBubble } from "./DashboardInsightMenuBubble";
 
-const alignPoints: IAlignPoint[] = [
-    { align: "tr tl" },
-    { align: "br bl" },
-    { align: "tl tr" },
-    { align: "tr tr" },
-    { align: "br br" },
-];
+const DashboardInsightMenuBody: React.FC<IDashboardInsightMenuProps> = (props) => {
+    const { items, widget, onClose } = props;
+    const [submenu, setSubmenu] = useState<IInsightMenuSubmenu | null>(null);
 
-const arrowDirections: ArrowDirections = {
-    "tr tr": "right",
-    "br br": "right",
-};
-
-const arrowOffsets: ArrowOffsets = {
-    "tr tl": [20, 0],
-    "tl tr": [-20, 0],
+    return submenu ? (
+        <DashboardInsightSubmenuContainer
+            onClose={onClose}
+            title={submenu.itemName}
+            onBack={() => setSubmenu(null)}
+        >
+            <DashboardInsightMenuSubmenu submenu={submenu} setSubmenu={setSubmenu} />
+        </DashboardInsightSubmenuContainer>
+    ) : (
+        <DashboardInsightMenuContainer onClose={onClose} widget={widget}>
+            <DashboardInsightMenuRoot items={items} setSubmenu={setSubmenu} />
+        </DashboardInsightMenuContainer>
+    );
 };
 
 export const DashboardInsightMenu: React.FC<IDashboardInsightMenuProps> = (props) => {
-    const { items, widget, onClose } = props;
-    const widgetRefAsString = objRefToString(widgetRef(widget));
-    const [submenu, setSubmenu] = useState<IInsightMenuSubmenu | null>(null);
+    const { widget, onClose } = props;
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
 
-    return (
-        <Bubble
-            alignTo={`.dash-item-action-widget-options-${stringUtils.simplifyText(widgetRefAsString)}`}
-            alignPoints={alignPoints}
-            arrowDirections={arrowDirections}
-            arrowOffsets={arrowOffsets}
-            className={cx(
-                "bubble-light",
-                "gd-configuration-bubble",
+    return isInEditMode ? (
+        <ConfigurationBubble
+            widget={widget}
+            classNames={cx(
                 "edit-insight-config",
                 "s-edit-insight-config",
                 "edit-insight-config-arrow-color",
                 "edit-insight-config-title-1-line",
             )}
-            closeOnOutsideClick
             onClose={onClose}
-            overlayClassName="gd-configuration-bubble-wrapper"
         >
-            {submenu ? (
-                <DashboardInsightSubmenuContainer
-                    onClose={onClose}
-                    title={submenu.itemName}
-                    onBack={() => setSubmenu(null)}
-                >
-                    <DashboardInsightMenuSubmenu submenu={submenu} setSubmenu={setSubmenu} />
-                </DashboardInsightSubmenuContainer>
-            ) : (
-                <DashboardInsightMenuContainer onClose={onClose} widget={widget}>
-                    <DashboardInsightMenuRoot items={items} setSubmenu={setSubmenu} />
-                </DashboardInsightMenuContainer>
-            )}
-        </Bubble>
+            <DashboardInsightMenuBody {...props} />
+        </ConfigurationBubble>
+    ) : (
+        <DashboardInsightMenuBubble onClose={onClose} widget={widget}>
+            <DashboardInsightMenuBody {...props} />
+        </DashboardInsightMenuBubble>
     );
 };
 

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyDashboardInsightMenu.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyDashboardInsightMenu.tsx
@@ -1,12 +1,13 @@
-// (C) 2020 GoodData Corporation
-import React from "react";
-
-import { IDashboardInsightMenuProps } from "../types";
+// (C) 2020-2022 GoodData Corporation
+import { DefaultDashboardInsightMenu } from "../DefaultDashboardInsightMenu";
+import { renderModeAware } from "../../../componentDefinition";
+import { CustomDashboardInsightMenuComponent } from "../types";
 import { LegacyInsightMenu } from "./LegacyInsightMenu";
 
 /**
  * @internal
  */
-export const LegacyDashboardInsightMenu = (props: IDashboardInsightMenuProps): JSX.Element => {
-    return <LegacyInsightMenu {...props} />;
-};
+export const LegacyDashboardInsightMenu = renderModeAware<CustomDashboardInsightMenuComponent>({
+    view: LegacyInsightMenu,
+    edit: DefaultDashboardInsightMenu,
+});

--- a/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyDashboardInsightMenuButton.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/insightMenu/LegacyDefaultDashboardInsightMenu/LegacyDashboardInsightMenuButton.tsx
@@ -1,12 +1,13 @@
-// (C) 2020 GoodData Corporation
-import React from "react";
-
-import { IDashboardInsightMenuButtonProps } from "../types";
+// (C) 2020-2022 GoodData Corporation
+import { renderModeAware } from "../../../componentDefinition";
+import { DefaultDashboardInsightMenuButton } from "../DefaultDashboardInsightMenu";
+import { CustomDashboardInsightMenuButtonComponent } from "../types";
 import { LegacyInsightMenuButton } from "./LegacyInsightMenu/LegacyInsightMenuButton";
 
 /**
  * @internal
  */
-export const LegacyDashboardInsightMenuButton = (props: IDashboardInsightMenuButtonProps): JSX.Element => {
-    return <LegacyInsightMenuButton {...props} />;
-};
+export const LegacyDashboardInsightMenuButton = renderModeAware<CustomDashboardInsightMenuButtonComponent>({
+    view: LegacyInsightMenuButton,
+    edit: DefaultDashboardInsightMenuButton,
+});

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DashboardWidget.tsx
@@ -29,6 +29,8 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
         //  components (or possibly the model) should deal with layout items that have no valid widgets associated
         //  and thus short-circuit.
         if (!widget) {
+            // eslint-disable-next-line no-console
+            console.warn("Attempting render an undefined widget.");
             return MissingWidget;
         }
 
@@ -40,18 +42,11 @@ export const DashboardWidget = (props: IDashboardWidgetProps): JSX.Element => {
 
         if (isDashboardWidget(widget)) {
             return DefaultDashboardWidget;
-        } else if (widget) {
-            // eslint-disable-next-line no-console
-            console.warn(`Unable to render widget ${extendedWidgetDebugStr(widget)}`);
-
-            return BadWidgetType;
-        } else {
-            // TODO: same as the above note
-            // eslint-disable-next-line no-console
-            console.warn("Attempting render an undefined widget.");
-
-            return MissingWidget;
         }
+
+        // eslint-disable-next-line no-console
+        console.warn(`Unable to render widget ${extendedWidgetDebugStr(widget)}`);
+        return BadWidgetType;
     }, [widget]);
 
     return (

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -34,6 +34,7 @@ import { useWidgetSelection } from "../common/useWidgetSelection";
 interface IDefaultDashboardInsightWidgetProps {
     widget: IInsightWidget;
     screen: ScreenSize;
+    dashboardItemClasses: string;
 
     onLoadingChanged?: OnLoadingChanged;
     onExportReady?: OnExportReady;
@@ -44,11 +45,7 @@ interface IDefaultDashboardInsightWidgetProps {
 // Since the behavior is nearly impossible to replicate reliably, let's be defensive here and not render
 // anything until the insights "catch up".
 export const DefaultDashboardInsightWidget: React.FC<IDefaultDashboardInsightWidgetProps> = (props) => {
-    const {
-        widget,
-        // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
-        index,
-    } = props;
+    const { widget } = props;
     const insights = useDashboardSelector(selectInsightsMap);
     const insight = insights.get(widget.insight);
 
@@ -60,14 +57,7 @@ export const DefaultDashboardInsightWidget: React.FC<IDefaultDashboardInsightWid
         return null;
     }
 
-    return (
-        <DefaultDashboardInsightWidgetCore
-            {...props}
-            insight={insight}
-            // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
-            index={index}
-        />
-    );
+    return <DefaultDashboardInsightWidgetCore {...props} insight={insight} />;
 };
 
 /**
@@ -75,16 +65,7 @@ export const DefaultDashboardInsightWidget: React.FC<IDefaultDashboardInsightWid
  */
 const DefaultDashboardInsightWidgetCore: React.FC<
     IDefaultDashboardInsightWidgetProps & { insight: IInsight }
-> = ({
-    widget,
-    insight,
-    screen,
-    onError,
-    onExportReady,
-    onLoadingChanged,
-    // @ts-expect-error Don't expose index prop on public interface (we need it only for css class for KD tests)
-    index,
-}) => {
+> = ({ widget, insight, screen, onError, onExportReady, onLoadingChanged, dashboardItemClasses }) => {
     const intl = useIntl();
     const visType = insightVisualizationUrl(insight).split(":")[1] as VisType;
     const { ref: widgetRef } = widget;
@@ -139,7 +120,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     return (
         <DashboardItem
             className={cx(
-                `s-dash-item-${index}`,
+                dashboardItemClasses,
                 "type-visualization",
                 "gd-dashboard-view-widget",
                 getVisTypeCssClass(widget.type, visType),

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardInsightWidget.tsx
@@ -17,6 +17,7 @@ import {
     isCustomWidget,
     useDashboardScheduledEmails,
     selectCanExportReport,
+    selectIsInEditMode,
 } from "../../../model";
 import {
     DashboardItem,
@@ -79,6 +80,7 @@ const DefaultDashboardInsightWidgetCore: React.FC<
     const { isScheduledEmailingVisible, enableInsightExportScheduling, onScheduleEmailingOpen } =
         useDashboardScheduledEmails();
     const canExportReport = useDashboardSelector(selectCanExportReport);
+    const isInEditMode = useDashboardSelector(selectIsInEditMode);
 
     const onScheduleExport = useCallback(() => {
         onScheduleEmailingOpen(widgetRef);
@@ -115,7 +117,19 @@ const DefaultDashboardInsightWidgetCore: React.FC<
         [InsightMenuComponentProvider, insight, widget],
     );
 
-    const { isSelectable, isSelected, onSelected } = useWidgetSelection(widget.ref);
+    const { isSelectable, isSelected, onSelected, closeConfigPanel, hasConfigPanelOpen } = useWidgetSelection(
+        widget.ref,
+    );
+
+    const onCloseClick = useCallback(() => {
+        if (isInEditMode) {
+            closeConfigPanel();
+        } else {
+            closeMenu();
+        }
+    }, [closeConfigPanel, closeMenu, isInEditMode]);
+
+    const shouldShowMenu = isInEditMode ? hasConfigPanelOpen : isMenuOpen;
 
     return (
         <DashboardItem
@@ -142,14 +156,14 @@ const DefaultDashboardInsightWidgetCore: React.FC<
                         <InsightMenuButtonComponent
                             insight={insight}
                             widget={widget}
-                            isOpen={isMenuOpen}
+                            isOpen={shouldShowMenu}
                             onClick={openMenu}
                             items={menuItems}
                         />
                     </>
                 )}
                 renderAfterContent={() => {
-                    if (!isMenuOpen) {
+                    if (!shouldShowMenu) {
                         return null;
                     }
 
@@ -157,8 +171,8 @@ const DefaultDashboardInsightWidgetCore: React.FC<
                         <InsightMenuComponent
                             insight={insight}
                             widget={widget}
-                            isOpen={isMenuOpen}
-                            onClose={closeMenu}
+                            isOpen={shouldShowMenu}
+                            onClose={onCloseClick}
                             items={menuItems}
                         />
                     );

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardKpiWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/DefaultDashboardKpiWidget.tsx
@@ -1,0 +1,41 @@
+// (C) 2022 GoodData Corporation
+import { FilterContextItem, IKpiWidget, ScreenSize, widgetRef } from "@gooddata/sdk-model";
+import cx from "classnames";
+import { OnError } from "@gooddata/sdk-ui";
+import React from "react";
+import { DashboardItem } from "../../presentationComponents";
+import { DashboardKpi } from "../kpi";
+import { useWidgetSelection } from "../common/useWidgetSelection";
+import { selectAlertByWidgetRef, useDashboardSelector } from "../../../model";
+import { IDashboardFilter } from "../../../types";
+
+interface IDefaultDashboardKpiWidgetProps {
+    kpiWidget: IKpiWidget;
+    screen: ScreenSize;
+    dashboardItemClasses: string;
+
+    onError?: OnError;
+    onFiltersChange?: (filters: (IDashboardFilter | FilterContextItem)[], resetOthers?: boolean) => void;
+}
+
+export const DefaultDashboardKpiWidget: React.FC<IDefaultDashboardKpiWidgetProps> = (props) => {
+    const { kpiWidget, onError, onFiltersChange, screen, dashboardItemClasses } = props;
+
+    const { isSelected } = useWidgetSelection(widgetRef(kpiWidget));
+    const alertSelector = selectAlertByWidgetRef(widgetRef(kpiWidget));
+    const alert = useDashboardSelector(alertSelector);
+
+    return (
+        <DashboardItem
+            className={cx("type-kpi", dashboardItemClasses, { "is-selected": isSelected })}
+            screen={screen}
+        >
+            <DashboardKpi
+                kpiWidget={kpiWidget}
+                alert={alert}
+                onFiltersChange={onFiltersChange}
+                onError={onError}
+            />
+        </DashboardItem>
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/widget/widget/useInsightMenu.ts
@@ -112,13 +112,10 @@ function useDefaultMenuItems(
 }
 
 function getDefaultMenuItemsGetter(renderMode: RenderMode, useLegacyMenu: boolean) {
-    if (useLegacyMenu) {
-        return getDefaultLegacyInsightMenuItems;
-    }
     switch (renderMode) {
         case "edit":
             return getDefaultInsightEditMenuItems;
         case "view":
-            return getDefaultInsightMenuItems;
+            return useLegacyMenu ? getDefaultLegacyInsightMenuItems : getDefaultInsightMenuItems;
     }
 }


### PR DESCRIPTION
* Fix how insight menu behaves in edit mode. This is just a quick fix to make it work, I will refactor this more significantly later.
* Step towards unified widget definitions.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
