### PR TITLE
RELATED: RAIL-4391 prevent unnecessary re-renders and re-executions

### DIFF
--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutGridRow.tsx
@@ -50,7 +50,6 @@ export function DashboardLayoutGridRow<TWidget>(props: DashboardLayoutGridRowPro
             itemRenderer={itemRenderer}
             widgetRenderer={widgetRenderer}
             screen={screen}
-            renderMode={renderMode}
         />
     ));
 

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutItem.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DefaultDashboardLayoutRenderer/DashboardLayoutItem.tsx
@@ -4,7 +4,6 @@ import { IDashboardLayoutItemRenderer, IDashboardLayoutWidgetRenderer } from "./
 import { IDashboardLayoutItemFacade } from "../../../_staging/dashboard/fluidLayout/facade/interfaces";
 import { DashboardLayoutItemRenderer } from "./DashboardLayoutItemRenderer";
 import { DashboardLayoutWidgetRenderer } from "./DashboardLayoutWidgetRenderer";
-import { RenderMode } from "../../../types";
 
 /**
  * @alpha
@@ -12,7 +11,6 @@ import { RenderMode } from "../../../types";
 export interface IDashboardLayoutItemProps<TWidget> {
     item: IDashboardLayoutItemFacade<TWidget>;
     screen: ScreenSize;
-    renderMode: RenderMode;
     itemRenderer?: IDashboardLayoutItemRenderer<TWidget>;
     widgetRenderer: IDashboardLayoutWidgetRenderer<TWidget>;
 }


### PR DESCRIPTION
* memoize renderers
* do not pass prop that is not used
* improve filters digests in useWidgetFilters

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
