### PR TITLE
RELATED: RAIL-4170 add support for adding existing widgets in existing sections

### DIFF
--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/moveSectionItemHandler.test.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/tests/moveSectionItemHandler.test.ts
@@ -47,7 +47,7 @@ describe("move layout section item handler", () => {
         it("should fail if bad target section index is provided", async () => {
             const originalLayout = selectLayout(Tester.state());
             const event: DashboardCommandFailed<MoveLayoutSection> = await Tester.dispatchAndWaitFor(
-                moveSectionItem(0, 0, originalLayout.sections.length, -1, TestCorrelation),
+                moveSectionItem(0, 0, originalLayout.sections.length + 1, -1, TestCorrelation),
                 "GDC.DASH/EVT.COMMAND.FAILED",
             );
 

--- a/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/layoutValidation.ts
+++ b/libs/sdk-ui-dashboard/src/model/commandHandlers/layout/validation/layoutValidation.ts
@@ -15,7 +15,8 @@ export function validateSectionPlacement(
         return true;
     }
 
-    return index < layout.sections.length;
+    // using <= here so that we can add to the last place not only by using -1 by also by using (lastIndex+1)
+    return index <= layout.sections.length;
 }
 
 export function validateSectionExists(
@@ -34,7 +35,8 @@ export function validateItemPlacement(section: ExtendedDashboardLayoutSection, i
         return true;
     }
 
-    return index < section.items.length;
+    // using <= here so that we can add to the last place not only by using -1 by also by using (lastIndex+1)
+    return index <= section.items.length;
 }
 
 export function validateItemExists(section: ExtendedDashboardLayoutSection, index: number): boolean {

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/Hotspot.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/Hotspot.tsx
@@ -1,0 +1,68 @@
+// (C) 2022 GoodData Corporation
+import React from "react";
+import cx from "classnames";
+import { getDropZoneDebugStyle } from "../debug";
+import { addSectionItem, selectSettings, useDashboardDispatch, useDashboardSelector } from "../../../model";
+import { useDashboardDrop } from "../useDashboardDrop";
+import { getInsightSizeInfo } from "@gooddata/sdk-ui-ext";
+import { insightRef, insightTitle } from "@gooddata/sdk-model";
+
+interface IHotspotProps {
+    sectionIndex: number;
+    itemIndex: number;
+    classNames?: string;
+    dropZoneType: "prev" | "next";
+}
+
+export const Hotspot: React.FC<IHotspotProps> = (props) => {
+    const { itemIndex, sectionIndex, classNames, dropZoneType } = props;
+
+    const dispatch = useDashboardDispatch();
+    const settings = useDashboardSelector(selectSettings);
+
+    const [{ canDrop, isOver }, dropRef] = useDashboardDrop(
+        "insightListItem",
+        {
+            drop: ({ insight }) => {
+                const sizeInfo = getInsightSizeInfo(insight, settings);
+                dispatch(
+                    addSectionItem(
+                        sectionIndex,
+                        // for "next" we need to add the item after the current index, for "prev" on the current one
+                        dropZoneType === "next" ? itemIndex + 1 : itemIndex,
+                        {
+                            type: "IDashboardLayoutItem",
+                            widget: {
+                                type: "insight",
+                                insight: insightRef(insight),
+                                ignoreDashboardFilters: [],
+                                drills: [],
+                                title: insightTitle(insight),
+                                description: "",
+                                configuration: { hideTitle: false },
+                                properties: {},
+                            },
+                            size: {
+                                xl: {
+                                    gridHeight: sizeInfo.height.default,
+                                    gridWidth: sizeInfo.width.default!,
+                                },
+                            },
+                        },
+                    ),
+                );
+            },
+        },
+        [dispatch],
+    );
+
+    const debugStyle = getDropZoneDebugStyle({ isOver });
+
+    return (
+        <div
+            className={cx(classNames, "dropzone", dropZoneType, { hidden: !canDrop })}
+            style={debugStyle}
+            ref={dropRef}
+        />
+    );
+};

--- a/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
+++ b/libs/sdk-ui-dashboard/src/presentation/dragAndDrop/draggableWidget/index.ts
@@ -1,3 +1,4 @@
 // (C) 2022 GoodData Corporation
 export * from "./DraggableInsightListItem";
 export * from "./SectionHotspot";
+export * from "./Hotspot";

--- a/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
+++ b/libs/sdk-ui-dashboard/src/presentation/layout/DashboardLayoutWidget.tsx
@@ -27,7 +27,7 @@ import {
 } from "./DefaultDashboardLayoutRenderer";
 import { ObjRefMap } from "../../_staging/metadata/objRefMap";
 import { useDashboardComponentsContext } from "../dashboardContexts";
-import { ResizeOverlay, useResizeStatus } from "../dragAndDrop";
+import { Hotspot, ResizeOverlay, useResizeStatus } from "../dragAndDrop";
 import { getDashboardLayoutWidgetDefaultHeight } from "../../model/layout";
 
 function calculateWidgetMinHeight(
@@ -128,6 +128,8 @@ export const DashboardLayoutWidget: IDashboardLayoutWidgetRenderer<
                 isUnderWidthMinLimit={false}
                 reachedHeightLimit={heightLimitReached}
             />
+            <Hotspot dropZoneType="prev" itemIndex={item.index()} sectionIndex={item.section().index()} />
+            <Hotspot dropZoneType="next" itemIndex={item.index()} sectionIndex={item.section().index()} />
         </DefaultWidgetRenderer>
     );
 };


### PR DESCRIPTION
Add support for adding existing widgets in existing sections.
Also relax placement validations to make the implementation significantly simpler.

**Caveats**

- will not show placeholders yet, so the user cannot preview what will happen to the layout, but the adding works properly: if you drop on the left side of a widget, the insight is added before it, otherwise after it.

---

Supported PR commands:

| Command                  | Description             |
| ------------------------ | ----------------------- |
| `ok to test`             | Re-run standard checks  |
| `extended test`          | BackstopJS tests        |
| `extended check sonar`   | SonarQube tests         |
| `extended check cypress` | Cypress E2E tests       |
| `extended check plugins` | Dashboard plugins tests |

---

# PR Checklist

-   [ ] commit messages adhere to the [commit message guidelines](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#what-should-the-commits-look-like)
-   [ ] review was done by a Code owner [if necessary](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-tell-if-my-pull-request-needs-approval-by-a-code-owner) (if you think it is not necessary, explain the reasoning in the description or in a comment)
-   [ ] `check` passes
-   [ ] `check-extended` passes
-   [ ] `check-extended-cypress` passes
-   [ ] `rush change` [was run if applicable](https://github.com/gooddata/gooddata-ui-sdk/blob/master/docs/contributing.md#how-do-i-describe-my-changes-for-the-changelog)
